### PR TITLE
Fix railway.json paths for standalone repo

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,9 +2,9 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "./apps/api-service/Dockerfile",
+    "dockerfilePath": "./Dockerfile",
     "watchPatterns": [
-      "/apps/api-service/**",
+      "/src/**",
       "/shared/**",
       "/pnpm-lock.yaml"
     ]

--- a/tests/unit/railway-config.test.ts
+++ b/tests/unit/railway-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+describe("railway.json", () => {
+  const root = resolve(import.meta.dirname, "../..");
+  const config = JSON.parse(
+    readFileSync(resolve(root, "railway.json"), "utf-8"),
+  );
+
+  it("references a Dockerfile that exists", () => {
+    const dockerfilePath = resolve(root, config.build.dockerfilePath);
+    expect(existsSync(dockerfilePath)).toBe(true);
+  });
+
+  it("uses DOCKERFILE builder", () => {
+    expect(config.build.builder).toBe("DOCKERFILE");
+  });
+
+  it("has a health check configured", () => {
+    expect(config.deploy.healthcheckPath).toBe("/health");
+  });
+
+  it("watches source and shared directories", () => {
+    const patterns: string[] = config.build.watchPatterns;
+    expect(patterns).toContain("/src/**");
+    expect(patterns).toContain("/shared/**");
+    expect(patterns).toContain("/pnpm-lock.yaml");
+  });
+});


### PR DESCRIPTION
## Summary
- Updated `dockerfilePath` from `./apps/api-service/Dockerfile` to `./Dockerfile` (monorepo path no longer exists)
- Updated `watchPatterns` from `/apps/api-service/**` to `/src/**`
- Added test to verify railway.json references a Dockerfile that actually exists

## Test plan
- [x] `railway-config.test.ts` verifies Dockerfile path exists, builder type, health check, and watch patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)