### PR TITLE
Add Railway best-practice deploy config

### DIFF
--- a/apps/api-service/railway.json
+++ b/apps/api-service/railway.json
@@ -6,11 +6,14 @@
     "watchPatterns": [
       "/src/**",
       "/shared/**",
-      "/pnpm-lock.yaml"
+      "/pnpm-lock.yaml",
+      "/Dockerfile"
     ]
   },
   "deploy": {
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 10
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
   }
 }

--- a/tests/unit/railway-config.test.ts
+++ b/tests/unit/railway-config.test.ts
@@ -26,5 +26,11 @@ describe("railway.json", () => {
     expect(patterns).toContain("/src/**");
     expect(patterns).toContain("/shared/**");
     expect(patterns).toContain("/pnpm-lock.yaml");
+    expect(patterns).toContain("/Dockerfile");
+  });
+
+  it("has restart policy configured", () => {
+    expect(config.deploy.restartPolicyType).toBe("ON_FAILURE");
+    expect(config.deploy.restartPolicyMaxRetries).toBe(5);
   });
 });


### PR DESCRIPTION
## Summary
- Add `restartPolicyType: ON_FAILURE` with max 5 retries for crash recovery
- Bump `healthcheckTimeout` from 10s to 30s (accounts for cold start)
- Add `/Dockerfile` to `watchPatterns` so Dockerfile changes trigger redeploys
- Added test for restart policy fields

## Context
Per [Railway config-as-code docs](https://docs.railway.com/reference/config-as-code), restart policies and healthcheck timeouts are recommended for production services.

## Test plan
- [x] `railway-config.test.ts` — 5 tests pass (Dockerfile exists, builder, healthcheck, watch patterns, restart policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)