### PR TITLE
Fix Dockerfile: replace broken pnpm deploy

### DIFF
--- a/tests/unit/dockerfile.test.ts
+++ b/tests/unit/dockerfile.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("Dockerfile", () => {
+  const root = resolve(import.meta.dirname, "../..");
+  const dockerfile = readFileSync(resolve(root, "Dockerfile"), "utf-8");
+
+  it("does not use pnpm deploy (unsupported for root workspace package)", () => {
+    expect(dockerfile).not.toContain("pnpm deploy");
+  });
+
+  it("installs prod-only deps in the production stage", () => {
+    expect(dockerfile).toContain("pnpm install --prod");
+  });
+
+  it("copies shared package build output to production stage", () => {
+    expect(dockerfile).toContain("shared/content/dist");
+    expect(dockerfile).toContain("shared/runs-client/dist");
+  });
+
+  it("uses multi-stage build", () => {
+    const fromStatements = dockerfile.match(/^FROM /gm);
+    expect(fromStatements!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("sets IPv4-first DNS for Neon compatibility", () => {
+    expect(dockerfile).toContain("dns-result-order=ipv4first");
+  });
+});


### PR DESCRIPTION
## Summary
- `pnpm deploy --prod /prod` fails because it requires `--filter` on a workspace package, but the root `@mcpfactory/api-service` is the workspace root, not a member
- Replaced with a proper multi-stage build: production stage runs `pnpm install --prod` and copies only built output from the builder stage
- Shared packages (`@mcpfactory/content`, `@mcpfactory/runs-client`) have zero runtime deps — only their compiled `dist/` is needed at runtime

## Test plan
- [x] `dockerfile.test.ts` — validates no `pnpm deploy`, prod install present, shared dist copied, multi-stage build, IPv4 DNS
- [x] `railway-config.test.ts` — still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)