### PR TITLE
fix: update CORS origins to distribute.you

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,11 @@ const PORT = process.env.PORT || 3000;
 // CORS - allow dashboard and MCP clients
 app.use(cors({
   origin: [
-    "https://dashboard.mcpfactory.org",
-    "https://mcpfactory.org",
+    "https://dashboard.distribute.you",
+    "https://distribute.you",
+    "https://performance.distribute.you",
     "http://localhost:3000",
     "http://localhost:3001",
-    "https://performance.mcpfactory.org",
     "http://localhost:3007",
   ],
   credentials: true,

--- a/tests/unit/cors.test.ts
+++ b/tests/unit/cors.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("CORS configuration", () => {
+  const indexSource = readFileSync(
+    join(__dirname, "../../src/index.ts"),
+    "utf-8",
+  );
+
+  const allowedOrigins = [
+    "https://dashboard.distribute.you",
+    "https://distribute.you",
+    "https://performance.distribute.you",
+    "http://localhost:3000",
+    "http://localhost:3001",
+    "http://localhost:3007",
+  ];
+
+  const blockedOrigins = [
+    "https://dashboard.mcpfactory.org",
+    "https://mcpfactory.org",
+    "https://performance.mcpfactory.org",
+  ];
+
+  for (const origin of allowedOrigins) {
+    it(`includes ${origin} in CORS origins`, () => {
+      expect(indexSource).toContain(`"${origin}"`);
+    });
+  }
+
+  for (const origin of blockedOrigins) {
+    it(`does not include old domain ${origin} in CORS origins`, () => {
+      expect(indexSource).not.toContain(`"${origin}"`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Replace old `mcpfactory.org` CORS origins with `distribute.you` domains (`dashboard.distribute.you`, `distribute.you`, `performance.distribute.you`)
- Fixes preflight failures for the dashboard deployed at `dashboard.distribute.you`
- Add regression test verifying allowed and blocked origins

## Test plan
- [x] CORS test verifies all 6 allowed origins are present in config
- [x] CORS test verifies old mcpfactory.org domains are removed
- [x] Full test suite passes (pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)