### PR TITLE
fix: slugify app name in register endpoint

### DIFF
--- a/src/routes/apps.ts
+++ b/src/routes/apps.ts
@@ -16,7 +16,15 @@ router.post("/apps/register", async (req, res) => {
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
-    const { name } = parsed.data;
+    const name = parsed.data.name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+
+    if (!name) {
+      return res.status(400).json({ error: "App name results in empty slug after normalization" });
+    }
 
     const result = await callExternalService(
       externalServices.key,

--- a/tests/unit/app-name-slugify.test.ts
+++ b/tests/unit/app-name-slugify.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+
+/** Mirrors the slugify logic in src/routes/apps.ts */
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+describe("App name slugification", () => {
+  it("converts PressBeat.io to pressbeat-io", () => {
+    expect(slugify("PressBeat.io")).toBe("pressbeat-io");
+  });
+
+  it("converts My Cool App! to my-cool-app", () => {
+    expect(slugify("My Cool App!")).toBe("my-cool-app");
+  });
+
+  it("collapses consecutive hyphens", () => {
+    expect(slugify("foo---bar")).toBe("foo-bar");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(slugify("--hello--")).toBe("hello");
+  });
+
+  it("passes through already-valid names unchanged", () => {
+    expect(slugify("my-app-123")).toBe("my-app-123");
+  });
+
+  it("handles uppercase-only input", () => {
+    expect(slugify("ACME")).toBe("acme");
+  });
+
+  it("returns empty string for all-special-character input", () => {
+    expect(slugify("...")).toBe("");
+  });
+});

--- a/tests/unit/apps-register.test.ts
+++ b/tests/unit/apps-register.test.ts
@@ -33,6 +33,13 @@ describe("POST /v1/apps/register route", () => {
     expect(content).toContain("body: { name }");
   });
 
+  it("should slugify the name before forwarding to key-service", () => {
+    expect(content).toContain(".toLowerCase()");
+    expect(content).toContain('.replace(/[^a-z0-9-]/g, "-")');
+    expect(content).toContain('.replace(/-+/g, "-")');
+    expect(content).toContain('.replace(/^-|-$/g, "")');
+  });
+
   it("should return 400 for invalid requests", () => {
     expect(content).toContain("400");
     expect(content).toContain("Invalid request");


### PR DESCRIPTION
## Summary
- Slugify the `name` field in `POST /v1/apps/register` before forwarding to key-service
- `PressBeat.io` → `pressbeat-io` instead of a 400 error
- Transformation: lowercase → replace non-alphanumeric with `-` → collapse `--` → trim leading/trailing `-`
- Returns 400 only if the result is empty (e.g. input was `...`)

## Test plan
- [x] Unit tests verify slugify logic with 7 cases (PressBeat.io, spaces, consecutive hyphens, etc.)
- [x] Existing register route tests updated to assert slugify steps are present
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)