### PR TITLE
fix: service client catch block swallows parsed error messages

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -91,12 +91,14 @@ export async function callExternalService<T>(
 
     if (!response.ok) {
       const errorText = await response.text();
+      let errorMessage: string;
       try {
         const errorJson = JSON.parse(errorText);
-        throw new Error(errorJson.error || `Service call failed: ${response.status}`);
+        errorMessage = errorJson.error || `Service call failed: ${response.status}`;
       } catch {
-        throw new Error(`Service call failed: ${response.status} - ${errorText}`);
+        errorMessage = `Service call failed: ${response.status} - ${errorText}`;
       }
+      throw new Error(errorMessage);
     }
 
     return response.json();

--- a/tests/unit/service-client-error-handling.test.ts
+++ b/tests/unit/service-client-error-handling.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { callExternalService } from "../../src/lib/service-client.js";
+
+const service = { url: "http://localhost:9999", apiKey: "test-key" };
+
+describe("callExternalService error handling", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should extract error message from JSON error response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve(JSON.stringify({ error: "Invalid API key format" })),
+      }),
+    );
+
+    await expect(callExternalService(service, "/validate")).rejects.toThrow(
+      "Invalid API key format",
+    );
+    // Must NOT contain the raw JSON wrapper
+    await expect(callExternalService(service, "/validate")).rejects.not.toThrow(
+      "Service call failed: 401",
+    );
+  });
+
+  it("should fall back to raw text when response is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal Server Error"),
+      }),
+    );
+
+    await expect(callExternalService(service, "/health")).rejects.toThrow(
+      "Service call failed: 500 - Internal Server Error",
+    );
+  });
+
+  it("should use status code when JSON has no error field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve(JSON.stringify({ message: "Forbidden" })),
+      }),
+    );
+
+    await expect(callExternalService(service, "/resource")).rejects.toThrow(
+      "Service call failed: 403",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed a bug in `callExternalService` where the `catch` block caught its own intentional `throw` from the `try` block, causing structured JSON error messages (e.g. `"Invalid API key format"`) to always be replaced with raw text like `"Service call failed: 401 - {"error":"..."}"`.
- Moved the `throw` outside the try-catch so parsed `.error` fields propagate cleanly to callers.
- Added regression tests covering JSON errors, non-JSON errors, and missing error fields.

## Test plan
- [x] New `service-client-error-handling.test.ts` — 3 tests verifying correct error extraction
- [x] Full test suite passes (251/252 — 1 pre-existing failure from missing dashboard file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)