### PR TITLE
fix: copy openapi.json to production Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN pnpm install --prod --no-frozen-lockfile
 
 # Copy built output
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/openapi.json ./openapi.json
 COPY --from=builder /app/shared/content/dist shared/content/dist
 COPY --from=builder /app/shared/runs-client/dist shared/runs-client/dist
 

--- a/tests/unit/dockerfile.test.ts
+++ b/tests/unit/dockerfile.test.ts
@@ -27,4 +27,8 @@ describe("Dockerfile", () => {
   it("sets IPv4-first DNS for Neon compatibility", () => {
     expect(dockerfile).toContain("dns-result-order=ipv4first");
   });
+
+  it("copies generated openapi.json to production stage", () => {
+    expect(dockerfile).toContain("COPY --from=builder /app/openapi.json");
+  });
 });


### PR DESCRIPTION
## Summary

- The Dockerfile's production stage only copied `dist/` but not the generated `openapi.json`, so the `/openapi.json` endpoint served stale or no content in prod
- Adds `COPY --from=builder /app/openapi.json ./openapi.json` to the production stage
- Adds test to verify `openapi.json` is copied in Dockerfile

## Context

PR #10 improved the OpenAPI auth documentation but the changes weren't visible on the live service because the generated `openapi.json` was never copied into the production Docker image.

## Test plan

- [x] Dockerfile test passes (verifies `openapi.json` copy line exists)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)