### PR TITLE
feat: support workflow style parameter and humanId filtering

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -578,6 +578,16 @@
               },
               "signatureName": {
                 "type": "string"
+              },
+              "humanId": {
+                "type": "string",
+                "nullable": true,
+                "description": "Human ID if styled after an expert"
+              },
+              "styleName": {
+                "type": "string",
+                "nullable": true,
+                "description": "Base style name for versioning (e.g. 'hormozi')"
               }
             },
             "required": [
@@ -587,7 +597,9 @@
               "channel",
               "audienceType",
               "signature",
-              "signatureName"
+              "signatureName",
+              "humanId",
+              "styleName"
             ]
           },
           "dag": {
@@ -682,6 +694,16 @@
                   "updated"
                 ],
                 "description": "Whether the workflow was created or updated"
+              },
+              "humanId": {
+                "type": "string",
+                "nullable": true,
+                "description": "Human ID if styled after an expert"
+              },
+              "styleName": {
+                "type": "string",
+                "nullable": true,
+                "description": "Base style name for versioning (e.g. 'hormozi')"
               }
             },
             "required": [
@@ -692,7 +714,9 @@
               "audienceType",
               "signature",
               "signatureName",
-              "action"
+              "action",
+              "humanId",
+              "styleName"
             ]
           },
           "dag": {
@@ -729,6 +753,37 @@
           "generatedDescription"
         ]
       },
+      "WorkflowStyle": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "human",
+              "brand"
+            ],
+            "description": "Style source type"
+          },
+          "humanId": {
+            "type": "string",
+            "description": "Human ID from human-service. Required when type is 'human'."
+          },
+          "brandId": {
+            "type": "string",
+            "description": "Brand ID from brand-service. Required when type is 'brand'."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Display name of the human or brand (e.g. 'Hormozi', 'My Brand')"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "description": "Optional style configuration. When provided, the workflow is generated in the style of an industry expert or brand."
+      },
       "GenerateWorkflowRequest": {
         "type": "object",
         "properties": {
@@ -763,6 +818,9 @@
               }
             },
             "description": "Optional hints to guide DAG generation"
+          },
+          "style": {
+            "$ref": "#/components/schemas/WorkflowStyle"
           }
         },
         "required": [
@@ -3339,6 +3397,16 @@
             "required": false,
             "description": "Filter by audience type (e.g. 'cold-outreach')",
             "name": "audienceType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter workflows by human expert ID"
+            },
+            "required": false,
+            "description": "Filter workflows by human expert ID",
+            "name": "humanId",
             "in": "query"
           },
           {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -19,6 +19,7 @@ router.get("/workflows", authenticate, requireOrg, requireUser, async (req: Auth
     if (req.query.category) params.set("category", req.query.category as string);
     if (req.query.channel) params.set("channel", req.query.channel as string);
     if (req.query.audienceType) params.set("audienceType", req.query.audienceType as string);
+    if (req.query.humanId) params.set("humanId", req.query.humanId as string);
 
     const result = await callExternalService(
       externalServices.workflow,
@@ -90,7 +91,7 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
       });
     }
 
-    const { description, hints } = parsed.data;
+    const { description, hints, style } = parsed.data;
 
     // Resolve keySource from billing-service
     const keySource = await fetchKeySource(req.orgId!);
@@ -107,6 +108,7 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
           keySource,
           description,
           hints,
+          ...(style && { style }),
         },
       }
     );

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -953,6 +953,7 @@ registry.registerPath({
       category: z.string().optional().describe("Filter by category (e.g. 'sales', 'pr')"),
       channel: z.string().optional().describe("Filter by channel (e.g. 'email')"),
       audienceType: z.string().optional().describe("Filter by audience type (e.g. 'cold-outreach')"),
+      humanId: z.string().optional().describe("Filter workflows by human expert ID"),
     }),
   },
   responses: {
@@ -1011,6 +1012,8 @@ registry.registerPath({
                 audienceType: z.string(),
                 signature: z.string(),
                 signatureName: z.string(),
+                humanId: z.string().nullable().describe("Human ID if styled after an expert"),
+                styleName: z.string().nullable().describe("Base style name for versioning (e.g. 'hormozi')"),
               }),
               dag: z.object({
                 nodes: z.array(z.any()),
@@ -1032,6 +1035,21 @@ registry.registerPath({
   },
 });
 
+export const WorkflowStyleSchema = z
+  .object({
+    type: z.enum(["human", "brand"]).describe("Style source type"),
+    humanId: z
+      .string()
+      .optional()
+      .describe("Human ID from human-service. Required when type is 'human'."),
+    brandId: z
+      .string()
+      .optional()
+      .describe("Brand ID from brand-service. Required when type is 'brand'."),
+    name: z.string().min(1).describe("Display name of the human or brand (e.g. 'Hormozi', 'My Brand')"),
+  })
+  .openapi("WorkflowStyle");
+
 export const GenerateWorkflowRequestSchema = z
   .object({
     description: z
@@ -1051,6 +1069,9 @@ export const GenerateWorkflowRequestSchema = z
       })
       .optional()
       .describe("Optional hints to guide DAG generation"),
+    style: WorkflowStyleSchema.optional().describe(
+      "Optional style configuration. When provided, the workflow is generated in the style of an industry expert or brand."
+    ),
   })
   .openapi("GenerateWorkflowRequest");
 
@@ -1085,6 +1106,8 @@ registry.registerPath({
                 signature: z.string().describe("SHA-256 hash of the canonical DAG"),
                 signatureName: z.string().describe("Human-readable name for this DAG variant"),
                 action: z.enum(["created", "updated"]).describe("Whether the workflow was created or updated"),
+                humanId: z.string().nullable().describe("Human ID if styled after an expert"),
+                styleName: z.string().nullable().describe("Base style name for versioning (e.g. 'hormozi')"),
               }),
               dag: z.object({
                 nodes: z.array(z.any()).describe("DAG nodes"),

--- a/tests/unit/workflows-generate.test.ts
+++ b/tests/unit/workflows-generate.test.ts
@@ -34,9 +34,10 @@ describe("POST /v1/workflows/generate route", () => {
     expect(content).toContain("orgId: req.orgId");
   });
 
-  it("should forward description and hints from request body", () => {
+  it("should forward description, hints, and style from request body", () => {
     expect(content).toContain("description");
     expect(content).toContain("hints");
+    expect(content).toContain("style");
   });
 
   it("should return 400 on invalid request", () => {
@@ -70,6 +71,14 @@ describe("GenerateWorkflowRequestSchema", () => {
     expect(content).toContain("expectedInputs");
   });
 
+  it("should have optional style with type, humanId, brandId, name", () => {
+    expect(content).toContain("WorkflowStyleSchema");
+    expect(content).toContain('"human"');
+    expect(content).toContain('"brand"');
+    expect(content).toContain("humanId");
+    expect(content).toContain("brandId");
+  });
+
   it("should register POST /v1/workflows/generate path in OpenAPI", () => {
     expect(content).toContain('path: "/v1/workflows/generate"');
     expect(content).toContain('method: "post"');
@@ -81,5 +90,14 @@ describe("GenerateWorkflowRequestSchema", () => {
     expect(content).toContain("workflow");
     expect(content).toContain("dag");
     expect(content).toContain("generatedDescription");
+  });
+
+  it("should include humanId and styleName in GenerateWorkflowResponse", () => {
+    // These fields appear in the response schema between signatureName and GenerateWorkflowResponse
+    const start = content.indexOf('path: "/v1/workflows/generate"');
+    const end = content.indexOf('"GenerateWorkflowResponse"');
+    const responseSection = content.slice(start, end);
+    expect(responseSection).toContain("humanId");
+    expect(responseSection).toContain("styleName");
   });
 });

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -63,6 +63,33 @@ describe("Workflow proxy routes", () => {
   it("should default appId to mcpfactory", () => {
     expect(content).toContain("mcpfactory");
   });
+
+  it("should forward humanId query param on GET /workflows", () => {
+    const listStart = content.indexOf('"/workflows"');
+    const bestStart = content.indexOf('"/workflows/best"');
+    const listBlock = content.slice(listStart, bestStart);
+
+    expect(listBlock).toContain("humanId");
+  });
+});
+
+describe("Workflow response schemas include style fields", () => {
+  const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+  const content = fs.readFileSync(schemaPath, "utf-8");
+
+  it("should include humanId and styleName in BestWorkflowResponse", () => {
+    const bestSection = content.slice(content.indexOf('"BestWorkflowResponse"'));
+    expect(bestSection).toContain("humanId");
+    expect(bestSection).toContain("styleName");
+  });
+
+  it("should include humanId query param on GET /v1/workflows", () => {
+    const listSection = content.slice(
+      content.indexOf('path: "/v1/workflows"'),
+      content.indexOf('path: "/v1/workflows/{id}"')
+    );
+    expect(listSection).toContain("humanId");
+  });
 });
 
 describe("Workflow routes are mounted in index.ts", () => {


### PR DESCRIPTION
## Summary
- Pass through the new `style` object on `POST /v1/workflows/generate` so callers can generate workflows in the style of an industry expert or brand (workflow-service PR #61)
- Forward the `humanId` query param on `GET /v1/workflows` for filtering styled workflows
- Add `humanId` (nullable) and `styleName` (nullable) to `GenerateWorkflowResponse` and `BestWorkflowResponse` schemas
- Regenerate `openapi.json` with `WorkflowStyle` schema and all new fields

## Test plan
- [x] Existing workflow proxy tests pass (28 tests)
- [x] New tests verify `style` field in request schema and route forwarding
- [x] New tests verify `humanId` query param forwarding on GET /workflows
- [x] New tests verify `humanId`/`styleName` in response schemas
- [x] Full test suite passes (269/270 — 1 pre-existing failure from missing cross-repo file)
- [x] OpenAPI spec regenerated and includes all new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)