### PR TITLE
fix: update OpenAPI server URL to api.distribute.you

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://api.mcpfactory.org"
+      "url": "https://api.distribute.you"
     }
   ],
   "tags": [

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -60,7 +60,7 @@ The API service resolves these external IDs to internal UUIDs via \`client-servi
   },
   servers: [
     {
-      url: process.env.SERVICE_URL || "https://api.mcpfactory.org",
+      url: process.env.SERVICE_URL || "https://api.distribute.you",
     },
   ],
   tags: [

--- a/tests/unit/openapi-auth-docs.test.ts
+++ b/tests/unit/openapi-auth-docs.test.ts
@@ -55,6 +55,12 @@ describe("OpenAPI spec — info description", () => {
   });
 });
 
+describe("OpenAPI spec — server URL", () => {
+  it("should default to api.distribute.you", () => {
+    expect(generatorContent).toContain("https://api.distribute.you");
+  });
+});
+
 describe("OpenAPI spec — identity header parameters on authenticated endpoints", () => {
   it("should inject x-org-id and x-user-id header parameters for authenticated operations", () => {
     expect(generatorContent).toContain('"x-org-id"');


### PR DESCRIPTION
## Summary
- Update the default OpenAPI server URL from `api.mcpfactory.org` (stale CNAME pointing to an old Railway service) to `api.distribute.you` (current production domain)
- Add test for the server URL default

## Test plan
- [x] OpenAPI auth docs tests pass (13/13)
- [x] `openapi.json` regenerated with correct server URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)