### PR TITLE
ci: add GitHub Actions with OpenAPI sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --no-frozen-lockfile
+
+      - name: Build shared packages
+        run: pnpm --filter "./shared/*" build
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
+  openapi-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --no-frozen-lockfile
+
+      - name: Regenerate OpenAPI spec from Zod schemas
+        run: pnpm generate:openapi
+
+      - name: Check openapi.json is up to date
+        run: |
+          if ! git diff --exit-code openapi.json; then
+            echo "::error::openapi.json is out of sync with Zod schemas. Run 'pnpm generate:openapi' and commit the result."
+            exit 1
+          fi

--- a/railway.json
+++ b/railway.json
@@ -6,6 +6,7 @@
     "watchPatterns": [
       "/src/**",
       "/shared/**",
+      "/scripts/**",
       "/pnpm-lock.yaml",
       "/Dockerfile"
     ]

--- a/tests/unit/ci.test.ts
+++ b/tests/unit/ci.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+describe("GitHub Actions CI", () => {
+  const root = resolve(import.meta.dirname, "../..");
+  const ciPath = resolve(root, ".github/workflows/ci.yml");
+
+  it("ci.yml exists", () => {
+    expect(existsSync(ciPath)).toBe(true);
+  });
+
+  const ci = readFileSync(ciPath, "utf-8");
+
+  it("runs unit tests", () => {
+    expect(ci).toContain("pnpm test:unit");
+  });
+
+  it("checks openapi.json stays in sync with Zod schemas", () => {
+    expect(ci).toContain("pnpm generate:openapi");
+    expect(ci).toContain("git diff --exit-code openapi.json");
+  });
+
+  it("builds shared packages before tests", () => {
+    expect(ci).toContain('pnpm --filter "./shared/*" build');
+  });
+});

--- a/tests/unit/railway-config.test.ts
+++ b/tests/unit/railway-config.test.ts
@@ -21,10 +21,11 @@ describe("railway.json", () => {
     expect(config.deploy.healthcheckPath).toBe("/health");
   });
 
-  it("watches source and shared directories", () => {
+  it("watches source, shared, and scripts directories", () => {
     const patterns: string[] = config.build.watchPatterns;
     expect(patterns).toContain("/src/**");
     expect(patterns).toContain("/shared/**");
+    expect(patterns).toContain("/scripts/**");
     expect(patterns).toContain("/pnpm-lock.yaml");
     expect(patterns).toContain("/Dockerfile");
   });


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow with two jobs:
  - **test**: runs `pnpm test:unit` (builds shared packages first)
  - **openapi-sync**: regenerates `openapi.json` from Zod schemas and fails if the committed spec is stale
- Add `/scripts/**` to Railway watch patterns so changes to `generate-openapi.ts` trigger redeploys
- Add tests for CI config

## How it works
When a dev changes a Zod schema but forgets to run `pnpm generate:openapi`, the `openapi-sync` job detects the diff and blocks the PR. This guarantees the committed OpenAPI spec always matches the Zod schemas.

## Test plan
- [x] CI tests pass (4/4)
- [x] Railway config tests pass (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)