### PR TITLE
fix: rename lifecycle service mock to transactionalEmail in tests

### DIFF
--- a/tests/unit/brand-delivery-stats.regression.test.ts
+++ b/tests/unit/brand-delivery-stats.regression.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
     campaign: { url: "http://mock-campaign", apiKey: "k" },
     key: { url: "http://mock-key", apiKey: "k" },
     scraping: { url: "http://mock-scraping", apiKey: "k" },
-    lifecycle: { url: "http://mock-lifecycle", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
     brand: { url: "http://mock-brand", apiKey: "k" },
   },
   services: {

--- a/tests/unit/email-lead-fields.regression.test.ts
+++ b/tests/unit/email-lead-fields.regression.test.ts
@@ -22,7 +22,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
     campaign: { url: "http://mock-campaign", apiKey: "k" },
     key: { url: "http://mock-key", apiKey: "k" },
     scraping: { url: "http://mock-scraping", apiKey: "k" },
-    lifecycle: { url: "http://mock-lifecycle", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
   },
   services: {
     client: "http://mock-client",

--- a/tests/unit/emailgen-stats-external.regression.test.ts
+++ b/tests/unit/emailgen-stats-external.regression.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
     campaign: { url: "http://mock-campaign", apiKey: "k" },
     key: { url: "http://mock-key", apiKey: "k" },
     scraping: { url: "http://mock-scraping", apiKey: "k" },
-    lifecycle: { url: "http://mock-lifecycle", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
     brand: { url: "http://mock-brand", apiKey: "k" },
     runs: { url: "http://mock-runs", apiKey: "k" },
   },

--- a/tests/unit/performance-leaderboard-stats.regression.test.ts
+++ b/tests/unit/performance-leaderboard-stats.regression.test.ts
@@ -4,7 +4,7 @@
  *    instead of emailsSent/emailsOpened/emailsClicked/emailsReplied), so all
  *    delivery stats were always 0.
  * 2. It summed transactional + broadcast stats, but transactional stats are
- *    lifecycle/test emails via Postmark — only broadcast (Instantly) is relevant.
+ *    transactional/test emails via Postmark — only broadcast (Instantly) is relevant.
  * 3. buildLeaderboardData relied on /campaigns/list which only returns ongoing
  *    campaigns, so brands was always empty when all campaigns were stopped.
  * 4. Campaign costs came from campaign-service which only lists ongoing campaigns.
@@ -34,7 +34,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
     key: { url: "http://mock-key", apiKey: "k" },
     replyQualification: { url: "http://mock-rq", apiKey: "k" },
     scraping: { url: "http://mock-scraping", apiKey: "k" },
-    lifecycle: { url: "http://mock-lifecycle", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
     brand: { url: "http://mock-brand", apiKey: "k" },
     runs: { url: "http://mock-runs", apiKey: "k" },
   },

--- a/tests/unit/reply-breakdown-no-dummy.regression.test.ts
+++ b/tests/unit/reply-breakdown-no-dummy.regression.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
     campaign: { url: "http://mock-campaign", apiKey: "k" },
     key: { url: "http://mock-key", apiKey: "k" },
     scraping: { url: "http://mock-scraping", apiKey: "k" },
-    lifecycle: { url: "http://mock-lifecycle", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
   },
   services: {
     client: "http://mock-client",


### PR DESCRIPTION
## Summary
- Renamed the `lifecycle` external service mock to `transactionalEmail` in all five test files that referenced it
- Updated mock URLs from `http://mock-lifecycle` to `http://mock-transactional-email`
- Updated comment in performance-leaderboard-stats test from "lifecycle/test emails" to "transactional/test emails"

## Test plan
- [x] All 29 tests in the 5 updated files pass (the 1 pre-existing failure in brand-delivery-stats is unrelated -- it references a dashboard file path that doesn't exist in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)