### PR TITLE
fix: remove default appId=mcpfactory filter from workflow endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3362,10 +3362,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Application ID (defaults to 'mcpfactory')"
+              "description": "Filter by application ID (opt-in, omit to return all)"
             },
             "required": false,
-            "description": "Application ID (defaults to 'mcpfactory')",
+            "description": "Filter by application ID (opt-in, omit to return all)",
             "name": "appId",
             "in": "query"
           },
@@ -3540,10 +3540,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Application ID (defaults to 'mcpfactory')"
+              "description": "Filter by application ID (opt-in, omit to return all)"
             },
             "required": false,
-            "description": "Application ID (defaults to 'mcpfactory')",
+            "description": "Filter by application ID (opt-in, omit to return all)",
             "name": "appId",
             "in": "query"
           },

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -14,8 +14,8 @@ router.get("/workflows", authenticate, requireOrg, requireUser, async (req: Auth
   try {
     const params = new URLSearchParams();
     params.set("orgId", req.orgId!);
-    params.set("appId", (req.query.appId as string) || "mcpfactory");
 
+    if (req.query.appId) params.set("appId", req.query.appId as string);
     if (req.query.category) params.set("category", req.query.category as string);
     if (req.query.channel) params.set("channel", req.query.channel as string);
     if (req.query.audienceType) params.set("audienceType", req.query.audienceType as string);
@@ -40,8 +40,8 @@ router.get("/workflows", authenticate, requireOrg, requireUser, async (req: Auth
 router.get("/workflows/best", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    params.set("appId", (req.query.appId as string) || "mcpfactory");
 
+    if (req.query.appId) params.set("appId", req.query.appId as string);
     if (req.query.category) params.set("category", req.query.category as string);
     if (req.query.channel) params.set("channel", req.query.channel as string);
     if (req.query.audienceType) params.set("audienceType", req.query.audienceType as string);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -949,7 +949,7 @@ registry.registerPath({
   security: authed,
   request: {
     query: z.object({
-      appId: z.string().optional().describe("Application ID (defaults to 'mcpfactory')"),
+      appId: z.string().optional().describe("Filter by application ID (opt-in, omit to return all)"),
       category: z.string().optional().describe("Filter by category (e.g. 'sales', 'pr')"),
       channel: z.string().optional().describe("Filter by channel (e.g. 'email')"),
       audienceType: z.string().optional().describe("Filter by audience type (e.g. 'cold-outreach')"),
@@ -990,7 +990,7 @@ registry.registerPath({
   security: authed,
   request: {
     query: z.object({
-      appId: z.string().optional().describe("Application ID (defaults to 'mcpfactory')"),
+      appId: z.string().optional().describe("Filter by application ID (opt-in, omit to return all)"),
       category: z.string().optional().describe("Filter by category (e.g. 'sales')"),
       channel: z.string().optional().describe("Filter by channel (e.g. 'email')"),
       audienceType: z.string().optional().describe("Filter by audience type (e.g. 'cold-outreach')"),

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -60,8 +60,14 @@ describe("Workflow proxy routes", () => {
     expect(bestBlock).toContain("objective");
   });
 
-  it("should default appId to mcpfactory", () => {
-    expect(content).toContain("mcpfactory");
+  it("should not default appId — it is an opt-in filter", () => {
+    // appId should only be forwarded if explicitly passed in query params
+    const listStart = content.indexOf('"/workflows"');
+    const bestStart = content.indexOf('"/workflows/best"');
+    const listBlock = content.slice(listStart, bestStart);
+
+    expect(listBlock).toContain('req.query.appId');
+    expect(listBlock).not.toContain('"mcpfactory"');
   });
 
   it("should forward humanId query param on GET /workflows", () => {


### PR DESCRIPTION
## Summary
- `GET /v1/workflows` and `GET /v1/workflows/best` no longer default `appId` to `"mcpfactory"`
- `appId` is now opt-in: if omitted, returns **all** workflows for the org
- Fixes empty results for orgs whose workflows were registered under a different appId
- OpenAPI schema updated: description now says "opt-in, omit to return all"

## Test plan
- [x] 13 workflow proxy tests pass, including new assertion that `mcpfactory` is not hardcoded
- [x] OpenAPI spec regenerated
- [ ] Dashboard should now see workflows without needing to pass `appId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)