### PR TITLE
fix: make all workflow GET filters optional

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -8,13 +8,13 @@ const router = Router();
 
 /**
  * GET /v1/workflows
- * List workflows for the authenticated org from workflow-service
+ * List all workflows from workflow-service. All query params are optional filters.
  */
 router.get("/workflows", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    params.set("orgId", req.orgId!);
 
+    if (req.query.orgId) params.set("orgId", req.query.orgId as string);
     if (req.query.appId) params.set("appId", req.query.appId as string);
     if (req.query.category) params.set("category", req.query.category as string);
     if (req.query.channel) params.set("channel", req.query.channel as string);

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -26,10 +26,11 @@ describe("Workflow proxy routes", () => {
     expect(content).toContain("requireOrg");
   });
 
-  it("should proxy GET /workflows with Clerk orgId", () => {
+  it("should proxy GET /workflows without forced filters", () => {
     expect(content).toContain('"/workflows"');
-    expect(content).toContain('params.set("orgId", req.orgId!)');
     expect(content).toContain("externalServices.workflow");
+    // orgId should NOT be force-injected — it's an opt-in filter like all others
+    expect(content).not.toContain('params.set("orgId", req.orgId!)');
   });
 
   it("should proxy GET /workflows/:id", () => {


### PR DESCRIPTION
## Summary
- `GET /v1/workflows` no longer force-injects `orgId` from auth context
- All query params are opt-in filters — when none are passed, returns **all** workflows on the platform
- Companion change: workflow-service PR #63 makes `orgId` optional on its side too

## Test plan
- [x] 13 workflow proxy tests pass
- [x] Test verifies orgId is NOT force-injected
- [ ] Dashboard can list all workflows without any filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)