### PR TITLE
fix: update remaining mcpfactory test assertions to distribute

### DIFF
--- a/shared/runs-client/tests/unit/package-exports.regression.test.ts
+++ b/shared/runs-client/tests/unit/package-exports.regression.test.ts
@@ -38,10 +38,10 @@ describe('runs-client package exports', () => {
  * Default must point to the production URL like other external services.
  */
 describe('runs-client default URL', () => {
-  it('compiled output should default to runs.mcpfactory.org, not localhost', () => {
+  it('compiled output should default to runs.distribute.org, not localhost', () => {
     const distPath = path.join(__dirname, '../../dist/index.js');
     const compiled = fs.readFileSync(distPath, 'utf-8');
-    expect(compiled).toContain('https://runs.mcpfactory.org');
+    expect(compiled).toContain('https://runs.distribute.org');
     expect(compiled).not.toContain('localhost:3006');
   });
 });

--- a/tests/integration/health.test.ts
+++ b/tests/integration/health.test.ts
@@ -8,7 +8,7 @@ describe("Health endpoints", () => {
   it("GET / returns API info", async () => {
     const response = await request(app).get("/");
     expect(response.status).toBe(200);
-    expect(response.body.name).toBe("MCPFactory API");
+    expect(response.body.name).toBe("Distribute API");
     expect(response.body.version).toBeDefined();
   });
 


### PR DESCRIPTION
## Summary
- Updated `runs-client` regression test to assert `runs.distribute.org` instead of `runs.mcpfactory.org`
- Updated health integration test to assert `"Distribute API"` instead of `"MCPFactory API"`

## Test plan
- [x] These are test files themselves — they pass with the updated assertions (295 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)