### PR TITLE
docs: update OpenAPI spec for leaderboard endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1105,10 +1105,55 @@
           "Performance"
         ],
         "summary": "Get performance leaderboard",
-        "description": "Returns public performance leaderboard data. No authentication required.",
+        "description": "Returns performance leaderboard data including brands, workflows, and hero stats. Requires authentication.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by application ID (opt-in, omit to return all)"
+            },
+            "required": false,
+            "description": "Filter by application ID (opt-in, omit to return all)",
+            "name": "appId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Leaderboard data with brands, models, and hero stats"
+            "description": "Leaderboard data with brands, workflows, and hero stats"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "502": {
             "description": "Upstream service error",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -168,9 +168,16 @@ registry.registerPath({
   tags: ["Performance"],
   summary: "Get performance leaderboard",
   description:
-    "Returns public performance leaderboard data. No authentication required.",
+    "Returns performance leaderboard data including brands, workflows, and hero stats. Requires authentication.",
+  security: authed,
+  request: {
+    query: z.object({
+      appId: z.string().optional().describe("Filter by application ID (opt-in, omit to return all)"),
+    }),
+  },
   responses: {
-    200: { description: "Leaderboard data with brands, models, and hero stats" },
+    200: { description: "Leaderboard data with brands, workflows, and hero stats" },
+    401: { description: "Unauthorized", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },
   },
 });


### PR DESCRIPTION
## Summary
- Updated OpenAPI spec for `GET /performance/leaderboard` to match the implementation fix from #24
- Added `security: bearerAuth` (was "No authentication required")
- Documented `appId` as optional query parameter filter
- Added 401 response code

## Test plan
- [x] `pnpm generate:openapi` regenerated cleanly
- [x] All 18 leaderboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)