### PR TITLE
fix: rename emailSending to emailGateway

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -32,7 +32,7 @@ export const externalServices = {
     url: process.env.SCRAPING_SERVICE_URL || "http://localhost:3010",
     apiKey: process.env.SCRAPING_SERVICE_API_KEY || "",
   },
-  emailSending: {
+  emailGateway: {
     url: process.env.EMAIL_GATEWAY_SERVICE_URL || "http://localhost:3009",
     apiKey: process.env.EMAIL_GATEWAY_SERVICE_API_KEY || "",
   },

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -41,7 +41,7 @@ async function fetchDeliveryStats(
   appId: string
 ): Promise<Record<string, number> | null> {
   const deliveryResult = await callExternalService<{ transactional: EmailGatewayStats; broadcast: EmailGatewayStats }>(
-    externalServices.emailSending,
+    externalServices.emailGateway,
     "/stats",
     {
       method: "POST",
@@ -492,7 +492,7 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
       stats.emailsGenerated = 0;
     }
 
-    // Delivery stats from postmark + instantly
+    // Delivery stats from email-gateway
     if (delivery) {
       Object.assign(stats, delivery);
     } else {

--- a/src/routes/performance.ts
+++ b/src/routes/performance.ts
@@ -118,16 +118,16 @@ function toBroadcastDeliveryStats(b: BroadcastStatsResponse | undefined | null):
   };
 }
 
-/** Fetch broadcast delivery stats from the unified email-sending service.
- *  Only uses broadcast stats (outreach emails via Instantly).
- *  Transactional stats are transactional/test emails via Postmark — not relevant. */
+/** Fetch broadcast delivery stats from email-gateway.
+ *  Only uses broadcast stats (outreach emails).
+ *  Transactional stats are transactional/test emails — not relevant. */
 async function fetchBroadcastDeliveryStats(filters: Record<string, string>): Promise<DeliveryStats> {
   try {
     const result = await callExternalService<{
       transactional: BroadcastStatsResponse;
       broadcast: BroadcastStatsResponse;
     }>(
-      externalServices.emailSending,
+      externalServices.emailGateway,
       "/stats",
       { method: "POST", body: filters }
     );
@@ -144,7 +144,7 @@ async function fetchWorkflowDeliveryStats(appId?: string): Promise<Map<string, D
     const result = await callExternalService<{
       groups: Array<{ key: string; broadcast: BroadcastStatsResponse }>;
     }>(
-      externalServices.emailSending,
+      externalServices.emailGateway,
       "/stats",
       { method: "POST", body: { ...(appId && { appId }), type: "broadcast", groupBy: "workflowName" } }
     );
@@ -198,7 +198,7 @@ function applyStatsToWorkflow(wf: WorkflowEntry, stats: DeliveryStats) {
 }
 
 /**
- * Enrich leaderboard email stats from the unified email-sending service.
+ * Enrich leaderboard email stats from email-gateway.
  * Uses per-brand stats via brandId filter and per-workflow stats via groupBy.
  */
 async function enrichWithDeliveryStats(data: LeaderboardData, appId?: string): Promise<void> {
@@ -441,7 +441,7 @@ router.get("/performance/leaderboard", authenticate, requireOrg, requireUser, as
 
     const data = await buildLeaderboardData(appId);
 
-    // Enrich with broadcast delivery stats from email-sending service
+    // Enrich with broadcast delivery stats from email-gateway
     try {
       await enrichWithDeliveryStats(data, appId);
     } catch (err) {

--- a/tests/unit/brand-delivery-stats.regression.test.ts
+++ b/tests/unit/brand-delivery-stats.regression.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
   callService: (...args: unknown[]) => mockCallService(...args),
   externalServices: {
     emailgen: { url: "http://mock-emailgen", apiKey: "k" },
-    emailSending: { url: "http://mock-email", apiKey: "k" },
+    emailGateway: { url: "http://mock-email", apiKey: "k" },
     replyQualification: { url: "http://mock-rq", apiKey: "k" },
     lead: { url: "http://mock-lead", apiKey: "k" },
     campaign: { url: "http://mock-campaign", apiKey: "k" },

--- a/tests/unit/email-gateway-env.regression.test.ts
+++ b/tests/unit/email-gateway-env.regression.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression test: the email-sending service was renamed to email-gateway.
+ * Regression test: the service key must be emailGateway (not emailSending).
  * The env vars must use EMAIL_GATEWAY_SERVICE_* so the stats fetch resolves.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -9,14 +9,14 @@ describe("Email gateway env var naming", () => {
     vi.resetModules();
   });
 
-  it("should read emailSending config from EMAIL_GATEWAY_SERVICE_* env vars", async () => {
+  it("should read emailGateway config from EMAIL_GATEWAY_SERVICE_* env vars", async () => {
     process.env.EMAIL_GATEWAY_SERVICE_URL = "https://email-gateway.distribute.you";
     process.env.EMAIL_GATEWAY_SERVICE_API_KEY = "test-gw-key";
 
     const { externalServices } = await import("../../src/lib/service-client.js");
 
-    expect(externalServices.emailSending.url).toBe("https://email-gateway.distribute.you");
-    expect(externalServices.emailSending.apiKey).toBe("test-gw-key");
+    expect(externalServices.emailGateway.url).toBe("https://email-gateway.distribute.you");
+    expect(externalServices.emailGateway.apiKey).toBe("test-gw-key");
   });
 
   it("should NOT read from old EMAIL_SENDING_SERVICE_* env vars", async () => {
@@ -28,8 +28,8 @@ describe("Email gateway env var naming", () => {
     const { externalServices } = await import("../../src/lib/service-client.js");
 
     // Should fall back to default, not pick up the old env var
-    expect(externalServices.emailSending.url).toBe("http://localhost:3009");
-    expect(externalServices.emailSending.apiKey).toBe("");
+    expect(externalServices.emailGateway.url).toBe("http://localhost:3009");
+    expect(externalServices.emailGateway.apiKey).toBe("");
 
     // cleanup
     delete process.env.EMAIL_SENDING_SERVICE_URL;

--- a/tests/unit/email-lead-fields.regression.test.ts
+++ b/tests/unit/email-lead-fields.regression.test.ts
@@ -16,7 +16,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
   callService: (...args: unknown[]) => mockCallService(...args),
   externalServices: {
     emailgen: { url: "http://mock-emailgen", apiKey: "k" },
-    emailSending: { url: "http://mock-email", apiKey: "k" },
+    emailGateway: { url: "http://mock-email", apiKey: "k" },
     replyQualification: { url: "http://mock-rq", apiKey: "k" },
     lead: { url: "http://mock-lead", apiKey: "k" },
     campaign: { url: "http://mock-campaign", apiKey: "k" },

--- a/tests/unit/emailgen-stats-external.regression.test.ts
+++ b/tests/unit/emailgen-stats-external.regression.test.ts
@@ -14,7 +14,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
   callExternalService: (...args: unknown[]) => mockCallExternalService(...args),
   externalServices: {
     emailgen: { url: "http://mock-emailgen", apiKey: "k" },
-    emailSending: { url: "http://mock-email", apiKey: "k" },
+    emailGateway: { url: "http://mock-email", apiKey: "k" },
     replyQualification: { url: "http://mock-rq", apiKey: "k" },
     lead: { url: "http://mock-lead", apiKey: "k" },
     campaign: { url: "http://mock-campaign", apiKey: "k" },

--- a/tests/unit/performance-leaderboard-stats.regression.test.ts
+++ b/tests/unit/performance-leaderboard-stats.regression.test.ts
@@ -28,7 +28,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
   externalServices: {
     client: { url: "http://mock-client", apiKey: "k" },
     emailgen: { url: "http://mock-emailgen", apiKey: "k" },
-    emailSending: { url: "http://mock-email", apiKey: "k" },
+    emailGateway: { url: "http://mock-email", apiKey: "k" },
     campaign: { url: "http://mock-campaign", apiKey: "k" },
     lead: { url: "http://mock-lead", apiKey: "k" },
     key: { url: "http://mock-key", apiKey: "k" },

--- a/tests/unit/reply-breakdown-no-dummy.regression.test.ts
+++ b/tests/unit/reply-breakdown-no-dummy.regression.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
   callService: (...args: unknown[]) => mockCallService(...args),
   externalServices: {
     emailgen: { url: "http://mock-emailgen", apiKey: "k" },
-    emailSending: { url: "http://mock-email", apiKey: "k" },
+    emailGateway: { url: "http://mock-email", apiKey: "k" },
     replyQualification: { url: "http://mock-rq", apiKey: "k" },
     lead: { url: "http://mock-lead", apiKey: "k" },
     campaign: { url: "http://mock-campaign", apiKey: "k" },


### PR DESCRIPTION
## Summary
- Renamed `externalServices.emailSending` → `externalServices.emailGateway` in service-client (the source of truth)
- Updated all references in `performance.ts`, `campaigns.ts`, and 6 test files
- Fixed stale comments ("email-sending service", "postmark + instantly") → "email-gateway"

## Test plan
- [x] All 297 tests pass (2 pre-existing failures unrelated)
- [x] Grep confirms zero remaining `emailSending` references in source/tests
- [x] Regression test updated to verify `emailGateway` key name

🤖 Generated with [Claude Code](https://claude.com/claude-code)