### PR TITLE
fix: leaderboard must not filter by org/user headers

### DIFF
--- a/src/routes/performance.ts
+++ b/src/routes/performance.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { callExternalService, externalServices } from "../lib/service-client.js";
-import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { authenticate, AuthenticatedRequest } from "../middleware/auth.js";
 import { getWorkflowCategory, getWorkflowDisplayName, getSectionKey, getSignatureName, SECTION_LABELS, type WorkflowCategory } from "@distribute/content";
 
 const router = Router();
@@ -435,7 +435,7 @@ function buildCategorySections(data: LeaderboardData): CategorySection[] {
 }
 
 // Authenticated route — appId is an optional filter
-router.get("/performance/leaderboard", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/performance/leaderboard", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const appId = req.query.appId as string | undefined;
 


### PR DESCRIPTION
## Summary
- Removed `requireOrg` and `requireUser` middleware from `/performance/leaderboard` — the leaderboard is a global view, auth headers identify the caller but must never filter data
- Added regression test verifying identical responses with and without org/user headers
- Updated existing regression test to assert `requireOrg`/`requireUser` are NOT on the leaderboard route

## Context
The dashboard sends `x-org-id`/`x-user-id` headers (needed for other endpoints) which caused `requireOrg`/`requireUser` to gate the leaderboard. While the data fetching itself was already global, the middleware forced callers to provide org/user context unnecessarily. Auth headers are for authorization only — data filtering should use explicit query params.

## Test plan
- [x] All 19 leaderboard tests pass
- [x] Regression test: source code no longer has `requireOrg`/`requireUser` on leaderboard route
- [x] Regression test: identical data returned with and without org/user headers
- [x] Full test suite: no new failures (2 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)