### PR TITLE
feat: instantly-service grouped stats for leaderboard workflows

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -60,6 +60,10 @@ export const externalServices = {
     url: process.env.CHAT_SERVICE_URL || "http://localhost:3021",
     apiKey: process.env.CHAT_SERVICE_API_KEY || "",
   },
+  instantly: {
+    url: process.env.INSTANTLY_SERVICE_URL || "http://localhost:3011",
+    apiKey: process.env.INSTANTLY_SERVICE_API_KEY || "",
+  },
 };
 
 interface ServiceCallOptions {


### PR DESCRIPTION
## Summary
- Workflow email stats now sourced from instantly-service `POST /stats/grouped` (via `run-ids-by-workflow` on runs-service), replacing email-gateway `groupBy` as primary source
- `emailsReplied` now counts positive replies only (lead_interested) — breaking change from instantly-service, no code change needed on callers
- Adds `recipients` field (unique recipient count) to `WorkflowEntry` and `CategorySectionStats`
- Falls back to email-gateway `groupBy`, then proportional distribution, if instantly-service returns no data

## Test plan
- [x] Existing 21 leaderboard regression tests updated and passing
- [x] New test: verifies correct runIds passed to instantly-service `/stats/grouped`
- [x] New test: verifies email-gateway `groupBy` fallback when instantly returns empty
- [x] Full test suite green (1 pre-existing unrelated failure in brand-delivery-stats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)