### PR TITLE
feat: add POST /v1/users/resolve proxy endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1295,6 +1295,72 @@
             "description": "Filter by run IDs"
           }
         }
+      },
+      "ResolveUserResponse": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal organization UUID"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal user UUID"
+          },
+          "orgCreated": {
+            "type": "boolean",
+            "description": "Whether a new org was created"
+          },
+          "userCreated": {
+            "type": "boolean",
+            "description": "Whether a new user was created"
+          }
+        },
+        "required": [
+          "orgId",
+          "userId",
+          "orgCreated",
+          "userCreated"
+        ]
+      },
+      "ResolveUserRequest": {
+        "type": "object",
+        "properties": {
+          "externalOrgId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "External organization ID (e.g. Clerk org ID)"
+          },
+          "externalUserId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "External user ID — use a generated UUID for anonymous users"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "User email address"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "User first name"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "User last name"
+          },
+          "imageUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "User avatar URL"
+          }
+        },
+        "required": [
+          "externalOrgId",
+          "externalUserId"
+        ]
       }
     },
     "parameters": {}
@@ -5690,6 +5756,91 @@
         "responses": {
           "200": {
             "description": "Aggregated sales stats"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+          }
+        ]
+      }
+    },
+    "/v1/users/resolve": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Resolve external user identity",
+        "description": "Map external org/user IDs to internal UUIDs via client-service (idempotent upsert). For anonymous users, generate a UUID as externalUserId — each call with a new ID creates a new user. Calling again with the same IDs updates optional contact fields (email, firstName, etc.).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveUserRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved identity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolveUserResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import billingRoutes from "./routes/billing.js";
 import { stripeWebhookHandler } from "./routes/billing.js";
 import emailsRoutes from "./routes/emails.js";
 import stripeRoutes from "./routes/stripe.js";
+import usersRoutes from "./routes/users.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { registerPlatformKeys } from "./startup.js";
 import { readFileSync, existsSync } from "fs";
@@ -94,6 +95,7 @@ app.use("/v1", chatRoutes);
 app.use("/v1", billingRoutes);
 app.use("/v1", emailsRoutes);
 app.use("/v1", stripeRoutes);
+app.use("/v1", usersRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,35 @@
+import { Router } from "express";
+import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { ResolveUserRequestSchema } from "../schemas.js";
+
+const router = Router();
+
+/**
+ * POST /v1/users/resolve
+ * Resolve external org/user IDs to internal UUIDs (idempotent upsert).
+ * For anonymous users, the caller generates a UUID as externalUserId.
+ */
+router.post("/users/resolve", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = ResolveUserRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+
+    const result = await callExternalService(
+      externalServices.client,
+      "/resolve",
+      {
+        method: "POST",
+        body: { appId: req.appId, ...parsed.data },
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Resolve user error:", error);
+    res.status(500).json({ error: error.message || "Failed to resolve user identity" });
+  }
+});
+
+export default router;

--- a/tests/unit/users-resolve.test.ts
+++ b/tests/unit/users-resolve.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock auth middleware
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.appId = "distribute-frontend";
+    req.authType = "user_key";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import usersRoutes from "../../src/routes/users.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", usersRoutes);
+  return app;
+}
+
+function mockFetchOk(responseData: any = {}) {
+  fetchCalls = [];
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    fetchCalls.push({ url, method: init?.method, body });
+    return { ok: true, json: () => Promise.resolve(responseData) };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/users/resolve
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/users/resolve", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockFetchOk({
+      orgId: "00000000-0000-0000-0000-000000000001",
+      userId: "00000000-0000-0000-0000-000000000002",
+      orgCreated: false,
+      userCreated: true,
+    });
+    app = createApp();
+  });
+
+  it("should proxy to client-service /resolve with appId injected", async () => {
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({
+        externalOrgId: "clerk_org_abc",
+        externalUserId: "anon_user_123",
+        email: "user@polarity.com",
+        firstName: "Kevin",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.userId).toBeDefined();
+    expect(res.body.userCreated).toBe(true);
+
+    const call = fetchCalls.find((c) => c.url.includes("/resolve"));
+    expect(call).toBeDefined();
+    expect(call!.method).toBe("POST");
+    expect(call!.body).toMatchObject({
+      appId: "distribute-frontend",
+      externalOrgId: "clerk_org_abc",
+      externalUserId: "anon_user_123",
+      email: "user@polarity.com",
+      firstName: "Kevin",
+    });
+  });
+
+  it("should pass through optional contact fields", async () => {
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({
+        externalOrgId: "clerk_org_abc",
+        externalUserId: "anon_user_456",
+        email: "jane@example.com",
+        firstName: "Jane",
+        lastName: "Doe",
+        imageUrl: "https://example.com/avatar.png",
+      });
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/resolve"));
+    expect(call!.body).toMatchObject({
+      appId: "distribute-frontend",
+      externalOrgId: "clerk_org_abc",
+      externalUserId: "anon_user_456",
+      email: "jane@example.com",
+      firstName: "Jane",
+      lastName: "Doe",
+      imageUrl: "https://example.com/avatar.png",
+    });
+  });
+
+  it("should work with only required fields (no contact info)", async () => {
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({
+        externalOrgId: "clerk_org_abc",
+        externalUserId: "anon_user_789",
+      });
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/resolve"));
+    expect(call!.body).toMatchObject({
+      appId: "distribute-frontend",
+      externalOrgId: "clerk_org_abc",
+      externalUserId: "anon_user_789",
+    });
+    // No optional fields sent
+    expect(call!.body.email).toBeUndefined();
+    expect(call!.body.firstName).toBeUndefined();
+  });
+
+  it("should return 400 when externalOrgId is missing", async () => {
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({ externalUserId: "anon_user_123" });
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 400 when externalUserId is missing", async () => {
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({ externalOrgId: "clerk_org_abc" });
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 400 when body is empty", async () => {
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 400 when email is invalid", async () => {
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({
+        externalOrgId: "clerk_org_abc",
+        externalUserId: "anon_user_123",
+        email: "not-an-email",
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 500 when client-service fails", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "Internal error" }),
+      text: () => Promise.resolve('{"error":"Internal error"}'),
+    }));
+    app = createApp();
+
+    const res = await request(app)
+      .post("/v1/users/resolve")
+      .send({
+        externalOrgId: "clerk_org_abc",
+        externalUserId: "anon_user_123",
+      });
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /v1/users/resolve` — proxy to client-service `POST /resolve` with `appId` injected from auth context
- Enables Polarity Course to create/update anonymous users by mapping external org/user IDs to internal UUIDs (idempotent upsert)
- Accepts optional contact fields: email, firstName, lastName, imageUrl
- Includes Zod schema, OpenAPI registration, and 8 unit tests

## Context
This completes the Polarity Course proxy endpoint work (PRs #29, #31). Client-service confirmed `POST /resolve` covers anonymous user creation — each call with a unique `externalUserId` creates a new user under the org.

## Test plan
- [x] 8 unit tests: happy path with/without contact fields, required field validation (4 cases), upstream error handling
- [x] `pnpm vitest run tests/unit/users-resolve.test.ts` — all pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)