### PR TITLE
docs: update key prefix from mcpf_* to distrib.*

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "distribute API",
-    "description": "API Gateway for distribute. Handles authentication, proxies to internal services, and exposes the public REST API.\n\n## Authentication\n\nAll authenticated endpoints require a Bearer token in the `Authorization` header.\n\nThere are two key types, each with different identity resolution behavior:\n\n### 1. User key (`mcpf_*`)\n\nIssued per-user via `POST /v1/api-keys`. The key already carries the user's internal org UUID — no extra headers needed.\n\n```\nAuthorization: Bearer mcpf_abc123...\n```\n\n### 2. App key (`mcpf_app_*`)\n\nIssued when an app registers via `POST /v1/apps/register`. The key identifies the **app**, not a user or org. To access endpoints that require org/user context (campaigns, keys, activity, etc.), you must also send two identity headers:\n\n| Header | Description | Example |\n|--------|-------------|---------|\n| `x-org-id` | External organization ID (e.g. Clerk org ID) | `org_2xyz...` |\n| `x-user-id` | External user ID (e.g. Clerk user ID) | `user_2abc...` |\n\n```\nAuthorization: Bearer mcpf_app_abc123...\nx-org-id: org_2xyzABC\nx-user-id: user_2abcDEF\n```\n\nThe API service resolves these external IDs to internal UUIDs via `client-service`. Both headers are **optional** — if omitted, the request proceeds without org/user context, which is fine for endpoints that only need app-level auth (e.g. `GET /v1/me`). But endpoints that require org context (e.g. `GET /v1/campaigns`) will return `400 Organization context required`.\n\n### Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Org context required but `x-org-id` header not provided (app key only) |\n| 401 | User identity required but `x-user-id` header not provided (app key only) |\n| 502 | Identity resolution failed (client-service unreachable) |\n",
+    "description": "API Gateway for distribute. Handles authentication, proxies to internal services, and exposes the public REST API.\n\n## Authentication\n\nAll authenticated endpoints require a Bearer token in the `Authorization` header.\n\nThere are two key types, each with different identity resolution behavior:\n\n### 1. User key (`distrib.usr_*`)\n\nIssued per-user via `POST /v1/api-keys`. The key already carries the user's internal org UUID — no extra headers needed.\n\n```\nAuthorization: Bearer distrib.usr_abc123...\n```\n\n### 2. App key (`distrib.app_*`)\n\nIssued when an app registers via `POST /v1/apps/register`. The key identifies the **app**, not a user or org. To access endpoints that require org/user context (campaigns, keys, activity, etc.), you must also send two identity headers:\n\n| Header | Description | Example |\n|--------|-------------|---------|\n| `x-org-id` | External organization ID (e.g. Clerk org ID) | `org_2xyz...` |\n| `x-user-id` | External user ID (e.g. Clerk user ID) | `user_2abc...` |\n\n```\nAuthorization: Bearer distrib.app_abc123...\nx-org-id: org_2xyzABC\nx-user-id: user_2abcDEF\n```\n\nThe API service resolves these external IDs to internal UUIDs via `client-service`. Both headers are **optional** — if omitted, the request proceeds without org/user context, which is fine for endpoints that only need app-level auth (e.g. `GET /v1/me`). But endpoints that require org context (e.g. `GET /v1/campaigns`) will return `400 Organization context required`.\n\n### Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Org context required but `x-org-id` header not provided (app key only) |\n| 401 | User identity required but `x-user-id` header not provided (app key only) |\n| 502 | Identity resolution failed (client-service unreachable) |\n",
     "version": "1.0.0"
   },
   "servers": [
@@ -69,7 +69,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Bearer token authentication. Two key types are supported:\n\n- **User key** (`mcpf_usr_*`): carries app, org, and user context. No extra headers needed. Recommended for API/MCP access.\n- **App key** (`mcpf_app_*`): identifies the app only (server-to-server). To access endpoints that require org/user context, also send `x-org-id` and `x-user-id` headers with your external IDs (e.g. Clerk IDs). The API resolves them to internal UUIDs via client-service.\n\nSee the top-level API description for full details and examples."
+        "description": "Bearer token authentication. Two key types are supported:\n\n- **User key** (`distrib.usr_*`): carries app, org, and user context. No extra headers needed. Recommended for API/MCP access.\n- **App key** (`distrib.app_*`): identifies the app only (server-to-server). To access endpoints that require org/user context, also send `x-org-id` and `x-user-id` headers with your external IDs (e.g. Clerk IDs). The API resolves them to internal UUIDs via client-service.\n\nSee the top-level API description for full details and examples."
       }
     },
     "schemas": {
@@ -1526,7 +1526,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -1535,7 +1535,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -1617,7 +1617,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -1626,7 +1626,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -1661,7 +1661,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -1670,7 +1670,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -1752,7 +1752,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -1761,7 +1761,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -1796,7 +1796,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -1805,7 +1805,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -1863,7 +1863,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -1872,7 +1872,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -1932,7 +1932,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -1941,7 +1941,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2001,7 +2001,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2010,7 +2010,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2070,7 +2070,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2079,7 +2079,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2139,7 +2139,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2148,7 +2148,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2249,7 +2249,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2258,7 +2258,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -2293,7 +2293,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2302,7 +2302,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2362,7 +2362,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2371,7 +2371,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2446,7 +2446,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2455,7 +2455,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       },
@@ -2522,7 +2522,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2531,7 +2531,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -2566,7 +2566,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2575,7 +2575,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2716,7 +2716,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2725,7 +2725,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       },
@@ -2782,7 +2782,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2791,7 +2791,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -2826,7 +2826,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2835,7 +2835,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -2910,7 +2910,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2919,7 +2919,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -2988,7 +2988,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -2997,7 +2997,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -3066,7 +3066,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3075,7 +3075,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -3144,7 +3144,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3153,7 +3153,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -3188,7 +3188,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3197,7 +3197,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -3282,7 +3282,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3291,7 +3291,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -3326,7 +3326,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3335,7 +3335,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -3395,7 +3395,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3404,7 +3404,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -3489,7 +3489,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3498,7 +3498,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -3567,7 +3567,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3576,7 +3576,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -3645,7 +3645,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3654,7 +3654,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -3689,7 +3689,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3698,7 +3698,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -3758,7 +3758,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3767,7 +3767,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -3827,7 +3827,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3836,7 +3836,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -3936,7 +3936,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -3945,7 +3945,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -4005,7 +4005,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4014,7 +4014,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -4114,7 +4114,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4123,7 +4123,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -4241,7 +4241,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4250,7 +4250,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4285,7 +4285,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4294,7 +4294,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -4384,7 +4384,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4393,7 +4393,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4462,7 +4462,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4471,7 +4471,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4538,7 +4538,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4547,7 +4547,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4597,7 +4597,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4606,7 +4606,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4656,7 +4656,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4665,7 +4665,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4715,7 +4715,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4724,7 +4724,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4793,7 +4793,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4802,7 +4802,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4861,7 +4861,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4870,7 +4870,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -4929,7 +4929,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -4938,7 +4938,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5053,7 +5053,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5062,7 +5062,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5121,7 +5121,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5130,7 +5130,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5199,7 +5199,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5208,7 +5208,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5243,7 +5243,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5252,7 +5252,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -5346,7 +5346,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5355,7 +5355,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5390,7 +5390,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5399,7 +5399,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -5493,7 +5493,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5502,7 +5502,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5537,7 +5537,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5546,7 +5546,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ],
         "responses": {
@@ -5640,7 +5640,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5649,7 +5649,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5718,7 +5718,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5727,7 +5727,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5796,7 +5796,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5805,7 +5805,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }
@@ -5881,7 +5881,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`mcpf_app_*`) on endpoints that need org context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
           },
           {
             "name": "x-user-id",
@@ -5890,7 +5890,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`mcpf_app_*`) on endpoints that need user context. Ignored when using a user key (`mcpf_*`)."
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
       }

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -22,15 +22,15 @@ All authenticated endpoints require a Bearer token in the \`Authorization\` head
 
 There are two key types, each with different identity resolution behavior:
 
-### 1. User key (\`mcpf_*\`)
+### 1. User key (\`distrib.usr_*\`)
 
 Issued per-user via \`POST /v1/api-keys\`. The key already carries the user's internal org UUID — no extra headers needed.
 
 \`\`\`
-Authorization: Bearer mcpf_abc123...
+Authorization: Bearer distrib.usr_abc123...
 \`\`\`
 
-### 2. App key (\`mcpf_app_*\`)
+### 2. App key (\`distrib.app_*\`)
 
 Issued when an app registers via \`POST /v1/apps/register\`. The key identifies the **app**, not a user or org. To access endpoints that require org/user context (campaigns, keys, activity, etc.), you must also send two identity headers:
 
@@ -40,7 +40,7 @@ Issued when an app registers via \`POST /v1/apps/register\`. The key identifies 
 | \`x-user-id\` | External user ID (e.g. Clerk user ID) | \`user_2abc...\` |
 
 \`\`\`
-Authorization: Bearer mcpf_app_abc123...
+Authorization: Bearer distrib.app_abc123...
 x-org-id: org_2xyzABC
 x-user-id: user_2abcDEF
 \`\`\`
@@ -92,8 +92,8 @@ const identityParams = [
     schema: { type: "string" as const },
     description:
       "External organization ID (e.g. Clerk org ID `org_2xyz...`). " +
-      "Required when using an app key (`mcpf_app_*`) on endpoints that need org context. " +
-      "Ignored when using a user key (`mcpf_*`).",
+      "Required when using an app key (`distrib.app_*`) on endpoints that need org context. " +
+      "Ignored when using a user key (`distrib.usr_*`).",
   },
   {
     name: "x-user-id",
@@ -102,8 +102,8 @@ const identityParams = [
     schema: { type: "string" as const },
     description:
       "External user ID (e.g. Clerk user ID `user_2abc...`). " +
-      "Required when using an app key (`mcpf_app_*`) on endpoints that need user context. " +
-      "Ignored when using a user key (`mcpf_*`).",
+      "Required when using an app key (`distrib.app_*`) on endpoints that need user context. " +
+      "Ignored when using a user key (`distrib.usr_*`).",
   },
 ];
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -10,9 +10,9 @@ export interface AuthenticatedRequest extends Request {
 
 /**
  * Authenticate via API key (app key or user key)
- * - App key (dist_app_*): resolved via key-service → appId, then external IDs
+ * - App key (distrib.app_*): resolved via key-service → appId, then external IDs
  *   from x-org-id/x-user-id headers resolved to internal UUIDs via client-service
- * - User key (dist_*): resolved via key-service → orgId (internal UUID directly)
+ * - User key (distrib.usr_*): resolved via key-service → appId, orgId, userId
  */
 export async function authenticate(
   req: AuthenticatedRequest,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -15,9 +15,9 @@ registry.registerComponent("securitySchemes", "bearerAuth", {
   scheme: "bearer",
   description:
     "Bearer token authentication. Two key types are supported:\n\n" +
-    "- **User key** (`mcpf_usr_*`): carries app, org, and user context. No extra headers needed. " +
+    "- **User key** (`distrib.usr_*`): carries app, org, and user context. No extra headers needed. " +
     "Recommended for API/MCP access.\n" +
-    "- **App key** (`mcpf_app_*`): identifies the app only (server-to-server). To access endpoints " +
+    "- **App key** (`distrib.app_*`): identifies the app only (server-to-server). To access endpoints " +
     "that require org/user context, also send `x-org-id` and `x-user-id` headers with your external IDs " +
     "(e.g. Clerk IDs). The API resolves them to internal UUIDs via client-service.\n\n" +
     "See the top-level API description for full details and examples.",

--- a/tests/unit/openapi-auth-docs.test.ts
+++ b/tests/unit/openapi-auth-docs.test.ts
@@ -11,9 +11,9 @@ const generatorContent = fs.readFileSync(generatorPath, "utf-8");
 describe("OpenAPI spec — auth documentation", () => {
   it("should document both key types in security scheme description", () => {
     expect(schemasContent).toContain("User key");
-    expect(schemasContent).toContain("mcpf_usr_*");
+    expect(schemasContent).toContain("distrib.usr_*");
     expect(schemasContent).toContain("App key");
-    expect(schemasContent).toContain("mcpf_app_*");
+    expect(schemasContent).toContain("distrib.app_*");
   });
 
   it("should mention x-org-id and x-user-id headers in security scheme", () => {
@@ -36,11 +36,11 @@ describe("OpenAPI spec — info description", () => {
   });
 
   it("should document user key flow with example", () => {
-    expect(generatorContent).toContain("Authorization: Bearer mcpf_abc123");
+    expect(generatorContent).toContain("Authorization: Bearer distrib.usr_abc123");
   });
 
   it("should document app key flow with identity headers example", () => {
-    expect(generatorContent).toContain("Authorization: Bearer mcpf_app_abc123");
+    expect(generatorContent).toContain("Authorization: Bearer distrib.app_abc123");
     expect(generatorContent).toContain("x-org-id: org_2xyzABC");
     expect(generatorContent).toContain("x-user-id: user_2abcDEF");
   });


### PR DESCRIPTION
## Summary
- Updates all documentation references from `mcpf_usr_*` / `mcpf_app_*` to `distrib.usr_*` / `distrib.app_*`
- Follows key-service PR #20 which changed the key generation prefix
- No runtime changes — auth middleware is prefix-agnostic (validates via key-service `/validate`)

## Files changed
- `src/schemas.ts` — bearerAuth security scheme description
- `src/middleware/auth.ts` — JSDoc comments
- `scripts/generate-openapi.ts` — API description, header param docs, examples
- `tests/unit/openapi-auth-docs.test.ts` — test assertions
- `openapi.json` — regenerated

## Test plan
- [x] `openapi-auth-docs.test.ts` — 13 tests pass
- [x] OpenAPI spec regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)