### PR TITLE
feat: add GET /v1/users proxy for paginated user listing

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1361,6 +1361,89 @@
           "externalOrgId",
           "externalUserId"
         ]
+      },
+      "ListUsersUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal user UUID"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "External user ID (e.g. Clerk user ID)"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true,
+            "description": "User email address"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true,
+            "description": "User first name"
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true,
+            "description": "User last name"
+          },
+          "imageUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "User avatar URL"
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true,
+            "description": "User phone number"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp of user creation"
+          }
+        },
+        "required": [
+          "id",
+          "externalId",
+          "email",
+          "firstName",
+          "lastName",
+          "imageUrl",
+          "phone",
+          "createdAt"
+        ]
+      },
+      "ListUsersResponse": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListUsersUser"
+            },
+            "description": "List of users"
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of users matching the query"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Limit used for this page"
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset used for this page"
+          }
+        },
+        "required": [
+          "users",
+          "total",
+          "limit",
+          "offset"
+        ]
       }
     },
     "parameters": {}
@@ -5893,6 +5976,109 @@
             "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
           }
         ]
+      }
+    },
+    "/v1/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "List users for the authenticated org",
+        "description": "Returns paginated users belonging to the caller's organization. Supports optional email filtering and offset-based pagination.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "email",
+              "description": "Filter by exact email address"
+            },
+            "required": false,
+            "description": "Filter by exact email address",
+            "name": "email",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50,
+              "description": "Max results (1–200, default 50)"
+            },
+            "required": false,
+            "description": "Max results (1–200, default 50)",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "minimum": 0,
+              "default": 0,
+              "description": "Pagination offset (default 0)"
+            },
+            "required": false,
+            "description": "Pagination offset (default 0)",
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated user list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListUsersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
-import { ResolveUserRequestSchema } from "../schemas.js";
+import { ResolveUserRequestSchema, ListUsersQuerySchema } from "../schemas.js";
 
 const router = Router();
 
@@ -29,6 +29,37 @@ router.post("/users/resolve", authenticate, requireOrg, async (req: Authenticate
   } catch (error: any) {
     console.error("Resolve user error:", error);
     res.status(500).json({ error: error.message || "Failed to resolve user identity" });
+  }
+});
+
+/**
+ * GET /v1/users
+ * List users for the authenticated org, with optional email filter and pagination.
+ */
+router.get("/users", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = ListUsersQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid query parameters", details: parsed.error.flatten() });
+    }
+
+    const { email, limit, offset } = parsed.data;
+    const params = new URLSearchParams({
+      appId: req.appId!,
+      orgId: req.orgId!,
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (email) params.set("email", email);
+
+    const result = await callExternalService(
+      externalServices.client,
+      `/users?${params.toString()}`,
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("List users error:", error);
+    res.status(500).json({ error: error.message || "Failed to list users" });
   }
 });
 


### PR DESCRIPTION
## Summary
- Adds `GET /v1/users` proxy endpoint that forwards to client-service `GET /users` with `appId` and `orgId` from auth context
- Supports optional `email` filter (exact match), `limit` (1–200, default 50), and `offset` pagination
- Includes Zod schema validation (`ListUsersQuerySchema`), OpenAPI registration with full response schema, and 7 new tests

## Test plan
- [x] 7 new tests covering: default params, email filter, custom limit/offset, omitted email, invalid email (400), upstream failure (500)
- [x] All 15 users tests pass (8 resolve + 7 listing)
- [x] Full test suite passes (pre-existing brand-delivery-stats failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)