### PR TITLE
fix: remove requireOrg from Stripe catalog endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5302,7 +5302,7 @@
           "Stripe"
         ],
         "summary": "Get a Stripe product",
-        "description": "Retrieve a Stripe product by ID. Uses the org's app Stripe key via key-service.",
+        "description": "Retrieve a Stripe product by ID. Uses the app's Stripe key via key-service. No org context required.",
         "security": [
           {
             "bearerAuth": []
@@ -5371,7 +5371,7 @@
           "Stripe"
         ],
         "summary": "Create a Stripe product",
-        "description": "Create a new Stripe product. Idempotent — returns existing product if the ID already exists.",
+        "description": "Create a new Stripe product. Idempotent — returns existing product if the ID already exists. No org context required (app-level operation).",
         "security": [
           {
             "bearerAuth": []
@@ -5449,7 +5449,7 @@
           "Stripe"
         ],
         "summary": "List prices for a product",
-        "description": "List all active prices for a Stripe product.",
+        "description": "List all active prices for a Stripe product. No org context required.",
         "security": [
           {
             "bearerAuth": []
@@ -5518,7 +5518,7 @@
           "Stripe"
         ],
         "summary": "Create a Stripe price",
-        "description": "Create a new price for a product. Supports one-time and recurring pricing.",
+        "description": "Create a new price for a product. Supports one-time and recurring pricing. No org context required (app-level operation).",
         "security": [
           {
             "bearerAuth": []
@@ -5596,7 +5596,7 @@
           "Stripe"
         ],
         "summary": "Get a Stripe coupon",
-        "description": "Retrieve a Stripe coupon by ID.",
+        "description": "Retrieve a Stripe coupon by ID. No org context required.",
         "security": [
           {
             "bearerAuth": []
@@ -5665,7 +5665,7 @@
           "Stripe"
         ],
         "summary": "Create a Stripe coupon",
-        "description": "Create a new coupon. Supports percent or fixed-amount discounts.",
+        "description": "Create a new coupon. Supports percent or fixed-amount discounts. No org context required (app-level operation).",
         "security": [
           {
             "bearerAuth": []

--- a/src/routes/stripe.ts
+++ b/src/routes/stripe.ts
@@ -17,9 +17,10 @@ const router = Router();
 
 /**
  * GET /v1/stripe/products/:productId
- * Retrieve a Stripe product by ID
+ * Retrieve a Stripe product by ID.
+ * Only needs appId (to resolve Stripe key) — no org context required.
  */
-router.get("/stripe/products/:productId", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/stripe/products/:productId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
     const result = await callExternalService(
@@ -35,9 +36,10 @@ router.get("/stripe/products/:productId", authenticate, requireOrg, async (req: 
 
 /**
  * POST /v1/stripe/products
- * Create a Stripe product
+ * Create a Stripe product.
+ * Only needs appId — orgId forwarded when available for tracking.
  */
-router.post("/stripe/products", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const parsed = CreateStripeProductRequestSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -49,7 +51,7 @@ router.post("/stripe/products", authenticate, requireOrg, async (req: Authentica
       "/products/create",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, ...parsed.data },
+        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
       }
     );
     res.json(result);
@@ -65,9 +67,10 @@ router.post("/stripe/products", authenticate, requireOrg, async (req: Authentica
 
 /**
  * GET /v1/stripe/products/:productId/prices
- * List active prices for a Stripe product
+ * List active prices for a Stripe product.
+ * Only needs appId — no org context required.
  */
-router.get("/stripe/products/:productId/prices", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/stripe/products/:productId/prices", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
     const result = await callExternalService(
@@ -83,9 +86,10 @@ router.get("/stripe/products/:productId/prices", authenticate, requireOrg, async
 
 /**
  * POST /v1/stripe/prices
- * Create a Stripe price
+ * Create a Stripe price.
+ * Only needs appId — orgId forwarded when available for tracking.
  */
-router.post("/stripe/prices", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const parsed = CreateStripePriceRequestSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -97,7 +101,7 @@ router.post("/stripe/prices", authenticate, requireOrg, async (req: Authenticate
       "/prices/create",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, ...parsed.data },
+        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
       }
     );
     res.json(result);
@@ -113,9 +117,10 @@ router.post("/stripe/prices", authenticate, requireOrg, async (req: Authenticate
 
 /**
  * GET /v1/stripe/coupons/:couponId
- * Retrieve a Stripe coupon by ID
+ * Retrieve a Stripe coupon by ID.
+ * Only needs appId — no org context required.
  */
-router.get("/stripe/coupons/:couponId", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { couponId } = req.params;
     const result = await callExternalService(
@@ -131,9 +136,10 @@ router.get("/stripe/coupons/:couponId", authenticate, requireOrg, async (req: Au
 
 /**
  * POST /v1/stripe/coupons
- * Create a Stripe coupon
+ * Create a Stripe coupon.
+ * Only needs appId — orgId forwarded when available for tracking.
  */
-router.post("/stripe/coupons", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const parsed = CreateStripeCouponRequestSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -145,7 +151,7 @@ router.post("/stripe/coupons", authenticate, requireOrg, async (req: Authenticat
       "/coupons/create",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, ...parsed.data },
+        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
       }
     );
     res.json(result);
@@ -156,12 +162,13 @@ router.post("/stripe/coupons", authenticate, requireOrg, async (req: Authenticat
 });
 
 // -----------------------------------------------------------------------
-// Checkout
+// Checkout (requires org context — user-facing operation)
 // -----------------------------------------------------------------------
 
 /**
  * POST /v1/stripe/checkout
- * Create a Stripe Checkout session
+ * Create a Stripe Checkout session.
+ * Requires org/user context for tracking the purchase.
  */
 router.post("/stripe/checkout", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
@@ -186,12 +193,13 @@ router.post("/stripe/checkout", authenticate, requireOrg, async (req: Authentica
 });
 
 // -----------------------------------------------------------------------
-// Stats
+// Stats (requires org context — scoped to org data)
 // -----------------------------------------------------------------------
 
 /**
  * POST /v1/stripe/stats
- * Get Stripe sales stats
+ * Get Stripe sales stats.
+ * Requires org context to scope the stats query.
  */
 router.post("/stripe/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1631,7 +1631,7 @@ registry.registerPath({
   path: "/v1/stripe/products/{productId}",
   tags: ["Stripe"],
   summary: "Get a Stripe product",
-  description: "Retrieve a Stripe product by ID. Uses the org's app Stripe key via key-service.",
+  description: "Retrieve a Stripe product by ID. Uses the app's Stripe key via key-service. No org context required.",
   security: authed,
   request: {
     params: z.object({ productId: z.string().describe("Stripe product ID") }),
@@ -1648,7 +1648,7 @@ registry.registerPath({
   path: "/v1/stripe/products",
   tags: ["Stripe"],
   summary: "Create a Stripe product",
-  description: "Create a new Stripe product. Idempotent — returns existing product if the ID already exists.",
+  description: "Create a new Stripe product. Idempotent — returns existing product if the ID already exists. No org context required (app-level operation).",
   security: authed,
   request: {
     body: {
@@ -1668,7 +1668,7 @@ registry.registerPath({
   path: "/v1/stripe/products/{productId}/prices",
   tags: ["Stripe"],
   summary: "List prices for a product",
-  description: "List all active prices for a Stripe product.",
+  description: "List all active prices for a Stripe product. No org context required.",
   security: authed,
   request: {
     params: z.object({ productId: z.string().describe("Stripe product ID") }),
@@ -1685,7 +1685,7 @@ registry.registerPath({
   path: "/v1/stripe/prices",
   tags: ["Stripe"],
   summary: "Create a Stripe price",
-  description: "Create a new price for a product. Supports one-time and recurring pricing.",
+  description: "Create a new price for a product. Supports one-time and recurring pricing. No org context required (app-level operation).",
   security: authed,
   request: {
     body: {
@@ -1705,7 +1705,7 @@ registry.registerPath({
   path: "/v1/stripe/coupons/{couponId}",
   tags: ["Stripe"],
   summary: "Get a Stripe coupon",
-  description: "Retrieve a Stripe coupon by ID.",
+  description: "Retrieve a Stripe coupon by ID. No org context required.",
   security: authed,
   request: {
     params: z.object({ couponId: z.string().describe("Stripe coupon ID") }),
@@ -1722,7 +1722,7 @@ registry.registerPath({
   path: "/v1/stripe/coupons",
   tags: ["Stripe"],
   summary: "Create a Stripe coupon",
-  description: "Create a new coupon. Supports percent or fixed-amount discounts.",
+  description: "Create a new coupon. Supports percent or fixed-amount discounts. No org context required (app-level operation).",
   security: authed,
   request: {
     body: {


### PR DESCRIPTION
## Summary
- Removes `requireOrg` middleware from 6 Stripe catalog endpoints (GET/POST product, GET/POST price, GET/POST coupon) — they only need `appId` to resolve the Stripe key
- Fixes `HTTP 400: Organization context required` errors when Polarity Course calls these endpoints with an app key during startup (no org/user context available)
- Makes `orgId` conditionally forwarded to stripe-service (only when present)
- Checkout and stats endpoints still require org context (user-facing operations)
- Adds 8 new tests covering app-key-without-org scenarios (22 total stripe tests)

## Test plan
- [x] 22 stripe proxy tests pass (14 existing + 8 new no-org tests)
- [x] OpenAPI spec regenerated with updated descriptions
- [x] Polarity Course startup flow: `POST /stripe/products` with app key → should now return 200 instead of 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)