### PR TITLE
feat: migrate to key-service unified /keys endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -398,26 +398,29 @@
           "campaignIds"
         ]
       },
-      "AddByokKeyRequest": {
+      "UpsertKeyRequest": {
         "type": "object",
         "properties": {
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "app",
+              "platform"
+            ],
+            "description": "Key store: 'org' (user-provided), 'app' (app-level), 'platform' (global)"
+          },
           "provider": {
             "type": "string",
-            "description": "Provider name (e.g. openai, anthropic, apollo)"
+            "description": "Provider name (e.g. openai, anthropic, stripe)"
           },
           "apiKey": {
             "type": "string",
             "description": "The API key value"
-          },
-          "scope": {
-            "type": "string",
-            "enum": [
-              "app"
-            ],
-            "description": "Key scope: 'app' for app-level key (no org/user needed). Omit for org-level BYOK."
           }
         },
         "required": [
+          "keySource",
           "provider",
           "apiKey"
         ]
@@ -2489,16 +2492,51 @@
         "tags": [
           "Keys"
         ],
-        "summary": "List BYOK keys",
-        "description": "List all BYOK (Bring Your Own Key) API keys for the organization",
+        "summary": "List provider keys",
+        "description": "List provider keys. Pass keySource query param to select the key store (org, app, platform). Defaults to 'org'.",
         "security": [
           {
             "bearerAuth": []
           }
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "org",
+                "app",
+                "platform"
+              ],
+              "description": "Key store to list from (default: 'org')"
+            },
+            "required": false,
+            "description": "Key store to list from (default: 'org')",
+            "name": "keySource",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          }
+        ],
         "responses": {
           "200": {
-            "description": "List of BYOK keys"
+            "description": "List of provider keys (masked)"
           },
           "401": {
             "description": "Unauthorized",
@@ -2520,34 +2558,14 @@
               }
             }
           }
-        },
-        "parameters": [
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
           "Keys"
         ],
-        "summary": "Add a provider key",
-        "description": "Store a provider API key. Use scope:'app' for app-level keys (no org/user needed). Omit scope for org-level BYOK keys.",
+        "summary": "Upsert a provider key",
+        "description": "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys, 'app' for app-level keys, 'platform' for global keys.",
         "security": [
           {
             "bearerAuth": []
@@ -2557,7 +2575,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AddByokKeyRequest"
+                "$ref": "#/components/schemas/UpsertKeyRequest"
               }
             }
           }
@@ -2624,8 +2642,8 @@
         "tags": [
           "Keys"
         ],
-        "summary": "Delete a BYOK key",
-        "description": "Remove a BYOK API key for a specific provider",
+        "summary": "Delete a provider key",
+        "description": "Remove a provider key. Pass keySource query param to select the key store (default: 'org').",
         "security": [
           {
             "bearerAuth": []
@@ -2641,6 +2659,21 @@
             "description": "Provider name",
             "name": "provider",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "org",
+                "app",
+                "platform"
+              ],
+              "description": "Key store (default: 'org')"
+            },
+            "required": false,
+            "description": "Key store (default: 'org')",
+            "name": "keySource",
+            "in": "query"
           },
           {
             "name": "x-org-id",
@@ -2667,72 +2700,6 @@
           },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/internal/keys/{provider}/decrypt": {
-      "get": {
-        "tags": [
-          "Keys"
-        ],
-        "summary": "Decrypt a BYOK key (internal)",
-        "description": "Get decrypted BYOK key value. Internal service-to-service endpoint.",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Provider name"
-            },
-            "required": true,
-            "description": "Provider name",
-            "name": "provider",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Organization ID"
-            },
-            "required": true,
-            "description": "Organization ID",
-            "name": "orgId",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Decrypted key"
-          },
-          "400": {
-            "description": "Missing orgId query parameter",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Key not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -1,20 +1,32 @@
 import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
-import { AddByokKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js";
+import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js";
 
 const router = Router();
 
+// -----------------------------------------------------------------------
+// Provider keys — transparent proxy to key-service unified /keys endpoints
+// -----------------------------------------------------------------------
+
 /**
  * GET /v1/keys
- * List BYOK keys for the organization
+ * List provider keys. keySource query param selects the key store (default: "org").
  */
-router.get("/keys", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const result = await callExternalService(
-      externalServices.key,
-      `/internal/keys?orgId=${req.orgId}`
-    );
+    const keySource = (req.query.keySource as string) || "org";
+
+    const params = new URLSearchParams({ keySource });
+    if (keySource === "org") {
+      if (!req.orgId) return res.status(400).json({ error: "Organization context required for org keys" });
+      params.set("orgId", req.orgId);
+    } else if (keySource === "app") {
+      if (!req.appId) return res.status(403).json({ error: "App key authentication required for app keys" });
+      params.set("appId", req.appId);
+    }
+
+    const result = await callExternalService(externalServices.key, `/keys?${params}`);
     res.json(result);
   } catch (error: any) {
     console.error("List keys error:", error);
@@ -24,68 +36,58 @@ router.get("/keys", authenticate, requireOrg, requireUser, async (req: Authentic
 
 /**
  * POST /v1/keys
- * Add a provider key. Supports:
- * - scope: "app" → app-scoped key (requires app key auth, no org/user needed)
- * - no scope → BYOK org-scoped key (requires org + user context)
+ * Upsert a provider key. keySource in body determines the key store.
  */
 router.post("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const parsed = AddByokKeyRequestSchema.safeParse(req.body);
+    const parsed = UpsertKeyRequestSchema.safeParse(req.body);
     if (!parsed.success) {
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
-    const { provider, apiKey, scope } = parsed.data;
+    const { keySource, provider, apiKey } = parsed.data;
 
-    if (scope === "app") {
-      if (!req.appId) {
-        return res.status(403).json({ error: "App-scoped keys require app key authentication" });
-      }
+    const body: Record<string, string> = { keySource, provider, apiKey };
 
-      const result = await callExternalService(
-        externalServices.key,
-        "/internal/app-keys",
-        {
-          method: "POST",
-          body: { appId: req.appId, provider, apiKey },
-        }
-      );
-      return res.json(result);
+    if (keySource === "org") {
+      if (!req.orgId) return res.status(400).json({ error: "Organization context required for org keys" });
+      body.orgId = req.orgId;
+    } else if (keySource === "app") {
+      if (!req.appId) return res.status(403).json({ error: "App key authentication required for app keys" });
+      body.appId = req.appId;
     }
 
-    // Default: BYOK key (requires org + user)
-    if (!req.orgId) {
-      return res.status(400).json({ error: "Organization context required" });
-    }
-    if (!req.userId) {
-      return res.status(401).json({ error: "User identity required" });
-    }
-
-    const result = await callExternalService(
-      externalServices.key,
-      "/internal/keys",
-      {
-        method: "POST",
-        body: { orgId: req.orgId, provider, apiKey },
-      }
-    );
+    const result = await callExternalService(externalServices.key, "/keys", {
+      method: "POST",
+      body,
+    });
     res.json(result);
   } catch (error: any) {
-    console.error("Add key error:", error);
-    res.status(500).json({ error: error.message || "Failed to add key" });
+    console.error("Upsert key error:", error);
+    res.status(500).json({ error: error.message || "Failed to upsert key" });
   }
 });
 
 /**
  * DELETE /v1/keys/:provider
- * Remove a BYOK key
+ * Delete a provider key. keySource query param selects the key store (default: "org").
  */
-router.delete("/keys/:provider", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { provider } = req.params;
+    const keySource = (req.query.keySource as string) || "org";
+
+    const params = new URLSearchParams({ keySource });
+    if (keySource === "org") {
+      if (!req.orgId) return res.status(400).json({ error: "Organization context required for org keys" });
+      params.set("orgId", req.orgId);
+    } else if (keySource === "app") {
+      if (!req.appId) return res.status(403).json({ error: "App key authentication required for app keys" });
+      params.set("appId", req.appId);
+    }
 
     const result = await callExternalService(
       externalServices.key,
-      `/internal/keys/${provider}?orgId=${req.orgId}`,
+      `/keys/${encodeURIComponent(provider)}?${params}`,
       { method: "DELETE" }
     );
     res.json(result);
@@ -95,33 +97,9 @@ router.delete("/keys/:provider", authenticate, requireOrg, requireUser, async (r
   }
 });
 
-/**
- * GET /internal/keys/:provider/decrypt
- * Get decrypted BYOK key (for internal service-to-service use)
- * Requires X-API-Key header for service auth
- */
-router.get("/internal/keys/:provider/decrypt", async (req, res) => {
-  try {
-    const { provider } = req.params;
-    const orgId = req.query.orgId as string;
-
-    if (!orgId) {
-      return res.status(400).json({ error: "orgId required" });
-    }
-
-    const result = await callExternalService(
-      externalServices.key,
-      `/internal/keys/${provider}/decrypt?orgId=${orgId}`
-    );
-    res.json(result);
-  } catch (error: any) {
-    if (error.message?.includes("404")) {
-      return res.status(404).json({ error: `${req.params.provider} key not configured` });
-    }
-    console.error("Decrypt key error:", error);
-    res.status(500).json({ error: error.message || "Failed to decrypt key" });
-  }
-});
+// -----------------------------------------------------------------------
+// API keys — user-facing API key management (unchanged, uses /internal/api-keys)
+// -----------------------------------------------------------------------
 
 /**
  * POST /v1/api-keys/session

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -468,32 +468,36 @@ registry.registerPath({
 });
 
 // ===================================================================
-// BYOK KEYS
+// PROVIDER KEYS
 // ===================================================================
 
-export const AddByokKeyRequestSchema = z
+export const UpsertKeyRequestSchema = z
   .object({
+    keySource: z
+      .enum(["org", "app", "platform"])
+      .describe("Key store: 'org' (user-provided), 'app' (app-level), 'platform' (global)"),
     provider: z
       .string()
-      .describe("Provider name (e.g. openai, anthropic, apollo)"),
+      .describe("Provider name (e.g. openai, anthropic, stripe)"),
     apiKey: z.string().describe("The API key value"),
-    scope: z
-      .enum(["app"])
-      .optional()
-      .describe("Key scope: 'app' for app-level key (no org/user needed). Omit for org-level BYOK."),
   })
-  .openapi("AddByokKeyRequest");
+  .openapi("UpsertKeyRequest");
 
 registry.registerPath({
   method: "get",
   path: "/v1/keys",
   tags: ["Keys"],
-  summary: "List BYOK keys",
+  summary: "List provider keys",
   description:
-    "List all BYOK (Bring Your Own Key) API keys for the organization",
+    "List provider keys. Pass keySource query param to select the key store (org, app, platform). Defaults to 'org'.",
   security: authed,
+  request: {
+    query: z.object({
+      keySource: z.enum(["org", "app", "platform"]).optional().describe("Key store to list from (default: 'org')"),
+    }),
+  },
   responses: {
-    200: { description: "List of BYOK keys" },
+    200: { description: "List of provider keys (masked)" },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -503,13 +507,13 @@ registry.registerPath({
   method: "post",
   path: "/v1/keys",
   tags: ["Keys"],
-  summary: "Add a provider key",
+  summary: "Upsert a provider key",
   description:
-    "Store a provider API key. Use scope:'app' for app-level keys (no org/user needed). Omit scope for org-level BYOK keys.",
+    "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys, 'app' for app-level keys, 'platform' for global keys.",
   security: authed,
   request: {
     body: {
-      content: { "application/json": { schema: AddByokKeyRequestSchema } },
+      content: { "application/json": { schema: UpsertKeyRequestSchema } },
     },
   },
   responses: {
@@ -524,40 +528,20 @@ registry.registerPath({
   method: "delete",
   path: "/v1/keys/{provider}",
   tags: ["Keys"],
-  summary: "Delete a BYOK key",
-  description: "Remove a BYOK API key for a specific provider",
+  summary: "Delete a provider key",
+  description: "Remove a provider key. Pass keySource query param to select the key store (default: 'org').",
   security: authed,
   request: {
     params: z.object({
       provider: z.string().describe("Provider name"),
     }),
+    query: z.object({
+      keySource: z.enum(["org", "app", "platform"]).optional().describe("Key store (default: 'org')"),
+    }),
   },
   responses: {
     200: { description: "Key deleted" },
     401: { description: "Unauthorized", content: errorContent },
-    500: { description: "Internal error", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "get",
-  path: "/v1/internal/keys/{provider}/decrypt",
-  tags: ["Keys"],
-  summary: "Decrypt a BYOK key (internal)",
-  description:
-    "Get decrypted BYOK key value. Internal service-to-service endpoint.",
-  request: {
-    params: z.object({
-      provider: z.string().describe("Provider name"),
-    }),
-    query: z.object({
-      orgId: z.string().describe("Organization ID"),
-    }),
-  },
-  responses: {
-    200: { description: "Decrypted key" },
-    400: { description: "Missing orgId query parameter", content: errorContent },
-    404: { description: "Key not found", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -23,9 +23,9 @@ export async function registerPlatformKeys(): Promise<void> {
 
   for (const { provider, envVar } of PLATFORM_KEYS) {
     const apiKey = process.env[envVar]!;
-    await callExternalService(externalServices.key, "/internal/platform-keys", {
+    await callExternalService(externalServices.key, "/keys", {
       method: "POST",
-      body: { provider, apiKey },
+      body: { keySource: "platform", provider, apiKey },
     });
     console.log(`[api-service] Platform key registered: ${provider}`);
   }

--- a/tests/unit/keys-app-scope.test.ts
+++ b/tests/unit/keys-app-scope.test.ts
@@ -8,48 +8,52 @@ const content = fs.readFileSync(keysRoutePath, "utf-8");
 const schemaPath = path.join(__dirname, "../../src/schemas.ts");
 const schemaContent = fs.readFileSync(schemaPath, "utf-8");
 
-describe("POST /v1/keys — app-scoped key support", () => {
-  it("should support scope field in AddByokKeyRequestSchema", () => {
-    expect(schemaContent).toContain("scope");
+describe("POST /v1/keys — unified keySource support", () => {
+  it("should use UpsertKeyRequestSchema with keySource field", () => {
+    expect(schemaContent).toContain("keySource");
+    expect(schemaContent).toContain('"org"');
     expect(schemaContent).toContain('"app"');
+    expect(schemaContent).toContain('"platform"');
   });
 
-  it("should proxy app-scoped keys to /internal/app-keys", () => {
-    expect(content).toContain('"/internal/app-keys"');
-    expect(content).toContain('scope === "app"');
+  it("should forward to unified /keys endpoint (not /internal/*)", () => {
+    // POST handler should call key-service POST /keys
+    expect(content).toContain('"/keys"');
+    // Should NOT use old /internal/app-keys or /internal/keys paths for provider keys
+    expect(content).not.toContain('"/internal/app-keys"');
+    expect(content).not.toContain('"/internal/keys"');
   });
 
-  it("should require appId for app-scoped key registration", () => {
-    expect(content).toContain("req.appId");
-    expect(content).toContain("App-scoped keys require app key authentication");
+  it("should inject orgId for keySource org", () => {
+    expect(content).toContain("orgId");
+    expect(content).toContain('Organization context required for org keys');
   });
 
-  it("should return 403 when app key auth is not used for scope:app", () => {
-    expect(content).toContain("403");
+  it("should inject appId for keySource app", () => {
+    expect(content).toContain("appId");
+    expect(content).toContain('App key authentication required for app keys');
   });
 
-  it("should send appId, provider, apiKey to key-service for app-scoped keys", () => {
-    expect(content).toContain("appId: req.appId");
+  it("should not expose a decrypt proxy", () => {
+    expect(content).not.toContain("/decrypt");
+    expect(content).not.toContain("decrypt");
   });
 });
 
-describe("POST /v1/keys — BYOK fallback", () => {
-  it("should still proxy default keys to /internal/keys", () => {
-    expect(content).toContain('"/internal/keys"');
-    expect(content).toContain("orgId: req.orgId");
+describe("GET /v1/keys — unified keySource support", () => {
+  it("should accept keySource query param", () => {
+    expect(content).toContain("req.query.keySource");
   });
 
-  it("should use authenticate middleware only (not requireOrg/requireUser in chain)", () => {
-    // POST handler should only have authenticate, not requireOrg/requireUser
-    const postLine = content.match(/router\.post\("\/keys"[^)]+\)/);
-    expect(postLine).toBeDefined();
-    expect(postLine![0]).toContain("authenticate");
-    expect(postLine![0]).not.toContain("requireOrg");
-    expect(postLine![0]).not.toContain("requireUser");
+  it("should default keySource to org", () => {
+    expect(content).toContain('|| "org"');
   });
+});
 
-  it("should check org and user inline for BYOK path", () => {
-    expect(content).toContain("Organization context required");
-    expect(content).toContain("User identity required");
+describe("DELETE /v1/keys/:provider — unified keySource support", () => {
+  it("should accept keySource query param", () => {
+    // DELETE handler also reads keySource from query
+    const deleteSection = content.slice(content.indexOf('router.delete("/keys/:provider"'));
+    expect(deleteSection).toContain("req.query.keySource");
   });
 });

--- a/tests/unit/keys-unified-proxy.test.ts
+++ b/tests/unit/keys-unified-proxy.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock auth middleware
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.appId = "distribute-frontend";
+    req.authType = "user_key";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import keysRoutes from "../../src/routes/keys.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", keysRoutes);
+  return app;
+}
+
+describe("POST /v1/keys — unified proxy", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      fetchCalls.push({ url, method: init?.method, body });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ provider: "stripe", maskedKey: "sk_l...abc", message: "stripe key saved successfully" }),
+      };
+    });
+    app = createApp();
+  });
+
+  it("should forward org keys to POST /keys with orgId", async () => {
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "org", provider: "stripe", apiKey: "sk_live_test" });
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys") && c.method === "POST");
+    expect(call).toBeDefined();
+    expect(call!.body).toEqual({
+      keySource: "org",
+      provider: "stripe",
+      apiKey: "sk_live_test",
+      orgId: "org_test456",
+    });
+  });
+
+  it("should forward app keys to POST /keys with appId", async () => {
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "app", provider: "anthropic", apiKey: "sk-ant-test" });
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys") && c.method === "POST");
+    expect(call).toBeDefined();
+    expect(call!.body).toEqual({
+      keySource: "app",
+      provider: "anthropic",
+      apiKey: "sk-ant-test",
+      appId: "distribute-frontend",
+    });
+  });
+
+  it("should forward platform keys to POST /keys without orgId/appId", async () => {
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "platform", provider: "gemini", apiKey: "gemini-key" });
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys") && c.method === "POST");
+    expect(call).toBeDefined();
+    expect(call!.body).toEqual({
+      keySource: "platform",
+      provider: "gemini",
+      apiKey: "gemini-key",
+    });
+  });
+
+  it("should reject invalid keySource", async () => {
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "bogus", provider: "stripe", apiKey: "sk_live_test" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("should reject missing provider", async () => {
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "org", apiKey: "sk_live_test" });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /v1/keys — unified proxy", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      fetchCalls.push({ url, method: init?.method });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ keys: [{ provider: "stripe", maskedKey: "sk_l...abc" }] }),
+      };
+    });
+    app = createApp();
+  });
+
+  it("should default keySource to org and include orgId", async () => {
+    const res = await request(app).get("/v1/keys");
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("keySource=org");
+    expect(call!.url).toContain("orgId=org_test456");
+  });
+
+  it("should forward keySource=app with appId", async () => {
+    const res = await request(app).get("/v1/keys?keySource=app");
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("keySource=app");
+    expect(call!.url).toContain("appId=distribute-frontend");
+  });
+
+  it("should forward keySource=platform without orgId/appId", async () => {
+    const res = await request(app).get("/v1/keys?keySource=platform");
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("keySource=platform");
+    expect(call!.url).not.toContain("orgId");
+    expect(call!.url).not.toContain("appId");
+  });
+});
+
+describe("DELETE /v1/keys/:provider — unified proxy", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      fetchCalls.push({ url, method: init?.method });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ message: "Key deleted" }),
+      };
+    });
+    app = createApp();
+  });
+
+  it("should default keySource to org and include orgId", async () => {
+    const res = await request(app).delete("/v1/keys/stripe");
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys/stripe") && c.method === "DELETE");
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("keySource=org");
+    expect(call!.url).toContain("orgId=org_test456");
+  });
+
+  it("should forward keySource=app with appId", async () => {
+    const res = await request(app).delete("/v1/keys/anthropic?keySource=app");
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/keys/anthropic") && c.method === "DELETE");
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("keySource=app");
+    expect(call!.url).toContain("appId=distribute-frontend");
+  });
+});
+
+describe("Decrypt proxy removal", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }));
+    app = createApp();
+  });
+
+  it("should not expose /internal/keys/:provider/decrypt", async () => {
+    const res = await request(app).get("/v1/internal/keys/stripe/decrypt?orgId=org_test456");
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -48,7 +48,7 @@ describe("registerPlatformKeys", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
-      if (url.includes("/internal/platform-keys")) {
+      if (url.includes("/keys") && body?.keySource === "platform") {
         return new Response(JSON.stringify({ provider: body?.provider, maskedKey: "sk-...xxx", message: "Platform key saved" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
@@ -68,7 +68,7 @@ describe("registerPlatformKeys", () => {
 
     await registerPlatformKeys();
 
-    const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/internal/platform-keys"));
+    const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/keys") && c.body?.keySource === "platform");
     expect(platformKeyCalls).toHaveLength(8);
 
     const providers = platformKeyCalls.map((c) => c.body?.provider);
@@ -82,6 +82,7 @@ describe("registerPlatformKeys", () => {
     expect(providers).toContain("stripe-webhook");
 
     for (const call of platformKeyCalls) {
+      expect(call.body).toHaveProperty("keySource", "platform");
       expect(call.body).not.toHaveProperty("appId");
     }
   });
@@ -98,7 +99,7 @@ describe("registerPlatformKeys", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
-      if (url.includes("/internal/platform-keys")) {
+      if (url.includes("/keys") && body?.keySource === "platform") {
         return new Response(JSON.stringify({ error: "Service unavailable" }), {
           status: 503,
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Migrates all provider key routes (`POST /keys`, `GET /keys`, `DELETE /keys/:provider`) from deprecated `/internal/*` paths to key-service's new unified `/keys` endpoints with `keySource` parameter
- Removes the insecure decrypt proxy (`GET /internal/keys/:provider/decrypt`) which had **no authentication middleware** — decrypt is backend-only and services should call key-service directly
- Updates `startup.ts` platform key registration to use `POST /keys { keySource: "platform" }` instead of `/internal/platform-keys`
- Replaces `AddByokKeyRequestSchema` (with `scope` field) with `UpsertKeyRequestSchema` (with `keySource: org|app|platform`)

## Test plan
- [x] All 28 key-related tests pass (keys-app-scope, keys-unified-proxy, keys-identity, keys-service-auth, startup)
- [x] Full test suite passes (1 pre-existing failure in brand-delivery-stats unrelated to this change)
- [ ] Verify key CRUD operations work end-to-end with key-service in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)