### PR TITLE
fix: block platform keySource and enforce authType on key routes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -405,10 +405,9 @@
             "type": "string",
             "enum": [
               "org",
-              "app",
-              "platform"
+              "app"
             ],
-            "description": "Key store: 'org' (user-provided), 'app' (app-level), 'platform' (global)"
+            "description": "Key store: 'org' (org-level, user-provided) or 'app' (app-level, requires app key auth)"
           },
           "provider": {
             "type": "string",
@@ -2493,7 +2492,7 @@
           "Keys"
         ],
         "summary": "List provider keys",
-        "description": "List provider keys. Pass keySource query param to select the key store (org, app, platform). Defaults to 'org'.",
+        "description": "List provider keys. Pass keySource query param to select the key store (org or app). Defaults to 'org'.",
         "security": [
           {
             "bearerAuth": []
@@ -2505,8 +2504,7 @@
               "type": "string",
               "enum": [
                 "org",
-                "app",
-                "platform"
+                "app"
               ],
               "description": "Key store to list from (default: 'org')"
             },
@@ -2565,7 +2563,7 @@
           "Keys"
         ],
         "summary": "Upsert a provider key",
-        "description": "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys, 'app' for app-level keys, 'platform' for global keys.",
+        "description": "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys (requires org context), 'app' for app-level keys (requires app key auth).",
         "security": [
           {
             "bearerAuth": []
@@ -2665,8 +2663,7 @@
               "type": "string",
               "enum": [
                 "org",
-                "app",
-                "platform"
+                "app"
               ],
               "description": "Key store (default: 'org')"
             },

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -5,6 +5,38 @@ import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js
 
 const router = Router();
 
+const ALLOWED_KEY_SOURCES = ["org", "app"] as const;
+type AllowedKeySource = (typeof ALLOWED_KEY_SOURCES)[number];
+
+/**
+ * Validate keySource + authType combination.
+ * - "org"  → any authenticated user with org context
+ * - "app"  → only app key auth (authType === "app_key")
+ * - "platform" → never allowed via public API
+ */
+function validateKeySourceAccess(
+  keySource: string,
+  req: AuthenticatedRequest,
+): { error: string; status: number } | { keySource: AllowedKeySource } {
+  if (!ALLOWED_KEY_SOURCES.includes(keySource as AllowedKeySource)) {
+    return { status: 403, error: `keySource "${keySource}" is not allowed via the public API` };
+  }
+
+  if (keySource === "app" && req.authType !== "app_key") {
+    return { status: 403, error: "keySource 'app' requires app key authentication" };
+  }
+
+  if (keySource === "org" && !req.orgId) {
+    return { status: 400, error: "Organization context required for org keys" };
+  }
+
+  if (keySource === "app" && !req.appId) {
+    return { status: 403, error: "App key authentication required for app keys" };
+  }
+
+  return { keySource: keySource as AllowedKeySource };
+}
+
 // -----------------------------------------------------------------------
 // Provider keys — transparent proxy to key-service unified /keys endpoints
 // -----------------------------------------------------------------------
@@ -16,15 +48,12 @@ const router = Router();
 router.get("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const keySource = (req.query.keySource as string) || "org";
+    const access = validateKeySourceAccess(keySource, req);
+    if ("error" in access) return res.status(access.status).json({ error: access.error });
 
-    const params = new URLSearchParams({ keySource });
-    if (keySource === "org") {
-      if (!req.orgId) return res.status(400).json({ error: "Organization context required for org keys" });
-      params.set("orgId", req.orgId);
-    } else if (keySource === "app") {
-      if (!req.appId) return res.status(403).json({ error: "App key authentication required for app keys" });
-      params.set("appId", req.appId);
-    }
+    const params = new URLSearchParams({ keySource: access.keySource });
+    if (access.keySource === "org") params.set("orgId", req.orgId!);
+    if (access.keySource === "app") params.set("appId", req.appId!);
 
     const result = await callExternalService(externalServices.key, `/keys?${params}`);
     res.json(result);
@@ -46,15 +75,12 @@ router.post("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
     }
     const { keySource, provider, apiKey } = parsed.data;
 
-    const body: Record<string, string> = { keySource, provider, apiKey };
+    const access = validateKeySourceAccess(keySource, req);
+    if ("error" in access) return res.status(access.status).json({ error: access.error });
 
-    if (keySource === "org") {
-      if (!req.orgId) return res.status(400).json({ error: "Organization context required for org keys" });
-      body.orgId = req.orgId;
-    } else if (keySource === "app") {
-      if (!req.appId) return res.status(403).json({ error: "App key authentication required for app keys" });
-      body.appId = req.appId;
-    }
+    const body: Record<string, string> = { keySource: access.keySource, provider, apiKey };
+    if (access.keySource === "org") body.orgId = req.orgId!;
+    if (access.keySource === "app") body.appId = req.appId!;
 
     const result = await callExternalService(externalServices.key, "/keys", {
       method: "POST",
@@ -76,14 +102,12 @@ router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest,
     const { provider } = req.params;
     const keySource = (req.query.keySource as string) || "org";
 
-    const params = new URLSearchParams({ keySource });
-    if (keySource === "org") {
-      if (!req.orgId) return res.status(400).json({ error: "Organization context required for org keys" });
-      params.set("orgId", req.orgId);
-    } else if (keySource === "app") {
-      if (!req.appId) return res.status(403).json({ error: "App key authentication required for app keys" });
-      params.set("appId", req.appId);
-    }
+    const access = validateKeySourceAccess(keySource, req);
+    if ("error" in access) return res.status(access.status).json({ error: access.error });
+
+    const params = new URLSearchParams({ keySource: access.keySource });
+    if (access.keySource === "org") params.set("orgId", req.orgId!);
+    if (access.keySource === "app") params.set("appId", req.appId!);
 
     const result = await callExternalService(
       externalServices.key,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -474,8 +474,8 @@ registry.registerPath({
 export const UpsertKeyRequestSchema = z
   .object({
     keySource: z
-      .enum(["org", "app", "platform"])
-      .describe("Key store: 'org' (user-provided), 'app' (app-level), 'platform' (global)"),
+      .enum(["org", "app"])
+      .describe("Key store: 'org' (org-level, user-provided) or 'app' (app-level, requires app key auth)"),
     provider: z
       .string()
       .describe("Provider name (e.g. openai, anthropic, stripe)"),
@@ -489,11 +489,11 @@ registry.registerPath({
   tags: ["Keys"],
   summary: "List provider keys",
   description:
-    "List provider keys. Pass keySource query param to select the key store (org, app, platform). Defaults to 'org'.",
+    "List provider keys. Pass keySource query param to select the key store (org or app). Defaults to 'org'.",
   security: authed,
   request: {
     query: z.object({
-      keySource: z.enum(["org", "app", "platform"]).optional().describe("Key store to list from (default: 'org')"),
+      keySource: z.enum(["org", "app"]).optional().describe("Key store to list from (default: 'org')"),
     }),
   },
   responses: {
@@ -509,7 +509,7 @@ registry.registerPath({
   tags: ["Keys"],
   summary: "Upsert a provider key",
   description:
-    "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys, 'app' for app-level keys, 'platform' for global keys.",
+    "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys (requires org context), 'app' for app-level keys (requires app key auth).",
   security: authed,
   request: {
     body: {
@@ -536,7 +536,7 @@ registry.registerPath({
       provider: z.string().describe("Provider name"),
     }),
     query: z.object({
-      keySource: z.enum(["org", "app", "platform"]).optional().describe("Key store (default: 'org')"),
+      keySource: z.enum(["org", "app"]).optional().describe("Key store (default: 'org')"),
     }),
   },
   responses: {

--- a/tests/unit/keys-app-scope.test.ts
+++ b/tests/unit/keys-app-scope.test.ts
@@ -9,29 +9,38 @@ const schemaPath = path.join(__dirname, "../../src/schemas.ts");
 const schemaContent = fs.readFileSync(schemaPath, "utf-8");
 
 describe("POST /v1/keys — unified keySource support", () => {
-  it("should use UpsertKeyRequestSchema with keySource field", () => {
+  it("should use UpsertKeyRequestSchema with keySource field (org and app only)", () => {
     expect(schemaContent).toContain("keySource");
     expect(schemaContent).toContain('"org"');
     expect(schemaContent).toContain('"app"');
-    expect(schemaContent).toContain('"platform"');
+  });
+
+  it("should not accept platform as a keySource in the schema", () => {
+    // UpsertKeyRequestSchema should only allow org and app
+    const schemaSection = schemaContent.slice(
+      schemaContent.indexOf("UpsertKeyRequestSchema"),
+      schemaContent.indexOf(".openapi(", schemaContent.indexOf("UpsertKeyRequestSchema")) + 30
+    );
+    expect(schemaSection).not.toContain('"platform"');
   });
 
   it("should forward to unified /keys endpoint (not /internal/*)", () => {
-    // POST handler should call key-service POST /keys
     expect(content).toContain('"/keys"');
-    // Should NOT use old /internal/app-keys or /internal/keys paths for provider keys
     expect(content).not.toContain('"/internal/app-keys"');
     expect(content).not.toContain('"/internal/keys"');
   });
 
-  it("should inject orgId for keySource org", () => {
-    expect(content).toContain("orgId");
-    expect(content).toContain('Organization context required for org keys');
+  it("should validate keySource access with authType", () => {
+    expect(content).toContain("validateKeySourceAccess");
+    expect(content).toContain("req.authType");
   });
 
-  it("should inject appId for keySource app", () => {
-    expect(content).toContain("appId");
-    expect(content).toContain('App key authentication required for app keys');
+  it("should block platform keySource via public API", () => {
+    expect(content).toContain("not allowed via the public API");
+  });
+
+  it("should require app_key auth for keySource app", () => {
+    expect(content).toContain("requires app key authentication");
   });
 
   it("should not expose a decrypt proxy", () => {
@@ -52,7 +61,6 @@ describe("GET /v1/keys — unified keySource support", () => {
 
 describe("DELETE /v1/keys/:provider — unified keySource support", () => {
   it("should accept keySource query param", () => {
-    // DELETE handler also reads keySource from query
     const deleteSection = content.slice(content.indexOf('router.delete("/keys/:provider"'));
     expect(deleteSection).toContain("req.query.keySource");
   });

--- a/tests/unit/keys-unified-proxy.test.ts
+++ b/tests/unit/keys-unified-proxy.test.ts
@@ -2,13 +2,28 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import express from "express";
 import request from "supertest";
 
-// Mock auth middleware
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+// Configurable auth state per test
+let mockAuth = {
+  userId: "user_test123",
+  orgId: "org_test456",
+  appId: "distribute-frontend",
+  authType: "user_key" as "user_key" | "app_key",
+};
+
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.userId = "user_test123";
-    req.orgId = "org_test456";
-    req.appId = "distribute-frontend";
-    req.authType = "user_key";
+    req.userId = mockAuth.userId;
+    req.orgId = mockAuth.orgId;
+    req.appId = mockAuth.appId;
+    req.authType = mockAuth.authType;
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -22,14 +37,6 @@ vi.mock("../../src/middleware/auth.js", () => ({
   AuthenticatedRequest: {},
 }));
 
-interface FetchCall {
-  url: string;
-  method?: string;
-  body?: any;
-}
-
-let fetchCalls: FetchCall[] = [];
-
 import keysRoutes from "../../src/routes/keys.js";
 
 function createApp() {
@@ -39,32 +46,42 @@ function createApp() {
   return app;
 }
 
-describe("POST /v1/keys — unified proxy", () => {
-  let app: express.Express;
-
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    fetchCalls = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      fetchCalls.push({ url, method: init?.method, body });
-      return {
-        ok: true,
-        json: () => Promise.resolve({ provider: "stripe", maskedKey: "sk_l...abc", message: "stripe key saved successfully" }),
-      };
-    });
-    app = createApp();
+function mockFetch() {
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    fetchCalls.push({ url, method: init?.method, body });
+    return {
+      ok: true,
+      json: () => Promise.resolve({ provider: "stripe", maskedKey: "sk_l...abc", message: "key saved" }),
+    };
   });
+}
 
-  it("should forward org keys to POST /keys with orgId", async () => {
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fetchCalls = [];
+  mockAuth = {
+    userId: "user_test123",
+    orgId: "org_test456",
+    appId: "distribute-frontend",
+    authType: "user_key",
+  };
+  mockFetch();
+});
+
+// -----------------------------------------------------------------------
+// POST /v1/keys
+// -----------------------------------------------------------------------
+
+describe("POST /v1/keys — user_key auth", () => {
+  it("should forward org keys with orgId", async () => {
+    const app = createApp();
     const res = await request(app)
       .post("/v1/keys")
       .send({ keySource: "org", provider: "stripe", apiKey: "sk_live_test" });
 
     expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys") && c.method === "POST");
-    expect(call).toBeDefined();
+    const call = fetchCalls.find((c) => c.method === "POST");
     expect(call!.body).toEqual({
       keySource: "org",
       provider: "stripe",
@@ -73,15 +90,43 @@ describe("POST /v1/keys — unified proxy", () => {
     });
   });
 
-  it("should forward app keys to POST /keys with appId", async () => {
+  it("should reject keySource 'app' from user_key auth", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "app", provider: "anthropic", apiKey: "sk-ant-test" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("app key authentication");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should reject keySource 'platform' — Zod validation rejects it", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "platform", provider: "gemini", apiKey: "gemini-key" });
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("POST /v1/keys — app_key auth", () => {
+  beforeEach(() => {
+    mockAuth.authType = "app_key";
+    mockAuth.orgId = "";
+    mockAuth.userId = "";
+  });
+
+  it("should forward app keys with appId", async () => {
+    const app = createApp();
     const res = await request(app)
       .post("/v1/keys")
       .send({ keySource: "app", provider: "anthropic", apiKey: "sk-ant-test" });
 
     expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys") && c.method === "POST");
-    expect(call).toBeDefined();
+    const call = fetchCalls.find((c) => c.method === "POST");
     expect(call!.body).toEqual({
       keySource: "app",
       provider: "anthropic",
@@ -90,142 +135,134 @@ describe("POST /v1/keys — unified proxy", () => {
     });
   });
 
-  it("should forward platform keys to POST /keys without orgId/appId", async () => {
+  it("should forward org keys when app_key has org context", async () => {
+    mockAuth.orgId = "org_test456";
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "org", provider: "stripe", apiKey: "sk_live_test" });
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.method === "POST");
+    expect(call!.body.keySource).toBe("org");
+    expect(call!.body.orgId).toBe("org_test456");
+  });
+
+  it("should reject org keys when app_key has no org context", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/keys")
+      .send({ keySource: "org", provider: "stripe", apiKey: "sk_live_test" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Organization context required");
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should reject keySource 'platform'", async () => {
+    const app = createApp();
     const res = await request(app)
       .post("/v1/keys")
       .send({ keySource: "platform", provider: "gemini", apiKey: "gemini-key" });
 
-    expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys") && c.method === "POST");
-    expect(call).toBeDefined();
-    expect(call!.body).toEqual({
-      keySource: "platform",
-      provider: "gemini",
-      apiKey: "gemini-key",
-    });
-  });
-
-  it("should reject invalid keySource", async () => {
-    const res = await request(app)
-      .post("/v1/keys")
-      .send({ keySource: "bogus", provider: "stripe", apiKey: "sk_live_test" });
-
     expect(res.status).toBe(400);
-  });
-
-  it("should reject missing provider", async () => {
-    const res = await request(app)
-      .post("/v1/keys")
-      .send({ keySource: "org", apiKey: "sk_live_test" });
-
-    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
   });
 });
 
-describe("GET /v1/keys — unified proxy", () => {
-  let app: express.Express;
+// -----------------------------------------------------------------------
+// GET /v1/keys
+// -----------------------------------------------------------------------
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    fetchCalls = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      fetchCalls.push({ url, method: init?.method });
-      return {
-        ok: true,
-        json: () => Promise.resolve({ keys: [{ provider: "stripe", maskedKey: "sk_l...abc" }] }),
-      };
-    });
-    app = createApp();
-  });
-
-  it("should default keySource to org and include orgId", async () => {
+describe("GET /v1/keys — authorization", () => {
+  it("should default to org and include orgId (user_key)", async () => {
+    const app = createApp();
     const res = await request(app).get("/v1/keys");
 
     expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys"));
-    expect(call).toBeDefined();
-    expect(call!.url).toContain("keySource=org");
-    expect(call!.url).toContain("orgId=org_test456");
+    const call = fetchCalls[0];
+    expect(call.url).toContain("keySource=org");
+    expect(call.url).toContain("orgId=org_test456");
   });
 
-  it("should forward keySource=app with appId", async () => {
+  it("should reject keySource=app from user_key", async () => {
+    const app = createApp();
+    const res = await request(app).get("/v1/keys?keySource=app");
+
+    expect(res.status).toBe(403);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should reject keySource=platform", async () => {
+    const app = createApp();
+    const res = await request(app).get("/v1/keys?keySource=platform");
+
+    expect(res.status).toBe(403);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should allow keySource=app from app_key", async () => {
+    mockAuth.authType = "app_key";
+    const app = createApp();
     const res = await request(app).get("/v1/keys?keySource=app");
 
     expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys"));
-    expect(call).toBeDefined();
-    expect(call!.url).toContain("keySource=app");
-    expect(call!.url).toContain("appId=distribute-frontend");
-  });
-
-  it("should forward keySource=platform without orgId/appId", async () => {
-    const res = await request(app).get("/v1/keys?keySource=platform");
-
-    expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys"));
-    expect(call).toBeDefined();
-    expect(call!.url).toContain("keySource=platform");
-    expect(call!.url).not.toContain("orgId");
-    expect(call!.url).not.toContain("appId");
+    const call = fetchCalls[0];
+    expect(call.url).toContain("keySource=app");
+    expect(call.url).toContain("appId=distribute-frontend");
   });
 });
 
-describe("DELETE /v1/keys/:provider — unified proxy", () => {
-  let app: express.Express;
+// -----------------------------------------------------------------------
+// DELETE /v1/keys/:provider
+// -----------------------------------------------------------------------
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    fetchCalls = [];
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      fetchCalls.push({ url, method: init?.method });
-      return {
-        ok: true,
-        json: () => Promise.resolve({ message: "Key deleted" }),
-      };
-    });
-    app = createApp();
-  });
-
-  it("should default keySource to org and include orgId", async () => {
+describe("DELETE /v1/keys/:provider — authorization", () => {
+  it("should default to org and include orgId", async () => {
+    const app = createApp();
     const res = await request(app).delete("/v1/keys/stripe");
 
     expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys/stripe") && c.method === "DELETE");
-    expect(call).toBeDefined();
+    const call = fetchCalls.find((c) => c.method === "DELETE");
     expect(call!.url).toContain("keySource=org");
     expect(call!.url).toContain("orgId=org_test456");
   });
 
-  it("should forward keySource=app with appId", async () => {
+  it("should reject keySource=app from user_key", async () => {
+    const app = createApp();
+    const res = await request(app).delete("/v1/keys/stripe?keySource=app");
+
+    expect(res.status).toBe(403);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should reject keySource=platform", async () => {
+    const app = createApp();
+    const res = await request(app).delete("/v1/keys/stripe?keySource=platform");
+
+    expect(res.status).toBe(403);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should allow keySource=app from app_key", async () => {
+    mockAuth.authType = "app_key";
+    const app = createApp();
     const res = await request(app).delete("/v1/keys/anthropic?keySource=app");
 
     expect(res.status).toBe(200);
-
-    const call = fetchCalls.find((c) => c.url.includes("/keys/anthropic") && c.method === "DELETE");
-    expect(call).toBeDefined();
+    const call = fetchCalls.find((c) => c.method === "DELETE");
     expect(call!.url).toContain("keySource=app");
     expect(call!.url).toContain("appId=distribute-frontend");
   });
 });
 
+// -----------------------------------------------------------------------
+// Decrypt proxy removal
+// -----------------------------------------------------------------------
+
 describe("Decrypt proxy removal", () => {
-  let app: express.Express;
-
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: true,
-      json: () => Promise.resolve({}),
-    }));
-    app = createApp();
-  });
-
   it("should not expose /internal/keys/:provider/decrypt", async () => {
+    const app = createApp();
     const res = await request(app).get("/v1/internal/keys/stripe/decrypt?orgId=org_test456");
     expect(res.status).toBe(404);
   });


### PR DESCRIPTION
## Summary
- **Security fix**: the public `/v1/keys` endpoints accepted `keySource: "platform"`, allowing any authenticated user to overwrite platform-wide API keys
- Adds `validateKeySourceAccess()` guard that enforces authorization rules on all three routes (GET, POST, DELETE):
  - `"platform"` → always blocked (403) — platform keys are only registered via `startup.ts` which calls key-service directly
  - `"app"` → requires `authType === "app_key"` — user keys cannot manage app-level keys
  - `"org"` → requires org context from auth
- Removes `"platform"` from `UpsertKeyRequestSchema` so Zod rejects it at validation time

## Test plan
- [x] 35 key-related tests pass, including 16 authorization boundary tests
- [x] Tests verify: user_key blocked from app/platform, app_key blocked from platform, platform blocked for all
- [x] Full suite: 372/373 pass (1 pre-existing failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)