### PR TITLE
fix: stop sending X-API-Key to /validate

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -95,6 +95,10 @@ export async function authenticate(
 
 /**
  * Validate API key against key-service /validate
+ *
+ * Uses fetch directly (not callExternalService) because:
+ * 1. /validate uses bearerAuth only — no service header needed
+ * 2. 401 responses are expected (invalid keys) and should not log stack traces
  */
 async function validateKey(apiKey: string): Promise<{
   type: "app" | "user";
@@ -102,23 +106,32 @@ async function validateKey(apiKey: string): Promise<{
   orgId?: string;
   userId?: string;
 } | null> {
+  const url = `${externalServices.key.url}/validate`;
+
   try {
-    const result = await callExternalService<{
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+
+    if (response.status === 401) return null;
+
+    if (!response.ok) {
+      console.error(`[auth] key-service /validate error: ${response.status}`);
+      return null;
+    }
+
+    const result = await response.json() as {
       valid: boolean;
       type: "app" | "user";
       appId?: string;
       orgId?: string;
       userId?: string;
-    }>(
-      externalServices.key,
-      "/validate",
-      { headers: { Authorization: `Bearer ${apiKey}` } }
-    );
+    };
 
     if (!result.valid) return null;
     return result;
   } catch (error) {
-    console.error("API key validation error:", error);
+    console.error("[auth] key-service /validate unreachable:", (error as Error).message);
     return null;
   }
 }

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -3,7 +3,11 @@ import express from "express";
 import request from "supertest";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../../src/middleware/auth.js";
 
-// Mock the service-client module
+// Mock fetch for validateKey (calls key-service /validate directly)
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Mock callExternalService for resolveExternalIds (calls client-service /resolve)
 vi.mock("../../src/lib/service-client.js", () => {
   const mockCallExternalService = vi.fn();
   return {
@@ -17,6 +21,24 @@ vi.mock("../../src/lib/service-client.js", () => {
 
 import { callExternalService } from "../../src/lib/service-client.js";
 const mockCall = vi.mocked(callExternalService);
+
+/** Helper: mock a successful key-service /validate response */
+function mockValidateSuccess(result: Record<string, unknown>) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(result),
+  });
+}
+
+/** Helper: mock a 401 from key-service /validate (invalid key) */
+function mockValidateUnauthorized() {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status: 401,
+    json: () => Promise.resolve({ error: "Invalid API key" }),
+  });
+}
 
 function createApp() {
   const app = express();
@@ -50,9 +72,9 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should resolve external IDs to internal UUIDs via client-service", async () => {
-    // key-service validates the app key
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
-    // client-service resolves external IDs
+    // key-service validates the app key (via fetch)
+    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
+    // client-service resolves external IDs (via callExternalService)
     mockCall.mockResolvedValueOnce({
       orgId: "org-uuid-123",
       userId: "user-uuid-456",
@@ -73,10 +95,16 @@ describe("Auth middleware — app key with identity headers", () => {
       authType: "app_key",
     });
 
+    // Verify fetch was called for /validate (no X-API-Key header)
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://key-service/validate",
+      { headers: { Authorization: "Bearer mcpf_app_test123" } },
+    );
+
     // Verify client-service was called with correct body
-    expect(mockCall).toHaveBeenCalledTimes(2);
-    expect(mockCall).toHaveBeenNthCalledWith(
-      2,
+    expect(mockCall).toHaveBeenCalledTimes(1);
+    expect(mockCall).toHaveBeenCalledWith(
       expect.objectContaining({ url: "http://client-service" }),
       "/resolve",
       {
@@ -91,8 +119,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 400 from requireOrg when identity headers are missing", async () => {
-    // key-service validates the app key
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
+    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
 
     const res = await request(app)
       .get("/v1/workflows")
@@ -104,7 +131,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 502 when client-service resolution fails", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
+    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
     mockCall.mockRejectedValueOnce(new Error("Connection refused"));
 
     const res = await request(app)
@@ -118,7 +145,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 502 when client-service returns empty orgId", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
+    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
     mockCall.mockResolvedValueOnce({ orgId: null, userId: null });
 
     const res = await request(app)
@@ -132,7 +159,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should allow /v1/me without identity headers for app keys", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
+    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
 
     const res = await request(app)
       .get("/v1/me")
@@ -143,7 +170,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 400 when only x-org-id is provided without x-user-id", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
+    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
 
     const res = await request(app)
       .get("/v1/workflows")
@@ -165,7 +192,7 @@ describe("Auth middleware — user key", () => {
   });
 
   it("should set appId, orgId, userId from key-service without client-service call", async () => {
-    mockCall.mockResolvedValueOnce({
+    mockValidateSuccess({
       valid: true,
       type: "user",
       appId: "distribute-frontend",
@@ -180,12 +207,13 @@ describe("Auth middleware — user key", () => {
     expect(res.status).toBe(200);
     expect(res.body.orgId).toBe("org-uuid-direct");
     expect(res.body.authType).toBe("user_key");
-    // Only one call (key validation), no client-service call
-    expect(mockCall).toHaveBeenCalledTimes(1);
+    // Only fetch for validation, no callExternalService for client-service
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockCall).toHaveBeenCalledTimes(0);
   });
 
   it("should pass requireOrg and requireUser when user key carries full identity", async () => {
-    mockCall.mockResolvedValueOnce({
+    mockValidateSuccess({
       valid: true,
       type: "user",
       appId: "distribute-frontend",
@@ -203,7 +231,8 @@ describe("Auth middleware — user key", () => {
       userId: "user-uuid-direct",
       authType: "user_key",
     });
-    expect(mockCall).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockCall).toHaveBeenCalledTimes(0);
   });
 });
 
@@ -221,8 +250,8 @@ describe("Auth middleware — error cases", () => {
     expect(res.body.error).toBe("Missing authentication");
   });
 
-  it("should return 401 when key-service rejects the key", async () => {
-    mockCall.mockResolvedValueOnce({ valid: false });
+  it("should return 401 when key-service returns valid:false", async () => {
+    mockValidateSuccess({ valid: false });
 
     const res = await request(app)
       .get("/v1/me")
@@ -230,5 +259,19 @@ describe("Auth middleware — error cases", () => {
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("Invalid API key");
+  });
+
+  it("should return 401 when key-service returns 401 (no stack trace logged)", async () => {
+    mockValidateUnauthorized();
+
+    const res = await request(app)
+      .get("/v1/me")
+      .set("Authorization", "Bearer mcpf_invalid");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid API key");
+    // Fetch was called but no callExternalService (no stack trace from throw)
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockCall).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -24,16 +24,22 @@ describe("Auth middleware — Bearer key authentication", () => {
 });
 
 describe("Auth middleware — key-service validation", () => {
-  it("should validate keys via key-service /validate", () => {
-    expect(content).toContain('"/validate"');
-    expect(content).toContain("callExternalService");
-    expect(content).toContain("externalServices.key");
+  it("should validate keys via key-service /validate using fetch directly", () => {
+    expect(content).toContain("/validate");
+    expect(content).toContain("externalServices.key.url");
+    // Uses fetch directly (not callExternalService) so /validate
+    // only gets bearerAuth, no X-API-Key service header
+    expect(content).toContain("await fetch(url");
   });
 
   it("should distinguish app keys from user keys", () => {
     expect(content).toContain('"app"');
     expect(content).toContain('"user"');
     expect(content).toContain("validation.type");
+  });
+
+  it("should handle 401 from key-service gracefully without logging stack traces", () => {
+    expect(content).toContain("response.status === 401");
   });
 });
 


### PR DESCRIPTION
## Summary
- **Root cause**: `callExternalService` always sends `X-API-Key` header, but key-service `/validate` only uses `bearerAuth`. The spurious header caused "Invalid API key" errors and noisy stack traces in prod logs.
- `validateKey` now uses `fetch` directly — only sends `Authorization: Bearer` (matching the key-service OpenAPI spec), handles 401 silently (expected for invalid keys), and only logs actual errors (5xx/network).
- Updated integration and static tests to match the new approach.

## Test plan
- [x] `auth-middleware.test.ts` — 11 tests pass (validates app key flow, user key flow, error cases, and that `/validate` receives no `X-API-Key`)
- [x] `auth.test.ts` — 22 tests pass (static assertions on auth middleware implementation)
- [x] Full test suite passes (397/397, 2 pre-existing failures in unrelated `brand-delivery-stats` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)