### PR TITLE
fix: migrate /validate to X-API-Key auth with ?key= query param

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -96,9 +96,7 @@ export async function authenticate(
 /**
  * Validate API key against key-service /validate
  *
- * Uses fetch directly (not callExternalService) because:
- * 1. /validate uses bearerAuth only — no service header needed
- * 2. 401 responses are expected (invalid keys) and should not log stack traces
+ * Uses callExternalService (X-API-Key auth) with the key passed as ?key= query param.
  */
 async function validateKey(apiKey: string): Promise<{
   type: "app" | "user";
@@ -106,32 +104,22 @@ async function validateKey(apiKey: string): Promise<{
   orgId?: string;
   userId?: string;
 } | null> {
-  const url = `${externalServices.key.url}/validate`;
-
   try {
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-    });
-
-    if (response.status === 401) return null;
-
-    if (!response.ok) {
-      console.error(`[auth] key-service /validate error: ${response.status}`);
-      return null;
-    }
-
-    const result = await response.json() as {
+    const result = await callExternalService<{
       valid: boolean;
       type: "app" | "user";
       appId?: string;
       orgId?: string;
       userId?: string;
-    };
+    }>(
+      externalServices.key,
+      `/validate?key=${encodeURIComponent(apiKey)}`,
+    );
 
     if (!result.valid) return null;
     return result;
   } catch (error) {
-    console.error("[auth] key-service /validate unreachable:", (error as Error).message);
+    console.error("[auth] key-service /validate error:", (error as Error).message);
     return null;
   }
 }

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -3,17 +3,13 @@ import express from "express";
 import request from "supertest";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../../src/middleware/auth.js";
 
-// Mock fetch for validateKey (calls key-service /validate directly)
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
-
-// Mock callExternalService for resolveExternalIds (calls client-service /resolve)
+// Mock callExternalService for both key-service /validate and client-service /resolve
 vi.mock("../../src/lib/service-client.js", () => {
   const mockCallExternalService = vi.fn();
   return {
     callExternalService: mockCallExternalService,
     externalServices: {
-      key: { url: "http://key-service", apiKey: "test" },
+      key: { url: "http://key-service", apiKey: "test-service-key" },
       client: { url: "http://client-service", apiKey: "test" },
     },
   };
@@ -21,24 +17,6 @@ vi.mock("../../src/lib/service-client.js", () => {
 
 import { callExternalService } from "../../src/lib/service-client.js";
 const mockCall = vi.mocked(callExternalService);
-
-/** Helper: mock a successful key-service /validate response */
-function mockValidateSuccess(result: Record<string, unknown>) {
-  mockFetch.mockResolvedValueOnce({
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve(result),
-  });
-}
-
-/** Helper: mock a 401 from key-service /validate (invalid key) */
-function mockValidateUnauthorized() {
-  mockFetch.mockResolvedValueOnce({
-    ok: false,
-    status: 401,
-    json: () => Promise.resolve({ error: "Invalid API key" }),
-  });
-}
 
 function createApp() {
   const app = express();
@@ -72,9 +50,11 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should resolve external IDs to internal UUIDs via client-service", async () => {
-    // key-service validates the app key (via fetch)
-    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
-    // client-service resolves external IDs (via callExternalService)
+    // First call: key-service /validate (via callExternalService)
+    mockCall.mockResolvedValueOnce({
+      valid: true, type: "app", appId: "test-app",
+    });
+    // Second call: client-service /resolve (via callExternalService)
     mockCall.mockResolvedValueOnce({
       orgId: "org-uuid-123",
       userId: "user-uuid-456",
@@ -95,16 +75,17 @@ describe("Auth middleware — app key with identity headers", () => {
       authType: "app_key",
     });
 
-    // Verify fetch was called for /validate (no X-API-Key header)
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledWith(
-      "http://key-service/validate",
-      { headers: { Authorization: "Bearer mcpf_app_test123" } },
+    // Verify callExternalService was called for /validate with ?key= query param
+    expect(mockCall).toHaveBeenCalledTimes(2);
+    expect(mockCall).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ url: "http://key-service" }),
+      "/validate?key=mcpf_app_test123",
     );
 
     // Verify client-service was called with correct body
-    expect(mockCall).toHaveBeenCalledTimes(1);
-    expect(mockCall).toHaveBeenCalledWith(
+    expect(mockCall).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({ url: "http://client-service" }),
       "/resolve",
       {
@@ -119,7 +100,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 400 from requireOrg when identity headers are missing", async () => {
-    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
+    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
 
     const res = await request(app)
       .get("/v1/workflows")
@@ -131,7 +112,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 502 when client-service resolution fails", async () => {
-    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
+    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
     mockCall.mockRejectedValueOnce(new Error("Connection refused"));
 
     const res = await request(app)
@@ -145,7 +126,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 502 when client-service returns empty orgId", async () => {
-    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
+    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
     mockCall.mockResolvedValueOnce({ orgId: null, userId: null });
 
     const res = await request(app)
@@ -159,7 +140,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should allow /v1/me without identity headers for app keys", async () => {
-    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
+    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
 
     const res = await request(app)
       .get("/v1/me")
@@ -170,7 +151,7 @@ describe("Auth middleware — app key with identity headers", () => {
   });
 
   it("should return 400 when only x-org-id is provided without x-user-id", async () => {
-    mockValidateSuccess({ valid: true, type: "app", appId: "test-app" });
+    mockCall.mockResolvedValueOnce({ valid: true, type: "app", appId: "test-app" });
 
     const res = await request(app)
       .get("/v1/workflows")
@@ -192,7 +173,7 @@ describe("Auth middleware — user key", () => {
   });
 
   it("should set appId, orgId, userId from key-service without client-service call", async () => {
-    mockValidateSuccess({
+    mockCall.mockResolvedValueOnce({
       valid: true,
       type: "user",
       appId: "distribute-frontend",
@@ -207,13 +188,12 @@ describe("Auth middleware — user key", () => {
     expect(res.status).toBe(200);
     expect(res.body.orgId).toBe("org-uuid-direct");
     expect(res.body.authType).toBe("user_key");
-    // Only fetch for validation, no callExternalService for client-service
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockCall).toHaveBeenCalledTimes(0);
+    // Only one callExternalService call for /validate, none for /resolve
+    expect(mockCall).toHaveBeenCalledTimes(1);
   });
 
   it("should pass requireOrg and requireUser when user key carries full identity", async () => {
-    mockValidateSuccess({
+    mockCall.mockResolvedValueOnce({
       valid: true,
       type: "user",
       appId: "distribute-frontend",
@@ -231,8 +211,7 @@ describe("Auth middleware — user key", () => {
       userId: "user-uuid-direct",
       authType: "user_key",
     });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockCall).toHaveBeenCalledTimes(0);
+    expect(mockCall).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -251,7 +230,7 @@ describe("Auth middleware — error cases", () => {
   });
 
   it("should return 401 when key-service returns valid:false", async () => {
-    mockValidateSuccess({ valid: false });
+    mockCall.mockResolvedValueOnce({ valid: false });
 
     const res = await request(app)
       .get("/v1/me")
@@ -261,8 +240,8 @@ describe("Auth middleware — error cases", () => {
     expect(res.body.error).toBe("Invalid API key");
   });
 
-  it("should return 401 when key-service returns 401 (no stack trace logged)", async () => {
-    mockValidateUnauthorized();
+  it("should return 401 when key-service call fails", async () => {
+    mockCall.mockRejectedValueOnce(new Error("Service call failed: 401"));
 
     const res = await request(app)
       .get("/v1/me")
@@ -270,8 +249,7 @@ describe("Auth middleware — error cases", () => {
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("Invalid API key");
-    // Fetch was called but no callExternalService (no stack trace from throw)
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockCall).not.toHaveBeenCalled();
+    // Only one callExternalService call for /validate
+    expect(mockCall).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -11,11 +11,6 @@ describe("Auth middleware — Bearer key authentication", () => {
     expect(content).toContain('startsWith("Bearer ")');
   });
 
-  it("should not support X-API-Key header authentication", () => {
-    expect(content).not.toContain('"x-api-key"');
-    expect(content).not.toContain("X-API-Key");
-  });
-
   it("should not use Clerk JWT verification", () => {
     expect(content).not.toContain("verifyToken");
     expect(content).not.toContain("@clerk/backend");
@@ -24,22 +19,21 @@ describe("Auth middleware — Bearer key authentication", () => {
 });
 
 describe("Auth middleware — key-service validation", () => {
-  it("should validate keys via key-service /validate using fetch directly", () => {
+  it("should validate keys via key-service /validate using callExternalService", () => {
     expect(content).toContain("/validate");
-    expect(content).toContain("externalServices.key.url");
-    // Uses fetch directly (not callExternalService) so /validate
-    // only gets bearerAuth, no X-API-Key service header
-    expect(content).toContain("await fetch(url");
+    expect(content).toContain("externalServices.key");
+    expect(content).toContain("callExternalService");
+  });
+
+  it("should pass the API key as a query parameter", () => {
+    expect(content).toContain("?key=");
+    expect(content).toContain("encodeURIComponent(apiKey)");
   });
 
   it("should distinguish app keys from user keys", () => {
     expect(content).toContain('"app"');
     expect(content).toContain('"user"');
     expect(content).toContain("validation.type");
-  });
-
-  it("should handle 401 from key-service gracefully without logging stack traces", () => {
-    expect(content).toContain("response.status === 401");
   });
 });
 


### PR DESCRIPTION
## Summary
- key-service dropped Bearer auth on `/validate` (PR #22 merged). Now uses `X-API-Key` + `?key=` query param like all other endpoints.
- Replaced raw `fetch` workaround in `validateKey` with `callExternalService`, which automatically sends the `X-API-Key` header.
- Updated all auth tests to match the new calling convention.

## Test plan
- [x] `auth.test.ts` — static assertions updated (32 tests pass)
- [x] `auth-middleware.test.ts` — functional tests updated, mock `callExternalService` for both key-service and client-service
- [x] Full test suite passes (396/397 — 1 pre-existing failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)