### PR TITLE
revert: undo app-level Stripe key registration

### DIFF
--- a/src/routes/stripe.ts
+++ b/src/routes/stripe.ts
@@ -8,7 +8,6 @@ import {
   CreateStripeCheckoutRequestSchema,
   StripeStatsRequestSchema,
 } from "../schemas.js";
-import { API_SERVICE_APP_ID } from "../startup.js";
 
 const router = Router();
 
@@ -26,7 +25,7 @@ router.get("/stripe/products/:productId", authenticate, async (req: Authenticate
     const { productId } = req.params;
     const result = await callExternalService(
       externalServices.stripe,
-      `/products/${encodeURIComponent(productId)}?appId=${encodeURIComponent(API_SERVICE_APP_ID)}`,
+      `/products/${encodeURIComponent(productId)}?appId=${encodeURIComponent(req.appId!)}`,
     );
     res.json(result);
   } catch (error: any) {
@@ -52,7 +51,7 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
       "/products/create",
       {
         method: "POST",
-        body: { appId: API_SERVICE_APP_ID, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
+        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
       }
     );
     res.json(result);
@@ -76,7 +75,7 @@ router.get("/stripe/products/:productId/prices", authenticate, async (req: Authe
     const { productId } = req.params;
     const result = await callExternalService(
       externalServices.stripe,
-      `/prices/by-product/${encodeURIComponent(productId)}?appId=${encodeURIComponent(API_SERVICE_APP_ID)}`,
+      `/prices/by-product/${encodeURIComponent(productId)}?appId=${encodeURIComponent(req.appId!)}`,
     );
     res.json(result);
   } catch (error: any) {
@@ -102,7 +101,7 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
       "/prices/create",
       {
         method: "POST",
-        body: { appId: API_SERVICE_APP_ID, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
+        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
       }
     );
     res.json(result);
@@ -126,7 +125,7 @@ router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedR
     const { couponId } = req.params;
     const result = await callExternalService(
       externalServices.stripe,
-      `/coupons/${encodeURIComponent(couponId)}?appId=${encodeURIComponent(API_SERVICE_APP_ID)}`,
+      `/coupons/${encodeURIComponent(couponId)}?appId=${encodeURIComponent(req.appId!)}`,
     );
     res.json(result);
   } catch (error: any) {
@@ -152,7 +151,7 @@ router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, r
       "/coupons/create",
       {
         method: "POST",
-        body: { appId: API_SERVICE_APP_ID, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
+        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
       }
     );
     res.json(result);
@@ -183,7 +182,7 @@ router.post("/stripe/checkout", authenticate, requireOrg, async (req: Authentica
       "/checkout/create",
       {
         method: "POST",
-        body: { appId: API_SERVICE_APP_ID, orgId: req.orgId, userId: req.userId, ...parsed.data },
+        body: { appId: req.appId, orgId: req.orgId, userId: req.userId, ...parsed.data },
       }
     );
     res.json(result);
@@ -214,7 +213,7 @@ router.post("/stripe/stats", authenticate, requireOrg, async (req: Authenticated
       "/stats",
       {
         method: "POST",
-        body: { appId: API_SERVICE_APP_ID, orgId: req.orgId, ...parsed.data },
+        body: { appId: req.appId, orgId: req.orgId, ...parsed.data },
       }
     );
     res.json(result);

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,7 +1,5 @@
 import { callExternalService, externalServices } from "./lib/service-client.js";
 
-export const API_SERVICE_APP_ID = "api-service";
-
 const PLATFORM_KEYS: { provider: string; envVar: string }[] = [
   { provider: "anthropic", envVar: "ANTHROPIC_API_KEY" },
   { provider: "apollo", envVar: "APOLLO_API_KEY" },
@@ -9,21 +7,15 @@ const PLATFORM_KEYS: { provider: string; envVar: string }[] = [
   { provider: "firecrawl", envVar: "FIRECRAWL_API_KEY" },
   { provider: "gemini", envVar: "GEMINI_API_KEY" },
   { provider: "postmark", envVar: "POSTMARK_API_KEY" },
-];
-
-/** Keys registered as app-level keys so downstream services can resolve them by appId */
-const APP_KEYS: { provider: string; envVar: string }[] = [
   { provider: "stripe", envVar: "STRIPE_SECRET_KEY" },
   { provider: "stripe-webhook", envVar: "STRIPE_WEBHOOK_SECRET" },
 ];
-
-const ALL_KEYS = [...PLATFORM_KEYS, ...APP_KEYS];
 
 export async function registerPlatformKeys(): Promise<void> {
   console.log("[api-service] Registering platform keys with key-service...");
 
   // Crash on missing env vars — all keys are required
-  const missing = ALL_KEYS.filter(({ envVar }) => !process.env[envVar]);
+  const missing = PLATFORM_KEYS.filter(({ envVar }) => !process.env[envVar]);
   if (missing.length > 0) {
     const names = missing.map(({ envVar }) => envVar).join(", ");
     throw new Error(`Missing required env vars: ${names}`);
@@ -38,14 +30,5 @@ export async function registerPlatformKeys(): Promise<void> {
     console.log(`[api-service] Platform key registered: ${provider}`);
   }
 
-  for (const { provider, envVar } of APP_KEYS) {
-    const apiKey = process.env[envVar]!;
-    await callExternalService(externalServices.key, "/internal/app-keys", {
-      method: "POST",
-      body: { appId: API_SERVICE_APP_ID, provider, apiKey },
-    });
-    console.log(`[api-service] App key registered: ${provider}`);
-  }
-
-  console.log(`[api-service] ${ALL_KEYS.length}/${ALL_KEYS.length} keys registered successfully`);
+  console.log(`[api-service] ${PLATFORM_KEYS.length}/${PLATFORM_KEYS.length} platform keys registered successfully`);
 }

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -12,7 +12,7 @@ vi.mock("@distribute/runs-client", () => ({
   getRunsBatch: vi.fn().mockResolvedValue(new Map()),
 }));
 
-import { registerPlatformKeys, API_SERVICE_APP_ID } from "../../src/startup.js";
+import { registerPlatformKeys } from "../../src/startup.js";
 
 function setAllEnvVars() {
   process.env.ANTHROPIC_API_KEY = "sk-ant-test";
@@ -55,13 +55,6 @@ describe("registerPlatformKeys", () => {
         });
       }
 
-      if (url.includes("/internal/app-keys") && body?.appId) {
-        return new Response(JSON.stringify({ provider: body?.provider, maskedKey: "sk-...xxx", message: "App key saved" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-
       return new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } });
     });
   });
@@ -70,39 +63,27 @@ describe("registerPlatformKeys", () => {
     process.env = { ...originalEnv };
   });
 
-  it("should register platform keys without appId and stripe keys as app keys", async () => {
+  it("should register all platform keys without appId", async () => {
     setAllEnvVars();
 
     await registerPlatformKeys();
 
-    // Platform keys — registered via POST /keys with keySource: "platform"
-    const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/keys") && !c.url.includes("/internal/") && c.body?.keySource === "platform");
-    expect(platformKeyCalls).toHaveLength(6);
+    const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/keys") && c.body?.keySource === "platform");
+    expect(platformKeyCalls).toHaveLength(8);
 
-    const platformProviders = platformKeyCalls.map((c) => c.body?.provider);
-    expect(platformProviders).toContain("anthropic");
-    expect(platformProviders).toContain("apollo");
-    expect(platformProviders).toContain("instantly");
-    expect(platformProviders).toContain("firecrawl");
-    expect(platformProviders).toContain("gemini");
-    expect(platformProviders).toContain("postmark");
+    const providers = platformKeyCalls.map((c) => c.body?.provider);
+    expect(providers).toContain("anthropic");
+    expect(providers).toContain("apollo");
+    expect(providers).toContain("instantly");
+    expect(providers).toContain("firecrawl");
+    expect(providers).toContain("gemini");
+    expect(providers).toContain("postmark");
+    expect(providers).toContain("stripe");
+    expect(providers).toContain("stripe-webhook");
 
     for (const call of platformKeyCalls) {
       expect(call.body).toHaveProperty("keySource", "platform");
       expect(call.body).not.toHaveProperty("appId");
-    }
-
-    // App keys — registered via POST /internal/app-keys with appId
-    const appKeyCalls = fetchCalls.filter((c) => c.url.includes("/internal/app-keys"));
-    expect(appKeyCalls).toHaveLength(2);
-
-    const appProviders = appKeyCalls.map((c) => c.body?.provider);
-    expect(appProviders).toContain("stripe");
-    expect(appProviders).toContain("stripe-webhook");
-
-    for (const call of appKeyCalls) {
-      expect(call.body).toHaveProperty("appId", API_SERVICE_APP_ID);
-      expect(call.body).not.toHaveProperty("keySource");
     }
   });
 
@@ -111,14 +92,14 @@ describe("registerPlatformKeys", () => {
     await expect(registerPlatformKeys()).rejects.toThrow("Missing required env vars");
   });
 
-  it("should throw when key-service returns an error for platform keys", async () => {
+  it("should throw when key-service returns an error", async () => {
     setAllEnvVars();
 
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
-      if (url.includes("/keys")) {
+      if (url.includes("/keys") && body?.keySource === "platform") {
         return new Response(JSON.stringify({ error: "Service unavailable" }), {
           status: 503,
           headers: { "Content-Type": "application/json" },

--- a/tests/unit/stripe-proxy.test.ts
+++ b/tests/unit/stripe-proxy.test.ts
@@ -76,7 +76,7 @@ describe("GET /v1/stripe/products/:productId", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call).toBeDefined();
-    expect(call!.url).toContain("appId=api-service");
+    expect(call!.url).toContain("appId=distribute-frontend");
   });
 });
 
@@ -101,7 +101,7 @@ describe("POST /v1/stripe/products", () => {
     expect(call).toBeDefined();
     expect(call!.method).toBe("POST");
     expect(call!.body).toMatchObject({
-      appId: "api-service",
+      appId: "distribute-frontend",
       orgId: "org_test456",
       name: "Course",
       description: "Online course",
@@ -136,7 +136,7 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/by-product/prod_123"));
     expect(call).toBeDefined();
-    expect(call!.url).toContain("appId=api-service");
+    expect(call!.url).toContain("appId=distribute-frontend");
   });
 });
 
@@ -159,7 +159,7 @@ describe("POST /v1/stripe/prices", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/create"));
     expect(call!.body).toMatchObject({
-      appId: "api-service",
+      appId: "distribute-frontend",
       productId: "prod_123",
       unitAmountCents: 4999,
     });
@@ -195,7 +195,7 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/WELCOME20"));
     expect(call).toBeDefined();
-    expect(call!.url).toContain("appId=api-service");
+    expect(call!.url).toContain("appId=distribute-frontend");
   });
 });
 
@@ -218,7 +218,7 @@ describe("POST /v1/stripe/coupons", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/create"));
     expect(call!.body).toMatchObject({
-      appId: "api-service",
+      appId: "distribute-frontend",
       percentOff: 20,
       duration: "once",
     });
@@ -262,7 +262,7 @@ describe("POST /v1/stripe/checkout", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/checkout/create"));
     expect(call!.body).toMatchObject({
-      appId: "api-service",
+      appId: "distribute-frontend",
       orgId: "org_test456",
       userId: "user_test123",
       lineItems: [{ priceId: "price_123", quantity: 1 }],
@@ -304,7 +304,7 @@ describe("POST /v1/stripe/stats", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/stats"));
     expect(call!.body).toMatchObject({
-      appId: "api-service",
+      appId: "distribute-frontend",
       orgId: "org_test456",
       brandId: "brand_abc",
     });
@@ -343,7 +343,7 @@ describe("Stripe catalog endpoints — app key without org context", () => {
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/products/create"));
-    expect(call!.body.appId).toBe("api-service");
+    expect(call!.body.appId).toBe("distribute-frontend");
     expect(call!.body.orgId).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- Reverts #44 — api-service should NOT register app-level keys on behalf of other apps
- The real fix belongs in `distribute-frontend`: it needs to register its own Stripe key via `POST /internal/app-keys` at startup
- api-service's role is only to register platform-level keys

## Test plan
- [x] Revert is clean, restores original behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)