### PR TITLE
fix: pass orgId to stripe-service for org-level Stripe key resolution

### DIFF
--- a/src/routes/stripe.ts
+++ b/src/routes/stripe.ts
@@ -18,14 +18,16 @@ const router = Router();
 /**
  * GET /v1/stripe/products/:productId
  * Retrieve a Stripe product by ID.
- * Only needs appId (to resolve Stripe key) — no org context required.
+ * Passes orgId when available so stripe-service can resolve org-level Stripe keys.
  */
 router.get("/stripe/products/:productId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
+    const qs = new URLSearchParams({ appId: req.appId! });
+    if (req.orgId) qs.set("orgId", req.orgId);
     const result = await callExternalService(
       externalServices.stripe,
-      `/products/${encodeURIComponent(productId)}?appId=${encodeURIComponent(req.appId!)}`,
+      `/products/${encodeURIComponent(productId)}?${qs}`,
     );
     res.json(result);
   } catch (error: any) {
@@ -68,14 +70,16 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
 /**
  * GET /v1/stripe/products/:productId/prices
  * List active prices for a Stripe product.
- * Only needs appId — no org context required.
+ * Passes orgId when available so stripe-service can resolve org-level Stripe keys.
  */
 router.get("/stripe/products/:productId/prices", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
+    const qs = new URLSearchParams({ appId: req.appId! });
+    if (req.orgId) qs.set("orgId", req.orgId);
     const result = await callExternalService(
       externalServices.stripe,
-      `/prices/by-product/${encodeURIComponent(productId)}?appId=${encodeURIComponent(req.appId!)}`,
+      `/prices/by-product/${encodeURIComponent(productId)}?${qs}`,
     );
     res.json(result);
   } catch (error: any) {
@@ -118,14 +122,16 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
 /**
  * GET /v1/stripe/coupons/:couponId
  * Retrieve a Stripe coupon by ID.
- * Only needs appId — no org context required.
+ * Passes orgId when available so stripe-service can resolve org-level Stripe keys.
  */
 router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { couponId } = req.params;
+    const qs = new URLSearchParams({ appId: req.appId! });
+    if (req.orgId) qs.set("orgId", req.orgId);
     const result = await callExternalService(
       externalServices.stripe,
-      `/coupons/${encodeURIComponent(couponId)}?appId=${encodeURIComponent(req.appId!)}`,
+      `/coupons/${encodeURIComponent(couponId)}?${qs}`,
     );
     res.json(result);
   } catch (error: any) {

--- a/tests/unit/stripe-proxy.test.ts
+++ b/tests/unit/stripe-proxy.test.ts
@@ -68,7 +68,7 @@ describe("GET /v1/stripe/products/:productId", () => {
     app = createApp();
   });
 
-  it("should proxy to stripe-service with appId query param", async () => {
+  it("should proxy to stripe-service with appId and orgId query params", async () => {
     const res = await request(app).get("/v1/stripe/products/prod_123");
 
     expect(res.status).toBe(200);
@@ -77,6 +77,7 @@ describe("GET /v1/stripe/products/:productId", () => {
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
+    expect(call!.url).toContain("orgId=org_test456");
   });
 });
 
@@ -128,7 +129,7 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
     app = createApp();
   });
 
-  it("should proxy to stripe-service prices endpoint", async () => {
+  it("should proxy to stripe-service prices endpoint with orgId", async () => {
     const res = await request(app).get("/v1/stripe/products/prod_123/prices");
 
     expect(res.status).toBe(200);
@@ -137,6 +138,7 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
     const call = fetchCalls.find((c) => c.url.includes("/prices/by-product/prod_123"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
+    expect(call!.url).toContain("orgId=org_test456");
   });
 });
 
@@ -187,7 +189,7 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
     app = createApp();
   });
 
-  it("should proxy to stripe-service coupons endpoint", async () => {
+  it("should proxy to stripe-service coupons endpoint with orgId", async () => {
     const res = await request(app).get("/v1/stripe/coupons/WELCOME20");
 
     expect(res.status).toBe(200);
@@ -196,6 +198,7 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
     const call = fetchCalls.find((c) => c.url.includes("/coupons/WELCOME20"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
+    expect(call!.url).toContain("orgId=org_test456");
   });
 });
 
@@ -331,9 +334,13 @@ describe("Stripe catalog endpoints — app key without org context", () => {
     appKeyApp = createApp();
   });
 
-  it("GET /v1/stripe/products/:id should work without org context", async () => {
+  it("GET /v1/stripe/products/:id should work without org context and omit orgId", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123");
     expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
+    expect(call!.url).toContain("appId=distribute-frontend");
+    expect(call!.url).not.toContain("orgId");
   });
 
   it("POST /v1/stripe/products should work without org context", async () => {
@@ -347,9 +354,13 @@ describe("Stripe catalog endpoints — app key without org context", () => {
     expect(call!.body.orgId).toBeUndefined();
   });
 
-  it("GET /v1/stripe/products/:id/prices should work without org context", async () => {
+  it("GET /v1/stripe/products/:id/prices should work without org context and omit orgId", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123/prices");
     expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/prices/by-product/prod_123"));
+    expect(call!.url).toContain("appId=distribute-frontend");
+    expect(call!.url).not.toContain("orgId");
   });
 
   it("POST /v1/stripe/prices should work without org context", async () => {
@@ -362,9 +373,13 @@ describe("Stripe catalog endpoints — app key without org context", () => {
     expect(call!.body.orgId).toBeUndefined();
   });
 
-  it("GET /v1/stripe/coupons/:id should work without org context", async () => {
+  it("GET /v1/stripe/coupons/:id should work without org context and omit orgId", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/coupons/WELCOME20");
     expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/coupons/WELCOME20"));
+    expect(call!.url).toContain("appId=distribute-frontend");
+    expect(call!.url).not.toContain("orgId");
   });
 
   it("POST /v1/stripe/coupons should work without org context", async () => {


### PR DESCRIPTION
## Summary
- GET catalog routes (products, prices, coupons) now pass `orgId` as a query parameter to stripe-service when org context is available
- This allows stripe-service to resolve org-level Stripe keys (e.g. PolarityCourse's own Stripe key) instead of only looking for app-level keys via `appId=distribute-frontend`
- When no org context is present (app key without headers), behavior is unchanged — only `appId` is passed

## Test plan
- [x] All 22 stripe-proxy tests pass (with org context: orgId included; without: orgId omitted)
- [ ] Verify PolarityCourse checkout flow works end-to-end after stripe-service picks up orgId for key resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)