### PR TITLE
fix: resolve keySource for Stripe proxy routes

### DIFF
--- a/src/routes/stripe.ts
+++ b/src/routes/stripe.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
+import { fetchKeySource } from "../lib/billing.js";
 import {
   CreateStripeProductRequestSchema,
   CreateStripePriceRequestSchema,
@@ -18,13 +19,18 @@ const router = Router();
 /**
  * GET /v1/stripe/products/:productId
  * Retrieve a Stripe product by ID.
- * Passes orgId when available so stripe-service can resolve org-level Stripe keys.
+ * Resolves keySource when org context is present so stripe-service uses
+ * the correct key (org-level BYOK vs platform).
  */
 router.get("/stripe/products/:productId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) qs.set("orgId", req.orgId);
+    if (req.orgId) {
+      const keySource = await fetchKeySource(req.orgId, req.appId!);
+      qs.set("orgId", req.orgId);
+      qs.set("keySource", keySource);
+    }
     const result = await callExternalService(
       externalServices.stripe,
       `/products/${encodeURIComponent(productId)}?${qs}`,
@@ -39,7 +45,7 @@ router.get("/stripe/products/:productId", authenticate, async (req: Authenticate
 /**
  * POST /v1/stripe/products
  * Create a Stripe product.
- * Only needs appId — orgId forwarded when available for tracking.
+ * Resolves keySource when org context is available.
  */
 router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
@@ -48,12 +54,19 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
+    const keySource = req.orgId ? await fetchKeySource(req.orgId, req.appId!) : undefined;
+
     const result = await callExternalService(
       externalServices.stripe,
       "/products/create",
       {
         method: "POST",
-        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
+        body: {
+          appId: req.appId,
+          ...(req.orgId && { orgId: req.orgId }),
+          ...(keySource && { keySource }),
+          ...parsed.data,
+        },
       }
     );
     res.json(result);
@@ -70,13 +83,17 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
 /**
  * GET /v1/stripe/products/:productId/prices
  * List active prices for a Stripe product.
- * Passes orgId when available so stripe-service can resolve org-level Stripe keys.
+ * Resolves keySource when org context is present.
  */
 router.get("/stripe/products/:productId/prices", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) qs.set("orgId", req.orgId);
+    if (req.orgId) {
+      const keySource = await fetchKeySource(req.orgId, req.appId!);
+      qs.set("orgId", req.orgId);
+      qs.set("keySource", keySource);
+    }
     const result = await callExternalService(
       externalServices.stripe,
       `/prices/by-product/${encodeURIComponent(productId)}?${qs}`,
@@ -91,7 +108,7 @@ router.get("/stripe/products/:productId/prices", authenticate, async (req: Authe
 /**
  * POST /v1/stripe/prices
  * Create a Stripe price.
- * Only needs appId — orgId forwarded when available for tracking.
+ * Resolves keySource when org context is available.
  */
 router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
@@ -100,12 +117,19 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
+    const keySource = req.orgId ? await fetchKeySource(req.orgId, req.appId!) : undefined;
+
     const result = await callExternalService(
       externalServices.stripe,
       "/prices/create",
       {
         method: "POST",
-        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
+        body: {
+          appId: req.appId,
+          ...(req.orgId && { orgId: req.orgId }),
+          ...(keySource && { keySource }),
+          ...parsed.data,
+        },
       }
     );
     res.json(result);
@@ -122,13 +146,17 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
 /**
  * GET /v1/stripe/coupons/:couponId
  * Retrieve a Stripe coupon by ID.
- * Passes orgId when available so stripe-service can resolve org-level Stripe keys.
+ * Resolves keySource when org context is present.
  */
 router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { couponId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) qs.set("orgId", req.orgId);
+    if (req.orgId) {
+      const keySource = await fetchKeySource(req.orgId, req.appId!);
+      qs.set("orgId", req.orgId);
+      qs.set("keySource", keySource);
+    }
     const result = await callExternalService(
       externalServices.stripe,
       `/coupons/${encodeURIComponent(couponId)}?${qs}`,
@@ -143,7 +171,7 @@ router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedR
 /**
  * POST /v1/stripe/coupons
  * Create a Stripe coupon.
- * Only needs appId — orgId forwarded when available for tracking.
+ * Resolves keySource when org context is available.
  */
 router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
@@ -152,12 +180,19 @@ router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, r
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
+    const keySource = req.orgId ? await fetchKeySource(req.orgId, req.appId!) : undefined;
+
     const result = await callExternalService(
       externalServices.stripe,
       "/coupons/create",
       {
         method: "POST",
-        body: { appId: req.appId, ...(req.orgId && { orgId: req.orgId }), ...parsed.data },
+        body: {
+          appId: req.appId,
+          ...(req.orgId && { orgId: req.orgId }),
+          ...(keySource && { keySource }),
+          ...parsed.data,
+        },
       }
     );
     res.json(result);
@@ -183,12 +218,14 @@ router.post("/stripe/checkout", authenticate, requireOrg, async (req: Authentica
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
+    const keySource = await fetchKeySource(req.orgId!, req.appId!);
+
     const result = await callExternalService(
       externalServices.stripe,
       "/checkout/create",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, userId: req.userId, ...parsed.data },
+        body: { appId: req.appId, orgId: req.orgId, userId: req.userId, keySource, ...parsed.data },
       }
     );
     res.json(result);
@@ -214,12 +251,14 @@ router.post("/stripe/stats", authenticate, requireOrg, async (req: Authenticated
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
+    const keySource = await fetchKeySource(req.orgId!, req.appId!);
+
     const result = await callExternalService(
       externalServices.stripe,
       "/stats",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, ...parsed.data },
+        body: { appId: req.appId, orgId: req.orgId, keySource, ...parsed.data },
       }
     );
     res.json(result);

--- a/tests/unit/stripe-proxy.test.ts
+++ b/tests/unit/stripe-proxy.test.ts
@@ -24,6 +24,11 @@ vi.mock("../../src/middleware/auth.js", () => ({
   AuthenticatedRequest: {},
 }));
 
+const mockFetchKeySource = vi.fn().mockResolvedValue("byok");
+vi.mock("../../src/lib/billing.js", () => ({
+  fetchKeySource: (...args: unknown[]) => mockFetchKeySource(...args),
+}));
+
 interface FetchCall {
   url: string;
   method?: string;
@@ -63,21 +68,25 @@ describe("GET /v1/stripe/products/:productId", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "prod_123", name: "Webinar Access" });
     app = createApp();
   });
 
-  it("should proxy to stripe-service with appId and orgId query params", async () => {
+  it("should proxy to stripe-service with appId, orgId, and keySource query params", async () => {
     const res = await request(app).get("/v1/stripe/products/prod_123");
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe("Webinar Access");
 
+    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute-frontend");
+
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).toContain("orgId=org_test456");
+    expect(call!.url).toContain("keySource=byok");
   });
 });
 
@@ -86,12 +95,13 @@ describe("POST /v1/stripe/products", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "prod_new", name: "Course" });
     app = createApp();
   });
 
-  it("should forward product creation with appId and orgId", async () => {
+  it("should forward product creation with appId, orgId, and keySource", async () => {
     const res = await request(app)
       .post("/v1/stripe/products")
       .send({ name: "Course", description: "Online course" });
@@ -104,6 +114,7 @@ describe("POST /v1/stripe/products", () => {
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
       orgId: "org_test456",
+      keySource: "byok",
       name: "Course",
       description: "Online course",
     });
@@ -124,12 +135,13 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ prices: [{ id: "price_123", unitAmount: 4999 }] });
     app = createApp();
   });
 
-  it("should proxy to stripe-service prices endpoint with orgId", async () => {
+  it("should proxy to stripe-service prices endpoint with orgId and keySource", async () => {
     const res = await request(app).get("/v1/stripe/products/prod_123/prices");
 
     expect(res.status).toBe(200);
@@ -139,6 +151,7 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).toContain("orgId=org_test456");
+    expect(call!.url).toContain("keySource=byok");
   });
 });
 
@@ -147,12 +160,13 @@ describe("POST /v1/stripe/prices", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "price_new" });
     app = createApp();
   });
 
-  it("should forward price creation with required fields", async () => {
+  it("should forward price creation with keySource", async () => {
     const res = await request(app)
       .post("/v1/stripe/prices")
       .send({ productId: "prod_123", unitAmountCents: 4999, currency: "usd" });
@@ -162,6 +176,7 @@ describe("POST /v1/stripe/prices", () => {
     const call = fetchCalls.find((c) => c.url.includes("/prices/create"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
+      keySource: "byok",
       productId: "prod_123",
       unitAmountCents: 4999,
     });
@@ -184,12 +199,13 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "WELCOME20", percentOff: 20 });
     app = createApp();
   });
 
-  it("should proxy to stripe-service coupons endpoint with orgId", async () => {
+  it("should proxy to stripe-service coupons endpoint with orgId and keySource", async () => {
     const res = await request(app).get("/v1/stripe/coupons/WELCOME20");
 
     expect(res.status).toBe(200);
@@ -199,6 +215,7 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).toContain("orgId=org_test456");
+    expect(call!.url).toContain("keySource=byok");
   });
 });
 
@@ -207,12 +224,13 @@ describe("POST /v1/stripe/coupons", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "WELCOME20" });
     app = createApp();
   });
 
-  it("should forward coupon creation", async () => {
+  it("should forward coupon creation with keySource", async () => {
     const res = await request(app)
       .post("/v1/stripe/coupons")
       .send({ percentOff: 20, duration: "once" });
@@ -222,6 +240,7 @@ describe("POST /v1/stripe/coupons", () => {
     const call = fetchCalls.find((c) => c.url.includes("/coupons/create"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
+      keySource: "byok",
       percentOff: 20,
       duration: "once",
     });
@@ -244,12 +263,13 @@ describe("POST /v1/stripe/checkout", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ url: "https://checkout.stripe.com/session_123", sessionId: "cs_123" });
     app = createApp();
   });
 
-  it("should forward checkout session creation with identity fields", async () => {
+  it("should forward checkout session creation with identity fields and keySource", async () => {
     const res = await request(app)
       .post("/v1/stripe/checkout")
       .send({
@@ -263,16 +283,35 @@ describe("POST /v1/stripe/checkout", () => {
     expect(res.status).toBe(200);
     expect(res.body.url).toContain("checkout.stripe.com");
 
+    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute-frontend");
+
     const call = fetchCalls.find((c) => c.url.includes("/checkout/create"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
       orgId: "org_test456",
       userId: "user_test123",
+      keySource: "byok",
       lineItems: [{ priceId: "price_123", quantity: 1 }],
       successUrl: "https://polarity.com/success",
       cancelUrl: "https://polarity.com/cancel",
       customerEmail: "user@polarity.com",
     });
+  });
+
+  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
+    mockFetchKeySource.mockResolvedValue("platform");
+    const res = await request(app)
+      .post("/v1/stripe/checkout")
+      .send({
+        lineItems: [{ priceId: "price_123", quantity: 1 }],
+        mode: "payment",
+        successUrl: "https://polarity.com/success",
+        cancelUrl: "https://polarity.com/cancel",
+      });
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.url.includes("/checkout/create"));
+    expect(call!.body.keySource).toBe("platform");
   });
 
   it("should return 400 when lineItems is missing", async () => {
@@ -292,12 +331,13 @@ describe("POST /v1/stripe/stats", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ totalRevenue: 12500, totalOrders: 5 });
     app = createApp();
   });
 
-  it("should forward stats request with identity", async () => {
+  it("should forward stats request with identity and keySource", async () => {
     const res = await request(app)
       .post("/v1/stripe/stats")
       .send({ brandId: "brand_abc" });
@@ -305,12 +345,23 @@ describe("POST /v1/stripe/stats", () => {
     expect(res.status).toBe(200);
     expect(res.body.totalRevenue).toBe(12500);
 
+    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute-frontend");
+
     const call = fetchCalls.find((c) => c.url.includes("/stats"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
       orgId: "org_test456",
+      keySource: "byok",
       brandId: "brand_abc",
     });
+  });
+
+  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
+    mockFetchKeySource.mockResolvedValue("platform");
+    await request(app).post("/v1/stripe/stats").send({});
+
+    const call = fetchCalls.find((c) => c.url.includes("/stats"));
+    expect(call!.body.keySource).toBe("platform");
   });
 
   it("should allow empty body for unfiltered stats", async () => {
@@ -328,22 +379,25 @@ describe("Stripe catalog endpoints — app key without org context", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockReset().mockResolvedValue("byok");
     // Simulate app key with NO org/user context
     mockAuthContext = { appId: "distribute-frontend", orgId: undefined, userId: undefined, authType: "app_key" };
     mockFetchOk({ id: "prod_123", name: "Webinar Access" });
     appKeyApp = createApp();
   });
 
-  it("GET /v1/stripe/products/:id should work without org context and omit orgId", async () => {
+  it("GET /v1/stripe/products/:id should work without org context and omit orgId/keySource", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123");
     expect(res.status).toBe(200);
+    expect(mockFetchKeySource).not.toHaveBeenCalled();
 
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).not.toContain("orgId");
+    expect(call!.url).not.toContain("keySource");
   });
 
-  it("POST /v1/stripe/products should work without org context", async () => {
+  it("POST /v1/stripe/products should work without org context (no keySource)", async () => {
     const res = await request(appKeyApp)
       .post("/v1/stripe/products")
       .send({ name: "Course" });
@@ -352,18 +406,20 @@ describe("Stripe catalog endpoints — app key without org context", () => {
     const call = fetchCalls.find((c) => c.url.includes("/products/create"));
     expect(call!.body.appId).toBe("distribute-frontend");
     expect(call!.body.orgId).toBeUndefined();
+    expect(call!.body.keySource).toBeUndefined();
   });
 
-  it("GET /v1/stripe/products/:id/prices should work without org context and omit orgId", async () => {
+  it("GET /v1/stripe/products/:id/prices should work without org context and omit orgId/keySource", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123/prices");
     expect(res.status).toBe(200);
+    expect(mockFetchKeySource).not.toHaveBeenCalled();
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/by-product/prod_123"));
-    expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).not.toContain("orgId");
+    expect(call!.url).not.toContain("keySource");
   });
 
-  it("POST /v1/stripe/prices should work without org context", async () => {
+  it("POST /v1/stripe/prices should work without org context (no keySource)", async () => {
     const res = await request(appKeyApp)
       .post("/v1/stripe/prices")
       .send({ productId: "prod_123", unitAmountCents: 4999, currency: "usd" });
@@ -371,18 +427,20 @@ describe("Stripe catalog endpoints — app key without org context", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/create"));
     expect(call!.body.orgId).toBeUndefined();
+    expect(call!.body.keySource).toBeUndefined();
   });
 
-  it("GET /v1/stripe/coupons/:id should work without org context and omit orgId", async () => {
+  it("GET /v1/stripe/coupons/:id should work without org context and omit orgId/keySource", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/coupons/WELCOME20");
     expect(res.status).toBe(200);
+    expect(mockFetchKeySource).not.toHaveBeenCalled();
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/WELCOME20"));
-    expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).not.toContain("orgId");
+    expect(call!.url).not.toContain("keySource");
   });
 
-  it("POST /v1/stripe/coupons should work without org context", async () => {
+  it("POST /v1/stripe/coupons should work without org context (no keySource)", async () => {
     const res = await request(appKeyApp)
       .post("/v1/stripe/coupons")
       .send({ percentOff: 20, duration: "once" });
@@ -390,6 +448,7 @@ describe("Stripe catalog endpoints — app key without org context", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/create"));
     expect(call!.body.orgId).toBeUndefined();
+    expect(call!.body.keySource).toBeUndefined();
   });
 
   it("POST /v1/stripe/checkout should return 400 without org context", async () => {
@@ -420,6 +479,7 @@ describe("Stripe proxy — error handling", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: false,


### PR DESCRIPTION
## Summary
- Adds `fetchKeySource()` calls to all Stripe proxy routes, matching the pattern already used by campaigns, workflows, brand, leads, and qualify
- Without `keySource`, stripe-service defaults to app-level key lookup — fails for BYOK clients (e.g. PolarityCourse) who register Stripe keys at org level
- Builds on #46 which added `orgId` forwarding; this adds the missing `keySource` resolution from billing-service
- Catalog endpoints (products/prices/coupons) resolve keySource only when org context is present, preserving app-key-only flows

## Test plan
- [x] All 24 stripe-proxy tests pass (added keySource assertions + platform/byok toggle tests)
- [x] All 10 keysource-forwarding tests still pass
- [x] Pre-existing failures in brand-delivery-stats and sales-outreach-cost-source are unrelated (confirmed on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)