### PR TITLE
docs: simplify API docs — org-first auth flow

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "distribute API",
-    "description": "API Gateway for distribute. Handles authentication, proxies to internal services, and exposes the public REST API.\n\n## Authentication\n\nAll authenticated endpoints require a Bearer token in the `Authorization` header.\n\nThere are two key types, each with different identity resolution behavior:\n\n### 1. User key (`distrib.usr_*`)\n\nIssued per-user via `POST /v1/api-keys`. The key already carries the user's internal org UUID — no extra headers needed.\n\n```\nAuthorization: Bearer distrib.usr_abc123...\n```\n\n### 2. App key (`distrib.app_*`)\n\nIssued when an app registers via `POST /v1/apps/register`. The key identifies the **app**, not a user or org. To access endpoints that require org/user context (campaigns, keys, activity, etc.), you must also send two identity headers:\n\n| Header | Description | Example |\n|--------|-------------|---------|\n| `x-org-id` | External organization ID (e.g. Clerk org ID) | `org_2xyz...` |\n| `x-user-id` | External user ID (e.g. Clerk user ID) | `user_2abc...` |\n\n```\nAuthorization: Bearer distrib.app_abc123...\nx-org-id: org_2xyzABC\nx-user-id: user_2abcDEF\n```\n\nThe API service resolves these external IDs to internal UUIDs via `client-service`. Both headers are **optional** — if omitted, the request proceeds without org/user context, which is fine for endpoints that only need app-level auth (e.g. `GET /v1/me`). But endpoints that require org context (e.g. `GET /v1/campaigns`) will return `400 Organization context required`.\n\n### Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Org context required but `x-org-id` header not provided (app key only) |\n| 401 | User identity required but `x-user-id` header not provided (app key only) |\n| 502 | Identity resolution failed (client-service unreachable) |\n",
+    "description": "API Gateway for distribute.\n\n## Quick Start\n\n1. Create an API key in the distribute dashboard, or via `POST /v1/api-keys`\n2. Use it as a Bearer token — that's it, no extra headers needed\n\n```\nAuthorization: Bearer distrib.usr_abc123...\n```\n\nYour key carries your org and user identity. All endpoints work out of the box.\n\n## Storing provider keys (BYOK)\n\nTo store your own provider API keys (e.g. OpenAI, Anthropic) for use in workflows:\n\n```\nPOST /v1/keys\nAuthorization: Bearer distrib.usr_abc123...\n\n{ \"keySource\": \"org\", \"provider\": \"openai\", \"apiKey\": \"sk-...\" }\n```\n\n## Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Organization context required (missing `x-org-id` — app key only) |\n| 502 | Identity resolution failed (internal service unreachable) |\n\n## Advanced: Platform integration\n\n> Most users do not need this section. It is for multi-tenant platforms that manage keys on behalf of multiple organizations.\n\nIf you're building a platform that operates across multiple orgs/users, register via `POST /v1/apps/register` to receive an app key (`distrib.app_*`). App keys identify the **platform**, not a user or org. To access org-scoped endpoints, send identity headers:\n\n```\nAuthorization: Bearer distrib.app_abc123...\nx-org-id: org_2xyzABC\nx-user-id: user_2abcDEF\n```\n\nThe API resolves these external IDs (e.g. Clerk IDs) to internal UUIDs via client-service. Both headers are **optional** — omit them for endpoints that only need app-level auth.\n",
     "version": "1.0.0"
   },
   "servers": [
@@ -16,8 +16,12 @@
       "description": "Health check and debug endpoints"
     },
     {
-      "name": "Apps",
-      "description": "App registration"
+      "name": "Authentication",
+      "description": "Create and manage your API keys"
+    },
+    {
+      "name": "Keys",
+      "description": "Store and manage provider API keys (BYOK)"
     },
     {
       "name": "Performance",
@@ -30,14 +34,6 @@
     {
       "name": "Campaigns",
       "description": "Campaign management"
-    },
-    {
-      "name": "Keys",
-      "description": "BYOK key management"
-    },
-    {
-      "name": "API Keys",
-      "description": "API key management"
     },
     {
       "name": "Leads",
@@ -62,6 +58,10 @@
     {
       "name": "Billing",
       "description": "Billing, credits, and checkout"
+    },
+    {
+      "name": "Platform",
+      "description": "Multi-tenant platform registration (advanced)"
     }
   ],
   "components": {
@@ -69,7 +69,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Bearer token authentication. Two key types are supported:\n\n- **User key** (`distrib.usr_*`): carries app, org, and user context. No extra headers needed. Recommended for API/MCP access.\n- **App key** (`distrib.app_*`): identifies the app only (server-to-server). To access endpoints that require org/user context, also send `x-org-id` and `x-user-id` headers with your external IDs (e.g. Clerk IDs). The API resolves them to internal UUIDs via client-service.\n\nSee the top-level API description for full details and examples."
+        "description": "Bearer token authentication.\n\nUse an API key (`distrib.usr_*`) as your Bearer token. Create one via `POST /v1/api-keys` or in the dashboard.\n\nFor multi-tenant platforms: app keys (`distrib.app_*`) are also supported — see the Platform section in the API description."
       }
     },
     "schemas": {
@@ -407,7 +407,7 @@
               "org",
               "app"
             ],
-            "description": "Key store: 'org' (org-level, user-provided) or 'app' (app-level, requires app key auth)"
+            "description": "Key scope. Use 'org' to store keys for your organization. 'app' is for multi-tenant platforms only (requires app key auth)"
           },
           "provider": {
             "type": "string",
@@ -1623,10 +1623,10 @@
     "/v1/apps/register": {
       "post": {
         "tags": [
-          "Apps"
+          "Platform"
         ],
-        "summary": "Register an app",
-        "description": "Register a new app and receive an API key. Idempotent: returns existing appId if already registered. The API key is only shown on first creation.",
+        "summary": "Register a platform app",
+        "description": "Register a multi-tenant platform app and receive an app key. Not needed for standard API access — use `POST /v1/api-keys` instead to create an API key. Idempotent: returns existing appId if already registered. The app key is only shown on first creation.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2591,7 +2591,7 @@
           "Keys"
         ],
         "summary": "List provider keys",
-        "description": "List provider keys. Pass keySource query param to select the key store (org or app). Defaults to 'org'.",
+        "description": "List stored provider keys (masked). Defaults to org-level keys.",
         "security": [
           {
             "bearerAuth": []
@@ -2605,10 +2605,10 @@
                 "org",
                 "app"
               ],
-              "description": "Key store to list from (default: 'org')"
+              "description": "Key scope (default: 'org'). Use 'app' only for multi-tenant platforms"
             },
             "required": false,
-            "description": "Key store to list from (default: 'org')",
+            "description": "Key scope (default: 'org'). Use 'app' only for multi-tenant platforms",
             "name": "keySource",
             "in": "query"
           },
@@ -2662,7 +2662,7 @@
           "Keys"
         ],
         "summary": "Upsert a provider key",
-        "description": "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys (requires org context), 'app' for app-level keys (requires app key auth).",
+        "description": "Store or update a provider API key (e.g. OpenAI, Anthropic). Most users should use keySource: 'org'. The 'app' key source is reserved for multi-tenant platforms managing keys on behalf of their users.",
         "security": [
           {
             "bearerAuth": []
@@ -2740,7 +2740,7 @@
           "Keys"
         ],
         "summary": "Delete a provider key",
-        "description": "Remove a provider key. Pass keySource query param to select the key store (default: 'org').",
+        "description": "Remove a stored provider key. Defaults to org-level keys.",
         "security": [
           {
             "bearerAuth": []
@@ -2764,10 +2764,10 @@
                 "org",
                 "app"
               ],
-              "description": "Key store (default: 'org')"
+              "description": "Key scope (default: 'org'). Use 'app' only for multi-tenant platforms"
             },
             "required": false,
-            "description": "Key store (default: 'org')",
+            "description": "Key scope (default: 'org'). Use 'app' only for multi-tenant platforms",
             "name": "keySource",
             "in": "query"
           },
@@ -2820,7 +2820,7 @@
     "/v1/api-keys": {
       "get": {
         "tags": [
-          "API Keys"
+          "Authentication"
         ],
         "summary": "List API keys",
         "description": "List all API keys for the organization",
@@ -2877,10 +2877,10 @@
       },
       "post": {
         "tags": [
-          "API Keys"
+          "Authentication"
         ],
         "summary": "Create an API key",
-        "description": "Generate a new permanent API key for the organization",
+        "description": "Create a new API key for your organization. This is the recommended way to authenticate with the API.",
         "security": [
           {
             "bearerAuth": []
@@ -2945,7 +2945,7 @@
     "/v1/api-keys/{id}": {
       "delete": {
         "tags": [
-          "API Keys"
+          "Authentication"
         ],
         "summary": "Revoke an API key",
         "description": "Delete/revoke an API key by ID",
@@ -3014,7 +3014,7 @@
     "/v1/api-keys/session": {
       "post": {
         "tags": [
-          "API Keys"
+          "Authentication"
         ],
         "summary": "Get or create session API key",
         "description": "Get or create a short-lived session API key for Foxy chat integration",

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -14,30 +14,43 @@ const document = generator.generateDocument({
   openapi: "3.0.0",
   info: {
     title: "distribute API",
-    description: `API Gateway for distribute. Handles authentication, proxies to internal services, and exposes the public REST API.
+    description: `API Gateway for distribute.
 
-## Authentication
+## Quick Start
 
-All authenticated endpoints require a Bearer token in the \`Authorization\` header.
-
-There are two key types, each with different identity resolution behavior:
-
-### 1. User key (\`distrib.usr_*\`)
-
-Issued per-user via \`POST /v1/api-keys\`. The key already carries the user's internal org UUID — no extra headers needed.
+1. Create an API key in the distribute dashboard, or via \`POST /v1/api-keys\`
+2. Use it as a Bearer token — that's it, no extra headers needed
 
 \`\`\`
 Authorization: Bearer distrib.usr_abc123...
 \`\`\`
 
-### 2. App key (\`distrib.app_*\`)
+Your key carries your org and user identity. All endpoints work out of the box.
 
-Issued when an app registers via \`POST /v1/apps/register\`. The key identifies the **app**, not a user or org. To access endpoints that require org/user context (campaigns, keys, activity, etc.), you must also send two identity headers:
+## Storing provider keys (BYOK)
 
-| Header | Description | Example |
-|--------|-------------|---------|
-| \`x-org-id\` | External organization ID (e.g. Clerk org ID) | \`org_2xyz...\` |
-| \`x-user-id\` | External user ID (e.g. Clerk user ID) | \`user_2abc...\` |
+To store your own provider API keys (e.g. OpenAI, Anthropic) for use in workflows:
+
+\`\`\`
+POST /v1/keys
+Authorization: Bearer distrib.usr_abc123...
+
+{ "keySource": "org", "provider": "openai", "apiKey": "sk-..." }
+\`\`\`
+
+## Error codes
+
+| Code | Meaning |
+|------|---------|
+| 401 | Missing or invalid Bearer token |
+| 400 | Organization context required (missing \`x-org-id\` — app key only) |
+| 502 | Identity resolution failed (internal service unreachable) |
+
+## Advanced: Platform integration
+
+> Most users do not need this section. It is for multi-tenant platforms that manage keys on behalf of multiple organizations.
+
+If you're building a platform that operates across multiple orgs/users, register via \`POST /v1/apps/register\` to receive an app key (\`distrib.app_*\`). App keys identify the **platform**, not a user or org. To access org-scoped endpoints, send identity headers:
 
 \`\`\`
 Authorization: Bearer distrib.app_abc123...
@@ -45,16 +58,7 @@ x-org-id: org_2xyzABC
 x-user-id: user_2abcDEF
 \`\`\`
 
-The API service resolves these external IDs to internal UUIDs via \`client-service\`. Both headers are **optional** — if omitted, the request proceeds without org/user context, which is fine for endpoints that only need app-level auth (e.g. \`GET /v1/me\`). But endpoints that require org context (e.g. \`GET /v1/campaigns\`) will return \`400 Organization context required\`.
-
-### Error codes
-
-| Code | Meaning |
-|------|---------|
-| 401 | Missing or invalid Bearer token |
-| 400 | Org context required but \`x-org-id\` header not provided (app key only) |
-| 401 | User identity required but \`x-user-id\` header not provided (app key only) |
-| 502 | Identity resolution failed (client-service unreachable) |
+The API resolves these external IDs (e.g. Clerk IDs) to internal UUIDs via client-service. Both headers are **optional** — omit them for endpoints that only need app-level auth.
 `,
     version: "1.0.0",
   },
@@ -65,18 +69,24 @@ The API service resolves these external IDs to internal UUIDs via \`client-servi
   ],
   tags: [
     { name: "Health", description: "Health check and debug endpoints" },
-    { name: "Apps", description: "App registration" },
+    { name: "Authentication", description: "Create and manage your API keys" },
+    {
+      name: "Keys",
+      description: "Store and manage provider API keys (BYOK)",
+    },
     { name: "Performance", description: "Public performance leaderboard" },
     { name: "User", description: "Current user information" },
     { name: "Campaigns", description: "Campaign management" },
-    { name: "Keys", description: "BYOK key management" },
-    { name: "API Keys", description: "API key management" },
     { name: "Leads", description: "Lead search" },
     { name: "Qualify", description: "Email reply qualification" },
     { name: "Brand", description: "Brand scraping and management" },
     { name: "Activity", description: "User activity tracking" },
     { name: "Chat", description: "AI chat with SSE streaming" },
     { name: "Billing", description: "Billing, credits, and checkout" },
+    {
+      name: "Platform",
+      description: "Multi-tenant platform registration (advanced)",
+    },
   ],
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -14,13 +14,11 @@ registry.registerComponent("securitySchemes", "bearerAuth", {
   type: "http",
   scheme: "bearer",
   description:
-    "Bearer token authentication. Two key types are supported:\n\n" +
-    "- **User key** (`distrib.usr_*`): carries app, org, and user context. No extra headers needed. " +
-    "Recommended for API/MCP access.\n" +
-    "- **App key** (`distrib.app_*`): identifies the app only (server-to-server). To access endpoints " +
-    "that require org/user context, also send `x-org-id` and `x-user-id` headers with your external IDs " +
-    "(e.g. Clerk IDs). The API resolves them to internal UUIDs via client-service.\n\n" +
-    "See the top-level API description for full details and examples.",
+    "Bearer token authentication.\n\n" +
+    "Use an API key (`distrib.usr_*`) as your Bearer token. " +
+    "Create one via `POST /v1/api-keys` or in the dashboard.\n\n" +
+    "For multi-tenant platforms: app keys (`distrib.app_*`) are also supported — " +
+    "see the Platform section in the API description.",
 });
 
 const authed: Record<string, string[]>[] = [{ bearerAuth: [] }];
@@ -140,10 +138,10 @@ export const RegisterAppResponseSchema = z
 registry.registerPath({
   method: "post",
   path: "/v1/apps/register",
-  tags: ["Apps"],
-  summary: "Register an app",
+  tags: ["Platform"],
+  summary: "Register a platform app",
   description:
-    "Register a new app and receive an API key. Idempotent: returns existing appId if already registered. The API key is only shown on first creation.",
+    "Register a multi-tenant platform app and receive an app key. Not needed for standard API access — use `POST /v1/api-keys` instead to create an API key. Idempotent: returns existing appId if already registered. The app key is only shown on first creation.",
   request: {
     body: {
       content: { "application/json": { schema: RegisterAppRequestSchema } },
@@ -481,7 +479,7 @@ export const UpsertKeyRequestSchema = z
   .object({
     keySource: z
       .enum(["org", "app"])
-      .describe("Key store: 'org' (org-level, user-provided) or 'app' (app-level, requires app key auth)"),
+      .describe("Key scope. Use 'org' to store keys for your organization. 'app' is for multi-tenant platforms only (requires app key auth)"),
     provider: z
       .string()
       .describe("Provider name (e.g. openai, anthropic, stripe)"),
@@ -495,11 +493,11 @@ registry.registerPath({
   tags: ["Keys"],
   summary: "List provider keys",
   description:
-    "List provider keys. Pass keySource query param to select the key store (org or app). Defaults to 'org'.",
+    "List stored provider keys (masked). Defaults to org-level keys.",
   security: authed,
   request: {
     query: z.object({
-      keySource: z.enum(["org", "app"]).optional().describe("Key store to list from (default: 'org')"),
+      keySource: z.enum(["org", "app"]).optional().describe("Key scope (default: 'org'). Use 'app' only for multi-tenant platforms"),
     }),
   },
   responses: {
@@ -515,7 +513,7 @@ registry.registerPath({
   tags: ["Keys"],
   summary: "Upsert a provider key",
   description:
-    "Store or update a provider API key. keySource determines the key store: 'org' for org-level keys (requires org context), 'app' for app-level keys (requires app key auth).",
+    "Store or update a provider API key (e.g. OpenAI, Anthropic). Most users should use keySource: 'org'. The 'app' key source is reserved for multi-tenant platforms managing keys on behalf of their users.",
   security: authed,
   request: {
     body: {
@@ -535,14 +533,14 @@ registry.registerPath({
   path: "/v1/keys/{provider}",
   tags: ["Keys"],
   summary: "Delete a provider key",
-  description: "Remove a provider key. Pass keySource query param to select the key store (default: 'org').",
+  description: "Remove a stored provider key. Defaults to org-level keys.",
   security: authed,
   request: {
     params: z.object({
       provider: z.string().describe("Provider name"),
     }),
     query: z.object({
-      keySource: z.enum(["org", "app"]).optional().describe("Key store (default: 'org')"),
+      keySource: z.enum(["org", "app"]).optional().describe("Key scope (default: 'org'). Use 'app' only for multi-tenant platforms"),
     }),
   },
   responses: {
@@ -568,7 +566,7 @@ export const CreateApiKeyRequestSchema = z
 registry.registerPath({
   method: "get",
   path: "/v1/api-keys",
-  tags: ["API Keys"],
+  tags: ["Authentication"],
   summary: "List API keys",
   description: "List all API keys for the organization",
   security: authed,
@@ -582,9 +580,9 @@ registry.registerPath({
 registry.registerPath({
   method: "post",
   path: "/v1/api-keys",
-  tags: ["API Keys"],
+  tags: ["Authentication"],
   summary: "Create an API key",
-  description: "Generate a new permanent API key for the organization",
+  description: "Create a new API key for your organization. This is the recommended way to authenticate with the API.",
   security: authed,
   request: {
     body: {
@@ -603,7 +601,7 @@ registry.registerPath({
 registry.registerPath({
   method: "delete",
   path: "/v1/api-keys/{id}",
-  tags: ["API Keys"],
+  tags: ["Authentication"],
   summary: "Revoke an API key",
   description: "Delete/revoke an API key by ID",
   security: authed,
@@ -620,7 +618,7 @@ registry.registerPath({
 registry.registerPath({
   method: "post",
   path: "/v1/api-keys/session",
-  tags: ["API Keys"],
+  tags: ["Authentication"],
   summary: "Get or create session API key",
   description:
     "Get or create a short-lived session API key for Foxy chat integration",

--- a/tests/unit/openapi-auth-docs.test.ts
+++ b/tests/unit/openapi-auth-docs.test.ts
@@ -9,40 +9,33 @@ const generatorPath = path.join(__dirname, "../../scripts/generate-openapi.ts");
 const generatorContent = fs.readFileSync(generatorPath, "utf-8");
 
 describe("OpenAPI spec — auth documentation", () => {
-  it("should document both key types in security scheme description", () => {
-    expect(schemasContent).toContain("User key");
+  it("should document user key as the default in security scheme", () => {
     expect(schemasContent).toContain("distrib.usr_*");
-    expect(schemasContent).toContain("App key");
+    expect(schemasContent).toContain("POST /v1/api-keys");
+  });
+
+  it("should mention app key as multi-tenant platform option", () => {
     expect(schemasContent).toContain("distrib.app_*");
+    expect(schemasContent).toContain("multi-tenant platform");
   });
 
-  it("should mention x-org-id and x-user-id headers in security scheme", () => {
-    expect(schemasContent).toContain("x-org-id");
-    expect(schemasContent).toContain("x-user-id");
-  });
-
-  it("should explain identity resolution via client-service in security scheme", () => {
-    expect(schemasContent).toContain("client-service");
-  });
-
-  it("should reference Clerk IDs as example external IDs in security scheme", () => {
-    expect(schemasContent).toContain("Clerk");
+  it("should reference Platform section for app key details", () => {
+    expect(schemasContent).toContain("Platform section");
   });
 });
 
 describe("OpenAPI spec — info description", () => {
-  it("should include Authentication section in API description", () => {
-    expect(generatorContent).toContain("## Authentication");
+  it("should include Quick Start section in API description", () => {
+    expect(generatorContent).toContain("## Quick Start");
   });
 
   it("should document user key flow with example", () => {
     expect(generatorContent).toContain("Authorization: Bearer distrib.usr_abc123");
   });
 
-  it("should document app key flow with identity headers example", () => {
-    expect(generatorContent).toContain("Authorization: Bearer distrib.app_abc123");
-    expect(generatorContent).toContain("x-org-id: org_2xyzABC");
-    expect(generatorContent).toContain("x-user-id: user_2abcDEF");
+  it("should include BYOK section with org keySource example", () => {
+    expect(generatorContent).toContain("## Storing provider keys (BYOK)");
+    expect(generatorContent).toContain('"keySource": "org"');
   });
 
   it("should document error codes for auth failures", () => {
@@ -50,8 +43,15 @@ describe("OpenAPI spec — info description", () => {
     expect(generatorContent).toContain("Identity resolution failed");
   });
 
-  it("should explain that identity headers are optional for app keys", () => {
-    expect(generatorContent).toContain("Both headers are **optional**");
+  it("should push app key docs to Advanced: Platform integration section", () => {
+    expect(generatorContent).toContain("## Advanced: Platform integration");
+    expect(generatorContent).toContain("multi-tenant platform");
+  });
+
+  it("should document app key flow with identity headers in platform section", () => {
+    expect(generatorContent).toContain("Authorization: Bearer distrib.app_abc123");
+    expect(generatorContent).toContain("x-org-id: org_2xyzABC");
+    expect(generatorContent).toContain("x-user-id: user_2abcDEF");
   });
 });
 
@@ -74,5 +74,37 @@ describe("OpenAPI spec — identity header parameters on authenticated endpoints
 
   it("should preserve existing parameters when adding identity headers", () => {
     expect(generatorContent).toContain("operation.parameters ?? []");
+  });
+});
+
+describe("OpenAPI spec — tag structure", () => {
+  it("should use Authentication tag for API key endpoints", () => {
+    expect(schemasContent).toContain('tags: ["Authentication"]');
+  });
+
+  it("should use Platform tag for app registration", () => {
+    expect(schemasContent).toContain('tags: ["Platform"]');
+  });
+
+  it("should define Authentication tag before Keys tag", () => {
+    const authTagPos = generatorContent.indexOf('"Authentication"');
+    const keysTagPos = generatorContent.indexOf('"Keys"');
+    expect(authTagPos).toBeLessThan(keysTagPos);
+  });
+
+  it("should define Platform tag last", () => {
+    const platformTagPos = generatorContent.indexOf('"Platform"');
+    const billingTagPos = generatorContent.indexOf('"Billing"');
+    expect(platformTagPos).toBeGreaterThan(billingTagPos);
+  });
+});
+
+describe("OpenAPI spec — keySource clarity", () => {
+  it("should describe keySource 'app' as multi-tenant platforms only", () => {
+    expect(schemasContent).toContain("multi-tenant platforms only");
+  });
+
+  it("should recommend 'org' as the default keySource", () => {
+    expect(schemasContent).toContain("Most users should use keySource: 'org'");
   });
 });


### PR DESCRIPTION
## Summary

- Restructured API docs so the default auth path is "create a user key → use it" instead of leading with app registration
- Moved app key documentation to an "Advanced: Platform integration" section — only relevant for multi-tenant platforms
- Renamed tags: "Apps" → "Platform" (last), "API Keys" → "Authentication" (early)
- Clarified `keySource` descriptions to explicitly say `'app'` is for multi-tenant platforms only
- Simplified the `bearerAuth` security scheme to lead with user key as the default

## Context

Client feedback: integrating a simple Next.js app, they followed `POST /v1/apps/register` → got an app key → hit 400 errors because app keys need identity headers. The correct path was a user key, but nothing in the docs guided them there.

## Test plan

- [x] All 19 `openapi-auth-docs` tests pass with updated assertions
- [x] `pnpm generate:openapi` regenerates cleanly
- [x] Verified in generated `openapi.json`: Quick Start in root description, Platform tag last, Authentication tag early, keySource descriptions mention multi-tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)