### PR TITLE
fix: resolve keySource in auth middleware and forward to all downstream services

### DIFF
--- a/src/lib/internal-headers.ts
+++ b/src/lib/internal-headers.ts
@@ -3,18 +3,16 @@ import { AuthenticatedRequest } from "../middleware/auth.js";
 /**
  * Build headers for internal service-to-service calls
  * Convention:
- * - x-org-id: Always required (internal UUID from client-service)
- * - x-user-id: Optional (provided if available)
+ * - x-org-id: Internal org UUID (when available)
+ * - x-user-id: Internal user UUID (when available)
+ * - x-app-id: App ID (when available)
+ * - x-key-source: Resolved key source from billing-service (when available)
  */
 export function buildInternalHeaders(req: AuthenticatedRequest): Record<string, string> {
-  const headers: Record<string, string> = {
-    "x-org-id": req.orgId!,
-  };
-  if (req.userId) {
-    headers["x-user-id"] = req.userId;
-  }
-  if (req.appId) {
-    headers["x-app-id"] = req.appId;
-  }
+  const headers: Record<string, string> = {};
+  if (req.orgId) headers["x-org-id"] = req.orgId;
+  if (req.userId) headers["x-user-id"] = req.userId;
+  if (req.appId) headers["x-app-id"] = req.appId;
+  if (req.keySource) headers["x-key-source"] = req.keySource;
   return headers;
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,11 +1,13 @@
 import { Request, Response, NextFunction } from "express";
 import { callExternalService, externalServices } from "../lib/service-client.js";
+import { fetchKeySource } from "../lib/billing.js";
 
 export interface AuthenticatedRequest extends Request {
   userId?: string;
   orgId?: string;
   appId?: string;
   authType?: "app_key" | "user_key";
+  keySource?: string;
 }
 
 /**
@@ -77,15 +79,23 @@ export async function authenticate(
           path: req.path,
         });
       }
-
-      return next();
+    } else {
+      // User key: all identity comes from the key itself — no headers needed
+      req.appId = validation.appId;
+      req.orgId = validation.orgId;
+      req.userId = validation.userId;
+      req.authType = "user_key";
     }
 
-    // User key: all identity comes from the key itself — no headers needed
-    req.appId = validation.appId;
-    req.orgId = validation.orgId;
-    req.userId = validation.userId;
-    req.authType = "user_key";
+    // Resolve keySource from billing-service (best-effort — don't block on failure)
+    if (req.orgId && req.appId) {
+      try {
+        req.keySource = await fetchKeySource(req.orgId, req.appId);
+      } catch (err) {
+        console.warn("[auth] Failed to resolve keySource:", (err as Error).message);
+      }
+    }
+
     return next();
   } catch (error) {
     console.error("Auth error:", error);

--- a/src/routes/activity.ts
+++ b/src/routes/activity.ts
@@ -17,6 +17,7 @@ router.post("/activity", authenticate, requireOrg, requireUser, async (req: Auth
         eventType: "user_active",
         userId: req.userId,
         orgId: req.orgId,
+        keySource: req.keySource,
       },
     }).catch((err) => console.warn("[activity] Transactional email failed:", err.message));
 

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -3,7 +3,7 @@ import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { createRun, getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 import { BrandScrapeRequestSchema, IcpSuggestionRequestSchema, SalesProfileFromUrlRequestSchema } from "../schemas.js";
-import { fetchKeySource } from "../lib/billing.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
 
@@ -19,9 +19,6 @@ router.post("/brand/scrape", authenticate, async (req: AuthenticatedRequest, res
     }
     const { url, skipCache } = parsed.data;
 
-    // Resolve keySource from billing-service (default to "platform" if no orgId)
-    const keySource = req.orgId ? await fetchKeySource(req.orgId, req.appId!) : "platform";
-
     const result = await callExternalService(
       externalServices.scraping,
       "/scrape",
@@ -32,7 +29,7 @@ router.post("/brand/scrape", authenticate, async (req: AuthenticatedRequest, res
           sourceService: req.appId!,
           sourceOrgId: req.orgId,
           userId: req.userId,
-          keySource,
+          keySource: req.keySource || "platform",
           skipCache,
         },
       }
@@ -57,9 +54,6 @@ router.post("/brand/sales-profile", authenticate, requireOrg, requireUser, async
     }
     const { url, skipCache } = parsed.data;
 
-    // Resolve keySource from billing-service
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     // Create a tracking run so brand-service can link costs
     const parentRun = await createRun({
       orgId: req.orgId!,
@@ -79,7 +73,7 @@ router.post("/brand/sales-profile", authenticate, requireOrg, requireUser, async
           appId: req.appId!,
           orgId: req.orgId!,
           userId: req.userId!,
-          keyType: keySource,
+          keyType: req.keySource,
           parentRunId: parentRun.id,
           skipCache,
         },
@@ -111,9 +105,13 @@ router.get("/brand/by-url", authenticate, async (req: AuthenticatedRequest, res)
       return res.status(400).json({ error: "url query param is required" });
     }
 
+    const params = new URLSearchParams({ url });
+    if (req.keySource) params.set("keySource", req.keySource);
+
     const result = await callExternalService(
       externalServices.scraping,
-      `/scrape/by-url?url=${encodeURIComponent(url)}`
+      `/scrape/by-url?${params}`,
+      { headers: buildInternalHeaders(req) },
     );
 
     res.json(result);
@@ -129,9 +127,13 @@ router.get("/brand/by-url", authenticate, async (req: AuthenticatedRequest, res)
  */
 router.get("/brands", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
+    const params = new URLSearchParams({ orgId: req.orgId! });
+    if (req.keySource) params.set("keySource", req.keySource);
+
     const result = await callExternalService(
       externalServices.brand,
-      `/brands?orgId=${req.orgId}`
+      `/brands?${params}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -148,7 +150,8 @@ router.get("/brands/:id", authenticate, async (req: AuthenticatedRequest, res) =
   try {
     const result = await callExternalService(
       externalServices.brand,
-      `/brands/${req.params.id}`
+      `/brands/${req.params.id}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -165,7 +168,8 @@ router.get("/brands/:id/sales-profile", authenticate, async (req: AuthenticatedR
   try {
     const result = await callExternalService(
       externalServices.brand,
-      `/brands/${req.params.id}/sales-profile`
+      `/brands/${req.params.id}/sales-profile`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -184,9 +188,13 @@ router.get("/brands/:id/sales-profile", authenticate, async (req: AuthenticatedR
  */
 router.get("/brand/sales-profiles", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
+    const params = new URLSearchParams({ orgId: req.orgId! });
+    if (req.keySource) params.set("keySource", req.keySource);
+
     const result = await callExternalService(
       externalServices.brand,
-      `/sales-profiles?orgId=${req.orgId}`
+      `/sales-profiles?${params}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -207,9 +215,6 @@ router.post("/brand/icp-suggestion", authenticate, requireOrg, requireUser, asyn
     }
     const { brandUrl } = parsed.data;
 
-    // Resolve keySource from billing-service
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     const result = await callExternalService(
       externalServices.brand,
       "/icp-suggestion",
@@ -219,7 +224,7 @@ router.post("/brand/icp-suggestion", authenticate, requireOrg, requireUser, asyn
           orgId: req.orgId,
           userId: req.userId,
           appId: req.appId!,
-          keySource,
+          keySource: req.keySource,
           url: brandUrl,
         },
       }
@@ -257,7 +262,8 @@ router.get("/brands/costs", authenticate, requireOrg, requireUser, async (req: A
       }>;
     }>(
       externalServices.runs,
-      `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(req.appId!)}&groupBy=brandId`
+      `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(req.appId!)}&groupBy=brandId`,
+      { headers: buildInternalHeaders(req) },
     );
 
     const costs: Record<string, string> = {};
@@ -294,7 +300,8 @@ router.get("/brands/:id/cost-breakdown", authenticate, requireOrg, requireUser, 
       }>;
     }>(
       externalServices.runs,
-      `/v1/stats/costs/by-cost-name?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(req.appId!)}&brandId=${encodeURIComponent(id)}`
+      `/v1/stats/costs/by-cost-name?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(req.appId!)}&brandId=${encodeURIComponent(id)}`,
+      { headers: buildInternalHeaders(req) },
     );
 
     res.json({ costs: data.costs || [] });
@@ -316,7 +323,8 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
     // 1. Get runs list from brand-service
     const data = await callExternalService<{ runs?: Array<{ id: string; taskName: string; status: string; startedAt: string; completedAt: string | null }> }>(
       externalServices.brand,
-      `/brands/${id}/runs`
+      `/brands/${id}/runs`,
+      { headers: buildInternalHeaders(req) },
     );
     const runs: Array<{ id: string; taskName: string; status: string; startedAt: string; completedAt: string | null }> = data.runs || [];
 
@@ -371,7 +379,8 @@ router.get("/brand/:id", authenticate, async (req: AuthenticatedRequest, res) =>
 
     const result = await callExternalService(
       externalServices.scraping,
-      `/scrape/${id}`
+      `/scrape/${id}`,
+      { headers: buildInternalHeaders(req) },
     );
 
     res.json(result);

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -4,7 +4,6 @@ import { callExternalService, externalServices } from "../lib/service-client.js"
 import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { createRun, updateRun, getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 import { CreateCampaignRequestSchema, BatchStatsRequestSchema } from "../schemas.js";
-import { fetchKeySource } from "../lib/billing.js";
 import { fetchRequiredProviders, fetchOrgKeys, resolveWorkflowByName } from "./workflows.js";
 
 function sendTransactionalEmail(
@@ -21,6 +20,7 @@ function sendTransactionalEmail(
       campaignId,
       orgId: req.orgId,
       userId: req.userId,
+      keySource: req.keySource,
       metadata,
     },
   }).catch((err) => console.warn(`[campaigns] Transactional email ${eventType} failed:`, err.message));
@@ -38,16 +38,17 @@ interface EmailGatewayStats {
 /** Fetch delivery stats from email-gateway (aggregates transactional + broadcast). */
 async function fetchDeliveryStats(
   filters: { campaignId?: string; brandId?: string },
-  orgId: string,
-  appId: string
+  req: AuthenticatedRequest,
 ): Promise<Record<string, number> | null> {
+  const orgId = req.orgId!;
+  const appId = req.appId!;
   const deliveryResult = await callExternalService<{ transactional: EmailGatewayStats; broadcast: EmailGatewayStats }>(
     externalServices.emailGateway,
     "/stats",
     {
       method: "POST",
-      headers: { "x-org-id": orgId },
-      body: { ...filters, appId, orgId },
+      headers: buildInternalHeaders(req),
+      body: { ...filters, appId, orgId, keySource: req.keySource },
     }
   ).catch((err) => {
     console.warn("[campaigns] Email-gateway stats failed:", (err as Error).message);
@@ -169,6 +170,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
           orgId: req.orgId,
           url: brandUrl,
           userId: req.userId,
+          keySource: req.keySource,
         },
       }
     );
@@ -186,9 +188,9 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
     });
     console.log("[api-service] POST /v1/campaigns \u2014 step 2 done: parent run created", { parentRunId: parentRun.id });
 
-    // 3. Resolve keySource from billing-service (byok vs pay-as-you-go)
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-    console.log("[api-service] POST /v1/campaigns — step 3: resolved keySource from billing-service", { keySource });
+    // 3. Use keySource from auth middleware (resolved from billing-service)
+    const keySource = req.keySource;
+    console.log("[api-service] POST /v1/campaigns — step 3: keySource from auth middleware", { keySource });
 
     // 3b. Pre-campaign key validation: if BYOK, check org has all required provider keys
     if (keySource === "byok") {
@@ -294,7 +296,7 @@ router.get("/campaigns/:id", authenticate, requireOrg, requireUser, async (req: 
       externalServices.campaign,
       `/campaigns/${id}`,
       {
-        headers: { "x-org-id": req.orgId! },
+        headers: buildInternalHeaders(req),
       }
     );
     res.json(result);
@@ -317,8 +319,8 @@ router.patch("/campaigns/:id", authenticate, requireOrg, requireUser, async (req
       `/campaigns/${id}`,
       {
         method: "PATCH",
-        headers: { "x-org-id": req.orgId! },
-        body: req.body,
+        headers: buildInternalHeaders(req),
+        body: { ...req.body, keySource: req.keySource },
       }
     );
     res.json(result);
@@ -341,8 +343,8 @@ router.post("/campaigns/:id/stop", authenticate, requireOrg, requireUser, async 
       `/campaigns/${id}`,
       {
         method: "PATCH",
-        headers: { "x-org-id": req.orgId! },
-        body: { status: "stop" },
+        headers: buildInternalHeaders(req),
+        body: { status: "stop", keySource: req.keySource },
       }
     );
 
@@ -389,9 +391,6 @@ router.post("/campaigns/:id/resume", authenticate, requireOrg, requireUser, asyn
       taskName: "resume-campaign",
     });
 
-    // Resolve keySource from billing-service
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     let result;
     try {
       result = await callExternalService(
@@ -399,8 +398,8 @@ router.post("/campaigns/:id/resume", authenticate, requireOrg, requireUser, asyn
         `/campaigns/${id}`,
         {
           method: "PATCH",
-          headers: { "x-org-id": req.orgId! },
-          body: { status: "activate", parentRunId: parentRun.id, keySource },
+          headers: buildInternalHeaders(req),
+          body: { status: "activate", parentRunId: parentRun.id, keySource: req.keySource },
         }
       );
     } catch (err) {
@@ -426,7 +425,7 @@ router.get("/campaigns/:id/runs", authenticate, requireOrg, requireUser, async (
       externalServices.campaign,
       `/campaigns/${id}/runs`,
       {
-        headers: { "x-org-id": req.orgId! },
+        headers: buildInternalHeaders(req),
       }
     );
     res.json(result);
@@ -445,13 +444,14 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
     const { id } = req.params;
     const orgId = req.orgId!;
     const appId = req.appId!;
+    const internalHeaders = buildInternalHeaders(req);
 
     // Fetch stats from all services in parallel using campaignId filter
     const [leadStats, emailgenStats, delivery, budgetUsage, costBreakdown, leadsFromRuns] = await Promise.all([
       callExternalService(
         externalServices.lead,
         `/stats?campaignId=${id}`,
-        { headers: { "x-app-id": appId, "x-org-id": orgId } }
+        { headers: internalHeaders }
       ).catch((err) => {
         console.warn("[campaigns] Lead-service stats failed:", (err as Error).message);
         return null;
@@ -459,16 +459,16 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
       callExternalService(
         externalServices.emailgen,
         "/stats",
-        { method: "POST", body: { campaignId: id, appId }, headers: { "x-org-id": orgId } }
+        { method: "POST", body: { campaignId: id, appId, keySource: req.keySource }, headers: internalHeaders }
       ).catch((err) => {
         console.warn("[campaigns] Emailgen stats failed:", (err as Error).message);
         return null;
       }),
-      fetchDeliveryStats({ campaignId: id }, orgId, appId),
+      fetchDeliveryStats({ campaignId: id }, req),
       callExternalService<{ results: Record<string, { totalCostInUsdCents: string | null }> }>(
         externalServices.campaign,
         "/campaigns/batch-budget-usage",
-        { method: "POST", body: { campaignIds: [id] } }
+        { method: "POST", body: { campaignIds: [id], keySource: req.keySource }, headers: internalHeaders }
       ).catch((err) => {
         console.warn("[campaigns] Budget usage failed:", (err as Error).message);
         return null;
@@ -476,7 +476,8 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
       // Full cost breakdown by cost name from runs-service (single source of truth)
       callExternalService<{ costs: Array<{ costName: string; totalCostInUsdCents: string; actualCostInUsdCents: string; provisionedCostInUsdCents: string; totalQuantity: string }> }>(
         externalServices.runs,
-        `/v1/stats/costs/by-cost-name?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(appId)}&campaignId=${encodeURIComponent(id)}`
+        `/v1/stats/costs/by-cost-name?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(appId)}&campaignId=${encodeURIComponent(id)}`,
+        { headers: internalHeaders }
       ).catch((err) => {
         console.warn("[campaigns] Cost breakdown failed:", (err as Error).message);
         return null;
@@ -484,7 +485,8 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
       // Lead-serve run count from runs-service (source of truth for leadsServed)
       callExternalService<{ groups: Array<{ dimensions: Record<string, string | null>; runCount: number }> }>(
         externalServices.runs,
-        `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(appId)}&campaignId=${encodeURIComponent(id)}&taskName=lead-serve&groupBy=serviceName`
+        `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(appId)}&campaignId=${encodeURIComponent(id)}&taskName=lead-serve&groupBy=serviceName`,
+        { headers: internalHeaders }
       ).catch((err) => {
         console.warn("[campaigns] Lead-serve runs stats failed:", (err as Error).message);
         return null;
@@ -563,13 +565,15 @@ router.post("/campaigns/batch-stats", authenticate, requireOrg, requireUser, asy
 
     const orgId = req.orgId!;
     const appId = req.appId!;
+    const internalHeaders = buildInternalHeaders(req);
 
     // Fetch budget usage and lead-serve run counts in bulk (one call each)
     const budgetUsagePromise = callExternalService<{
       results: Record<string, { totalCostInUsdCents: string | null }>;
     }>(externalServices.campaign, "/campaigns/batch-budget-usage", {
       method: "POST",
-      body: { campaignIds },
+      body: { campaignIds, keySource: req.keySource },
+      headers: internalHeaders,
     }).catch((err) => {
       console.warn("[campaigns] Batch budget usage failed:", (err as Error).message);
       return null;
@@ -580,7 +584,8 @@ router.post("/campaigns/batch-stats", authenticate, requireOrg, requireUser, asy
       groups: Array<{ dimensions: Record<string, string | null>; runCount: number }>;
     }>(
       externalServices.runs,
-      `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(appId)}&taskName=lead-serve&groupBy=campaignId`
+      `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&appId=${encodeURIComponent(appId)}&taskName=lead-serve&groupBy=campaignId`,
+      { headers: internalHeaders },
     ).catch((err) => {
       console.warn("[campaigns] Batch lead-serve runs stats failed:", (err as Error).message);
       return null;
@@ -594,14 +599,14 @@ router.post("/campaigns/batch-stats", authenticate, requireOrg, requireUser, asy
             callExternalService(
               externalServices.lead,
               `/stats?campaignId=${id}`,
-              { headers: { "x-app-id": appId, "x-org-id": orgId } }
+              { headers: internalHeaders }
             ).catch(() => null),
             callExternalService(
               externalServices.emailgen,
               "/stats",
-              { method: "POST", body: { campaignId: id, appId }, headers: { "x-org-id": orgId } }
+              { method: "POST", body: { campaignId: id, appId, keySource: req.keySource }, headers: internalHeaders }
             ).catch(() => null),
-            fetchDeliveryStats({ campaignId: id }, orgId, appId),
+            fetchDeliveryStats({ campaignId: id }, req),
           ]);
 
           return { campaignId: id, leadStats, emailgenStats, delivery };
@@ -691,7 +696,7 @@ router.get("/campaigns/:id/leads", authenticate, requireOrg, requireUser, async 
       externalServices.lead,
       `/leads?campaignId=${id}`,
       {
-        headers: { "x-app-id": req.appId!, "x-org-id": req.orgId! },
+        headers: buildInternalHeaders(req),
       }
     ) as { leads: Array<Record<string, unknown>> };
 
@@ -775,7 +780,7 @@ router.get("/campaigns/:id/emails", authenticate, requireOrg, requireUser, async
       externalServices.emailgen,
       `/generations?campaignId=${id}`,
       {
-        headers: { "x-org-id": req.orgId! },
+        headers: buildInternalHeaders(req),
       }
     ) as { generations: Array<Record<string, unknown>> };
 
@@ -833,9 +838,8 @@ router.get("/campaigns/:id/emails", authenticate, requireOrg, requireUser, async
 router.get("/brands/:brandId/delivery-stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { brandId } = req.params;
-    const orgId = req.orgId!;
 
-    const delivery = await fetchDeliveryStats({ brandId }, orgId, req.appId!);
+    const delivery = await fetchDeliveryStats({ brandId }, req);
 
     res.json(delivery ?? {
       emailsSent: 0,
@@ -865,6 +869,7 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
   const { id } = req.params;
   const orgId = req.orgId!;
   const appId = req.appId!;
+  const internalHeaders = buildInternalHeaders(req);
 
   // SSE headers
   res.writeHead(200, {
@@ -893,19 +898,19 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
         callExternalService<{ campaign: { status: string } }>(
           externalServices.campaign,
           `/campaigns/${id}`,
-          { headers: { "x-org-id": orgId } }
+          { headers: internalHeaders }
         ).catch(() => null),
         callExternalService<{ served: number; buffered: number; skipped: number }>(
           externalServices.lead,
           `/stats?campaignId=${id}`,
-          { headers: { "x-app-id": appId, "x-org-id": orgId } }
+          { headers: internalHeaders }
         ).catch(() => null),
         callExternalService<{ stats?: { emailsGenerated?: number } }>(
           externalServices.emailgen,
           "/stats",
-          { method: "POST", body: { campaignId: id, appId }, headers: { "x-org-id": orgId } }
+          { method: "POST", body: { campaignId: id, appId, keySource: req.keySource }, headers: internalHeaders }
         ).catch(() => null),
-        fetchDeliveryStats({ campaignId: id }, orgId, appId),
+        fetchDeliveryStats({ campaignId: id }, req),
       ]);
 
       if (closed) return;

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -15,7 +15,7 @@ router.put("/chat/config", authenticate, requireOrg, requireUser, async (req: Au
     const result = await callExternalService(
       externalServices.chat,
       `/apps/${req.appId}/config`,
-      { method: "PUT", body: req.body, headers: buildInternalHeaders(req) }
+      { method: "PUT", body: { ...req.body, keySource: req.keySource }, headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
@@ -34,6 +34,7 @@ router.post("/chat", authenticate, requireOrg, requireUser, async (req: Authenti
         body: {
           ...req.body,
           appId: req.appId || req.body.appId,
+          keySource: req.keySource,
         },
         headers: buildInternalHeaders(req),
         expressRes: res,

--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -2,7 +2,6 @@ import { Router } from "express";
 import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { SendEmailRequestSchema, EmailStatsRequestSchema, DeployEmailTemplatesRequestSchema } from "../schemas.js";
-import { fetchKeySource } from "../lib/billing.js";
 
 const router = Router();
 
@@ -17,8 +16,6 @@ router.post("/emails/send", authenticate, requireOrg, async (req: AuthenticatedR
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     const result = await callExternalService(
       externalServices.transactionalEmail,
       "/send",
@@ -28,7 +25,7 @@ router.post("/emails/send", authenticate, requireOrg, async (req: AuthenticatedR
           appId: req.appId,
           orgId: req.orgId,
           userId: req.userId,
-          keySource,
+          keySource: req.keySource,
           ...parsed.data,
         },
       }
@@ -59,6 +56,7 @@ router.post("/emails/stats", authenticate, requireOrg, async (req: Authenticated
         body: {
           appId: req.appId,
           orgId: req.orgId,
+          keySource: req.keySource,
           ...parsed.data,
         },
       }
@@ -88,6 +86,7 @@ router.put("/emails/templates", authenticate, requireOrg, async (req: Authentica
         method: "PUT",
         body: {
           appId: req.appId,
+          keySource: req.keySource,
           ...parsed.data,
         },
       }

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js";
 
 const router = Router();
@@ -17,7 +18,9 @@ router.get("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
     const params = new URLSearchParams({ keySource: "org", orgId: req.orgId });
-    const result = await callExternalService(externalServices.key, `/keys?${params}`);
+    const result = await callExternalService(externalServices.key, `/keys?${params}`, {
+      headers: buildInternalHeaders(req),
+    });
     res.json(result);
   } catch (error: any) {
     console.error("List keys error:", error);
@@ -41,6 +44,7 @@ router.post("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
     const result = await callExternalService(externalServices.key, "/keys", {
       method: "POST",
       body: { keySource: "org", provider, apiKey, orgId: req.orgId },
+      headers: buildInternalHeaders(req),
     });
     res.json(result);
   } catch (error: any) {
@@ -61,7 +65,7 @@ router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest,
     const result = await callExternalService(
       externalServices.key,
       `/keys/${encodeURIComponent(provider)}?${params}`,
-      { method: "DELETE" }
+      { method: "DELETE", headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
@@ -85,7 +89,8 @@ router.post("/api-keys/session", authenticate, requireOrg, requireUser, async (r
       "/internal/api-keys/session",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, userId: req.userId },
+        body: { appId: req.appId, orgId: req.orgId, userId: req.userId, keySource: req.keySource },
+        headers: buildInternalHeaders(req),
       }
     );
     res.json(result);
@@ -117,8 +122,10 @@ router.post("/api-keys", authenticate, requireOrg, requireUser, async (req: Auth
           orgId: req.orgId,
           userId: req.userId,
           createdBy: req.userId,
+          keySource: req.keySource,
           name,
         },
+        headers: buildInternalHeaders(req),
       }
     );
     res.json(result);
@@ -136,7 +143,8 @@ router.get("/api-keys", authenticate, requireOrg, requireUser, async (req: Authe
   try {
     const result = await callExternalService(
       externalServices.key,
-      `/internal/api-keys?orgId=${req.orgId}`
+      `/internal/api-keys?orgId=${req.orgId}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -158,7 +166,8 @@ router.delete("/api-keys/:id", authenticate, requireOrg, requireUser, async (req
       `/internal/api-keys/${id}`,
       {
         method: "DELETE",
-        body: { orgId: req.orgId },
+        body: { orgId: req.orgId, keySource: req.keySource },
+        headers: buildInternalHeaders(req),
       }
     );
     res.json(result);

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { LeadSearchRequestSchema } from "../schemas.js";
-import { fetchKeySource } from "../lib/billing.js";
 
 const router = Router();
 
@@ -24,15 +24,12 @@ router.post("/leads/search", authenticate, requireOrg, requireUser, async (req: 
       per_page,
     } = parsed.data;
 
-    // Resolve keySource from billing-service
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     const result = await callExternalService(
       externalServices.lead,
       "/search",
       {
         method: "POST",
-        headers: { "x-app-id": req.appId!, "x-org-id": req.orgId! },
+        headers: buildInternalHeaders(req),
         body: {
           personTitles: person_titles,
           organizationLocations: organization_locations,
@@ -42,7 +39,7 @@ router.post("/leads/search", authenticate, requireOrg, requireUser, async (req: 
           appId: req.appId!,
           orgId: req.orgId,
           userId: req.userId,
-          keySource,
+          keySource: req.keySource,
         },
       }
     );

--- a/src/routes/qualify.ts
+++ b/src/routes/qualify.ts
@@ -31,8 +31,13 @@ router.post("/qualify", authenticate, async (req: AuthenticatedRequest, res) => 
     // Use orgId from auth if not provided
     const orgId = sourceOrgId || req.orgId;
 
-    // Resolve keySource from billing-service (default to "platform" if no orgId)
-    const keySource = orgId ? await fetchKeySource(orgId, req.appId!) : "platform";
+    // Use middleware-resolved keySource when sourceOrgId matches req.orgId or is absent.
+    // Only re-resolve if sourceOrgId is a different org.
+    let keySource: string | undefined = req.keySource;
+    if (sourceOrgId && sourceOrgId !== req.orgId && req.appId) {
+      keySource = await fetchKeySource(sourceOrgId, req.appId);
+    }
+    if (!keySource) keySource = "platform";
 
     const result = await callExternalService(
       externalServices.replyQualification,

--- a/src/routes/stripe.ts
+++ b/src/routes/stripe.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
-import { fetchKeySource } from "../lib/billing.js";
 import {
   CreateStripeProductRequestSchema,
   CreateStripePriceRequestSchema,
@@ -19,18 +18,13 @@ const router = Router();
 /**
  * GET /v1/stripe/products/:productId
  * Retrieve a Stripe product by ID.
- * Resolves keySource when org context is present so stripe-service uses
- * the correct key (org-level BYOK vs platform).
  */
 router.get("/stripe/products/:productId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) {
-      const keySource = await fetchKeySource(req.orgId, req.appId!);
-      qs.set("orgId", req.orgId);
-      qs.set("keySource", keySource);
-    }
+    if (req.orgId) qs.set("orgId", req.orgId);
+    if (req.keySource) qs.set("keySource", req.keySource);
     const result = await callExternalService(
       externalServices.stripe,
       `/products/${encodeURIComponent(productId)}?${qs}`,
@@ -45,7 +39,6 @@ router.get("/stripe/products/:productId", authenticate, async (req: Authenticate
 /**
  * POST /v1/stripe/products
  * Create a Stripe product.
- * Resolves keySource when org context is available.
  */
 router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
@@ -53,8 +46,6 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
     if (!parsed.success) {
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
-
-    const keySource = req.orgId ? await fetchKeySource(req.orgId, req.appId!) : undefined;
 
     const result = await callExternalService(
       externalServices.stripe,
@@ -64,7 +55,7 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
         body: {
           appId: req.appId,
           ...(req.orgId && { orgId: req.orgId }),
-          ...(keySource && { keySource }),
+          ...(req.keySource && { keySource: req.keySource }),
           ...parsed.data,
         },
       }
@@ -83,17 +74,13 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
 /**
  * GET /v1/stripe/products/:productId/prices
  * List active prices for a Stripe product.
- * Resolves keySource when org context is present.
  */
 router.get("/stripe/products/:productId/prices", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { productId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) {
-      const keySource = await fetchKeySource(req.orgId, req.appId!);
-      qs.set("orgId", req.orgId);
-      qs.set("keySource", keySource);
-    }
+    if (req.orgId) qs.set("orgId", req.orgId);
+    if (req.keySource) qs.set("keySource", req.keySource);
     const result = await callExternalService(
       externalServices.stripe,
       `/prices/by-product/${encodeURIComponent(productId)}?${qs}`,
@@ -108,7 +95,6 @@ router.get("/stripe/products/:productId/prices", authenticate, async (req: Authe
 /**
  * POST /v1/stripe/prices
  * Create a Stripe price.
- * Resolves keySource when org context is available.
  */
 router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
@@ -116,8 +102,6 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
     if (!parsed.success) {
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
-
-    const keySource = req.orgId ? await fetchKeySource(req.orgId, req.appId!) : undefined;
 
     const result = await callExternalService(
       externalServices.stripe,
@@ -127,7 +111,7 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
         body: {
           appId: req.appId,
           ...(req.orgId && { orgId: req.orgId }),
-          ...(keySource && { keySource }),
+          ...(req.keySource && { keySource: req.keySource }),
           ...parsed.data,
         },
       }
@@ -146,17 +130,13 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
 /**
  * GET /v1/stripe/coupons/:couponId
  * Retrieve a Stripe coupon by ID.
- * Resolves keySource when org context is present.
  */
 router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { couponId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) {
-      const keySource = await fetchKeySource(req.orgId, req.appId!);
-      qs.set("orgId", req.orgId);
-      qs.set("keySource", keySource);
-    }
+    if (req.orgId) qs.set("orgId", req.orgId);
+    if (req.keySource) qs.set("keySource", req.keySource);
     const result = await callExternalService(
       externalServices.stripe,
       `/coupons/${encodeURIComponent(couponId)}?${qs}`,
@@ -171,7 +151,6 @@ router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedR
 /**
  * POST /v1/stripe/coupons
  * Create a Stripe coupon.
- * Resolves keySource when org context is available.
  */
 router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
@@ -179,8 +158,6 @@ router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, r
     if (!parsed.success) {
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
-
-    const keySource = req.orgId ? await fetchKeySource(req.orgId, req.appId!) : undefined;
 
     const result = await callExternalService(
       externalServices.stripe,
@@ -190,7 +167,7 @@ router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, r
         body: {
           appId: req.appId,
           ...(req.orgId && { orgId: req.orgId }),
-          ...(keySource && { keySource }),
+          ...(req.keySource && { keySource: req.keySource }),
           ...parsed.data,
         },
       }
@@ -209,7 +186,6 @@ router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, r
 /**
  * POST /v1/stripe/checkout
  * Create a Stripe Checkout session.
- * Requires org/user context for tracking the purchase.
  */
 router.post("/stripe/checkout", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
@@ -218,14 +194,12 @@ router.post("/stripe/checkout", authenticate, requireOrg, async (req: Authentica
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     const result = await callExternalService(
       externalServices.stripe,
       "/checkout/create",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, userId: req.userId, keySource, ...parsed.data },
+        body: { appId: req.appId, orgId: req.orgId, userId: req.userId, keySource: req.keySource, ...parsed.data },
       }
     );
     res.json(result);
@@ -242,7 +216,6 @@ router.post("/stripe/checkout", authenticate, requireOrg, async (req: Authentica
 /**
  * POST /v1/stripe/stats
  * Get Stripe sales stats.
- * Requires org context to scope the stats query.
  */
 router.post("/stripe/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
@@ -251,14 +224,12 @@ router.post("/stripe/stats", authenticate, requireOrg, async (req: Authenticated
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     const result = await callExternalService(
       externalServices.stripe,
       "/stats",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, keySource, ...parsed.data },
+        body: { appId: req.appId, orgId: req.orgId, keySource: req.keySource, ...parsed.data },
       }
     );
     res.json(result);

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { ResolveUserRequestSchema, ListUsersQuerySchema } from "../schemas.js";
 
 const router = Router();
@@ -22,7 +23,8 @@ router.post("/users/resolve", authenticate, requireOrg, async (req: Authenticate
       "/resolve",
       {
         method: "POST",
-        body: { appId: req.appId, ...parsed.data },
+        body: { appId: req.appId, keySource: req.keySource, ...parsed.data },
+        headers: buildInternalHeaders(req),
       }
     );
     res.json(result);
@@ -55,6 +57,7 @@ router.get("/users", authenticate, requireOrg, async (req: AuthenticatedRequest,
     const result = await callExternalService(
       externalServices.client,
       `/users?${params.toString()}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { GenerateWorkflowRequestSchema } from "../schemas.js";
-import { fetchKeySource } from "../lib/billing.js";
 
 const router = Router();
 
@@ -82,7 +82,8 @@ router.get("/workflows", authenticate, requireOrg, requireUser, async (req: Auth
 
     const result = await callExternalService<{ workflows: Array<{ id: string; [key: string]: unknown }> }>(
       externalServices.workflow,
-      `/workflows?${params.toString()}`
+      `/workflows?${params.toString()}`,
+      { headers: buildInternalHeaders(req) },
     );
 
     const workflows = result.workflows ?? [];
@@ -117,7 +118,8 @@ router.get("/workflows/best", authenticate, requireOrg, requireUser, async (req:
 
     const result = await callExternalService(
       externalServices.workflow,
-      `/workflows/best?${params.toString()}`
+      `/workflows/best?${params.toString()}`,
+      { headers: buildInternalHeaders(req) },
     );
 
     res.json(result);
@@ -130,8 +132,6 @@ router.get("/workflows/best", authenticate, requireOrg, requireUser, async (req:
 /**
  * GET /v1/workflows/:id/summary
  * Returns an AI-generated summary of a workflow's DAG in natural language.
- * Fetches the workflow (with DAG) from workflow-service and generates a summary
- * using the Anthropic API (via content-generation service).
  */
 router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
@@ -141,7 +141,8 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
     const [workflow, requiredProviders] = await Promise.all([
       callExternalService<{ workflow: { id: string; name: string; dag?: { nodes: Array<{ id: string; type: string; config?: Record<string, unknown> }>; edges: Array<{ from: string; to: string }> } } }>(
         externalServices.workflow,
-        `/workflows/${id}`
+        `/workflows/${id}`,
+        { headers: buildInternalHeaders(req) },
       ).then((r) => r.workflow),
       fetchRequiredProviders(id),
     ]);
@@ -161,7 +162,6 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
     }
 
     // Build a concise summary from the DAG structure
-    // Follow topological order based on edges
     const nodeMap = new Map(dag.nodes.map((n) => [n.id, n]));
     const inDegree = new Map<string, number>();
     for (const n of dag.nodes) inDegree.set(n.id, 0);
@@ -184,7 +184,6 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
       }
     }
 
-    // Generate step descriptions from ordered nodes
     const steps: string[] = [];
     for (let i = 0; i < ordered.length; i++) {
       const node = nodeMap.get(ordered[i]);
@@ -195,7 +194,6 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
       const method = config.method as string | undefined;
       const path = config.path as string | undefined;
 
-      // Build a human-readable step description
       let desc = node.id.replace(/[-_]/g, " ");
       if (node.type === "http.call" && service) {
         const providerHint = service.charAt(0).toUpperCase() + service.slice(1);
@@ -211,7 +209,6 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
       steps.push(`${i + 1}. ${desc}`);
     }
 
-    // Build summary from the steps
     const providerList = requiredProviders.length > 0
       ? ` Uses ${requiredProviders.join(", ")}.`
       : "";
@@ -238,13 +235,11 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
     const { id } = req.params;
     const orgId = req.orgId!;
 
-    // Fetch required providers and org keys in parallel
     const [requiredProviders, orgKeys] = await Promise.all([
       fetchRequiredProviders(id),
       fetchOrgKeys(orgId),
     ]);
 
-    // Build a map of configured providers
     const configuredMap = new Map(orgKeys.map((k) => [k.provider, k.maskedKey]));
 
     const keys = requiredProviders.map((provider) => ({
@@ -255,12 +250,12 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
 
     const missing = keys.filter((k) => !k.configured).map((k) => k.provider);
 
-    // We need the workflow name — fetch from workflow-service
     let workflowName = id;
     try {
       const wf = await callExternalService<{ workflow: { name: string } }>(
         externalServices.workflow,
-        `/workflows/${id}`
+        `/workflows/${id}`,
+        { headers: buildInternalHeaders(req) },
       );
       workflowName = wf.workflow?.name ?? id;
     } catch {
@@ -290,7 +285,8 @@ router.get("/workflows/:id", authenticate, requireOrg, requireUser, async (req: 
     const [workflow, requiredProviders] = await Promise.all([
       callExternalService(
         externalServices.workflow,
-        `/workflows/${id}`
+        `/workflows/${id}`,
+        { headers: buildInternalHeaders(req) },
       ),
       fetchRequiredProviders(id),
     ]);
@@ -323,9 +319,6 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
 
     const { description, hints, style } = parsed.data;
 
-    // Resolve keySource from billing-service
-    const keySource = await fetchKeySource(req.orgId!, req.appId!);
-
     const result = await callExternalService(
       externalServices.workflow,
       "/workflows/generate",
@@ -335,7 +328,7 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
           appId: req.appId!,
           orgId: req.orgId,
           userId: req.userId,
-          keySource,
+          keySource: req.keySource,
           description,
           hints,
           ...(style && { style }),

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -3,6 +3,11 @@ import express from "express";
 import request from "supertest";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../../src/middleware/auth.js";
 
+// Mock billing module — keySource resolution is best-effort in middleware
+vi.mock("../../src/lib/billing.js", () => ({
+  fetchKeySource: vi.fn().mockResolvedValue("byok"),
+}));
+
 // Mock callExternalService for both key-service /validate and client-service /resolve
 vi.mock("../../src/lib/service-client.js", () => {
   const mockCallExternalService = vi.fn();

--- a/tests/unit/brand-sales-profile-from-url.test.ts
+++ b/tests/unit/brand-sales-profile-from-url.test.ts
@@ -12,13 +12,14 @@ import express from "express";
  *   5. Returns the sales profile response as-is
  */
 
-// Mock auth middleware to skip real auth
+// Mock auth middleware to skip real auth — keySource resolved in middleware
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
     req.userId = "user_test123";
     req.orgId = "org_test456";
     req.appId = "distribute";
     req.authType = "app_key";
+    req.keySource = "byok";
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -99,9 +100,6 @@ describe("POST /v1/brand/sales-profile", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(fakeSalesProfile);
-
-    // Verify keySource was resolved
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     // Verify a tracking run was created
     expect(mockCreateRun).toHaveBeenCalledWith({

--- a/tests/unit/campaign-key-validation.test.ts
+++ b/tests/unit/campaign-key-validation.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import express from "express";
 import request from "supertest";
 
+// Configurable auth context — keySource resolved in middleware
+let mockKeySource: string | undefined = "byok";
+
 // Mock auth middleware
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
@@ -9,6 +12,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
     req.orgId = "org_test456";
     req.appId = "distribute";
     req.authType = "user_key";
+    req.keySource = mockKeySource;
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -66,7 +70,7 @@ describe("POST /v1/campaigns — pre-campaign BYOK key validation", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
+    mockKeySource = "byok";
   });
 
   it("should return 400 with missing_keys when org lacks required providers", async () => {
@@ -175,7 +179,7 @@ describe("POST /v1/campaigns — pre-campaign BYOK key validation", () => {
   });
 
   it("should skip validation when keySource is platform (not byok)", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+    mockKeySource = "platform";
 
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
       if (url.includes("/brands")) return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -11,6 +11,9 @@ import express from "express";
  * No ICP resolution — that's campaign-service's job.
  */
 
+// Configurable auth context — keySource resolved in middleware
+let mockKeySource: string | undefined = "byok";
+
 // Mock auth middleware
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
@@ -18,6 +21,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
     req.orgId = "org_test456";
     req.appId = "distribute";
     req.authType = "app_key";
+    req.keySource = mockKeySource;
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -58,7 +62,7 @@ describe("POST /v1/campaigns with targetAudience", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
+    mockKeySource = "byok";
     fetchCalls = [];
 
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
@@ -145,8 +149,8 @@ describe("POST /v1/campaigns with targetAudience", () => {
     expect(scrapeCall).toBeUndefined();
   });
 
-  it("should resolve keySource from billing-service and forward to campaign-service", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource from middleware to campaign-service", async () => {
+    mockKeySource = "platform";
 
     const app = createApp();
     const res = await request(app)
@@ -166,15 +170,14 @@ describe("POST /v1/campaigns with targetAudience", () => {
       });
 
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.appId === "distribute");
     expect(campaignCall).toBeDefined();
     expect(campaignCall!.body!.keySource).toBe("platform");
   });
 
-  it("should default to 'platform' keySource when billing-service is unreachable", async () => {
-    mockFetchKeySource.mockResolvedValue("platform"); // billing.ts fallback
+  it("should default to 'platform' keySource when middleware resolves fallback", async () => {
+    mockKeySource = "platform";
 
     const app = createApp();
     const res = await request(app)

--- a/tests/unit/emailgen-stats-external.regression.test.ts
+++ b/tests/unit/emailgen-stats-external.regression.test.ts
@@ -42,7 +42,14 @@ vi.mock("../../src/middleware/auth.js", () => ({
 }));
 
 vi.mock("../../src/lib/internal-headers.js", () => ({
-  buildInternalHeaders: () => ({}),
+  buildInternalHeaders: (req: any) => {
+    const headers: Record<string, string> = {};
+    if (req.orgId) headers["x-org-id"] = req.orgId;
+    if (req.userId) headers["x-user-id"] = req.userId;
+    if (req.appId) headers["x-app-id"] = req.appId;
+    if (req.keySource) headers["x-key-source"] = req.keySource;
+    return headers;
+  },
 }));
 
 vi.mock("@distribute/runs-client", () => ({

--- a/tests/unit/emails.test.ts
+++ b/tests/unit/emails.test.ts
@@ -7,13 +7,14 @@ vi.mock("../../src/lib/billing.js", () => ({
   fetchKeySource: vi.fn().mockResolvedValue("platform"),
 }));
 
-// Mock auth middleware
+// Mock auth middleware — keySource is now resolved in middleware
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
     req.userId = "user_test123";
     req.orgId = "org_test456";
     req.appId = "distribute-frontend";
     req.authType = "user_key";
+    req.keySource = "platform";
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {

--- a/tests/unit/icp-suggestion-keytype.regression.test.ts
+++ b/tests/unit/icp-suggestion-keytype.regression.test.ts
@@ -10,6 +10,9 @@ import express from "express";
  * instead of a generic 500.
  */
 
+// Configurable auth context — keySource resolved in middleware
+let mockKeySource: string | undefined = "byok";
+
 // Mock auth middleware to skip real auth
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
@@ -17,6 +20,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
     req.orgId = "org_test456";
     req.appId = "distribute";
     req.authType = "app_key";
+    req.keySource = mockKeySource;
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -53,7 +57,7 @@ function createBrandApp() {
 describe("POST /v1/brand/icp-suggestion", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
+    mockKeySource = "byok";
   });
 
   it("should resolve keySource from billing-service and forward to brand-service", async () => {
@@ -80,11 +84,10 @@ describe("POST /v1/brand/icp-suggestion", () => {
     expect(capturedBody!.appId).toBe("distribute");
     expect(capturedBody!.url).toBe("https://example.com");
     expect(capturedBody!.orgId).toBe("org_test456");
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
   });
 
-  it("should forward keySource 'platform' when billing-service returns payg", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg", async () => {
+    mockKeySource = "platform";
 
     let capturedBody: Record<string, unknown> | undefined;
 

--- a/tests/unit/internal-headers.test.ts
+++ b/tests/unit/internal-headers.test.ts
@@ -24,4 +24,13 @@ describe("buildInternalHeaders", () => {
     // Should check if req.appId exists before adding
     expect(content).toContain("if (req.appId)");
   });
+
+  it("should include x-key-source when req.keySource is set", () => {
+    expect(content).toContain('"x-key-source"');
+    expect(content).toContain("req.keySource");
+  });
+
+  it("should conditionally add x-key-source (not always)", () => {
+    expect(content).toContain("if (req.keySource)");
+  });
 });

--- a/tests/unit/keysource-forwarding.test.ts
+++ b/tests/unit/keysource-forwarding.test.ts
@@ -16,13 +16,17 @@ import express from "express";
  * 7. POST /v1/emails/send
  */
 
-// Mock auth middleware
+// Configurable auth context — tests can toggle keySource
+let mockKeySource: string | undefined = "byok";
+
+// Mock auth middleware — keySource is now resolved here (mirroring real authenticate middleware)
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
     req.userId = "user_test123";
     req.orgId = "org_test456";
     req.appId = "distribute";
     req.authType = "app_key";
+    req.keySource = mockKeySource;
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -43,7 +47,7 @@ vi.mock("@distribute/runs-client", () => ({
   updateRun: vi.fn().mockResolvedValue({ id: "parent-run-123", status: "failed" }),
 }));
 
-// Mock billing module
+// Mock billing module (still needed for qualify.ts sourceOrgId override path)
 const mockFetchKeySource = vi.fn().mockResolvedValue("byok");
 vi.mock("../../src/lib/billing.js", () => ({
   fetchKeySource: (...args: unknown[]) => mockFetchKeySource(...args),
@@ -69,6 +73,7 @@ let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unkn
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  mockKeySource = "byok";
   mockFetchKeySource.mockResolvedValue("byok");
   fetchCalls = [];
 
@@ -83,12 +88,11 @@ beforeEach(() => {
 // 1. POST /v1/campaigns/:id/resume
 // ---------------------------------------------------------------
 describe("POST /v1/campaigns/:id/resume — keySource forwarding", () => {
-  it("should resolve keySource from billing-service and forward to campaign-service", async () => {
+  it("should forward keySource from middleware to campaign-service", async () => {
     const app = createApp(campaignRouter);
     const res = await request(app).post("/v1/campaigns/camp-123/resume").send({});
 
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     const patchCall = fetchCalls.find((c) => c.url.includes("/campaigns/camp-123") && c.method === "PATCH");
     expect(patchCall).toBeDefined();
@@ -96,8 +100,8 @@ describe("POST /v1/campaigns/:id/resume — keySource forwarding", () => {
     expect(patchCall!.body!.status).toBe("activate");
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockKeySource = "platform";
     const app = createApp(campaignRouter);
     await request(app).post("/v1/campaigns/camp-123/resume").send({});
 
@@ -110,14 +114,13 @@ describe("POST /v1/campaigns/:id/resume — keySource forwarding", () => {
 // 2. POST /v1/workflows/generate
 // ---------------------------------------------------------------
 describe("POST /v1/workflows/generate — keySource forwarding", () => {
-  it("should resolve keySource and forward to workflow-service", async () => {
+  it("should forward keySource from middleware to workflow-service", async () => {
     const app = createApp(workflowRouter);
     const res = await request(app)
       .post("/v1/workflows/generate")
       .send({ description: "Generate a cold outreach workflow for SaaS founders" });
 
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     const generateCall = fetchCalls.find((c) => c.url.includes("/workflows/generate") && c.method === "POST");
     expect(generateCall).toBeDefined();
@@ -127,8 +130,8 @@ describe("POST /v1/workflows/generate — keySource forwarding", () => {
     expect(generateCall!.body!.userId).toBe("user_test123");
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockKeySource = "platform";
     const app = createApp(workflowRouter);
     await request(app)
       .post("/v1/workflows/generate")
@@ -143,14 +146,13 @@ describe("POST /v1/workflows/generate — keySource forwarding", () => {
 // 4. POST /v1/leads/search
 // ---------------------------------------------------------------
 describe("POST /v1/leads/search — keySource forwarding", () => {
-  it("should resolve keySource and forward to lead-service", async () => {
+  it("should forward keySource from middleware to lead-service", async () => {
     const app = createApp(leadRouter);
     const res = await request(app)
       .post("/v1/leads/search")
       .send({ person_titles: ["CTO"] });
 
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     const searchCall = fetchCalls.find((c) => c.url.includes("/search") && c.method === "POST");
     expect(searchCall).toBeDefined();
@@ -160,8 +162,8 @@ describe("POST /v1/leads/search — keySource forwarding", () => {
     expect(searchCall!.body!.userId).toBe("user_test123");
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockKeySource = "platform";
     const app = createApp(leadRouter);
     await request(app)
       .post("/v1/leads/search")
@@ -176,7 +178,7 @@ describe("POST /v1/leads/search — keySource forwarding", () => {
 // 5. POST /v1/qualify
 // ---------------------------------------------------------------
 describe("POST /v1/qualify — keySource forwarding", () => {
-  it("should resolve keySource and forward to reply-qualification service", async () => {
+  it("should forward keySource from middleware to reply-qualification service", async () => {
     const app = createApp(qualifyRouter);
     const res = await request(app)
       .post("/v1/qualify")
@@ -187,7 +189,6 @@ describe("POST /v1/qualify — keySource forwarding", () => {
       });
 
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     const qualifyCall = fetchCalls.find((c) => c.url.includes("/qualify") && c.method === "POST");
     expect(qualifyCall).toBeDefined();
@@ -196,8 +197,8 @@ describe("POST /v1/qualify — keySource forwarding", () => {
     expect(qualifyCall!.body!.userId).toBe("user_test123");
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockKeySource = "platform";
     const app = createApp(qualifyRouter);
     await request(app)
       .post("/v1/qualify")
@@ -216,14 +217,13 @@ describe("POST /v1/qualify — keySource forwarding", () => {
 // 6. POST /v1/brand/scrape
 // ---------------------------------------------------------------
 describe("POST /v1/brand/scrape — keySource forwarding", () => {
-  it("should resolve keySource and forward to scraping-service", async () => {
+  it("should forward keySource from middleware to scraping-service", async () => {
     const app = createApp(brandRouter);
     const res = await request(app)
       .post("/v1/brand/scrape")
       .send({ url: "https://example.com" });
 
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     const scrapeCall = fetchCalls.find((c) => c.url.includes("/scrape") && c.method === "POST");
     expect(scrapeCall).toBeDefined();
@@ -231,8 +231,8 @@ describe("POST /v1/brand/scrape — keySource forwarding", () => {
     expect(scrapeCall!.body!.userId).toBe("user_test123");
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockKeySource = "platform";
     const app = createApp(brandRouter);
     await request(app)
       .post("/v1/brand/scrape")
@@ -247,7 +247,7 @@ describe("POST /v1/brand/scrape — keySource forwarding", () => {
 // 7. POST /v1/emails/send
 // ---------------------------------------------------------------
 describe("POST /v1/emails/send — keySource forwarding", () => {
-  it("should resolve keySource and forward to transactional-email-service", async () => {
+  it("should forward keySource from middleware to transactional-email-service", async () => {
     const app = createApp(emailsRouter);
     const res = await request(app)
       .post("/v1/emails/send")
@@ -257,7 +257,6 @@ describe("POST /v1/emails/send — keySource forwarding", () => {
       });
 
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute");
 
     const sendCall = fetchCalls.find((c) => c.url.includes("/send") && c.method === "POST");
     expect(sendCall).toBeDefined();
@@ -267,8 +266,8 @@ describe("POST /v1/emails/send — keySource forwarding", () => {
     expect(sendCall!.body!.userId).toBe("user_test123");
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockKeySource = "platform";
     const app = createApp(emailsRouter);
     await request(app)
       .post("/v1/emails/send")

--- a/tests/unit/stripe-proxy.test.ts
+++ b/tests/unit/stripe-proxy.test.ts
@@ -3,7 +3,7 @@ import express from "express";
 import request from "supertest";
 
 // Configurable auth context — tests can toggle org/user presence
-let mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456" as string | undefined, userId: "user_test123" as string | undefined, authType: "user_key" as string };
+let mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456" as string | undefined, userId: "user_test123" as string | undefined, authType: "user_key" as string, keySource: "byok" as string | undefined };
 
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
@@ -11,6 +11,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
     req.authType = mockAuthContext.authType;
     if (mockAuthContext.orgId) req.orgId = mockAuthContext.orgId;
     if (mockAuthContext.userId) req.userId = mockAuthContext.userId;
+    if (mockAuthContext.keySource) req.keySource = mockAuthContext.keySource;
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -60,7 +61,7 @@ function mockFetchOk(responseData: any = {}) {
 // ---------------------------------------------------------------------------
 
 function resetAuthContext() {
-  mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456", userId: "user_test123", authType: "user_key" };
+  mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456", userId: "user_test123", authType: "user_key", keySource: "byok" };
 }
 
 describe("GET /v1/stripe/products/:productId", () => {
@@ -68,7 +69,6 @@ describe("GET /v1/stripe/products/:productId", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "prod_123", name: "Webinar Access" });
     app = createApp();
@@ -79,8 +79,6 @@ describe("GET /v1/stripe/products/:productId", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe("Webinar Access");
-
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute-frontend");
 
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call).toBeDefined();
@@ -95,7 +93,6 @@ describe("POST /v1/stripe/products", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "prod_new", name: "Course" });
     app = createApp();
@@ -135,7 +132,6 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ prices: [{ id: "price_123", unitAmount: 4999 }] });
     app = createApp();
@@ -160,7 +156,6 @@ describe("POST /v1/stripe/prices", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "price_new" });
     app = createApp();
@@ -199,7 +194,6 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "WELCOME20", percentOff: 20 });
     app = createApp();
@@ -224,7 +218,6 @@ describe("POST /v1/stripe/coupons", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ id: "WELCOME20" });
     app = createApp();
@@ -263,7 +256,6 @@ describe("POST /v1/stripe/checkout", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ url: "https://checkout.stripe.com/session_123", sessionId: "cs_123" });
     app = createApp();
@@ -283,8 +275,6 @@ describe("POST /v1/stripe/checkout", () => {
     expect(res.status).toBe(200);
     expect(res.body.url).toContain("checkout.stripe.com");
 
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute-frontend");
-
     const call = fetchCalls.find((c) => c.url.includes("/checkout/create"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
@@ -298,8 +288,8 @@ describe("POST /v1/stripe/checkout", () => {
     });
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockAuthContext.keySource = "platform";
     const res = await request(app)
       .post("/v1/stripe/checkout")
       .send({
@@ -331,7 +321,6 @@ describe("POST /v1/stripe/stats", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     mockFetchOk({ totalRevenue: 12500, totalOrders: 5 });
     app = createApp();
@@ -345,8 +334,6 @@ describe("POST /v1/stripe/stats", () => {
     expect(res.status).toBe(200);
     expect(res.body.totalRevenue).toBe(12500);
 
-    expect(mockFetchKeySource).toHaveBeenCalledWith("org_test456", "distribute-frontend");
-
     const call = fetchCalls.find((c) => c.url.includes("/stats"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
@@ -356,8 +343,8 @@ describe("POST /v1/stripe/stats", () => {
     });
   });
 
-  it("should forward keySource 'platform' when billing returns payg/trial", async () => {
-    mockFetchKeySource.mockResolvedValue("platform");
+  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+    mockAuthContext.keySource = "platform";
     await request(app).post("/v1/stripe/stats").send({});
 
     const call = fetchCalls.find((c) => c.url.includes("/stats"));
@@ -379,9 +366,8 @@ describe("Stripe catalog endpoints — app key without org context", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockReset().mockResolvedValue("byok");
-    // Simulate app key with NO org/user context
-    mockAuthContext = { appId: "distribute-frontend", orgId: undefined, userId: undefined, authType: "app_key" };
+    // Simulate app key with NO org/user context — keySource is undefined (middleware can't resolve without orgId)
+    mockAuthContext = { appId: "distribute-frontend", orgId: undefined, userId: undefined, authType: "app_key", keySource: undefined };
     mockFetchOk({ id: "prod_123", name: "Webinar Access" });
     appKeyApp = createApp();
   });
@@ -389,7 +375,6 @@ describe("Stripe catalog endpoints — app key without org context", () => {
   it("GET /v1/stripe/products/:id should work without org context and omit orgId/keySource", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123");
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).not.toHaveBeenCalled();
 
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call!.url).toContain("appId=distribute-frontend");
@@ -412,7 +397,6 @@ describe("Stripe catalog endpoints — app key without org context", () => {
   it("GET /v1/stripe/products/:id/prices should work without org context and omit orgId/keySource", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123/prices");
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).not.toHaveBeenCalled();
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/by-product/prod_123"));
     expect(call!.url).not.toContain("orgId");
@@ -433,7 +417,6 @@ describe("Stripe catalog endpoints — app key without org context", () => {
   it("GET /v1/stripe/coupons/:id should work without org context and omit orgId/keySource", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/coupons/WELCOME20");
     expect(res.status).toBe(200);
-    expect(mockFetchKeySource).not.toHaveBeenCalled();
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/WELCOME20"));
     expect(call!.url).not.toContain("orgId");
@@ -479,7 +462,6 @@ describe("Stripe proxy — error handling", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockFetchKeySource.mockResolvedValue("byok");
     resetAuthContext();
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: false,


### PR DESCRIPTION
## Summary
- Resolves `keySource` (byok/platform) once in the `authenticate` middleware via billing-service, stored on `req.keySource`
- Updates `buildInternalHeaders` to include `x-key-source` header alongside `x-org-id`, `x-user-id`, `x-app-id`
- Every route that proxies to an internal service now forwards `keySource` via headers and/or body params
- Fixes PolarityCourse bug: stripe-service couldn't find their org-level Stripe key because `keySource` wasn't forwarded

### Files changed (23)
**Core**: `auth.ts` (middleware keySource resolution), `internal-headers.ts` (x-key-source header)
**Routes**: activity, brand, campaigns, chat, emails, keys, leads, qualify, stripe, users, workflows
**Tests**: Updated 9 test files to set `req.keySource` in mock auth; added `x-key-source` tests for buildInternalHeaders

### Exceptions
- `performance.ts`: Unchanged (cross-org analytics aggregation, doesn't use key stores)
- `billing.ts`: Unchanged (hardcodes "platform" — billing IS the keySource resolver)
- `qualify.ts`: Still calls `fetchKeySource` for `sourceOrgId` override case where a different org is specified

## Test plan
- [x] All 372 tests pass (3 pre-existing failures unrelated to this PR)
- [x] keySource forwarding tests updated for middleware approach
- [x] buildInternalHeaders tests verify x-key-source inclusion
- [x] Stripe proxy tests verify keySource in both query params and body

🤖 Generated with [Claude Code](https://claude.com/claude-code)