### PR TITLE
feat: register Postmark stream IDs at startup

### DIFF
--- a/src/startup.ts
+++ b/src/startup.ts
@@ -7,6 +7,9 @@ const PLATFORM_KEYS: { provider: string; envVar: string }[] = [
   { provider: "firecrawl", envVar: "FIRECRAWL_API_KEY" },
   { provider: "gemini", envVar: "GEMINI_API_KEY" },
   { provider: "postmark", envVar: "POSTMARK_API_KEY" },
+  { provider: "postmark-broadcast-stream", envVar: "POSTMARK_BROADCAST_STREAM_ID" },
+  { provider: "postmark-inbound-stream", envVar: "POSTMARK_INBOUND_STREAM_ID" },
+  { provider: "postmark-transactional-stream", envVar: "POSTMARK_TRANSACTIONAL_STREAM_ID" },
   { provider: "stripe", envVar: "STRIPE_SECRET_KEY" },
   { provider: "stripe-webhook", envVar: "STRIPE_WEBHOOK_SECRET" },
 ];

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -21,6 +21,9 @@ function setAllEnvVars() {
   process.env.FIRECRAWL_API_KEY = "fc-test";
   process.env.GEMINI_API_KEY = "gemini-test";
   process.env.POSTMARK_API_KEY = "postmark-test";
+  process.env.POSTMARK_BROADCAST_STREAM_ID = "broadcast";
+  process.env.POSTMARK_INBOUND_STREAM_ID = "inbound";
+  process.env.POSTMARK_TRANSACTIONAL_STREAM_ID = "outbound";
   process.env.STRIPE_SECRET_KEY = "sk_test_stripe";
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 }
@@ -32,6 +35,9 @@ function deleteAllEnvVars() {
   delete process.env.FIRECRAWL_API_KEY;
   delete process.env.GEMINI_API_KEY;
   delete process.env.POSTMARK_API_KEY;
+  delete process.env.POSTMARK_BROADCAST_STREAM_ID;
+  delete process.env.POSTMARK_INBOUND_STREAM_ID;
+  delete process.env.POSTMARK_TRANSACTIONAL_STREAM_ID;
   delete process.env.STRIPE_SECRET_KEY;
   delete process.env.STRIPE_WEBHOOK_SECRET;
 }
@@ -69,7 +75,7 @@ describe("registerPlatformKeys", () => {
     await registerPlatformKeys();
 
     const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/keys") && c.body?.keySource === "platform");
-    expect(platformKeyCalls).toHaveLength(8);
+    expect(platformKeyCalls).toHaveLength(11);
 
     const providers = platformKeyCalls.map((c) => c.body?.provider);
     expect(providers).toContain("anthropic");
@@ -78,6 +84,9 @@ describe("registerPlatformKeys", () => {
     expect(providers).toContain("firecrawl");
     expect(providers).toContain("gemini");
     expect(providers).toContain("postmark");
+    expect(providers).toContain("postmark-broadcast-stream");
+    expect(providers).toContain("postmark-inbound-stream");
+    expect(providers).toContain("postmark-transactional-stream");
     expect(providers).toContain("stripe");
     expect(providers).toContain("stripe-webhook");
 


### PR DESCRIPTION
## Summary
- Registers 3 new Postmark stream ID env vars as platform keys at startup: `POSTMARK_BROADCAST_STREAM_ID`, `POSTMARK_INBOUND_STREAM_ID`, `POSTMARK_TRANSACTIONAL_STREAM_ID`
- These are now available via key-service for downstream services (transactional-email-service, postmark-service) to resolve via standard key resolution

## Test plan
- [x] Startup test updated: expects 11 platform keys (was 8), verifies all 3 new providers registered
- [x] All 4 startup tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)