### PR TITLE
fix: forward orgId and userId on all email routes

### DIFF
--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -56,6 +56,7 @@ router.post("/emails/stats", authenticate, requireOrg, async (req: Authenticated
         body: {
           appId: req.appId,
           orgId: req.orgId,
+          userId: req.userId,
           keySource: req.keySource,
           ...parsed.data,
         },
@@ -86,6 +87,8 @@ router.put("/emails/templates", authenticate, requireOrg, async (req: Authentica
         method: "PUT",
         body: {
           appId: req.appId,
+          orgId: req.orgId,
+          userId: req.userId,
           keySource: req.keySource,
           ...parsed.data,
         },

--- a/tests/unit/emails.test.ts
+++ b/tests/unit/emails.test.ts
@@ -133,7 +133,7 @@ describe("POST /v1/emails/stats", () => {
     app = createApp();
   });
 
-  it("should forward stats request with appId and orgId", async () => {
+  it("should forward stats request with appId, orgId, userId and keySource", async () => {
     const res = await request(app)
       .post("/v1/emails/stats")
       .send({ eventType: "webinar_welcome" });
@@ -146,6 +146,8 @@ describe("POST /v1/emails/stats", () => {
     expect(statsCall!.body).toMatchObject({
       appId: "distribute-frontend",
       orgId: "org_test456",
+      userId: "user_test123",
+      keySource: "platform",
       eventType: "webinar_welcome",
     });
   });
@@ -176,7 +178,7 @@ describe("PUT /v1/emails/templates", () => {
     app = createApp();
   });
 
-  it("should forward template deployment with appId", async () => {
+  it("should forward template deployment with appId, orgId, userId and keySource", async () => {
     const res = await request(app)
       .put("/v1/emails/templates")
       .send({
@@ -197,6 +199,9 @@ describe("PUT /v1/emails/templates", () => {
     expect(deployCall!.method).toBe("PUT");
     expect(deployCall!.body).toMatchObject({
       appId: "distribute-frontend",
+      orgId: "org_test456",
+      userId: "user_test123",
+      keySource: "platform",
       templates: [
         {
           name: "webinar_welcome",


### PR DESCRIPTION
## Summary
- `POST /v1/emails/stats` was missing `userId` in the body forwarded to transactional-email-service
- `PUT /v1/emails/templates` was missing both `orgId` and `userId`
- These are now required by transactional-email-service — without them, requests fail with 400

## Test plan
- [x] Updated email tests to assert `orgId`, `userId`, and `keySource` on `/stats` and `/templates` calls
- [x] All 8 email tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)