### PR TITLE
refactor: rename keySource byok → org

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -65,7 +65,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Bearer token authentication.\n\nUse an API key (`distrib.usr_*`) as your Bearer token. Create one via `POST /v1/api-keys` or in the dashboard.\n\nFor multi-tenant platforms: app keys (`distrib.app_*`) are also supported — see the Platform section in the API description."
+        "description": "Bearer token authentication.\n\nUse an API key (`distrib.usr_*`) as your Bearer token. Create one via `POST /v1/api-keys` or in the dashboard.\n\nYour key carries your org and user identity. No extra headers needed."
       }
     },
     "schemas": {
@@ -1792,7 +1792,7 @@
             "description": "Created campaign"
           },
           "400": {
-            "description": "Validation error. If keySource is 'byok' and the org is missing required provider keys, returns error code `missing_keys` with lists of missing and configured providers.",
+            "description": "Validation error. If keySource is 'org' and the org is missing required provider keys, returns error code `missing_keys` with lists of missing and configured providers.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,6 +1,6 @@
 import { callExternalService, externalServices } from "./service-client.js";
 
-export type KeySource = "platform" | "byok";
+export type KeySource = "platform" | "org";
 
 interface BillingAccount {
   id: string;
@@ -22,6 +22,6 @@ export async function fetchKeySource(orgId: string, appId: string): Promise<KeyS
     "/v1/accounts",
     { headers: { "x-app-id": appId, "x-org-id": orgId, "x-key-source": "platform" } }
   );
-  if (result.billingMode === "byok") return "byok";
+  if (result.billingMode === "byok") return "org";
   return "platform";
 }

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -86,7 +86,7 @@ router.post("/brand/sales-profile", authenticate, requireOrg, requireUser, async
     const msg = error.message || "Failed to extract sales profile";
     if (msg.includes("No Anthropic API key found")) {
       return res.status(400).json({
-        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys (BYOK).",
+        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
       });
     }
     res.status(500).json({ error: msg });
@@ -235,7 +235,7 @@ router.post("/brand/icp-suggestion", authenticate, requireOrg, requireUser, asyn
     const msg = error.message || "Failed to get ICP suggestion";
     if (msg.includes("No Anthropic API key found")) {
       return res.status(400).json({
-        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys (BYOK).",
+        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
       });
     }
     res.status(500).json({ error: msg });

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -192,8 +192,8 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
     const keySource = req.keySource;
     console.log("[api-service] POST /v1/campaigns — step 3: keySource from auth middleware", { keySource });
 
-    // 3b. Pre-campaign key validation: if BYOK, check org has all required provider keys
-    if (keySource === "byok") {
+    // 3b. Pre-campaign key validation: if org-provided keys, check org has all required provider keys
+    if (keySource === "org") {
       const workflow = await resolveWorkflowByName(parsed.data.workflowName);
       if (workflow) {
         const [requiredProviders, orgKeys] = await Promise.all([
@@ -207,7 +207,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
           const missing = requiredProviders.filter((p) => !configuredSet.has(p));
 
           if (missing.length > 0) {
-            console.warn("[api-service] POST /v1/campaigns — missing BYOK keys", { missing, configured });
+            console.warn("[api-service] POST /v1/campaigns — missing org keys", { missing, configured });
             await updateRun(parentRun.id, "failed").catch(() => {});
             return res.status(400).json({
               error: "missing_keys",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -241,7 +241,7 @@ registry.registerPath({
     200: { description: "Created campaign" },
     400: {
       description:
-        "Validation error. If keySource is 'byok' and the org is missing required provider keys, " +
+        "Validation error. If keySource is 'org' and the org is missing required provider keys, " +
         "returns error code `missing_keys` with lists of missing and configured providers.",
       content: errorContent,
     },

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -5,7 +5,7 @@ import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../
 
 // Mock billing module — keySource resolution is best-effort in middleware
 vi.mock("../../src/lib/billing.js", () => ({
-  fetchKeySource: vi.fn().mockResolvedValue("byok"),
+  fetchKeySource: vi.fn().mockResolvedValue("org"),
 }));
 
 // Mock callExternalService for both key-service /validate and client-service /resolve

--- a/tests/unit/billing.test.ts
+++ b/tests/unit/billing.test.ts
@@ -75,11 +75,11 @@ describe("fetchKeySource", () => {
     expect(result).toBe("platform");
   });
 
-  it("should return 'byok' for byok billing mode", async () => {
+  it("should return 'org' for byok billing mode", async () => {
     global.fetch = vi.fn().mockResolvedValue(mockBillingAccountResponse("byok"));
 
     const result = await fetchKeySource("org-123", "distribute");
-    expect(result).toBe("byok");
+    expect(result).toBe("org");
   });
 
   it("should throw when billing-service is unreachable", async () => {

--- a/tests/unit/brand-sales-profile-from-url.test.ts
+++ b/tests/unit/brand-sales-profile-from-url.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
     req.orgId = "org_test456";
     req.appId = "distribute";
     req.authType = "app_key";
-    req.keySource = "byok";
+    req.keySource = "org";
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {
@@ -81,7 +81,7 @@ describe("POST /v1/brand/sales-profile", () => {
     app = buildApp();
     capturedBody = undefined;
 
-    mockFetchKeySource.mockResolvedValue("byok");
+    mockFetchKeySource.mockResolvedValue("org");
     mockCreateRun.mockResolvedValue({ id: "run-parent-001" });
 
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
@@ -116,7 +116,7 @@ describe("POST /v1/brand/sales-profile", () => {
       appId: "distribute",
       orgId: "org_test456",
       userId: "user_test123",
-      keyType: "byok",
+      keyType: "org",
       parentRunId: "run-parent-001",
     });
   });

--- a/tests/unit/campaign-key-validation.test.ts
+++ b/tests/unit/campaign-key-validation.test.ts
@@ -3,7 +3,7 @@ import express from "express";
 import request from "supertest";
 
 // Configurable auth context — keySource resolved in middleware
-let mockKeySource: string | undefined = "byok";
+let mockKeySource: string | undefined = "org";
 
 // Mock auth middleware
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -34,7 +34,7 @@ vi.mock("@distribute/runs-client", () => ({
 }));
 
 // Mock billing module
-const mockFetchKeySource = vi.fn().mockResolvedValue("byok");
+const mockFetchKeySource = vi.fn().mockResolvedValue("org");
 vi.mock("../../src/lib/billing.js", () => ({
   fetchKeySource: (...args: unknown[]) => mockFetchKeySource(...args),
 }));
@@ -65,12 +65,12 @@ const validCampaignBody = {
 // ---------------------------------------------------------------------------
 // Pre-campaign key validation on POST /v1/campaigns
 // ---------------------------------------------------------------------------
-describe("POST /v1/campaigns — pre-campaign BYOK key validation", () => {
+describe("POST /v1/campaigns — pre-campaign org key validation", () => {
   let app: express.Express;
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockKeySource = "byok";
+    mockKeySource = "org";
   });
 
   it("should return 400 with missing_keys when org lacks required providers", async () => {
@@ -178,7 +178,7 @@ describe("POST /v1/campaigns — pre-campaign BYOK key validation", () => {
     expect(res.body.campaign).toBeDefined();
   });
 
-  it("should skip validation when keySource is platform (not byok)", async () => {
+  it("should skip validation when keySource is platform (not org)", async () => {
     mockKeySource = "platform";
 
     global.fetch = vi.fn().mockImplementation(async (url: string) => {

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -12,7 +12,7 @@ import express from "express";
  */
 
 // Configurable auth context — keySource resolved in middleware
-let mockKeySource: string | undefined = "byok";
+let mockKeySource: string | undefined = "org";
 
 // Mock auth middleware
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -42,8 +42,8 @@ vi.mock("@distribute/runs-client", () => ({
   updateRun: vi.fn().mockResolvedValue({ id: "parent-run-123", status: "failed" }),
 }));
 
-// Mock billing module — default to "byok"
-const mockFetchKeySource = vi.fn().mockResolvedValue("byok");
+// Mock billing module — default to "org"
+const mockFetchKeySource = vi.fn().mockResolvedValue("org");
 vi.mock("../../src/lib/billing.js", () => ({
   fetchKeySource: (...args: unknown[]) => mockFetchKeySource(...args),
 }));
@@ -62,7 +62,7 @@ describe("POST /v1/campaigns with targetAudience", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockKeySource = "byok";
+    mockKeySource = "org";
     fetchCalls = [];
 
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
@@ -137,7 +137,7 @@ describe("POST /v1/campaigns with targetAudience", () => {
     expect(campaignCall!.body!.socialProof).toBe("Backed by 60 sponsors including Acme, Globex");
     expect(campaignCall!.body!.brandId).toBe("brand-uuid-123");
     expect(campaignCall!.body!.orgId).toBe("org_test456");
-    expect(campaignCall!.body!.keySource).toBe("byok");
+    expect(campaignCall!.body!.keySource).toBe("org");
 
     // Verify NO Apollo fields were sent
     expect(campaignCall!.body!.personTitles).toBeUndefined();

--- a/tests/unit/icp-suggestion-keytype.regression.test.ts
+++ b/tests/unit/icp-suggestion-keytype.regression.test.ts
@@ -11,7 +11,7 @@ import express from "express";
  */
 
 // Configurable auth context — keySource resolved in middleware
-let mockKeySource: string | undefined = "byok";
+let mockKeySource: string | undefined = "org";
 
 // Mock auth middleware to skip real auth
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -40,7 +40,7 @@ vi.mock("@distribute/runs-client", () => ({
 }));
 
 // Mock billing module
-const mockFetchKeySource = vi.fn().mockResolvedValue("byok");
+const mockFetchKeySource = vi.fn().mockResolvedValue("org");
 vi.mock("../../src/lib/billing.js", () => ({
   fetchKeySource: (...args: unknown[]) => mockFetchKeySource(...args),
 }));
@@ -57,7 +57,7 @@ function createBrandApp() {
 describe("POST /v1/brand/icp-suggestion", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    mockKeySource = "byok";
+    mockKeySource = "org";
   });
 
   it("should resolve keySource from billing-service and forward to brand-service", async () => {
@@ -80,7 +80,7 @@ describe("POST /v1/brand/icp-suggestion", () => {
       .send({ brandUrl: "https://example.com" });
 
     expect(capturedBody).toBeDefined();
-    expect(capturedBody!.keySource).toBe("byok");
+    expect(capturedBody!.keySource).toBe("org");
     expect(capturedBody!.appId).toBe("distribute");
     expect(capturedBody!.url).toBe("https://example.com");
     expect(capturedBody!.orgId).toBe("org_test456");
@@ -111,15 +111,15 @@ describe("POST /v1/brand/icp-suggestion", () => {
     expect(capturedBody!.keySource).toBe("platform");
   });
 
-  it("should return 400 with helpful message when Anthropic BYOK key is missing", async () => {
-    const errorBody = JSON.stringify({ error: "No Anthropic API key found (keyType: byok)" });
+  it("should return 400 with helpful message when Anthropic org key is missing", async () => {
+    const errorBody = JSON.stringify({ error: "No Anthropic API key found (keyType: org)" });
     global.fetch = vi.fn().mockImplementation(async (_url: string) => {
       if (typeof _url === "string" && _url.includes("/icp-suggestion")) {
         return {
           ok: false,
           status: 400,
           text: () => Promise.resolve(errorBody),
-          json: () => Promise.resolve({ error: "No Anthropic API key found (keyType: byok)" }),
+          json: () => Promise.resolve({ error: "No Anthropic API key found (keyType: org)" }),
         };
       }
       return { ok: true, json: () => Promise.resolve({}) };
@@ -132,7 +132,7 @@ describe("POST /v1/brand/icp-suggestion", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Anthropic API key not configured");
-    expect(res.body.error).toContain("BYOK");
+    expect(res.body.error).toContain("API Keys");
   });
 
   it("should return 400 when brandUrl is missing", async () => {

--- a/tests/unit/keysource-forwarding.test.ts
+++ b/tests/unit/keysource-forwarding.test.ts
@@ -17,7 +17,7 @@ import express from "express";
  */
 
 // Configurable auth context — tests can toggle keySource
-let mockKeySource: string | undefined = "byok";
+let mockKeySource: string | undefined = "org";
 
 // Mock auth middleware — keySource is now resolved here (mirroring real authenticate middleware)
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -48,7 +48,7 @@ vi.mock("@distribute/runs-client", () => ({
 }));
 
 // Mock billing module (still needed for qualify.ts sourceOrgId override path)
-const mockFetchKeySource = vi.fn().mockResolvedValue("byok");
+const mockFetchKeySource = vi.fn().mockResolvedValue("org");
 vi.mock("../../src/lib/billing.js", () => ({
   fetchKeySource: (...args: unknown[]) => mockFetchKeySource(...args),
 }));
@@ -73,8 +73,8 @@ let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unkn
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  mockKeySource = "byok";
-  mockFetchKeySource.mockResolvedValue("byok");
+  mockKeySource = "org";
+  mockFetchKeySource.mockResolvedValue("org");
   fetchCalls = [];
 
   global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
@@ -96,7 +96,7 @@ describe("POST /v1/campaigns/:id/resume — keySource forwarding", () => {
 
     const patchCall = fetchCalls.find((c) => c.url.includes("/campaigns/camp-123") && c.method === "PATCH");
     expect(patchCall).toBeDefined();
-    expect(patchCall!.body!.keySource).toBe("byok");
+    expect(patchCall!.body!.keySource).toBe("org");
     expect(patchCall!.body!.status).toBe("activate");
   });
 
@@ -124,7 +124,7 @@ describe("POST /v1/workflows/generate — keySource forwarding", () => {
 
     const generateCall = fetchCalls.find((c) => c.url.includes("/workflows/generate") && c.method === "POST");
     expect(generateCall).toBeDefined();
-    expect(generateCall!.body!.keySource).toBe("byok");
+    expect(generateCall!.body!.keySource).toBe("org");
     expect(generateCall!.body!.appId).toBe("distribute");
     expect(generateCall!.body!.orgId).toBe("org_test456");
     expect(generateCall!.body!.userId).toBe("user_test123");
@@ -156,7 +156,7 @@ describe("POST /v1/leads/search — keySource forwarding", () => {
 
     const searchCall = fetchCalls.find((c) => c.url.includes("/search") && c.method === "POST");
     expect(searchCall).toBeDefined();
-    expect(searchCall!.body!.keySource).toBe("byok");
+    expect(searchCall!.body!.keySource).toBe("org");
     expect(searchCall!.body!.appId).toBe("distribute");
     expect(searchCall!.body!.orgId).toBe("org_test456");
     expect(searchCall!.body!.userId).toBe("user_test123");
@@ -192,7 +192,7 @@ describe("POST /v1/qualify — keySource forwarding", () => {
 
     const qualifyCall = fetchCalls.find((c) => c.url.includes("/qualify") && c.method === "POST");
     expect(qualifyCall).toBeDefined();
-    expect(qualifyCall!.body!.keySource).toBe("byok");
+    expect(qualifyCall!.body!.keySource).toBe("org");
     expect(qualifyCall!.body!.appId).toBe("distribute");
     expect(qualifyCall!.body!.userId).toBe("user_test123");
   });
@@ -227,7 +227,7 @@ describe("POST /v1/brand/scrape — keySource forwarding", () => {
 
     const scrapeCall = fetchCalls.find((c) => c.url.includes("/scrape") && c.method === "POST");
     expect(scrapeCall).toBeDefined();
-    expect(scrapeCall!.body!.keySource).toBe("byok");
+    expect(scrapeCall!.body!.keySource).toBe("org");
     expect(scrapeCall!.body!.userId).toBe("user_test123");
   });
 
@@ -260,7 +260,7 @@ describe("POST /v1/emails/send — keySource forwarding", () => {
 
     const sendCall = fetchCalls.find((c) => c.url.includes("/send") && c.method === "POST");
     expect(sendCall).toBeDefined();
-    expect(sendCall!.body!.keySource).toBe("byok");
+    expect(sendCall!.body!.keySource).toBe("org");
     expect(sendCall!.body!.appId).toBe("distribute");
     expect(sendCall!.body!.orgId).toBe("org_test456");
     expect(sendCall!.body!.userId).toBe("user_test123");

--- a/tests/unit/stripe-proxy.test.ts
+++ b/tests/unit/stripe-proxy.test.ts
@@ -3,7 +3,7 @@ import express from "express";
 import request from "supertest";
 
 // Configurable auth context — tests can toggle org/user presence
-let mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456" as string | undefined, userId: "user_test123" as string | undefined, authType: "user_key" as string, keySource: "byok" as string | undefined };
+let mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456" as string | undefined, userId: "user_test123" as string | undefined, authType: "user_key" as string, keySource: "org" as string | undefined };
 
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
@@ -25,7 +25,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
   AuthenticatedRequest: {},
 }));
 
-const mockFetchKeySource = vi.fn().mockResolvedValue("byok");
+const mockFetchKeySource = vi.fn().mockResolvedValue("org");
 vi.mock("../../src/lib/billing.js", () => ({
   fetchKeySource: (...args: unknown[]) => mockFetchKeySource(...args),
 }));
@@ -61,7 +61,7 @@ function mockFetchOk(responseData: any = {}) {
 // ---------------------------------------------------------------------------
 
 function resetAuthContext() {
-  mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456", userId: "user_test123", authType: "user_key", keySource: "byok" };
+  mockAuthContext = { appId: "distribute-frontend", orgId: "org_test456", userId: "user_test123", authType: "user_key", keySource: "org" };
 }
 
 describe("GET /v1/stripe/products/:productId", () => {
@@ -84,7 +84,7 @@ describe("GET /v1/stripe/products/:productId", () => {
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).toContain("orgId=org_test456");
-    expect(call!.url).toContain("keySource=byok");
+    expect(call!.url).toContain("keySource=org");
   });
 });
 
@@ -111,7 +111,7 @@ describe("POST /v1/stripe/products", () => {
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
       orgId: "org_test456",
-      keySource: "byok",
+      keySource: "org",
       name: "Course",
       description: "Online course",
     });
@@ -147,7 +147,7 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).toContain("orgId=org_test456");
-    expect(call!.url).toContain("keySource=byok");
+    expect(call!.url).toContain("keySource=org");
   });
 });
 
@@ -171,7 +171,7 @@ describe("POST /v1/stripe/prices", () => {
     const call = fetchCalls.find((c) => c.url.includes("/prices/create"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
-      keySource: "byok",
+      keySource: "org",
       productId: "prod_123",
       unitAmountCents: 4999,
     });
@@ -209,7 +209,7 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
     expect(call!.url).toContain("orgId=org_test456");
-    expect(call!.url).toContain("keySource=byok");
+    expect(call!.url).toContain("keySource=org");
   });
 });
 
@@ -233,7 +233,7 @@ describe("POST /v1/stripe/coupons", () => {
     const call = fetchCalls.find((c) => c.url.includes("/coupons/create"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
-      keySource: "byok",
+      keySource: "org",
       percentOff: 20,
       duration: "once",
     });
@@ -280,7 +280,7 @@ describe("POST /v1/stripe/checkout", () => {
       appId: "distribute-frontend",
       orgId: "org_test456",
       userId: "user_test123",
-      keySource: "byok",
+      keySource: "org",
       lineItems: [{ priceId: "price_123", quantity: 1 }],
       successUrl: "https://polarity.com/success",
       cancelUrl: "https://polarity.com/cancel",
@@ -338,7 +338,7 @@ describe("POST /v1/stripe/stats", () => {
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
       orgId: "org_test456",
-      keySource: "byok",
+      keySource: "org",
       brandId: "brand_abc",
     });
   });


### PR DESCRIPTION
## Summary
- Renames keySource value `"byok"` to `"org"` across the entire codebase (source, tests, OpenAPI spec)
- `"platform"` stays unchanged — the two valid keySource values are now `"platform"` and `"org"`
- The billing-service `billingMode: "byok"` is still mapped correctly — `fetchKeySource()` now returns `"org"` instead of `"byok"` for that mode
- Removes "(BYOK)" from user-facing error messages

## Test plan
- [x] All 13 changed files (source + tests + openapi.json) updated consistently
- [x] `pnpm test` passes — 0 regressions (3 pre-existing failures unrelated to this change)
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)