### PR TITLE
fix: forward orgId and userId as headers on all downstream calls

### DIFF
--- a/src/routes/activity.ts
+++ b/src/routes/activity.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
 
@@ -12,12 +13,12 @@ router.post("/activity", authenticate, requireOrg, requireUser, async (req: Auth
   try {
     callExternalService(externalServices.transactionalEmail, "/send", {
       method: "POST",
+      headers: buildInternalHeaders(req),
       body: {
         appId: req.appId!,
         eventType: "user_active",
         userId: req.userId,
         orgId: req.orgId,
-        keySource: req.keySource,
       },
     }).catch((err) => console.warn("[activity] Transactional email failed:", err.message));
 

--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { SendEmailRequestSchema, EmailStatsRequestSchema, DeployEmailTemplatesRequestSchema } from "../schemas.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
 
@@ -21,11 +22,11 @@ router.post("/emails/send", authenticate, requireOrg, async (req: AuthenticatedR
       "/send",
       {
         method: "POST",
+        headers: buildInternalHeaders(req),
         body: {
           appId: req.appId,
           orgId: req.orgId,
           userId: req.userId,
-          keySource: req.keySource,
           ...parsed.data,
         },
       }
@@ -53,11 +54,10 @@ router.post("/emails/stats", authenticate, requireOrg, async (req: Authenticated
       "/stats",
       {
         method: "POST",
+        headers: buildInternalHeaders(req),
         body: {
           appId: req.appId,
           orgId: req.orgId,
-          userId: req.userId,
-          keySource: req.keySource,
           ...parsed.data,
         },
       }
@@ -85,11 +85,9 @@ router.put("/emails/templates", authenticate, requireOrg, async (req: Authentica
       "/templates",
       {
         method: "PUT",
+        headers: buildInternalHeaders(req),
         body: {
           appId: req.appId,
-          orgId: req.orgId,
-          userId: req.userId,
-          keySource: req.keySource,
           ...parsed.data,
         },
       }

--- a/src/routes/qualify.ts
+++ b/src/routes/qualify.ts
@@ -3,6 +3,7 @@ import { authenticate, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { QualifyRequestSchema } from "../schemas.js";
 import { fetchKeySource } from "../lib/billing.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
 
@@ -39,11 +40,17 @@ router.post("/qualify", authenticate, async (req: AuthenticatedRequest, res) => 
     }
     if (!keySource) keySource = "platform";
 
+    // Build headers; override x-key-source if sourceOrgId resolved a different keySource
+    const headers = buildInternalHeaders(req);
+    if (keySource) headers["x-key-source"] = keySource;
+    if (orgId && orgId !== req.orgId) headers["x-org-id"] = orgId;
+
     const result = await callExternalService(
       externalServices.replyQualification,
       "/qualify",
       {
         method: "POST",
+        headers,
         body: {
           sourceService,
           sourceOrgId: orgId,
@@ -55,7 +62,6 @@ router.post("/qualify", authenticate, async (req: AuthenticatedRequest, res) => 
           bodyHtml,
           appId: req.appId!,
           userId: req.userId,
-          keySource,
           byokApiKey,
         },
       }

--- a/src/routes/stripe.ts
+++ b/src/routes/stripe.ts
@@ -8,6 +8,7 @@ import {
   CreateStripeCheckoutRequestSchema,
   StripeStatsRequestSchema,
 } from "../schemas.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
 
@@ -23,11 +24,10 @@ router.get("/stripe/products/:productId", authenticate, async (req: Authenticate
   try {
     const { productId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) qs.set("orgId", req.orgId);
-    if (req.keySource) qs.set("keySource", req.keySource);
     const result = await callExternalService(
       externalServices.stripe,
       `/products/${encodeURIComponent(productId)}?${qs}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -52,10 +52,9 @@ router.post("/stripe/products", authenticate, async (req: AuthenticatedRequest, 
       "/products/create",
       {
         method: "POST",
+        headers: buildInternalHeaders(req),
         body: {
           appId: req.appId,
-          ...(req.orgId && { orgId: req.orgId }),
-          ...(req.keySource && { keySource: req.keySource }),
           ...parsed.data,
         },
       }
@@ -79,11 +78,10 @@ router.get("/stripe/products/:productId/prices", authenticate, async (req: Authe
   try {
     const { productId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) qs.set("orgId", req.orgId);
-    if (req.keySource) qs.set("keySource", req.keySource);
     const result = await callExternalService(
       externalServices.stripe,
       `/prices/by-product/${encodeURIComponent(productId)}?${qs}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -108,10 +106,9 @@ router.post("/stripe/prices", authenticate, async (req: AuthenticatedRequest, re
       "/prices/create",
       {
         method: "POST",
+        headers: buildInternalHeaders(req),
         body: {
           appId: req.appId,
-          ...(req.orgId && { orgId: req.orgId }),
-          ...(req.keySource && { keySource: req.keySource }),
           ...parsed.data,
         },
       }
@@ -135,11 +132,10 @@ router.get("/stripe/coupons/:couponId", authenticate, async (req: AuthenticatedR
   try {
     const { couponId } = req.params;
     const qs = new URLSearchParams({ appId: req.appId! });
-    if (req.orgId) qs.set("orgId", req.orgId);
-    if (req.keySource) qs.set("keySource", req.keySource);
     const result = await callExternalService(
       externalServices.stripe,
       `/coupons/${encodeURIComponent(couponId)}?${qs}`,
+      { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
@@ -164,10 +160,9 @@ router.post("/stripe/coupons", authenticate, async (req: AuthenticatedRequest, r
       "/coupons/create",
       {
         method: "POST",
+        headers: buildInternalHeaders(req),
         body: {
           appId: req.appId,
-          ...(req.orgId && { orgId: req.orgId }),
-          ...(req.keySource && { keySource: req.keySource }),
           ...parsed.data,
         },
       }
@@ -199,7 +194,8 @@ router.post("/stripe/checkout", authenticate, requireOrg, async (req: Authentica
       "/checkout/create",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, userId: req.userId, keySource: req.keySource, ...parsed.data },
+        headers: buildInternalHeaders(req),
+        body: { appId: req.appId, ...parsed.data },
       }
     );
     res.json(result);
@@ -229,7 +225,8 @@ router.post("/stripe/stats", authenticate, requireOrg, async (req: Authenticated
       "/stats",
       {
         method: "POST",
-        body: { appId: req.appId, orgId: req.orgId, keySource: req.keySource, ...parsed.data },
+        headers: buildInternalHeaders(req),
+        body: { appId: req.appId, ...parsed.data },
       }
     );
     res.json(result);

--- a/tests/unit/emails.test.ts
+++ b/tests/unit/emails.test.ts
@@ -32,6 +32,7 @@ interface FetchCall {
   url: string;
   method?: string;
   body?: any;
+  headers?: Record<string, string>;
 }
 
 let fetchCalls: FetchCall[] = [];
@@ -53,7 +54,8 @@ describe("POST /v1/emails/send", () => {
     fetchCalls = [];
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      fetchCalls.push({ url, method: init?.method, body });
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
       return {
         ok: true,
         json: () => Promise.resolve({ results: [{ email: "test@example.com", sent: true }] }),
@@ -82,12 +84,15 @@ describe("POST /v1/emails/send", () => {
       appId: "distribute-frontend",
       orgId: "org_test456",
       userId: "user_test123",
-      keySource: "platform",
       eventType: "webinar_welcome",
       recipientEmail: "user@polarity.com",
       productId: "webinar-123",
       metadata: { name: "Kevin" },
     });
+    expect(sendCall!.body.keySource).toBeUndefined();
+    expect(sendCall!.headers!["x-org-id"]).toBe("org_test456");
+    expect(sendCall!.headers!["x-user-id"]).toBe("user_test123");
+    expect(sendCall!.headers!["x-key-source"]).toBe("platform");
   });
 
   it("should return 400 when eventType is missing", async () => {
@@ -124,7 +129,8 @@ describe("POST /v1/emails/stats", () => {
     fetchCalls = [];
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      fetchCalls.push({ url, method: init?.method, body });
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
       return {
         ok: true,
         json: () => Promise.resolve({ stats: { totalEmails: 42, sent: 40, failed: 2 } }),
@@ -133,7 +139,7 @@ describe("POST /v1/emails/stats", () => {
     app = createApp();
   });
 
-  it("should forward stats request with appId, orgId, userId and keySource", async () => {
+  it("should forward stats request with filters in body and identity in headers", async () => {
     const res = await request(app)
       .post("/v1/emails/stats")
       .send({ eventType: "webinar_welcome" });
@@ -146,10 +152,13 @@ describe("POST /v1/emails/stats", () => {
     expect(statsCall!.body).toMatchObject({
       appId: "distribute-frontend",
       orgId: "org_test456",
-      userId: "user_test123",
-      keySource: "platform",
       eventType: "webinar_welcome",
     });
+    expect(statsCall!.body.userId).toBeUndefined();
+    expect(statsCall!.body.keySource).toBeUndefined();
+    expect(statsCall!.headers!["x-org-id"]).toBe("org_test456");
+    expect(statsCall!.headers!["x-user-id"]).toBe("user_test123");
+    expect(statsCall!.headers!["x-key-source"]).toBe("platform");
   });
 
   it("should allow empty body for unfiltered stats", async () => {
@@ -169,7 +178,8 @@ describe("PUT /v1/emails/templates", () => {
     fetchCalls = [];
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      fetchCalls.push({ url, method: init?.method, body });
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
       return {
         ok: true,
         json: () => Promise.resolve({ templates: [{ name: "webinar_welcome", action: "created" }] }),
@@ -178,7 +188,7 @@ describe("PUT /v1/emails/templates", () => {
     app = createApp();
   });
 
-  it("should forward template deployment with appId, orgId, userId and keySource", async () => {
+  it("should forward template deployment with appId in body and identity in headers", async () => {
     const res = await request(app)
       .put("/v1/emails/templates")
       .send({
@@ -199,9 +209,6 @@ describe("PUT /v1/emails/templates", () => {
     expect(deployCall!.method).toBe("PUT");
     expect(deployCall!.body).toMatchObject({
       appId: "distribute-frontend",
-      orgId: "org_test456",
-      userId: "user_test123",
-      keySource: "platform",
       templates: [
         {
           name: "webinar_welcome",
@@ -210,6 +217,12 @@ describe("PUT /v1/emails/templates", () => {
         },
       ],
     });
+    expect(deployCall!.body.orgId).toBeUndefined();
+    expect(deployCall!.body.userId).toBeUndefined();
+    expect(deployCall!.body.keySource).toBeUndefined();
+    expect(deployCall!.headers!["x-org-id"]).toBe("org_test456");
+    expect(deployCall!.headers!["x-user-id"]).toBe("user_test123");
+    expect(deployCall!.headers!["x-key-source"]).toBe("platform");
   });
 
   it("should return 400 when templates array is empty", async () => {

--- a/tests/unit/keysource-forwarding.test.ts
+++ b/tests/unit/keysource-forwarding.test.ts
@@ -69,7 +69,7 @@ function createApp(...routers: express.Router[]) {
   return app;
 }
 
-let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown> }>;
+let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown>; headers?: Record<string, string> }>;
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -79,7 +79,8 @@ beforeEach(() => {
 
   global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
     const body = init?.body ? JSON.parse(init.body as string) : undefined;
-    fetchCalls.push({ url, method: init?.method, body });
+    const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+    fetchCalls.push({ url, method: init?.method, body, headers });
     return { ok: true, json: () => Promise.resolve({ campaign: { id: "c-1", status: "ongoing" } }) };
   });
 });
@@ -178,7 +179,7 @@ describe("POST /v1/leads/search — keySource forwarding", () => {
 // 5. POST /v1/qualify
 // ---------------------------------------------------------------
 describe("POST /v1/qualify — keySource forwarding", () => {
-  it("should forward keySource from middleware to reply-qualification service", async () => {
+  it("should forward keySource in headers to reply-qualification service", async () => {
     const app = createApp(qualifyRouter);
     const res = await request(app)
       .post("/v1/qualify")
@@ -192,12 +193,12 @@ describe("POST /v1/qualify — keySource forwarding", () => {
 
     const qualifyCall = fetchCalls.find((c) => c.url.includes("/qualify") && c.method === "POST");
     expect(qualifyCall).toBeDefined();
-    expect(qualifyCall!.body!.keySource).toBe("byok");
+    expect(qualifyCall!.headers!["x-key-source"]).toBe("byok");
     expect(qualifyCall!.body!.appId).toBe("distribute");
     expect(qualifyCall!.body!.userId).toBe("user_test123");
   });
 
-  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+  it("should forward keySource 'platform' in headers when middleware resolves payg/trial", async () => {
     mockKeySource = "platform";
     const app = createApp(qualifyRouter);
     await request(app)
@@ -209,7 +210,7 @@ describe("POST /v1/qualify — keySource forwarding", () => {
       });
 
     const qualifyCall = fetchCalls.find((c) => c.url.includes("/qualify") && c.method === "POST");
-    expect(qualifyCall!.body!.keySource).toBe("platform");
+    expect(qualifyCall!.headers!["x-key-source"]).toBe("platform");
   });
 });
 
@@ -247,7 +248,7 @@ describe("POST /v1/brand/scrape — keySource forwarding", () => {
 // 7. POST /v1/emails/send
 // ---------------------------------------------------------------
 describe("POST /v1/emails/send — keySource forwarding", () => {
-  it("should forward keySource from middleware to transactional-email-service", async () => {
+  it("should forward keySource in headers to transactional-email-service", async () => {
     const app = createApp(emailsRouter);
     const res = await request(app)
       .post("/v1/emails/send")
@@ -260,13 +261,15 @@ describe("POST /v1/emails/send — keySource forwarding", () => {
 
     const sendCall = fetchCalls.find((c) => c.url.includes("/send") && c.method === "POST");
     expect(sendCall).toBeDefined();
-    expect(sendCall!.body!.keySource).toBe("byok");
+    expect(sendCall!.headers!["x-key-source"]).toBe("byok");
+    expect(sendCall!.headers!["x-org-id"]).toBe("org_test456");
+    expect(sendCall!.headers!["x-user-id"]).toBe("user_test123");
     expect(sendCall!.body!.appId).toBe("distribute");
     expect(sendCall!.body!.orgId).toBe("org_test456");
     expect(sendCall!.body!.userId).toBe("user_test123");
   });
 
-  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+  it("should forward keySource 'platform' in headers when middleware resolves payg/trial", async () => {
     mockKeySource = "platform";
     const app = createApp(emailsRouter);
     await request(app)
@@ -277,6 +280,6 @@ describe("POST /v1/emails/send — keySource forwarding", () => {
       });
 
     const sendCall = fetchCalls.find((c) => c.url.includes("/send") && c.method === "POST");
-    expect(sendCall!.body!.keySource).toBe("platform");
+    expect(sendCall!.headers!["x-key-source"]).toBe("platform");
   });
 });

--- a/tests/unit/stripe-proxy.test.ts
+++ b/tests/unit/stripe-proxy.test.ts
@@ -34,6 +34,7 @@ interface FetchCall {
   url: string;
   method?: string;
   body?: any;
+  headers?: Record<string, string>;
 }
 
 let fetchCalls: FetchCall[] = [];
@@ -51,7 +52,8 @@ function mockFetchOk(responseData: any = {}) {
   fetchCalls = [];
   global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
     const body = init?.body ? JSON.parse(init.body as string) : undefined;
-    fetchCalls.push({ url, method: init?.method, body });
+    const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+    fetchCalls.push({ url, method: init?.method, body, headers });
     return { ok: true, json: () => Promise.resolve(responseData) };
   });
 }
@@ -74,7 +76,7 @@ describe("GET /v1/stripe/products/:productId", () => {
     app = createApp();
   });
 
-  it("should proxy to stripe-service with appId, orgId, and keySource query params", async () => {
+  it("should proxy to stripe-service with appId in query and identity in headers", async () => {
     const res = await request(app).get("/v1/stripe/products/prod_123");
 
     expect(res.status).toBe(200);
@@ -83,8 +85,9 @@ describe("GET /v1/stripe/products/:productId", () => {
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
-    expect(call!.url).toContain("orgId=org_test456");
-    expect(call!.url).toContain("keySource=byok");
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-user-id"]).toBe("user_test123");
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 });
 
@@ -98,7 +101,7 @@ describe("POST /v1/stripe/products", () => {
     app = createApp();
   });
 
-  it("should forward product creation with appId, orgId, and keySource", async () => {
+  it("should forward product creation with identity in headers", async () => {
     const res = await request(app)
       .post("/v1/stripe/products")
       .send({ name: "Course", description: "Online course" });
@@ -108,13 +111,11 @@ describe("POST /v1/stripe/products", () => {
     const call = fetchCalls.find((c) => c.url.includes("/products/create"));
     expect(call).toBeDefined();
     expect(call!.method).toBe("POST");
-    expect(call!.body).toMatchObject({
-      appId: "distribute-frontend",
-      orgId: "org_test456",
-      keySource: "byok",
-      name: "Course",
-      description: "Online course",
-    });
+    expect(call!.body).toMatchObject({ appId: "distribute-frontend", name: "Course", description: "Online course" });
+    expect(call!.body.orgId).toBeUndefined();
+    expect(call!.body.keySource).toBeUndefined();
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 
   it("should return 400 when name is missing", async () => {
@@ -137,7 +138,7 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
     app = createApp();
   });
 
-  it("should proxy to stripe-service prices endpoint with orgId and keySource", async () => {
+  it("should proxy to stripe-service prices endpoint with identity in headers", async () => {
     const res = await request(app).get("/v1/stripe/products/prod_123/prices");
 
     expect(res.status).toBe(200);
@@ -146,8 +147,8 @@ describe("GET /v1/stripe/products/:productId/prices", () => {
     const call = fetchCalls.find((c) => c.url.includes("/prices/by-product/prod_123"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
-    expect(call!.url).toContain("orgId=org_test456");
-    expect(call!.url).toContain("keySource=byok");
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 });
 
@@ -161,7 +162,7 @@ describe("POST /v1/stripe/prices", () => {
     app = createApp();
   });
 
-  it("should forward price creation with keySource", async () => {
+  it("should forward price creation with identity in headers", async () => {
     const res = await request(app)
       .post("/v1/stripe/prices")
       .send({ productId: "prod_123", unitAmountCents: 4999, currency: "usd" });
@@ -169,12 +170,9 @@ describe("POST /v1/stripe/prices", () => {
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/create"));
-    expect(call!.body).toMatchObject({
-      appId: "distribute-frontend",
-      keySource: "byok",
-      productId: "prod_123",
-      unitAmountCents: 4999,
-    });
+    expect(call!.body).toMatchObject({ appId: "distribute-frontend", productId: "prod_123", unitAmountCents: 4999 });
+    expect(call!.body.keySource).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 
   it("should return 400 when productId is missing", async () => {
@@ -199,7 +197,7 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
     app = createApp();
   });
 
-  it("should proxy to stripe-service coupons endpoint with orgId and keySource", async () => {
+  it("should proxy to stripe-service coupons endpoint with identity in headers", async () => {
     const res = await request(app).get("/v1/stripe/coupons/WELCOME20");
 
     expect(res.status).toBe(200);
@@ -208,8 +206,8 @@ describe("GET /v1/stripe/coupons/:couponId", () => {
     const call = fetchCalls.find((c) => c.url.includes("/coupons/WELCOME20"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("appId=distribute-frontend");
-    expect(call!.url).toContain("orgId=org_test456");
-    expect(call!.url).toContain("keySource=byok");
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 });
 
@@ -223,7 +221,7 @@ describe("POST /v1/stripe/coupons", () => {
     app = createApp();
   });
 
-  it("should forward coupon creation with keySource", async () => {
+  it("should forward coupon creation with identity in headers", async () => {
     const res = await request(app)
       .post("/v1/stripe/coupons")
       .send({ percentOff: 20, duration: "once" });
@@ -231,12 +229,9 @@ describe("POST /v1/stripe/coupons", () => {
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/create"));
-    expect(call!.body).toMatchObject({
-      appId: "distribute-frontend",
-      keySource: "byok",
-      percentOff: 20,
-      duration: "once",
-    });
+    expect(call!.body).toMatchObject({ appId: "distribute-frontend", percentOff: 20, duration: "once" });
+    expect(call!.body.keySource).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 
   it("should return 400 when duration is missing", async () => {
@@ -261,7 +256,7 @@ describe("POST /v1/stripe/checkout", () => {
     app = createApp();
   });
 
-  it("should forward checkout session creation with identity fields and keySource", async () => {
+  it("should forward checkout session creation with identity in headers", async () => {
     const res = await request(app)
       .post("/v1/stripe/checkout")
       .send({
@@ -278,17 +273,17 @@ describe("POST /v1/stripe/checkout", () => {
     const call = fetchCalls.find((c) => c.url.includes("/checkout/create"));
     expect(call!.body).toMatchObject({
       appId: "distribute-frontend",
-      orgId: "org_test456",
-      userId: "user_test123",
-      keySource: "byok",
       lineItems: [{ priceId: "price_123", quantity: 1 }],
       successUrl: "https://polarity.com/success",
       cancelUrl: "https://polarity.com/cancel",
       customerEmail: "user@polarity.com",
     });
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-user-id"]).toBe("user_test123");
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 
-  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+  it("should forward keySource 'platform' in headers when middleware resolves payg/trial", async () => {
     mockAuthContext.keySource = "platform";
     const res = await request(app)
       .post("/v1/stripe/checkout")
@@ -301,7 +296,7 @@ describe("POST /v1/stripe/checkout", () => {
 
     expect(res.status).toBe(200);
     const call = fetchCalls.find((c) => c.url.includes("/checkout/create"));
-    expect(call!.body.keySource).toBe("platform");
+    expect(call!.headers!["x-key-source"]).toBe("platform");
   });
 
   it("should return 400 when lineItems is missing", async () => {
@@ -326,7 +321,7 @@ describe("POST /v1/stripe/stats", () => {
     app = createApp();
   });
 
-  it("should forward stats request with identity and keySource", async () => {
+  it("should forward stats request with identity in headers", async () => {
     const res = await request(app)
       .post("/v1/stripe/stats")
       .send({ brandId: "brand_abc" });
@@ -335,20 +330,19 @@ describe("POST /v1/stripe/stats", () => {
     expect(res.body.totalRevenue).toBe(12500);
 
     const call = fetchCalls.find((c) => c.url.includes("/stats"));
-    expect(call!.body).toMatchObject({
-      appId: "distribute-frontend",
-      orgId: "org_test456",
-      keySource: "byok",
-      brandId: "brand_abc",
-    });
+    expect(call!.body).toMatchObject({ appId: "distribute-frontend", brandId: "brand_abc" });
+    expect(call!.body.orgId).toBeUndefined();
+    expect(call!.body.keySource).toBeUndefined();
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-key-source"]).toBe("byok");
   });
 
-  it("should forward keySource 'platform' when middleware resolves payg/trial", async () => {
+  it("should forward keySource 'platform' in headers when middleware resolves payg/trial", async () => {
     mockAuthContext.keySource = "platform";
     await request(app).post("/v1/stripe/stats").send({});
 
     const call = fetchCalls.find((c) => c.url.includes("/stats"));
-    expect(call!.body.keySource).toBe("platform");
+    expect(call!.headers!["x-key-source"]).toBe("platform");
   });
 
   it("should allow empty body for unfiltered stats", async () => {
@@ -372,17 +366,17 @@ describe("Stripe catalog endpoints — app key without org context", () => {
     appKeyApp = createApp();
   });
 
-  it("GET /v1/stripe/products/:id should work without org context and omit orgId/keySource", async () => {
+  it("GET /v1/stripe/products/:id should work without org context and omit identity headers", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123");
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/products/prod_123"));
     expect(call!.url).toContain("appId=distribute-frontend");
-    expect(call!.url).not.toContain("orgId");
-    expect(call!.url).not.toContain("keySource");
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBeUndefined();
   });
 
-  it("POST /v1/stripe/products should work without org context (no keySource)", async () => {
+  it("POST /v1/stripe/products should work without org context (no identity headers)", async () => {
     const res = await request(appKeyApp)
       .post("/v1/stripe/products")
       .send({ name: "Course" });
@@ -390,48 +384,48 @@ describe("Stripe catalog endpoints — app key without org context", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/products/create"));
     expect(call!.body.appId).toBe("distribute-frontend");
-    expect(call!.body.orgId).toBeUndefined();
-    expect(call!.body.keySource).toBeUndefined();
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBeUndefined();
   });
 
-  it("GET /v1/stripe/products/:id/prices should work without org context and omit orgId/keySource", async () => {
+  it("GET /v1/stripe/products/:id/prices should work without org context and omit identity headers", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/products/prod_123/prices");
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/by-product/prod_123"));
-    expect(call!.url).not.toContain("orgId");
-    expect(call!.url).not.toContain("keySource");
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBeUndefined();
   });
 
-  it("POST /v1/stripe/prices should work without org context (no keySource)", async () => {
+  it("POST /v1/stripe/prices should work without org context (no identity headers)", async () => {
     const res = await request(appKeyApp)
       .post("/v1/stripe/prices")
       .send({ productId: "prod_123", unitAmountCents: 4999, currency: "usd" });
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/prices/create"));
-    expect(call!.body.orgId).toBeUndefined();
-    expect(call!.body.keySource).toBeUndefined();
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBeUndefined();
   });
 
-  it("GET /v1/stripe/coupons/:id should work without org context and omit orgId/keySource", async () => {
+  it("GET /v1/stripe/coupons/:id should work without org context and omit identity headers", async () => {
     const res = await request(appKeyApp).get("/v1/stripe/coupons/WELCOME20");
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/WELCOME20"));
-    expect(call!.url).not.toContain("orgId");
-    expect(call!.url).not.toContain("keySource");
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBeUndefined();
   });
 
-  it("POST /v1/stripe/coupons should work without org context (no keySource)", async () => {
+  it("POST /v1/stripe/coupons should work without org context (no identity headers)", async () => {
     const res = await request(appKeyApp)
       .post("/v1/stripe/coupons")
       .send({ percentOff: 20, duration: "once" });
     expect(res.status).toBe(200);
 
     const call = fetchCalls.find((c) => c.url.includes("/coupons/create"));
-    expect(call!.body.orgId).toBeUndefined();
-    expect(call!.body.keySource).toBeUndefined();
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-key-source"]).toBeUndefined();
   });
 
   it("POST /v1/stripe/checkout should return 400 without org context", async () => {


### PR DESCRIPTION
## Summary
- Use `buildInternalHeaders(req)` on all remaining routes (`emails.ts`, `stripe.ts`, `activity.ts`, `qualify.ts`) so identity (`x-org-id`, `x-user-id`, `x-key-source`) is always forwarded as HTTP headers
- Remove identity fields (`orgId`, `userId`, `keySource`) from request bodies and query params where they were incorrectly placed — prevents them from being misinterpreted as business-logic filters (e.g. `userId` in stats body changing query results)
- Update tests to verify identity is forwarded via headers, not body/query params

## Test plan
- [x] All 44 targeted tests pass (emails, stripe-proxy, keysource-forwarding)
- [x] Full test suite: 372 passed, 6 failed (all 6 pre-existing on clean main)
- [ ] Verify email sending works for growthagency.dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)