### PR TITLE
fix: remove stale appId from createRun call

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -87,7 +87,6 @@ export async function authenticate(
         const run = await createRun({
           orgId: req.orgId,
           userId: req.userId,
-          appId: "api-service",
           serviceName: "api-service",
           taskName: `${req.method} ${req.baseUrl}${req.path}`,
         });

--- a/tests/__mocks__/runs-client.ts
+++ b/tests/__mocks__/runs-client.ts
@@ -29,7 +29,6 @@ export type Run = {
   id: string;
   organizationId: string;
   userId: string | null;
-  appId: string;
   brandId: string | null;
   campaignId: string | null;
   serviceName: string;
@@ -57,7 +56,6 @@ export type RunWithOwnCost = Run & {
 export type CreateRunParams = {
   orgId: string;
   userId?: string;
-  appId: string;
   brandId?: string;
   campaignId?: string;
   serviceName: string;
@@ -68,18 +66,20 @@ export type CreateRunParams = {
 export type CostItem = {
   costName: string;
   quantity: number;
+  costSource: "platform" | "org";
 };
 
 export type ListRunsParams = {
   orgId: string;
   userId?: string;
-  appId?: string;
   brandId?: string;
   campaignId?: string;
   serviceName?: string;
   taskName?: string;
   status?: string;
   parentRunId?: string;
+  startedAfter?: string;
+  startedBefore?: string;
   limit?: number;
   offset?: number;
 };
@@ -89,7 +89,6 @@ export async function createRun(_params: CreateRunParams): Promise<Run> {
     id: "mock-run-id",
     organizationId: "mock-org-uuid",
     userId: null,
-    appId: "distribute",
     brandId: null,
     campaignId: null,
     serviceName: "mock-service",
@@ -108,7 +107,6 @@ export async function updateRun(_runId: string, _status: "completed" | "failed")
     id: _runId,
     organizationId: "mock-org-uuid",
     userId: null,
-    appId: "distribute",
     brandId: null,
     campaignId: null,
     serviceName: "mock-service",


### PR DESCRIPTION
## Summary
- Removed `appId` from the `createRun` call in `src/middleware/auth.ts` — it was removed from `CreateRunParams` in runs-client (#58) but this callsite was missed, breaking the build
- Aligned the test mock (`tests/__mocks__/runs-client.ts`) with the current runs-client types: removed `appId` from `Run`/`CreateRunParams`/`ListRunsParams`, added `costSource` to `CostItem`, added `startedAfter`/`startedBefore` to `ListRunsParams`

## Test plan
- [x] `pnpm build` passes (was failing before)
- [x] All 350 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)