### PR TITLE
fix: add missing inter-service headers to campaign email sends

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -13,6 +13,7 @@ function sendTransactionalEmail(
 ) {
   callExternalService(externalServices.transactionalEmail, "/send", {
     method: "POST",
+    headers: buildInternalHeaders(req),
     body: {
       eventType,
       brandId,

--- a/tests/unit/campaign-email-headers.regression.test.ts
+++ b/tests/unit/campaign-email-headers.regression.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Regression: sendTransactionalEmail in campaigns.ts called
+ * callExternalService without buildInternalHeaders(req), so x-org-id,
+ * x-user-id, and x-run-id were never sent to transactional-email-service.
+ * After inter-service headers became required, campaign emails
+ * (campaign_created, campaign_stopped) silently failed with 400.
+ */
+describe("campaigns sendTransactionalEmail headers", () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, "../../src/routes/campaigns.ts"),
+    "utf-8"
+  );
+
+  it("should pass buildInternalHeaders(req) when calling transactional-email-service", () => {
+    // Extract the sendTransactionalEmail function body
+    const fnMatch = src.match(
+      /function sendTransactionalEmail\([\s\S]*?\.catch\([\s\S]*?\);?\s*\}/
+    );
+    expect(fnMatch).not.toBeNull();
+    const fnBody = fnMatch![0];
+
+    expect(fnBody).toContain("headers: buildInternalHeaders(req)");
+  });
+});


### PR DESCRIPTION
## Summary
- `sendTransactionalEmail` in campaigns.ts called `callExternalService` without `buildInternalHeaders(req)`
- After inter-service headers became required, campaign emails (`campaign_created`, `campaign_stopped`) silently failed with 400
- Added `headers: buildInternalHeaders(req)` to match the pattern in activity.ts and emails.ts

## Test plan
- [x] Regression test verifying `sendTransactionalEmail` includes `buildInternalHeaders(req)`
- [x] Full test suite passes (358 tests, 48 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)