### PR TITLE
fix: forward provider key CRUD to /internal/keys

### DIFF
--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -7,7 +7,7 @@ import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js
 const router = Router();
 
 // -----------------------------------------------------------------------
-// Provider keys — transparent proxy to key-service unified /keys endpoints
+// Provider keys — transparent proxy to key-service /internal/keys endpoints
 // -----------------------------------------------------------------------
 
 /**
@@ -18,7 +18,7 @@ router.get("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
     const params = new URLSearchParams({ orgId: req.orgId });
-    const result = await callExternalService(externalServices.key, `/keys?${params}`, {
+    const result = await callExternalService(externalServices.key, `/internal/keys?${params}`, {
       headers: buildInternalHeaders(req),
     });
     res.json(result);
@@ -41,7 +41,7 @@ router.post("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
     if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
 
     const { provider, apiKey } = parsed.data;
-    const result = await callExternalService(externalServices.key, "/keys", {
+    const result = await callExternalService(externalServices.key, "/internal/keys", {
       method: "POST",
       body: { provider, apiKey, orgId: req.orgId },
       headers: buildInternalHeaders(req),
@@ -64,7 +64,7 @@ router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest,
     const params = new URLSearchParams({ orgId: req.orgId });
     const result = await callExternalService(
       externalServices.key,
-      `/keys/${encodeURIComponent(provider)}?${params}`,
+      `/internal/keys/${encodeURIComponent(provider)}?${params}`,
       { method: "DELETE", headers: buildInternalHeaders(req) }
     );
     res.json(result);

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -44,7 +44,7 @@ interface KeyItem {
 async function fetchOrgKeys(orgId: string): Promise<KeyItem[]> {
   const result = await callExternalService<{ keys: KeyItem[] }>(
     externalServices.key,
-    `/keys?orgId=${encodeURIComponent(orgId)}`
+    `/internal/keys?orgId=${encodeURIComponent(orgId)}`
   );
   return result.keys ?? [];
 }

--- a/tests/unit/key-upsert-path.regression.test.ts
+++ b/tests/unit/key-upsert-path.regression.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Regression: api-service forwarded provider key CRUD to key-service at
+ * /keys (GET, POST) and /keys/:provider (DELETE). These paths don't exist
+ * in key-service — they live under /internal/keys. The requests fell through
+ * to key-service's 404 handler, returning {"error":"Not found"}.
+ *
+ * Fix: forward to /internal/keys, /internal/keys/:provider instead.
+ */
+describe("provider key routes forward to /internal/keys", () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, "../../src/routes/keys.ts"),
+    "utf-8"
+  );
+
+  it("GET /v1/keys should forward to /internal/keys on key-service", () => {
+    expect(src).toContain('`/internal/keys?${params}`');
+  });
+
+  it("POST /v1/keys should forward to /internal/keys on key-service", () => {
+    expect(src).toContain('"/internal/keys"');
+  });
+
+  it("DELETE /v1/keys/:provider should forward to /internal/keys/:provider on key-service", () => {
+    expect(src).toContain('`/internal/keys/${encodeURIComponent(provider)}?${params}`');
+  });
+
+  it("should NOT call /keys directly (without /internal prefix)", () => {
+    // Extract only the provider keys section (before the API keys section)
+    const providerSection = src.split("// API keys")[0];
+    // Check that no callExternalService call uses bare /keys path
+    const bareKeyCalls = providerSection.match(/callExternalService\([^)]*,\s*["'`]\/keys[^i]/g);
+    expect(bareKeyCalls).toBeNull();
+  });
+});
+
+describe("workflows fetchOrgKeys forwards to /internal/keys", () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, "../../src/routes/workflows.ts"),
+    "utf-8"
+  );
+
+  it("fetchOrgKeys should call /internal/keys on key-service", () => {
+    expect(src).toContain('`/internal/keys?orgId=${encodeURIComponent(orgId)}`');
+  });
+
+  it("should NOT call bare /keys on key-service", () => {
+    const bareKeyCalls = src.match(/callExternalService\([^)]*key[^)]*,\s*["'`]\/keys[^i]/g);
+    expect(bareKeyCalls).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- api-service was forwarding provider key CRUD (GET/POST/DELETE `/v1/keys`) to `/keys` on key-service, but those endpoints live under `/internal/keys`
- Requests fell through to key-service's 404 handler, returning `{"error":"Not found"}`
- Also fixed `fetchOrgKeys` in `workflows.ts` which had the same bare `/keys` path

## Test plan
- [x] Regression test verifies all 3 routes in `keys.ts` use `/internal/keys`
- [x] Regression test verifies `fetchOrgKeys` in `workflows.ts` uses `/internal/keys`
- [x] Negative test ensures no bare `/keys` calls remain
- [x] All 362 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)