### PR TITLE
fix: migrate key-service calls from /internal/* to new routes

### DIFF
--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -7,7 +7,7 @@ import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js
 const router = Router();
 
 // -----------------------------------------------------------------------
-// Provider keys — transparent proxy to key-service /internal/keys endpoints
+// Provider keys — transparent proxy to key-service /keys endpoints
 // -----------------------------------------------------------------------
 
 /**
@@ -17,8 +17,7 @@ const router = Router();
 router.get("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
-    const params = new URLSearchParams({ orgId: req.orgId });
-    const result = await callExternalService(externalServices.key, `/internal/keys?${params}`, {
+    const result = await callExternalService(externalServices.key, "/keys", {
       headers: buildInternalHeaders(req),
     });
     res.json(result);
@@ -41,9 +40,9 @@ router.post("/keys", authenticate, async (req: AuthenticatedRequest, res) => {
     if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
 
     const { provider, apiKey } = parsed.data;
-    const result = await callExternalService(externalServices.key, "/internal/keys", {
+    const result = await callExternalService(externalServices.key, "/keys", {
       method: "POST",
-      body: { provider, apiKey, orgId: req.orgId },
+      body: { provider, apiKey },
       headers: buildInternalHeaders(req),
     });
     res.json(result);
@@ -61,10 +60,9 @@ router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest,
   try {
     if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
     const { provider } = req.params;
-    const params = new URLSearchParams({ orgId: req.orgId });
     const result = await callExternalService(
       externalServices.key,
-      `/internal/keys/${encodeURIComponent(provider)}?${params}`,
+      `/keys/${encodeURIComponent(provider)}`,
       { method: "DELETE", headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -75,7 +73,7 @@ router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest,
 });
 
 // -----------------------------------------------------------------------
-// API keys — user-facing API key management (unchanged, uses /internal/api-keys)
+// API keys — user-facing API key management
 // -----------------------------------------------------------------------
 
 /**
@@ -86,10 +84,9 @@ router.post("/api-keys/session", authenticate, requireOrg, requireUser, async (r
   try {
     const result = await callExternalService(
       externalServices.key,
-      "/internal/api-keys/session",
+      "/api-keys/session",
       {
         method: "POST",
-        body: { orgId: req.orgId, userId: req.userId },
         headers: buildInternalHeaders(req),
       }
     );
@@ -114,12 +111,10 @@ router.post("/api-keys", authenticate, requireOrg, requireUser, async (req: Auth
 
     const result = await callExternalService(
       externalServices.key,
-      "/internal/api-keys",
+      "/api-keys",
       {
         method: "POST",
         body: {
-          orgId: req.orgId,
-          userId: req.userId,
           createdBy: req.userId,
           name,
         },
@@ -141,7 +136,7 @@ router.get("/api-keys", authenticate, requireOrg, requireUser, async (req: Authe
   try {
     const result = await callExternalService(
       externalServices.key,
-      `/internal/api-keys?orgId=${req.orgId}`,
+      "/api-keys",
       { headers: buildInternalHeaders(req) },
     );
     res.json(result);
@@ -161,10 +156,9 @@ router.delete("/api-keys/:id", authenticate, requireOrg, requireUser, async (req
 
     const result = await callExternalService(
       externalServices.key,
-      `/internal/api-keys/${id}`,
+      `/api-keys/${id}`,
       {
         method: "DELETE",
-        body: { orgId: req.orgId },
         headers: buildInternalHeaders(req),
       }
     );

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -41,10 +41,11 @@ interface KeyItem {
 /**
  * Fetch the org's configured BYOK keys from key-service.
  */
-async function fetchOrgKeys(orgId: string): Promise<KeyItem[]> {
+async function fetchOrgKeys(headers: Record<string, string>): Promise<KeyItem[]> {
   const result = await callExternalService<{ keys: KeyItem[] }>(
     externalServices.key,
-    `/internal/keys?orgId=${encodeURIComponent(orgId)}`
+    "/keys",
+    { headers },
   );
   return result.keys ?? [];
 }
@@ -221,11 +222,10 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
 router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
-    const orgId = req.orgId!;
 
     const [requiredProviders, orgKeys] = await Promise.all([
       fetchRequiredProviders(id),
-      fetchOrgKeys(orgId),
+      fetchOrgKeys(buildInternalHeaders(req)),
     ]);
 
     const configuredMap = new Map(orgKeys.map((k) => [k.provider, k.maskedKey]));

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -26,7 +26,7 @@ export async function registerPlatformKeys(): Promise<void> {
 
   for (const { provider, envVar } of PLATFORM_KEYS) {
     const apiKey = process.env[envVar]!;
-    await callExternalService(externalServices.key, "/internal/platform-keys", {
+    await callExternalService(externalServices.key, "/platform-keys", {
       method: "POST",
       body: { provider, apiKey },
     });

--- a/tests/unit/key-upsert-path.regression.test.ts
+++ b/tests/unit/key-upsert-path.regression.test.ts
@@ -3,52 +3,55 @@ import * as fs from "fs";
 import * as path from "path";
 
 /**
- * Regression: api-service forwarded provider key CRUD to key-service at
- * /keys (GET, POST) and /keys/:provider (DELETE). These paths don't exist
- * in key-service — they live under /internal/keys. The requests fell through
- * to key-service's 404 handler, returning {"error":"Not found"}.
+ * Regression: api-service previously forwarded provider key CRUD to key-service
+ * at /internal/keys. After key-service breaking change, all /internal/* routes
+ * were removed. Routes now use /keys, /api-keys, /platform-keys directly.
  *
- * Fix: forward to /internal/keys, /internal/keys/:provider instead.
+ * Also: orgId is no longer sent in request bodies or query params — key-service
+ * reads it from x-org-id header.
  */
-describe("provider key routes forward to /internal/keys", () => {
+describe("provider key routes forward to /keys (no /internal/ prefix)", () => {
   const src = fs.readFileSync(
     path.join(__dirname, "../../src/routes/keys.ts"),
     "utf-8"
   );
 
-  it("GET /v1/keys should forward to /internal/keys on key-service", () => {
-    expect(src).toContain('`/internal/keys?${params}`');
+  it("GET /v1/keys should forward to /keys on key-service", () => {
+    expect(src).toContain('"/keys"');
   });
 
-  it("POST /v1/keys should forward to /internal/keys on key-service", () => {
-    expect(src).toContain('"/internal/keys"');
+  it("POST /v1/keys should forward to /keys on key-service", () => {
+    expect(src).toContain('"/keys"');
   });
 
-  it("DELETE /v1/keys/:provider should forward to /internal/keys/:provider on key-service", () => {
-    expect(src).toContain('`/internal/keys/${encodeURIComponent(provider)}?${params}`');
+  it("DELETE /v1/keys/:provider should forward to /keys/:provider on key-service", () => {
+    expect(src).toContain('`/keys/${encodeURIComponent(provider)}`');
   });
 
-  it("should NOT call /keys directly (without /internal prefix)", () => {
-    // Extract only the provider keys section (before the API keys section)
-    const providerSection = src.split("// API keys")[0];
-    // Check that no callExternalService call uses bare /keys path
-    const bareKeyCalls = providerSection.match(/callExternalService\([^)]*,\s*["'`]\/keys[^i]/g);
-    expect(bareKeyCalls).toBeNull();
+  it("should NOT use /internal/ prefix for any key-service calls", () => {
+    const internalCalls = src.match(/\/internal\//g);
+    expect(internalCalls).toBeNull();
+  });
+
+  it("should NOT pass orgId in request bodies", () => {
+    // Ensure no body contains orgId for key-service calls
+    const orgIdInBody = src.match(/body:\s*\{[^}]*orgId/g);
+    expect(orgIdInBody).toBeNull();
   });
 });
 
-describe("workflows fetchOrgKeys forwards to /internal/keys", () => {
+describe("workflows fetchOrgKeys forwards to /keys (no /internal/ prefix)", () => {
   const src = fs.readFileSync(
     path.join(__dirname, "../../src/routes/workflows.ts"),
     "utf-8"
   );
 
-  it("fetchOrgKeys should call /internal/keys on key-service", () => {
-    expect(src).toContain('`/internal/keys?orgId=${encodeURIComponent(orgId)}`');
+  it("fetchOrgKeys should call /keys on key-service", () => {
+    expect(src).toContain('"/keys"');
   });
 
-  it("should NOT call bare /keys on key-service", () => {
-    const bareKeyCalls = src.match(/callExternalService\([^)]*key[^)]*,\s*["'`]\/keys[^i]/g);
-    expect(bareKeyCalls).toBeNull();
+  it("should NOT use /internal/ prefix for key-service calls", () => {
+    const keyServiceInternalCalls = src.match(/externalServices\.key[^)]*\/internal\//g);
+    expect(keyServiceInternalCalls).toBeNull();
   });
 });

--- a/tests/unit/keys-identity.test.ts
+++ b/tests/unit/keys-identity.test.ts
@@ -25,6 +25,7 @@ interface FetchCall {
   url: string;
   method?: string;
   body?: any;
+  headers?: Record<string, string>;
 }
 
 let fetchCalls: FetchCall[] = [];
@@ -38,7 +39,7 @@ function createApp() {
   return app;
 }
 
-describe("POST /v1/api-keys — identity forwarding", () => {
+describe("POST /v1/api-keys — identity forwarding via headers", () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -46,7 +47,10 @@ describe("POST /v1/api-keys — identity forwarding", () => {
     fetchCalls = [];
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      fetchCalls.push({ url, method: init?.method, body });
+      const headers = Object.fromEntries(
+        Object.entries(init?.headers ?? {}).filter(([_, v]) => v)
+      ) as Record<string, string>;
+      fetchCalls.push({ url, method: init?.method, body, headers });
       return {
         ok: true,
         json: () => Promise.resolve({
@@ -63,7 +67,7 @@ describe("POST /v1/api-keys — identity forwarding", () => {
     app = createApp();
   });
 
-  it("should pass orgId, userId, and createdBy to key-service", async () => {
+  it("should pass createdBy and name in body, orgId/userId only in headers", async () => {
     const res = await request(app)
       .post("/v1/api-keys")
       .send({ name: "Polarity Course" });
@@ -72,19 +76,20 @@ describe("POST /v1/api-keys — identity forwarding", () => {
     expect(res.body.key).toBe("mcpf_usr_abc123");
 
     const createCall = fetchCalls.find(
-      (c) => c.url.includes("/internal/api-keys") && c.method === "POST"
+      (c) => c.url.includes("/api-keys") && c.method === "POST" && !c.url.includes("session")
     );
     expect(createCall).toBeDefined();
     expect(createCall!.body).toEqual({
-      orgId: "org_test456",
-      userId: "user_test123",
       createdBy: "user_test123",
       name: "Polarity Course",
     });
+    // orgId and userId should NOT be in the body
+    expect(createCall!.body).not.toHaveProperty("orgId");
+    expect(createCall!.body).not.toHaveProperty("userId");
   });
 });
 
-describe("POST /v1/api-keys/session — identity forwarding", () => {
+describe("POST /v1/api-keys/session — identity forwarding via headers only", () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -106,7 +111,7 @@ describe("POST /v1/api-keys/session — identity forwarding", () => {
     app = createApp();
   });
 
-  it("should pass orgId and userId to key-service session endpoint", async () => {
+  it("should not pass any body to key-service session endpoint", async () => {
     const res = await request(app)
       .post("/v1/api-keys/session")
       .send({});
@@ -114,12 +119,10 @@ describe("POST /v1/api-keys/session — identity forwarding", () => {
     expect(res.status).toBe(200);
 
     const sessionCall = fetchCalls.find(
-      (c) => c.url.includes("/internal/api-keys/session") && c.method === "POST"
+      (c) => c.url.includes("/api-keys/session") && c.method === "POST"
     );
     expect(sessionCall).toBeDefined();
-    expect(sessionCall!.body).toEqual({
-      orgId: "org_test456",
-      userId: "user_test123",
-    });
+    // No body should be sent — orgId and userId come from headers
+    expect(sessionCall!.body).toBeUndefined();
   });
 });

--- a/tests/unit/keys-unified-proxy.test.ts
+++ b/tests/unit/keys-unified-proxy.test.ts
@@ -71,7 +71,7 @@ beforeEach(() => {
 // -----------------------------------------------------------------------
 
 describe("POST /v1/keys — org keys only", () => {
-  it("should forward org keys with orgId (no keySource)", async () => {
+  it("should forward org keys without orgId in body (no keySource)", async () => {
     const app = createApp();
     const res = await request(app)
       .post("/v1/keys")
@@ -82,7 +82,6 @@ describe("POST /v1/keys — org keys only", () => {
     expect(call!.body).toEqual({
       provider: "stripe",
       apiKey: "sk_live_test",
-      orgId: "org_test456",
     });
   });
 
@@ -104,14 +103,15 @@ describe("POST /v1/keys — org keys only", () => {
 // -----------------------------------------------------------------------
 
 describe("GET /v1/keys — org keys only", () => {
-  it("should list org keys with orgId (no keySource)", async () => {
+  it("should list org keys without orgId in query (no keySource)", async () => {
     const app = createApp();
     const res = await request(app).get("/v1/keys");
 
     expect(res.status).toBe(200);
     const call = fetchCalls[0];
     expect(call.url).not.toContain("keySource");
-    expect(call.url).toContain("orgId=org_test456");
+    expect(call.url).not.toContain("orgId");
+    expect(call.url).toContain("/keys");
   });
 
   it("should reject when no org context", async () => {
@@ -130,14 +130,15 @@ describe("GET /v1/keys — org keys only", () => {
 // -----------------------------------------------------------------------
 
 describe("DELETE /v1/keys/:provider — org keys only", () => {
-  it("should delete org key with orgId (no keySource)", async () => {
+  it("should delete org key without orgId in query (no keySource)", async () => {
     const app = createApp();
     const res = await request(app).delete("/v1/keys/stripe");
 
     expect(res.status).toBe(200);
     const call = fetchCalls.find((c) => c.method === "DELETE");
     expect(call!.url).not.toContain("keySource");
-    expect(call!.url).toContain("orgId=org_test456");
+    expect(call!.url).not.toContain("orgId");
+    expect(call!.url).toContain("/keys/stripe");
   });
 
   it("should reject when no org context", async () => {

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -54,7 +54,7 @@ describe("registerPlatformKeys", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
-      if (url.includes("/internal/platform-keys")) {
+      if (url.includes("/platform-keys")) {
         return new Response(JSON.stringify({ provider: body?.provider, maskedKey: "sk-...xxx", message: "Platform key saved" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
@@ -74,7 +74,7 @@ describe("registerPlatformKeys", () => {
 
     await registerPlatformKeys();
 
-    const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/internal/platform-keys"));
+    const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/platform-keys"));
     expect(platformKeyCalls).toHaveLength(11);
 
     const providers = platformKeyCalls.map((c) => c.body?.provider);
@@ -110,7 +110,7 @@ describe("registerPlatformKeys", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
-      if (url.includes("/internal/platform-keys")) {
+      if (url.includes("/platform-keys")) {
         return new Response(JSON.stringify({ error: "Service unavailable" }), {
           status: 503,
           headers: { "Content-Type": "application/json" },

--- a/tests/unit/workflow-enrichment.test.ts
+++ b/tests/unit/workflow-enrichment.test.ts
@@ -265,7 +265,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
           json: () => Promise.resolve({ providers: ["apollo", "anthropic", "instantly"] }),
         };
       }
-      if (url.includes("/keys?")) {
+      if (url.match(/\/keys$/) || url.includes("/keys?")) {
         return {
           ok: true,
           json: () =>
@@ -307,7 +307,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
       if (url.includes("/required-providers")) {
         return { ok: true, json: () => Promise.resolve({ providers: ["apollo"] }) };
       }
-      if (url.includes("/keys?")) {
+      if (url.match(/\/keys$/) || url.includes("/keys?")) {
         return {
           ok: true,
           json: () => Promise.resolve({ keys: [{ provider: "apollo", maskedKey: "apol...123" }] }),
@@ -330,12 +330,12 @@ describe("GET /v1/workflows/:id/key-status", () => {
     expect(res.body.missing).toEqual([]);
   });
 
-  it("should fetch org keys with correct orgId", async () => {
+  it("should fetch org keys via /keys without orgId in query (uses headers)", async () => {
     await request(app).get("/v1/workflows/wf-1/key-status");
 
-    const keysCall = fetchCalls.find((c) => c.url.includes("/keys?"));
+    const keysCall = fetchCalls.find((c) => c.url.match(/\/keys$/));
     expect(keysCall).toBeDefined();
     expect(keysCall!.url).not.toContain("keySource");
-    expect(keysCall!.url).toContain("orgId=org_test456");
+    expect(keysCall!.url).not.toContain("orgId");
   });
 });


### PR DESCRIPTION
## Summary
- key-service removed all `/internal/*` route prefixes. Updates all calls in api-service to use the new paths: `/keys`, `/api-keys`, `/platform-keys`
- Removes `orgId`/`userId` from request bodies and query parameters — key-service now reads these exclusively from `x-org-id`/`x-user-id` headers (already sent via `buildInternalHeaders`)
- `POST /api-keys/session` no longer sends a request body (both values come from headers)

## Test plan
- [x] All 365 tests pass across 49 test files
- [x] Regression tests updated to verify no `/internal/` prefix remains
- [x] Identity tests verify orgId/userId removed from bodies
- [ ] Deploy and verify key CRUD operations work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)