### PR TITLE
feat: add OutcomeType enum to shared content

### DIFF
--- a/shared/content/src/index.ts
+++ b/shared/content/src/index.ts
@@ -17,6 +17,12 @@ export {
 export type { Feature, Step, FaqItem, SupportedClient, ByokProvider } from "./features.js";
 export { BRAND } from "./brand.js";
 export {
+  OUTCOME_DEFINITIONS,
+  OUTCOME_LABELS,
+  getOutcomeDefinition,
+} from "./outcomes.js";
+export type { OutcomeType, OutcomeDefinition } from "./outcomes.js";
+export {
   WORKFLOW_DEFINITIONS,
   getWorkflowDefinition,
   getWorkflowDefinitionsByCategory,

--- a/shared/content/src/outcomes.ts
+++ b/shared/content/src/outcomes.ts
@@ -1,0 +1,53 @@
+/**
+ * Outcome types represent the concrete business results a user wants from a campaign.
+ * Workflows are strategies to achieve one or more of these outcomes.
+ */
+export type OutcomeType =
+  | "interested-replies"
+  | "link-clicks"
+  | "meetings-booked"
+  | "press-mentions";
+
+export interface OutcomeDefinition {
+  type: OutcomeType;
+  label: string;
+  description: string;
+  icon: string;
+}
+
+export const OUTCOME_DEFINITIONS: OutcomeDefinition[] = [
+  {
+    type: "interested-replies",
+    label: "Interested Replies",
+    description: "Get replies from prospects who are interested in your offer.",
+    icon: "message-circle",
+  },
+  {
+    type: "link-clicks",
+    label: "Link Clicks",
+    description: "Drive visits to your website, landing page, or booking link.",
+    icon: "mouse-pointer-click",
+  },
+  {
+    type: "meetings-booked",
+    label: "Meetings Booked",
+    description: "Get prospects to book a demo or sales call.",
+    icon: "calendar-check",
+  },
+  {
+    type: "press-mentions",
+    label: "Press Mentions",
+    description: "Get articles published or interviews with journalists.",
+    icon: "newspaper",
+  },
+];
+
+export const OUTCOME_LABELS: Record<OutcomeType, string> = {
+  "interested-replies": "Interested Replies",
+  "link-clicks": "Link Clicks",
+  "meetings-booked": "Meetings Booked",
+  "press-mentions": "Press Mentions",
+};
+
+export const getOutcomeDefinition = (type: OutcomeType) =>
+  OUTCOME_DEFINITIONS.find((o) => o.type === type);

--- a/shared/content/src/workflows.ts
+++ b/shared/content/src/workflows.ts
@@ -1,3 +1,5 @@
+import type { OutcomeType } from "./outcomes.js";
+
 export type WorkflowCategory = "sales" | "pr";
 export type WorkflowChannel = "email";
 export type WorkflowAudienceType = "cold-outreach";
@@ -15,6 +17,8 @@ export interface WorkflowDefinition {
   audienceType: WorkflowAudienceType;
   /** Icon identifier for UI */
   icon: string;
+  /** Which outcomes this workflow can deliver, ordered by relevance. */
+  targetOutcomes: OutcomeType[];
 }
 
 export const WORKFLOW_DEFINITIONS: WorkflowDefinition[] = [
@@ -27,6 +31,7 @@ export const WORKFLOW_DEFINITIONS: WorkflowDefinition[] = [
     channel: "email",
     audienceType: "cold-outreach",
     icon: "envelope",
+    targetOutcomes: ["interested-replies", "link-clicks"],
   },
   {
     sectionKey: "pr-email-cold-outreach",
@@ -37,6 +42,7 @@ export const WORKFLOW_DEFINITIONS: WorkflowDefinition[] = [
     channel: "email",
     audienceType: "cold-outreach",
     icon: "newspaper",
+    targetOutcomes: ["press-mentions"],
   },
 ];
 

--- a/shared/content/tests/outcomes.test.ts
+++ b/shared/content/tests/outcomes.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  OUTCOME_DEFINITIONS,
+  OUTCOME_LABELS,
+  getOutcomeDefinition,
+} from "../src/outcomes.js";
+
+describe("OUTCOME_DEFINITIONS", () => {
+  it("has at least 4 outcome definitions", () => {
+    expect(OUTCOME_DEFINITIONS.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("each definition has required fields", () => {
+    for (const outcome of OUTCOME_DEFINITIONS) {
+      expect(outcome.type).toBeTruthy();
+      expect(outcome.label).toBeTruthy();
+      expect(outcome.description).toBeTruthy();
+      expect(outcome.icon).toBeTruthy();
+    }
+  });
+
+  it("each type has a matching OUTCOME_LABELS entry", () => {
+    for (const outcome of OUTCOME_DEFINITIONS) {
+      expect(OUTCOME_LABELS[outcome.type]).toBeTruthy();
+    }
+  });
+});
+
+describe("getOutcomeDefinition", () => {
+  it("returns definition for known type", () => {
+    const outcome = getOutcomeDefinition("interested-replies");
+    expect(outcome).toBeDefined();
+    expect(outcome!.label).toBe("Interested Replies");
+  });
+
+  it("returns undefined for unknown type", () => {
+    expect(getOutcomeDefinition("nonexistent" as any)).toBeUndefined();
+  });
+});
+
+describe("OUTCOME_LABELS", () => {
+  it("has labels for all outcome types", () => {
+    expect(OUTCOME_LABELS["interested-replies"]).toBe("Interested Replies");
+    expect(OUTCOME_LABELS["link-clicks"]).toBe("Link Clicks");
+    expect(OUTCOME_LABELS["meetings-booked"]).toBe("Meetings Booked");
+    expect(OUTCOME_LABELS["press-mentions"]).toBe("Press Mentions");
+  });
+});

--- a/shared/content/tests/workflows.test.ts
+++ b/shared/content/tests/workflows.test.ts
@@ -26,6 +26,7 @@ describe("WORKFLOW_DEFINITIONS", () => {
       expect(wf.channel).toBeTruthy();
       expect(wf.audienceType).toBeTruthy();
       expect(wf.icon).toBeTruthy();
+      expect(wf.targetOutcomes.length).toBeGreaterThanOrEqual(1);
     }
   });
 

--- a/shared/content/vitest.config.ts
+++ b/shared/content/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `OutcomeType` union type (`interested-replies`, `link-clicks`, `meetings-booked`, `press-mentions`) in `shared/content/src/outcomes.ts`
- Adds `targetOutcomes` field to `WorkflowDefinition` — each workflow declares which outcomes it delivers
- Sales cold email → `["interested-replies", "link-clicks"]`, PR outreach → `["press-mentions"]`
- Includes `OUTCOME_DEFINITIONS`, `OUTCOME_LABELS`, and `getOutcomeDefinition()` helpers
- Adds vitest config for shared/content package (was inheriting root config incorrectly)

## Test plan
- [x] New `outcomes.test.ts` with 6 tests covering definitions, labels, and lookup
- [x] Updated `workflows.test.ts` to validate `targetOutcomes` on every workflow definition
- [x] All 25 shared content tests pass
- [x] All 365 root tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)