### PR TITLE
feat: add tags field to WorkflowDefinition

### DIFF
--- a/shared/content/src/index.ts
+++ b/shared/content/src/index.ts
@@ -26,6 +26,7 @@ export {
   WORKFLOW_DEFINITIONS,
   getWorkflowDefinition,
   getWorkflowDefinitionsByCategory,
+  getWorkflowDefinitionsByTag,
   WORKFLOW_CATEGORY_LABELS,
   SECTION_LABELS,
   parseWorkflowName,

--- a/shared/content/src/workflows.ts
+++ b/shared/content/src/workflows.ts
@@ -19,6 +19,8 @@ export interface WorkflowDefinition {
   icon: string;
   /** Which outcomes this workflow can deliver, ordered by relevance. */
   targetOutcomes: OutcomeType[];
+  /** Free-form tags describing channels/techniques used (e.g. ["email", "linkedin"]). */
+  tags: string[];
 }
 
 export const WORKFLOW_DEFINITIONS: WorkflowDefinition[] = [
@@ -32,6 +34,7 @@ export const WORKFLOW_DEFINITIONS: WorkflowDefinition[] = [
     audienceType: "cold-outreach",
     icon: "envelope",
     targetOutcomes: ["interested-replies", "link-clicks"],
+    tags: ["email"],
   },
   {
     sectionKey: "pr-email-cold-outreach",
@@ -43,6 +46,7 @@ export const WORKFLOW_DEFINITIONS: WorkflowDefinition[] = [
     audienceType: "cold-outreach",
     icon: "newspaper",
     targetOutcomes: ["press-mentions"],
+    tags: ["email"],
   },
 ];
 
@@ -51,6 +55,9 @@ export const getWorkflowDefinition = (sectionKey: string) =>
 
 export const getWorkflowDefinitionsByCategory = (cat: WorkflowCategory) =>
   WORKFLOW_DEFINITIONS.filter((w) => w.category === cat);
+
+export const getWorkflowDefinitionsByTag = (tag: string) =>
+  WORKFLOW_DEFINITIONS.filter((w) => w.tags.includes(tag));
 
 export interface ParsedWorkflowName {
   category: WorkflowCategory;

--- a/shared/content/tests/workflows.test.ts
+++ b/shared/content/tests/workflows.test.ts
@@ -3,6 +3,7 @@ import {
   WORKFLOW_DEFINITIONS,
   getWorkflowDefinition,
   getWorkflowDefinitionsByCategory,
+  getWorkflowDefinitionsByTag,
   parseWorkflowName,
   getSectionKey,
   getSignatureName,
@@ -27,6 +28,7 @@ describe("WORKFLOW_DEFINITIONS", () => {
       expect(wf.audienceType).toBeTruthy();
       expect(wf.icon).toBeTruthy();
       expect(wf.targetOutcomes.length).toBeGreaterThanOrEqual(1);
+      expect(Array.isArray(wf.tags)).toBe(true);
     }
   });
 
@@ -132,6 +134,18 @@ describe("getWorkflowDisplayName", () => {
 
   it("title-cases the raw name for invalid format", () => {
     expect(getWorkflowDisplayName("my-custom-thing")).toBe("My Custom Thing");
+  });
+});
+
+describe("getWorkflowDefinitionsByTag", () => {
+  it("filters by email tag", () => {
+    const email = getWorkflowDefinitionsByTag("email");
+    expect(email.length).toBeGreaterThanOrEqual(2);
+    expect(email.every((w) => w.tags.includes("email"))).toBe(true);
+  });
+
+  it("returns empty for unknown tag", () => {
+    expect(getWorkflowDefinitionsByTag("nonexistent")).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `tags: string[]` to `WorkflowDefinition` to align with workflow-service's new tag support
- Both existing workflows tagged with `["email"]`
- Adds `getWorkflowDefinitionsByTag()` helper for filtering workflows by tag
- Exported from `@distribute/content`

## Context
Workflow-service now supports `tags` on workflow definitions (deploy with `tags: ["email", "linkedin"]`, filter with `GET /workflows?tag=email`). This PR aligns the shared content types.

## Test plan
- [x] Updated workflow tests to validate `tags` field on every definition
- [x] New tests for `getWorkflowDefinitionsByTag()` 
- [x] All 27 shared content tests pass
- [x] All 365 root tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)