### PR TITLE
feat: admin key auth for dashboard

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -6,14 +6,18 @@ export interface AuthenticatedRequest extends Request {
   userId?: string;
   orgId?: string;
   runId?: string;
-  authType?: "app_key" | "user_key";
+  authType?: "app_key" | "user_key" | "admin";
 }
 
 /**
- * Authenticate via API key (app key or user key)
- * - App key (distrib.app_*): resolved via key-service, then external IDs
- *   from x-org-id/x-user-id headers resolved to internal UUIDs via client-service
- * - User key (distrib.usr_*): resolved via key-service → orgId, userId
+ * Authenticate via Bearer token. Two paths:
+ *
+ * 1. Admin key → Bearer token matches ADMIN_DISTRIBUTE_API_KEY env var (dashboard).
+ *    External Clerk IDs from x-org-id / x-user-id are resolved via client-service.
+ *
+ * 2. Client key → Bearer token validated via key-service.
+ *    - App key (distrib.app_*): external IDs from x-org-id/x-user-id resolved via client-service.
+ *    - User key (distrib.usr_*): identity comes from the key itself.
  */
 export async function authenticate(
   req: AuthenticatedRequest,
@@ -29,27 +33,19 @@ export async function authenticate(
 
     const key = authHeader.slice(7);
 
-    // Validate key with key-service
-    const validation = await validateKey(key);
-    if (!validation) {
-      return res.status(401).json({ error: "Invalid API key" });
-    }
+    // ── Path 1: Admin / dashboard auth ──
+    if (key === process.env.ADMIN_DISTRIBUTE_API_KEY) {
+      req.authType = "admin";
 
-    // App key: optionally resolve external IDs
-    if (validation.type === "app") {
-      req.authType = "app_key";
-
+      // Dashboard sends external Clerk IDs → resolve to internal UUIDs
       const externalOrgId = req.headers["x-org-id"] as string | undefined;
       const externalUserId = req.headers["x-user-id"] as string | undefined;
 
       if (externalOrgId && externalUserId) {
-        const resolved = await resolveExternalIds(
-          externalOrgId,
-          externalUserId,
-        );
+        const resolved = await resolveExternalIds(externalOrgId, externalUserId);
 
         if (!resolved) {
-          console.error("[auth] Identity resolution returned null", {
+          console.error("[auth] Admin identity resolution returned null", {
             externalOrgId,
             externalUserId,
           });
@@ -57,7 +53,7 @@ export async function authenticate(
         }
 
         if (!resolved.orgId || !resolved.userId) {
-          console.error("[auth] Identity resolution returned empty IDs", {
+          console.error("[auth] Admin identity resolution returned empty IDs", {
             resolved,
             externalOrgId,
             externalUserId,
@@ -67,18 +63,57 @@ export async function authenticate(
 
         req.orgId = resolved.orgId;
         req.userId = resolved.userId;
-      } else if (externalOrgId || externalUserId) {
-        console.warn("[auth] App key request has only one identity header", {
-          hasOrgId: !!externalOrgId,
-          hasUserId: !!externalUserId,
-          path: req.path,
-        });
       }
+      // Admin without org/user context is valid (e.g. listing all orgs)
+
     } else {
-      // User key: all identity comes from the key itself — no headers needed
-      req.orgId = validation.orgId;
-      req.userId = validation.userId;
-      req.authType = "user_key";
+      // ── Path 2: Client auth via key-service ──
+      const validation = await validateKey(key);
+      if (!validation) {
+        return res.status(401).json({ error: "Invalid API key" });
+      }
+
+      if (validation.type === "app") {
+        req.authType = "app_key";
+
+        const externalOrgId = req.headers["x-org-id"] as string | undefined;
+        const externalUserId = req.headers["x-user-id"] as string | undefined;
+
+        if (externalOrgId && externalUserId) {
+          const resolved = await resolveExternalIds(externalOrgId, externalUserId);
+
+          if (!resolved) {
+            console.error("[auth] Identity resolution returned null", {
+              externalOrgId,
+              externalUserId,
+            });
+            return res.status(502).json({ error: "Identity resolution failed" });
+          }
+
+          if (!resolved.orgId || !resolved.userId) {
+            console.error("[auth] Identity resolution returned empty IDs", {
+              resolved,
+              externalOrgId,
+              externalUserId,
+            });
+            return res.status(502).json({ error: "Identity resolution returned incomplete data" });
+          }
+
+          req.orgId = resolved.orgId;
+          req.userId = resolved.userId;
+        } else if (externalOrgId || externalUserId) {
+          console.warn("[auth] App key request has only one identity header", {
+            hasOrgId: !!externalOrgId,
+            hasUserId: !!externalUserId,
+            path: req.path,
+          });
+        }
+      } else {
+        // User key: all identity comes from the key itself
+        req.orgId = validation.orgId;
+        req.userId = validation.userId;
+        req.authType = "user_key";
+      }
     }
 
     // Create a request run for tracking (best-effort — don't block if runs-service is down)

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -11,7 +11,7 @@ global.fetch = vi.fn().mockResolvedValue({
   json: () => Promise.resolve({}),
 });
 
-process.env.API_SERVICE_API_KEY = "test-service-secret";
+process.env.ADMIN_DISTRIBUTE_API_KEY = "test-admin-distribute-key";
 process.env.KEY_SERVICE_URL = "http://localhost:3001";
 process.env.KEY_SERVICE_API_KEY = "test-key-service-api-key";
 process.env.LEAD_SERVICE_URL = "http://localhost:3006";

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -24,6 +24,8 @@ vi.mock("../../src/lib/service-client.js", () => {
 import { callExternalService } from "../../src/lib/service-client.js";
 const mockCall = vi.mocked(callExternalService);
 
+const ADMIN_KEY = "test-admin-distribute-key";
+
 function createApp() {
   const app = express();
   app.use(express.json());
@@ -47,11 +49,94 @@ function createApp() {
   return app;
 }
 
+describe("Auth middleware — admin key", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_DISTRIBUTE_API_KEY = ADMIN_KEY;
+    app = createApp();
+  });
+
+  it("should authenticate with admin key and resolve external IDs via client-service", async () => {
+    // Admin key matches env var → client-service /resolve called
+    mockCall.mockResolvedValueOnce({
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+      orgCreated: false,
+      userCreated: false,
+    });
+
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("Authorization", `Bearer ${ADMIN_KEY}`)
+      .set("x-org-id", "org_2clerkOrg")
+      .set("x-user-id", "user_2clerkUser");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+      authType: "admin",
+    });
+
+    // Only client-service /resolve called — NO key-service /validate
+    expect(mockCall).toHaveBeenCalledTimes(1);
+    expect(mockCall).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "http://client-service" }),
+      "/resolve",
+      {
+        method: "POST",
+        body: {
+          externalOrgId: "org_2clerkOrg",
+          externalUserId: "user_2clerkUser",
+        },
+      },
+    );
+  });
+
+  it("should allow admin key without org/user headers (admin-only access)", async () => {
+    const res = await request(app)
+      .get("/v1/me")
+      .set("Authorization", `Bearer ${ADMIN_KEY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ orgId: null, userId: null, authType: "admin" });
+    // No external calls at all
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("should return 502 when client-service resolution fails for admin key", async () => {
+    mockCall.mockRejectedValueOnce(new Error("Connection refused"));
+
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("Authorization", `Bearer ${ADMIN_KEY}`)
+      .set("x-org-id", "org_2clerkOrg")
+      .set("x-user-id", "user_2clerkUser");
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("Identity resolution failed");
+  });
+
+  it("should return 401 when Bearer token does not match admin key and key-service rejects it", async () => {
+    mockCall.mockResolvedValueOnce({ valid: false });
+
+    const res = await request(app)
+      .get("/v1/me")
+      .set("Authorization", "Bearer wrong-key");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid API key");
+  });
+});
+
 describe("Auth middleware — app key with identity headers", () => {
   let app: express.Express;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.ADMIN_DISTRIBUTE_API_KEY = ADMIN_KEY;
     app = createApp();
   });
 
@@ -174,6 +259,7 @@ describe("Auth middleware — user key", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.ADMIN_DISTRIBUTE_API_KEY = ADMIN_KEY;
     app = createApp();
   });
 
@@ -223,6 +309,7 @@ describe("Auth middleware — error cases", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.ADMIN_DISTRIBUTE_API_KEY = ADMIN_KEY;
     app = createApp();
   });
 

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -18,8 +18,24 @@ describe("Auth middleware — Bearer key authentication", () => {
   });
 });
 
+describe("Auth middleware — admin key authentication", () => {
+  it("should check Bearer token against ADMIN_DISTRIBUTE_API_KEY env var", () => {
+    expect(content).toContain("ADMIN_DISTRIBUTE_API_KEY");
+    expect(content).toContain("process.env.ADMIN_DISTRIBUTE_API_KEY");
+  });
+
+  it("should set authType to admin for admin key", () => {
+    expect(content).toContain('"admin"');
+  });
+
+  it("should resolve external IDs via client-service for admin requests", () => {
+    expect(content).toContain("Admin identity resolution");
+    expect(content).toContain("resolveExternalIds");
+  });
+});
+
 describe("Auth middleware — key-service validation", () => {
-  it("should validate keys via key-service /validate using callExternalService", () => {
+  it("should validate client keys via key-service /validate using callExternalService", () => {
     expect(content).toContain("/validate");
     expect(content).toContain("externalServices.key");
     expect(content).toContain("callExternalService");
@@ -59,11 +75,10 @@ describe("Auth middleware — app key identity resolution", () => {
   it("should resolve external IDs via client-service POST /resolve", () => {
     expect(content).toContain('"/resolve"');
     expect(content).toContain("externalServices.client");
-    expect(content).toContain("method: \"POST\"");
+    expect(content).toContain('method: "POST"');
   });
 
   it("should send externalOrgId and externalUserId to client-service (no appId in resolve body)", () => {
-    // appId should not appear in the /resolve call body or the AuthenticatedRequest interface
     expect(content).not.toContain("req.appId");
     expect(content).not.toContain("appId?: string");
     expect(content).toContain("externalOrgId");


### PR DESCRIPTION
## Summary
- Bearer token is now checked against `ADMIN_DISTRIBUTE_API_KEY` env var first (dashboard/admin auth), then falls back to key-service validation (client org/user keys)
- Admin path resolves external Clerk IDs via client-service (same as app keys)
- `authType: "admin"` set on request for admin-authenticated calls
- Renamed env var from `API_SERVICE_API_KEY` to `ADMIN_DISTRIBUTE_API_KEY` — **must be renamed in Railway**

## Test plan
- [x] Admin key authenticates successfully with identity headers resolved via client-service
- [x] Admin key works without org/user headers (admin-only access)
- [x] Admin key returns 502 when client-service resolution fails
- [x] Wrong admin key falls through to key-service validation
- [x] Existing app key and user key flows unchanged
- [x] All 372 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)