### PR TITLE
refactor: remove app_key, admin + user_key only

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -131,8 +131,8 @@
           "authType": {
             "type": "string",
             "enum": [
-              "app_key",
-              "user_key"
+              "user_key",
+              "admin"
             ]
           }
         }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -6,7 +6,7 @@ export interface AuthenticatedRequest extends Request {
   userId?: string;
   orgId?: string;
   runId?: string;
-  authType?: "app_key" | "user_key" | "admin";
+  authType?: "user_key" | "admin";
 }
 
 /**
@@ -15,9 +15,7 @@ export interface AuthenticatedRequest extends Request {
  * 1. Admin key → Bearer token matches ADMIN_DISTRIBUTE_API_KEY env var (dashboard).
  *    External Clerk IDs from x-org-id / x-user-id are resolved via client-service.
  *
- * 2. Client key → Bearer token validated via key-service.
- *    - App key (distrib.app_*): external IDs from x-org-id/x-user-id resolved via client-service.
- *    - User key (distrib.usr_*): identity comes from the key itself.
+ * 2. User key (distrib.usr_*) → validated via key-service. Identity comes from the key itself.
  */
 export async function authenticate(
   req: AuthenticatedRequest,
@@ -67,53 +65,15 @@ export async function authenticate(
       // Admin without org/user context is valid (e.g. listing all orgs)
 
     } else {
-      // ── Path 2: Client auth via key-service ──
+      // ── Path 2: User key auth via key-service ──
       const validation = await validateKey(key);
       if (!validation) {
         return res.status(401).json({ error: "Invalid API key" });
       }
 
-      if (validation.type === "app") {
-        req.authType = "app_key";
-
-        const externalOrgId = req.headers["x-org-id"] as string | undefined;
-        const externalUserId = req.headers["x-user-id"] as string | undefined;
-
-        if (externalOrgId && externalUserId) {
-          const resolved = await resolveExternalIds(externalOrgId, externalUserId);
-
-          if (!resolved) {
-            console.error("[auth] Identity resolution returned null", {
-              externalOrgId,
-              externalUserId,
-            });
-            return res.status(502).json({ error: "Identity resolution failed" });
-          }
-
-          if (!resolved.orgId || !resolved.userId) {
-            console.error("[auth] Identity resolution returned empty IDs", {
-              resolved,
-              externalOrgId,
-              externalUserId,
-            });
-            return res.status(502).json({ error: "Identity resolution returned incomplete data" });
-          }
-
-          req.orgId = resolved.orgId;
-          req.userId = resolved.userId;
-        } else if (externalOrgId || externalUserId) {
-          console.warn("[auth] App key request has only one identity header", {
-            hasOrgId: !!externalOrgId,
-            hasUserId: !!externalUserId,
-            path: req.path,
-          });
-        }
-      } else {
-        // User key: all identity comes from the key itself
-        req.orgId = validation.orgId;
-        req.userId = validation.userId;
-        req.authType = "user_key";
-      }
+      req.orgId = validation.orgId;
+      req.userId = validation.userId;
+      req.authType = "user_key";
     }
 
     // Create a request run for tracking (best-effort — don't block if runs-service is down)
@@ -147,19 +107,15 @@ export async function authenticate(
 }
 
 /**
- * Validate API key against key-service /validate
- *
- * Uses callExternalService (X-API-Key auth) with the key passed as ?key= query param.
+ * Validate user API key against key-service /validate
  */
 async function validateKey(apiKey: string): Promise<{
-  type: "app" | "user";
   orgId?: string;
   userId?: string;
 } | null> {
   try {
     const result = await callExternalService<{
       valid: boolean;
-      type: "app" | "user";
       orgId?: string;
       userId?: string;
     }>(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -155,7 +155,7 @@ registry.registerPath({
             .object({
               userId: z.string().optional(),
               orgId: z.string().optional(),
-              authType: z.enum(["app_key", "user_key"]).optional(),
+              authType: z.enum(["user_key", "admin"]).optional(),
             })
             .openapi("MeResponse"),
         },

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -59,7 +59,6 @@ describe("Auth middleware — admin key", () => {
   });
 
   it("should authenticate with admin key and resolve external IDs via client-service", async () => {
-    // Admin key matches env var → client-service /resolve called
     mockCall.mockResolvedValueOnce({
       orgId: "org-uuid-123",
       userId: "user-uuid-456",
@@ -102,7 +101,6 @@ describe("Auth middleware — admin key", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ orgId: null, userId: null, authType: "admin" });
-    // No external calls at all
     expect(mockCall).not.toHaveBeenCalled();
   });
 
@@ -131,129 +129,6 @@ describe("Auth middleware — admin key", () => {
   });
 });
 
-describe("Auth middleware — app key with identity headers", () => {
-  let app: express.Express;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    process.env.ADMIN_DISTRIBUTE_API_KEY = ADMIN_KEY;
-    app = createApp();
-  });
-
-  it("should resolve external IDs to internal UUIDs via client-service", async () => {
-    // First call: key-service /validate (via callExternalService)
-    mockCall.mockResolvedValueOnce({
-      valid: true, type: "app",
-    });
-    // Second call: client-service /resolve (via callExternalService)
-    mockCall.mockResolvedValueOnce({
-      orgId: "org-uuid-123",
-      userId: "user-uuid-456",
-      orgCreated: false,
-      userCreated: false,
-    });
-
-    const res = await request(app)
-      .get("/v1/workflows")
-      .set("Authorization", "Bearer mcpf_app_test123")
-      .set("x-org-id", "org_2clerkOrg")
-      .set("x-user-id", "user_2clerkUser");
-
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      orgId: "org-uuid-123",
-      userId: "user-uuid-456",
-      authType: "app_key",
-    });
-
-    // Verify callExternalService was called for /validate with ?key= query param
-    expect(mockCall).toHaveBeenCalledTimes(2);
-    expect(mockCall).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ url: "http://key-service" }),
-      "/validate?key=mcpf_app_test123",
-    );
-
-    // Verify client-service was called with correct body
-    expect(mockCall).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ url: "http://client-service" }),
-      "/resolve",
-      {
-        method: "POST",
-        body: {
-          externalOrgId: "org_2clerkOrg",
-          externalUserId: "user_2clerkUser",
-        },
-      },
-    );
-  });
-
-  it("should return 400 from requireOrg when identity headers are missing", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app" });
-
-    const res = await request(app)
-      .get("/v1/workflows")
-      .set("Authorization", "Bearer mcpf_app_test123");
-    // No x-org-id or x-user-id headers
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Organization context required");
-  });
-
-  it("should return 502 when client-service resolution fails", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app" });
-    mockCall.mockRejectedValueOnce(new Error("Connection refused"));
-
-    const res = await request(app)
-      .get("/v1/workflows")
-      .set("Authorization", "Bearer mcpf_app_test123")
-      .set("x-org-id", "org_2clerkOrg")
-      .set("x-user-id", "user_2clerkUser");
-
-    expect(res.status).toBe(502);
-    expect(res.body.error).toBe("Identity resolution failed");
-  });
-
-  it("should return 502 when client-service returns empty orgId", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app" });
-    mockCall.mockResolvedValueOnce({ orgId: null, userId: null });
-
-    const res = await request(app)
-      .get("/v1/workflows")
-      .set("Authorization", "Bearer mcpf_app_test123")
-      .set("x-org-id", "org_2clerkOrg")
-      .set("x-user-id", "user_2clerkUser");
-
-    expect(res.status).toBe(502);
-    expect(res.body.error).toBe("Identity resolution returned incomplete data");
-  });
-
-  it("should allow /v1/me without identity headers for app keys", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app" });
-
-    const res = await request(app)
-      .get("/v1/me")
-      .set("Authorization", "Bearer mcpf_app_test123");
-
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ orgId: null, userId: null, authType: "app_key" });
-  });
-
-  it("should return 400 when only x-org-id is provided without x-user-id", async () => {
-    mockCall.mockResolvedValueOnce({ valid: true, type: "app" });
-
-    const res = await request(app)
-      .get("/v1/workflows")
-      .set("Authorization", "Bearer mcpf_app_test123")
-      .set("x-org-id", "org_2clerkOrg");
-    // No x-user-id → resolution skipped → requireOrg fires
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Organization context required");
-  });
-});
-
 describe("Auth middleware — user key", () => {
   let app: express.Express;
 
@@ -266,7 +141,6 @@ describe("Auth middleware — user key", () => {
   it("should set orgId, userId from key-service without client-service call", async () => {
     mockCall.mockResolvedValueOnce({
       valid: true,
-      type: "user",
       orgId: "org-uuid-direct",
       userId: "user-uuid-direct",
     });
@@ -285,7 +159,6 @@ describe("Auth middleware — user key", () => {
   it("should pass requireOrg and requireUser when user key carries full identity", async () => {
     mockCall.mockResolvedValueOnce({
       valid: true,
-      type: "user",
       orgId: "org-uuid-direct",
       userId: "user-uuid-direct",
     });
@@ -339,7 +212,6 @@ describe("Auth middleware — error cases", () => {
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("Invalid API key");
-    // Only one callExternalService call for /validate
     expect(mockCall).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -34,8 +34,8 @@ describe("Auth middleware — admin key authentication", () => {
   });
 });
 
-describe("Auth middleware — key-service validation", () => {
-  it("should validate client keys via key-service /validate using callExternalService", () => {
+describe("Auth middleware — key-service validation (user keys only)", () => {
+  it("should validate user keys via key-service /validate using callExternalService", () => {
     expect(content).toContain("/validate");
     expect(content).toContain("externalServices.key");
     expect(content).toContain("callExternalService");
@@ -46,43 +46,27 @@ describe("Auth middleware — key-service validation", () => {
     expect(content).toContain("encodeURIComponent(apiKey)");
   });
 
-  it("should distinguish app keys from user keys", () => {
-    expect(content).toContain('"app"');
-    expect(content).toContain('"user"');
-    expect(content).toContain("validation.type");
+  it("should not have app_key auth type", () => {
+    expect(content).not.toContain('"app_key"');
+    expect(content).not.toContain("app_key");
   });
 });
 
-describe("Auth middleware — app key identity resolution", () => {
+describe("Auth middleware — identity resolution", () => {
   it("should read external IDs from x-org-id and x-user-id headers", () => {
     expect(content).toContain('"x-org-id"');
     expect(content).toContain('"x-user-id"');
   });
 
-  it("should make x-org-id and x-user-id optional for app keys", () => {
-    expect(content).not.toContain("App key authentication requires x-org-id and x-user-id headers");
-  });
-
-  it("should NOT set appId on the request (appId removed from interface)", () => {
+  it("should NOT set appId on the request", () => {
     expect(content).not.toContain("req.appId");
     expect(content).not.toContain("appId?: string");
-  });
-
-  it("should only resolve external IDs when both headers are provided", () => {
-    expect(content).toContain("if (externalOrgId && externalUserId)");
   });
 
   it("should resolve external IDs via client-service POST /resolve", () => {
     expect(content).toContain('"/resolve"');
     expect(content).toContain("externalServices.client");
     expect(content).toContain('method: "POST"');
-  });
-
-  it("should send externalOrgId and externalUserId to client-service (no appId in resolve body)", () => {
-    expect(content).not.toContain("req.appId");
-    expect(content).not.toContain("appId?: string");
-    expect(content).toContain("externalOrgId");
-    expect(content).toContain("externalUserId");
   });
 
   it("should return 502 when identity resolution fails", () => {
@@ -93,14 +77,6 @@ describe("Auth middleware — app key identity resolution", () => {
   it("should return 502 when identity resolution returns incomplete data", () => {
     expect(content).toContain("Identity resolution returned incomplete data");
     expect(content).toContain("!resolved.orgId || !resolved.userId");
-  });
-
-  it("should warn when only one identity header is provided", () => {
-    expect(content).toContain("App key request has only one identity header");
-  });
-
-  it("should set authType to app_key for app key authentication", () => {
-    expect(content).toContain('"app_key"');
   });
 });
 

--- a/tests/unit/brand-sales-profile-from-url.test.ts
+++ b/tests/unit/brand-sales-profile-from-url.test.ts
@@ -16,7 +16,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
     req.userId = "user_test123";
     req.orgId = "org_test456";
-    req.authType = "app_key";
+    req.authType = "admin";
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
     req.userId = "user_test123";
     req.orgId = "org_test456";
-    req.authType = "app_key";
+    req.authType = "admin";
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {

--- a/tests/unit/icp-suggestion-keytype.regression.test.ts
+++ b/tests/unit/icp-suggestion-keytype.regression.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
     req.userId = "user_test123";
     req.orgId = "org_test456";
-    req.authType = "app_key";
+    req.authType = "admin";
     next();
   },
   requireOrg: (req: any, res: any, next: any) => {

--- a/tests/unit/keys-unified-proxy.test.ts
+++ b/tests/unit/keys-unified-proxy.test.ts
@@ -14,7 +14,7 @@ let fetchCalls: FetchCall[] = [];
 let mockAuth = {
   userId: "user_test123",
   orgId: "org_test456",
-  authType: "user_key" as "user_key" | "app_key",
+  authType: "user_key" as "user_key" | "admin",
 };
 
 vi.mock("../../src/middleware/auth.js", () => ({

--- a/tests/unit/stripe-proxy.test.ts
+++ b/tests/unit/stripe-proxy.test.ts
@@ -319,7 +319,7 @@ describe("Stripe catalog endpoints — app key without org context", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     // Simulate app key with NO org/user context
-    mockAuthContext = { orgId: undefined, userId: undefined, authType: "app_key" };
+    mockAuthContext = { orgId: undefined, userId: undefined, authType: "admin" };
     mockFetchOk({ id: "prod_123", name: "Webinar Access" });
     appKeyApp = createApp();
   });


### PR DESCRIPTION
## Summary
- Removed `app_key` auth type (`distrib.app_*`) — replaced by admin key (`ADMIN_DISTRIBUTE_API_KEY`)
- Auth now has exactly two paths: **admin** (dashboard) and **user_key** (client org keys)
- Updated `AuthenticatedRequest.authType` to `"user_key" | "admin"`
- Regenerated `openapi.json`

## Test plan
- [x] All 361 tests pass
- [x] No remaining `app_key` references in source or tests
- [x] OpenAPI spec updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)