### PR TITLE
fix: placeholder headers for /resolve during auth

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -148,6 +148,12 @@ async function resolveExternalIds(
       {
         method: "POST",
         body: { externalOrgId, externalUserId },
+        // Called during auth before a run exists — pass placeholder headers
+        headers: {
+          "x-run-id": "auth",
+          "x-org-id": "auth",
+          "x-user-id": "auth",
+        },
       }
     );
     return result;

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -90,6 +90,11 @@ describe("Auth middleware — admin key", () => {
           externalOrgId: "org_2clerkOrg",
           externalUserId: "user_2clerkUser",
         },
+        headers: {
+          "x-run-id": "auth",
+          "x-org-id": "auth",
+          "x-user-id": "auth",
+        },
       },
     );
   });


### PR DESCRIPTION
## Summary
- Pass placeholder `x-run-id`, `x-org-id`, `x-user-id` headers (`"auth"`) when calling client-service `/resolve` during authentication
- Fixes 502 errors: client-service requires these headers but `/resolve` is called before a run or identity exists (chicken-and-egg problem)
- Temporary workaround — client-service should exempt `/resolve` from required headers

## Test plan
- [x] All 361 tests pass
- [x] Fixes prod 502 errors on admin auth with Clerk ID resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)