### PR TITLE
fix: pass internal headers on downstream calls

### DIFF
--- a/src/routes/performance.ts
+++ b/src/routes/performance.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { authenticate, AuthenticatedRequest } from "../middleware/auth.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { getWorkflowCategory, getWorkflowDisplayName, getSectionKey, getSignatureName, SECTION_LABELS, type WorkflowCategory } from "@distribute/content";
 
 const router = Router();
@@ -448,13 +449,13 @@ async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[]):
 
 /** Get all brands across all orgs from brand-service.
  *  This is more reliable than /campaigns/list which only returns ongoing campaigns. */
-async function fetchAllBrands(): Promise<{
+async function fetchAllBrands(headers: Record<string, string> = {}): Promise<{
   brands: Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }>;
   orgIds: string[];
 }> {
   // Get all org IDs from brand-service
   const resp = await callExternalService<{ organization_ids: string[] }>(
-    externalServices.brand, "/org-ids"
+    externalServices.brand, "/org-ids", { headers }
   );
   const orgIds = resp.organization_ids || [];
 
@@ -466,7 +467,7 @@ async function fetchAllBrands(): Promise<{
       try {
         const { brands } = await callExternalService<{
           brands: Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }>;
-        }>(externalServices.brand, `/brands?orgId=${encodeURIComponent(orgId)}`);
+        }>(externalServices.brand, `/brands?orgId=${encodeURIComponent(orgId)}`, { headers });
         return brands || [];
       } catch {
         return [];
@@ -500,10 +501,10 @@ interface RunsStatsGroup {
 
 /** Build leaderboard data from brand-service + runs-service public endpoint.
  *  Uses brand-service for brands, runs-service for costs + workflows. */
-async function buildLeaderboardData(): Promise<{ data: LeaderboardData; orgIds: string[] }> {
+async function buildLeaderboardData(headers: Record<string, string> = {}): Promise<{ data: LeaderboardData; orgIds: string[] }> {
   // 1. Get brands + workflow stats + brand costs in parallel
   const [{ brands: allBrands, orgIds }, workflowStatsResult, brandCosts] = await Promise.all([
-    fetchAllBrands(),
+    fetchAllBrands(headers),
     // Workflow stats from runs-service public endpoint
     callExternalService<{ groups: RunsStatsGroup[] }>(
       externalServices.runs,
@@ -617,7 +618,7 @@ function buildCategorySections(data: LeaderboardData): CategorySection[] {
 
 router.get("/performance/leaderboard", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { data, orgIds } = await buildLeaderboardData();
+    const { data, orgIds } = await buildLeaderboardData(buildInternalHeaders(req));
 
     // Enrich with delivery stats (instantly-service for workflows, email-gateway for brands)
     try {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -18,11 +18,12 @@ interface WorkflowProviders {
  * Fetch requiredProviders for a single workflow by ID from workflow-service.
  * Returns an empty array on failure (best-effort enrichment).
  */
-async function fetchRequiredProviders(workflowId: string): Promise<string[]> {
+async function fetchRequiredProviders(workflowId: string, headers: Record<string, string> = {}): Promise<string[]> {
   try {
     const result = await callExternalService<WorkflowProviders>(
       externalServices.workflow,
-      `/workflows/${workflowId}/required-providers`
+      `/workflows/${workflowId}/required-providers`,
+      { headers },
     );
     return result.providers ?? [];
   } catch (err) {
@@ -78,9 +79,10 @@ router.get("/workflows", authenticate, requireOrg, requireUser, async (req: Auth
     const workflows = result.workflows ?? [];
 
     // Enrich each workflow with requiredProviders in parallel
+    const internalHeaders = buildInternalHeaders(req);
     const enriched = await Promise.all(
       workflows.map(async (wf) => {
-        const requiredProviders = await fetchRequiredProviders(wf.id);
+        const requiredProviders = await fetchRequiredProviders(wf.id, internalHeaders);
         return { ...wf, requiredProviders };
       })
     );
@@ -133,7 +135,7 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
         `/workflows/${id}`,
         { headers: buildInternalHeaders(req) },
       ).then((r) => r.workflow),
-      fetchRequiredProviders(id),
+      fetchRequiredProviders(id, buildInternalHeaders(req)),
     ]);
 
     if (!workflow) {
@@ -223,9 +225,10 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
   try {
     const { id } = req.params;
 
+    const internalHeaders = buildInternalHeaders(req);
     const [requiredProviders, orgKeys] = await Promise.all([
-      fetchRequiredProviders(id),
-      fetchOrgKeys(buildInternalHeaders(req)),
+      fetchRequiredProviders(id, internalHeaders),
+      fetchOrgKeys(internalHeaders),
     ]);
 
     const configuredMap = new Map(orgKeys.map((k) => [k.provider, k.maskedKey]));
@@ -276,7 +279,7 @@ router.get("/workflows/:id", authenticate, requireOrg, requireUser, async (req: 
         `/workflows/${id}`,
         { headers: buildInternalHeaders(req) },
       ),
-      fetchRequiredProviders(id),
+      fetchRequiredProviders(id, buildInternalHeaders(req)),
     ]);
 
     const wfObj = workflow as { workflow?: Record<string, unknown> };


### PR DESCRIPTION
## Summary
- `fetchRequiredProviders` now accepts and forwards internal headers to workflow-service
- `fetchAllBrands` now accepts and forwards internal headers to brand-service
- Fixes 502s on `/v1/workflows` (required-providers enrichment) and `/performance/leaderboard` (`/org-ids`)

## Test plan
- [x] All 361 tests pass
- [x] Fixes workflow-service "x-org-id, x-user-id, and x-run-id headers are required" errors
- [x] Fixes brand-service "Missing required headers" errors on leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)