### PR TITLE
fix: return 404 instead of 500 when brand has no sales profile

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -106,7 +106,9 @@ export async function callExternalService<T>(
       } catch {
         errorMessage = `Service call failed: ${response.status} - ${errorText}`;
       }
-      throw new Error(errorMessage);
+      const err = new Error(errorMessage) as Error & { statusCode: number };
+      err.statusCode = response.status;
+      throw err;
     }
 
     return response.json();

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -159,7 +159,7 @@ router.get("/brands/:id/sales-profile", authenticate, async (req: AuthenticatedR
     );
     res.json(result);
   } catch (error: any) {
-    if (error.message?.includes("404")) {
+    if (error.statusCode === 404 || error.message?.includes("404")) {
       return res.status(404).json({ error: "Sales profile not found" });
     }
     console.error("Get brand sales profile error:", error);

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -329,7 +329,7 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
     res.json(result);
   } catch (error: any) {
     console.error("Generate workflow error:", error.message);
-    const status = error.message?.includes("422") ? 422 : 500;
+    const status = error.statusCode === 422 || error.message?.includes("422") ? 422 : 500;
     res.status(status).json({ error: error.message || "Failed to generate workflow" });
   }
 });

--- a/tests/unit/brand-sales-profile-404.regression.test.ts
+++ b/tests/unit/brand-sales-profile-404.regression.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * Regression: GET /v1/brands/:id/sales-profile returned 500 when brand-service
+ * returned 404 with a JSON error body (e.g. { "error": "Sales profile not found" }).
+ *
+ * Root cause: callExternalService threw an Error whose message was the JSON
+ * `error` field (no status code). The route handler checked
+ * `error.message.includes("404")` — which was false — so it fell through to
+ * the generic 500 handler.
+ *
+ * Fix: callExternalService now attaches `statusCode` to the Error object, and
+ * the handler checks `error.statusCode === 404` first.
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+describe("GET /v1/brands/:id/sales-profile – 404 handling", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("should return 404 (not 500) when brand-service returns 404 with JSON error body", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"Sales profile not found"}'),
+    }));
+
+    const res = await request(app).get("/v1/brands/51b35f30-2d44-4492-9af8-df14ebafc9cd/sales-profile");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Sales profile not found");
+  });
+
+  it("should return 404 when brand-service returns 404 with plain text body", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not Found"),
+    }));
+
+    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("should return 200 when brand-service returns a sales profile", async () => {
+    const profile = { id: "sp-1", brandId: "b-1", valueProposition: "Test" };
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve(profile),
+    }));
+
+    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(profile);
+  });
+
+  it("should return 500 for genuine server errors from brand-service", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('{"error":"Internal server error"}'),
+    }));
+
+    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
+
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- `callExternalService` now attaches `error.statusCode` from the upstream HTTP response to thrown errors
- `GET /v1/brands/:id/sales-profile` checks `error.statusCode === 404` instead of relying on string-matching `error.message.includes("404")`, which failed when brand-service returned a JSON error body like `{"error": "Sales profile not found"}`
- Same fix applied to the workflow generate endpoint's 422 check

## Test plan
- [x] Regression test: brand-service returns 404 with JSON body → api-service returns 404 (not 500)
- [x] Regression test: brand-service returns 404 with plain text body → api-service returns 404
- [x] Test: brand-service returns 200 → api-service returns 200
- [x] Test: brand-service returns 500 → api-service returns 500
- [x] All 373 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)