### PR TITLE
fix: key-status endpoint respects key source preferences

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -840,18 +840,27 @@
           },
           "configured": {
             "type": "boolean",
-            "description": "Whether the org has a key configured for this provider"
+            "description": "Whether a key is available for this provider (via platform or org key)"
           },
           "maskedKey": {
             "type": "string",
             "nullable": true,
-            "description": "Masked key value, or null if not configured"
+            "description": "Masked org key value, or null if not configured"
+          },
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Key source preference: 'platform' (default) or 'org' (BYOK)"
           }
         },
         "required": [
           "provider",
           "configured",
-          "maskedKey"
+          "maskedKey",
+          "keySource"
         ]
       },
       "WorkflowKeyStatusResponse": {
@@ -4331,7 +4340,7 @@
           "Workflows"
         ],
         "summary": "Get key status for a workflow",
-        "description": "Compares the workflow's required providers against the org's configured BYOK keys. Returns which keys are present and which are missing, along with an overall readiness flag.",
+        "description": "Compares the workflow's required providers against the org's key configuration, taking into account key source preferences (platform vs org). Providers using platform keys are always ready. Returns which keys are present and which are missing, along with an overall readiness flag.",
         "security": [
           {
             "bearerAuth": []

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -51,6 +51,29 @@ async function fetchOrgKeys(headers: Record<string, string>): Promise<KeyItem[]>
   return result.keys ?? [];
 }
 
+interface KeySourceItem {
+  provider: string;
+  keySource: "org" | "platform";
+}
+
+/**
+ * Fetch the org's key source preferences from key-service.
+ * Providers not listed default to "platform".
+ */
+async function fetchKeySources(headers: Record<string, string>): Promise<KeySourceItem[]> {
+  try {
+    const result = await callExternalService<{ sources: KeySourceItem[] }>(
+      externalServices.key,
+      "/keys/sources",
+      { headers },
+    );
+    return result.sources ?? [];
+  } catch (err) {
+    console.warn("[workflows] Failed to fetch key sources:", (err as Error).message);
+    return [];
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Routes
 // ---------------------------------------------------------------------------
@@ -226,18 +249,27 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
     const { id } = req.params;
 
     const internalHeaders = buildInternalHeaders(req);
-    const [requiredProviders, orgKeys] = await Promise.all([
+    const [requiredProviders, orgKeys, keySources] = await Promise.all([
       fetchRequiredProviders(id, internalHeaders),
       fetchOrgKeys(internalHeaders),
+      fetchKeySources(internalHeaders),
     ]);
 
     const configuredMap = new Map(orgKeys.map((k) => [k.provider, k.maskedKey]));
+    const sourceMap = new Map(keySources.map((s) => [s.provider, s.keySource]));
 
-    const keys = requiredProviders.map((provider) => ({
-      provider,
-      configured: configuredMap.has(provider),
-      maskedKey: configuredMap.get(provider) ?? null,
-    }));
+    const keys = requiredProviders.map((provider) => {
+      const keySource = sourceMap.get(provider) ?? "platform";
+      const hasOrgKey = configuredMap.has(provider);
+      // Platform keys are always available; org keys must be explicitly configured
+      const configured = keySource === "platform" || hasOrgKey;
+      return {
+        provider,
+        configured,
+        maskedKey: configuredMap.get(provider) ?? null,
+        keySource,
+      };
+    });
 
     const missing = keys.filter((k) => !k.configured).map((k) => k.provider);
 
@@ -337,6 +369,6 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
 // ---------------------------------------------------------------------------
 // Exported helpers
 // ---------------------------------------------------------------------------
-export { fetchRequiredProviders, fetchOrgKeys };
+export { fetchRequiredProviders, fetchOrgKeys, fetchKeySources };
 
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1142,8 +1142,9 @@ registry.registerPath({
 export const WorkflowKeyStatusItemSchema = z
   .object({
     provider: z.string().describe("Provider name (e.g. 'apollo', 'anthropic')"),
-    configured: z.boolean().describe("Whether the org has a key configured for this provider"),
-    maskedKey: z.string().nullable().describe("Masked key value, or null if not configured"),
+    configured: z.boolean().describe("Whether a key is available for this provider (via platform or org key)"),
+    maskedKey: z.string().nullable().describe("Masked org key value, or null if not configured"),
+    keySource: z.enum(["org", "platform"]).describe("Key source preference: 'platform' (default) or 'org' (BYOK)"),
   })
   .openapi("WorkflowKeyStatusItem");
 
@@ -1162,7 +1163,9 @@ registry.registerPath({
   tags: ["Workflows"],
   summary: "Get key status for a workflow",
   description:
-    "Compares the workflow's required providers against the org's configured BYOK keys. " +
+    "Compares the workflow's required providers against the org's key configuration, " +
+    "taking into account key source preferences (platform vs org). " +
+    "Providers using platform keys are always ready. " +
     "Returns which keys are present and which are missing, along with an overall readiness flag.",
   security: authed,
   request: {

--- a/tests/unit/workflow-enrichment.test.ts
+++ b/tests/unit/workflow-enrichment.test.ts
@@ -252,74 +252,96 @@ describe("GET /v1/workflows/:id/summary", () => {
 describe("GET /v1/workflows/:id/key-status", () => {
   let app: express.Express;
 
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    fetchCalls = [];
+  /** Helper to build a fetch mock with configurable key sources */
+  function buildFetchMock(opts: {
+    requiredProviders?: string[];
+    orgKeys?: Array<{ provider: string; maskedKey: string }>;
+    keySources?: Array<{ provider: string; keySource: "org" | "platform" }>;
+    workflowName?: string;
+  } = {}) {
+    const {
+      requiredProviders = ["apollo", "anthropic", "instantly"],
+      orgKeys = [
+        { provider: "apollo", maskedKey: "apol...123" },
+        { provider: "anthropic", maskedKey: "sk-...abc" },
+      ],
+      keySources = [],
+      workflowName = "sales-email-cold-outreach-v1",
+    } = opts;
 
-    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+    return vi.fn().mockImplementation(async (url: string) => {
       fetchCalls.push({ url });
 
       if (url.includes("/required-providers")) {
-        return {
-          ok: true,
-          json: () => Promise.resolve({ providers: ["apollo", "anthropic", "instantly"] }),
-        };
+        return { ok: true, json: () => Promise.resolve({ providers: requiredProviders }) };
+      }
+      if (url.includes("/keys/sources")) {
+        return { ok: true, json: () => Promise.resolve({ sources: keySources }) };
       }
       if (url.match(/\/keys$/) || url.includes("/keys?")) {
-        return {
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              keys: [
-                { provider: "apollo", maskedKey: "apol...123" },
-                { provider: "anthropic", maskedKey: "sk-...abc" },
-              ],
-            }),
-        };
+        return { ok: true, json: () => Promise.resolve({ keys: orgKeys }) };
       }
       if (url.match(/\/workflows\/wf-1$/)) {
-        return {
-          ok: true,
-          json: () => Promise.resolve({ workflow: { name: "sales-email-cold-outreach-v1" } }),
-        };
+        return { ok: true, json: () => Promise.resolve({ workflow: { name: workflowName } }) };
       }
       return { ok: true, json: () => Promise.resolve({}) };
     });
+  }
 
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    global.fetch = buildFetchMock();
     app = createApp();
   });
 
-  it("should return key status with missing providers", async () => {
+  it("should return key status with missing providers (org source, no key)", async () => {
+    // All providers use org keys, but instantly has no key configured
+    global.fetch = buildFetchMock({
+      keySources: [
+        { provider: "apollo", keySource: "org" },
+        { provider: "anthropic", keySource: "org" },
+        { provider: "instantly", keySource: "org" },
+      ],
+    });
+    app = createApp();
+
     const res = await request(app).get("/v1/workflows/wf-1/key-status");
 
     expect(res.status).toBe(200);
     expect(res.body.workflowName).toBe("sales-email-cold-outreach-v1");
     expect(res.body.ready).toBe(false);
     expect(res.body.keys).toHaveLength(3);
-    expect(res.body.keys).toContainEqual({ provider: "apollo", configured: true, maskedKey: "apol...123" });
-    expect(res.body.keys).toContainEqual({ provider: "anthropic", configured: true, maskedKey: "sk-...abc" });
-    expect(res.body.keys).toContainEqual({ provider: "instantly", configured: false, maskedKey: null });
+    expect(res.body.keys).toContainEqual({ provider: "apollo", configured: true, maskedKey: "apol...123", keySource: "org" });
+    expect(res.body.keys).toContainEqual({ provider: "anthropic", configured: true, maskedKey: "sk-...abc", keySource: "org" });
+    expect(res.body.keys).toContainEqual({ provider: "instantly", configured: false, maskedKey: null, keySource: "org" });
     expect(res.body.missing).toEqual(["instantly"]);
   });
 
-  it("should return ready=true when all keys are configured", async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (url.includes("/required-providers")) {
-        return { ok: true, json: () => Promise.resolve({ providers: ["apollo"] }) };
-      }
-      if (url.match(/\/keys$/) || url.includes("/keys?")) {
-        return {
-          ok: true,
-          json: () => Promise.resolve({ keys: [{ provider: "apollo", maskedKey: "apol...123" }] }),
-        };
-      }
-      if (url.match(/\/workflows\/wf-1$/)) {
-        return {
-          ok: true,
-          json: () => Promise.resolve({ workflow: { name: "simple-flow" } }),
-        };
-      }
-      return { ok: true, json: () => Promise.resolve({}) };
+  it("should return ready=true when all providers use platform keys (default)", async () => {
+    // No key sources set → all default to platform → always ready
+    global.fetch = buildFetchMock({
+      requiredProviders: ["anthropic", "apollo"],
+      orgKeys: [], // No org keys configured
+      keySources: [], // Defaults to platform
+    });
+    app = createApp();
+
+    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ready).toBe(true);
+    expect(res.body.missing).toEqual([]);
+    expect(res.body.keys).toContainEqual({ provider: "anthropic", configured: true, maskedKey: null, keySource: "platform" });
+    expect(res.body.keys).toContainEqual({ provider: "apollo", configured: true, maskedKey: null, keySource: "platform" });
+  });
+
+  it("should return ready=true when all org-source keys are configured", async () => {
+    global.fetch = buildFetchMock({
+      requiredProviders: ["apollo"],
+      orgKeys: [{ provider: "apollo", maskedKey: "apol...123" }],
+      keySources: [{ provider: "apollo", keySource: "org" }],
+      workflowName: "simple-flow",
     });
     app = createApp();
 
@@ -330,12 +352,68 @@ describe("GET /v1/workflows/:id/key-status", () => {
     expect(res.body.missing).toEqual([]);
   });
 
+  it("should handle mixed key sources correctly", async () => {
+    // anthropic uses platform (ready), instantly uses org but has no key (missing)
+    global.fetch = buildFetchMock({
+      requiredProviders: ["anthropic", "instantly"],
+      orgKeys: [],
+      keySources: [
+        { provider: "instantly", keySource: "org" },
+        // anthropic not listed → defaults to platform
+      ],
+    });
+    app = createApp();
+
+    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ready).toBe(false);
+    expect(res.body.keys).toContainEqual({ provider: "anthropic", configured: true, maskedKey: null, keySource: "platform" });
+    expect(res.body.keys).toContainEqual({ provider: "instantly", configured: false, maskedKey: null, keySource: "org" });
+    expect(res.body.missing).toEqual(["instantly"]);
+  });
+
+  it("should fetch key sources from /keys/sources", async () => {
+    await request(app).get("/v1/workflows/wf-1/key-status");
+
+    const sourcesCall = fetchCalls.find((c) => c.url.includes("/keys/sources"));
+    expect(sourcesCall).toBeDefined();
+  });
+
   it("should fetch org keys via /keys without orgId in query (uses headers)", async () => {
     await request(app).get("/v1/workflows/wf-1/key-status");
 
-    const keysCall = fetchCalls.find((c) => c.url.match(/\/keys$/));
+    const keysCall = fetchCalls.find((c) => c.url.match(/\/keys$/) && !c.url.includes("/keys/sources"));
     expect(keysCall).toBeDefined();
     expect(keysCall!.url).not.toContain("keySource");
     expect(keysCall!.url).not.toContain("orgId");
+  });
+
+  it("should gracefully handle key sources fetch failure (default to platform)", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      fetchCalls.push({ url });
+
+      if (url.includes("/required-providers")) {
+        return { ok: true, json: () => Promise.resolve({ providers: ["anthropic"] }) };
+      }
+      if (url.includes("/keys/sources")) {
+        return { ok: false, text: () => Promise.resolve("Internal error") };
+      }
+      if (url.match(/\/keys$/) || url.includes("/keys?")) {
+        return { ok: true, json: () => Promise.resolve({ keys: [] }) };
+      }
+      if (url.match(/\/workflows\/wf-1$/)) {
+        return { ok: true, json: () => Promise.resolve({ workflow: { name: "test-flow" } }) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+    app = createApp();
+
+    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+
+    // Should default to platform → configured = true
+    expect(res.status).toBe(200);
+    expect(res.body.ready).toBe(true);
+    expect(res.body.keys).toContainEqual({ provider: "anthropic", configured: true, maskedKey: null, keySource: "platform" });
   });
 });


### PR DESCRIPTION
## Summary
- The `GET /v1/workflows/{id}/key-status` endpoint now fetches key source preferences from key-service (`GET /keys/sources`) alongside org keys
- Providers using platform keys (the default) are marked as `configured: true` — no more false "missing keys" warnings for trial users
- Adds `keySource` field (`"org"` or `"platform"`) to each key status item in the response
- Gracefully degrades if key-service `/keys/sources` is unavailable (defaults to platform = ready)

## Test plan
- [x] Existing tests updated to cover key source logic
- [x] New test: platform-default providers show `ready=true` even without org keys
- [x] New test: mixed key sources (some platform, some org) handled correctly
- [x] New test: graceful fallback when `/keys/sources` fails
- [x] Full test suite passes (377 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)