### PR TITLE
feat: GET /brands/:id/sales-profile is now get-or-create

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3383,8 +3383,8 @@
         "tags": [
           "Brand"
         ],
-        "summary": "Get brand sales profile",
-        "description": "Get the sales profile for a specific brand",
+        "summary": "Get or create brand sales profile",
+        "description": "Get the sales profile for a brand. If none exists, automatically triggers extraction (scrape + AI analysis) and returns the result. Always returns a profile.",
         "security": [
           {
             "bearerAuth": []
@@ -3422,10 +3422,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Brand sales profile"
+            "description": "Brand sales profile (includes cached, brandId, and profile fields)"
           },
-          "401": {
-            "description": "Unauthorized",
+          "400": {
+            "description": "Anthropic API key not configured",
             "content": {
               "application/json": {
                 "schema": {
@@ -3434,8 +3434,8 @@
               }
             }
           },
-          "404": {
-            "description": "Sales profile not found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -148,9 +148,10 @@ router.get("/brands/:id", authenticate, async (req: AuthenticatedRequest, res) =
 
 /**
  * GET /v1/brands/:id/sales-profile
- * Get sales profile for a specific brand
+ * Get-or-create: returns the sales profile for a brand, triggering extraction
+ * automatically if none exists yet. Always returns a profile.
  */
-router.get("/brands/:id/sales-profile", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/brands/:id/sales-profile", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.brand,
@@ -159,11 +160,14 @@ router.get("/brands/:id/sales-profile", authenticate, async (req: AuthenticatedR
     );
     res.json(result);
   } catch (error: any) {
-    if (error.statusCode === 404 || error.message?.includes("404")) {
-      return res.status(404).json({ error: "Sales profile not found" });
-    }
     console.error("Get brand sales profile error:", error);
-    res.status(500).json({ error: error.message || "Failed to get sales profile" });
+    const msg = error.message || "Failed to get sales profile";
+    if (msg.includes("No Anthropic API key found")) {
+      return res.status(400).json({
+        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
+      });
+    }
+    res.status(500).json({ error: msg });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -784,14 +784,16 @@ registry.registerPath({
   method: "get",
   path: "/v1/brands/{id}/sales-profile",
   tags: ["Brand"],
-  summary: "Get brand sales profile",
-  description: "Get the sales profile for a specific brand",
+  summary: "Get or create brand sales profile",
+  description:
+    "Get the sales profile for a brand. If none exists, automatically triggers " +
+    "extraction (scrape + AI analysis) and returns the result. Always returns a profile.",
   security: authed,
   request: { params: BrandIdParam },
   responses: {
-    200: { description: "Brand sales profile" },
+    200: { description: "Brand sales profile (includes cached, brandId, and profile fields)" },
+    400: { description: "Anthropic API key not configured", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
-    404: { description: "Sales profile not found", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
 });

--- a/tests/unit/brand-sales-profile-404.regression.test.ts
+++ b/tests/unit/brand-sales-profile-404.regression.test.ts
@@ -3,16 +3,14 @@ import request from "supertest";
 import express from "express";
 
 /**
- * Regression: GET /v1/brands/:id/sales-profile returned 500 when brand-service
- * returned 404 with a JSON error body (e.g. { "error": "Sales profile not found" }).
+ * GET /v1/brands/:id/sales-profile is now a get-or-create endpoint.
+ * brand-service automatically triggers extraction if no profile exists,
+ * so this endpoint no longer returns 404.
  *
- * Root cause: callExternalService threw an Error whose message was the JSON
- * `error` field (no status code). The route handler checked
- * `error.message.includes("404")` — which was false — so it fell through to
- * the generic 500 handler.
- *
- * Fix: callExternalService now attaches `statusCode` to the Error object, and
- * the handler checks `error.statusCode === 404` first.
+ * Tests cover:
+ *  - 200 on success (with cached/brandId fields)
+ *  - 400 when Anthropic key is missing (extraction triggered but no key)
+ *  - 500 for genuine server errors
  */
 
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -40,7 +38,7 @@ function buildApp() {
   return app;
 }
 
-describe("GET /v1/brands/:id/sales-profile – 404 handling", () => {
+describe("GET /v1/brands/:id/sales-profile – get-or-create", () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -48,33 +46,8 @@ describe("GET /v1/brands/:id/sales-profile – 404 handling", () => {
     app = buildApp();
   });
 
-  it("should return 404 (not 500) when brand-service returns 404 with JSON error body", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 404,
-      text: () => Promise.resolve('{"error":"Sales profile not found"}'),
-    }));
-
-    const res = await request(app).get("/v1/brands/51b35f30-2d44-4492-9af8-df14ebafc9cd/sales-profile");
-
-    expect(res.status).toBe(404);
-    expect(res.body.error).toBe("Sales profile not found");
-  });
-
-  it("should return 404 when brand-service returns 404 with plain text body", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 404,
-      text: () => Promise.resolve("Not Found"),
-    }));
-
-    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
-
-    expect(res.status).toBe(404);
-  });
-
-  it("should return 200 when brand-service returns a sales profile", async () => {
-    const profile = { id: "sp-1", brandId: "b-1", valueProposition: "Test" };
+  it("should return 200 with sales profile", async () => {
+    const profile = { cached: true, brandId: "b-1", profile: { valueProposition: "Test" } };
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: true,
       json: () => Promise.resolve(profile),
@@ -84,6 +57,33 @@ describe("GET /v1/brands/:id/sales-profile – 404 handling", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(profile);
+  });
+
+  it("should return 200 when extraction is triggered (not cached)", async () => {
+    const profile = { cached: false, brandId: "b-1", profile: { valueProposition: "Freshly extracted" } };
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve(profile),
+    }));
+
+    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
+
+    expect(res.status).toBe(200);
+    expect(res.body.cached).toBe(false);
+    expect(res.body.profile.valueProposition).toBe("Freshly extracted");
+  });
+
+  it("should return 400 when Anthropic key is missing", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"error":"No Anthropic API key found"}'),
+    }));
+
+    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Anthropic API key not configured");
   });
 
   it("should return 500 for genuine server errors from brand-service", async () => {


### PR DESCRIPTION
## Summary
- Updated `GET /v1/brands/:id/sales-profile` to reflect brand-service's new get-or-create behavior (no more 404s — extraction is auto-triggered)
- Added `requireOrg`/`requireUser` middleware since extraction needs org/user context for key resolution
- Added Anthropic API key error handling (400 instead of 500 when key is missing during extraction)
- Updated OpenAPI spec: removed 404 response, added 400, updated description
- Rewrote regression tests to cover the new behavior (cached vs fresh extraction, Anthropic key error)

## Test plan
- [x] All 381 tests pass (54 files)
- [x] Regression test updated: no more 404 assertions, added Anthropic key + extraction tests
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)