### PR TITLE
fix: forward missing x-org-id, x-user-id, x-run-id headers

### DIFF
--- a/shared/runs-client/src/index.ts
+++ b/shared/runs-client/src/index.ts
@@ -146,11 +146,11 @@ function identityHeaders(opts: { orgId?: string; userId?: string; runId?: string
 /**
  * Create a new run in runs-service.
  */
-export async function createRun(params: CreateRunParams): Promise<Run> {
+export async function createRun(params: CreateRunParams, headers?: Record<string, string>): Promise<Run> {
   return runsRequest<Run>("/v1/runs", {
     method: "POST",
     body: params,
-    headers: identityHeaders({ orgId: params.orgId, userId: params.userId }),
+    headers: { ...identityHeaders({ orgId: params.orgId, userId: params.userId }), ...headers },
   });
 }
 
@@ -160,12 +160,13 @@ export async function createRun(params: CreateRunParams): Promise<Run> {
 export async function updateRun(
   runId: string,
   status: "completed" | "failed",
-  orgId?: string
+  orgId?: string,
+  headers?: Record<string, string>
 ): Promise<Run> {
   return runsRequest<Run>(`/v1/runs/${runId}`, {
     method: "PATCH",
     body: { status },
-    headers: identityHeaders({ orgId, runId }),
+    headers: { ...identityHeaders({ orgId, runId }), ...headers },
   });
 }
 
@@ -177,21 +178,22 @@ export async function updateRun(
 export async function addCosts(
   runId: string,
   items: CostItem[],
-  orgId?: string
+  orgId?: string,
+  headers?: Record<string, string>
 ): Promise<{ costs: RunCost[] }> {
   return runsRequest<{ costs: RunCost[] }>(`/v1/runs/${runId}/costs`, {
     method: "POST",
     body: { items },
-    headers: identityHeaders({ orgId, runId }),
+    headers: { ...identityHeaders({ orgId, runId }), ...headers },
   });
 }
 
 /**
  * Get a single run with costs (including descendant runs and their costs).
  */
-export async function getRun(runId: string, orgId?: string): Promise<RunWithCosts> {
+export async function getRun(runId: string, orgId?: string, headers?: Record<string, string>): Promise<RunWithCosts> {
   return runsRequest<RunWithCosts>(`/v1/runs/${runId}`, {
-    headers: identityHeaders({ orgId, runId }),
+    headers: { ...identityHeaders({ orgId, runId }), ...headers },
   });
 }
 
@@ -199,7 +201,8 @@ export async function getRun(runId: string, orgId?: string): Promise<RunWithCost
  * List runs with filters. Returns runs with ownCostInUsdCents.
  */
 export async function listRuns(
-  params: ListRunsParams
+  params: ListRunsParams,
+  headers?: Record<string, string>
 ): Promise<{ runs: RunWithOwnCost[]; limit: number; offset: number }> {
   const searchParams = new URLSearchParams();
   searchParams.set("orgId", params.orgId);
@@ -217,7 +220,7 @@ export async function listRuns(
 
   return runsRequest<{ runs: RunWithOwnCost[]; limit: number; offset: number }>(
     `/v1/runs?${searchParams.toString()}`,
-    { headers: identityHeaders({ orgId: params.orgId, userId: params.userId }) }
+    { headers: { ...identityHeaders({ orgId: params.orgId, userId: params.userId }), ...headers } }
   );
 }
 
@@ -227,10 +230,11 @@ export async function listRuns(
  */
 export async function getRunsBatch(
   runIds: string[],
-  orgId?: string
+  orgId?: string,
+  headers?: Record<string, string>
 ): Promise<Map<string, RunWithCosts>> {
   if (runIds.length === 0) return new Map();
-  const results = await Promise.all(runIds.map((id) => getRun(id, orgId)));
+  const results = await Promise.all(runIds.map((id) => getRun(id, orgId, headers)));
   return new Map(results.map((r) => [r.id, r]));
 }
 
@@ -238,7 +242,8 @@ export async function getRunsBatch(
  * Get aggregated cost summary.
  */
 export async function getRunSummary(
-  params: RunSummaryParams
+  params: RunSummaryParams,
+  headers?: Record<string, string>
 ): Promise<{ breakdown: SummaryBreakdown[] }> {
   const searchParams = new URLSearchParams();
   searchParams.set("organizationId", params.organizationId);
@@ -249,6 +254,6 @@ export async function getRunSummary(
 
   return runsRequest<{ breakdown: SummaryBreakdown[] }>(
     `/v1/runs/summary?${searchParams.toString()}`,
-    { headers: identityHeaders({ orgId: params.organizationId }) }
+    { headers: { ...identityHeaders({ orgId: params.organizationId }), ...headers } }
   );
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -90,7 +90,9 @@ export async function authenticate(
         // Auto-close the run when the response finishes
         res.on("finish", () => {
           const status = res.statusCode < 400 ? "completed" : "failed";
-          updateRun(run.id, status, req.orgId).catch((e: unknown) =>
+          const headers: Record<string, string> = {};
+          if (req.userId) headers["x-user-id"] = req.userId;
+          updateRun(run.id, status, req.orgId, headers).catch((e: unknown) =>
             console.warn("[auth] Failed to update run:", (e as Error).message)
           );
         });

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -24,6 +24,7 @@ router.post("/brand/scrape", authenticate, async (req: AuthenticatedRequest, res
       "/scrape",
       {
         method: "POST",
+        headers: buildInternalHeaders(req),
         body: {
           url,
           sourceService: "api-service",
@@ -350,7 +351,7 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
     const runIds = runs.map((r) => r.id);
     let runMap = new Map<string, RunWithCosts>();
     try {
-      runMap = await getRunsBatch(runIds, req.orgId);
+      runMap = await getRunsBatch(runIds, req.orgId, buildInternalHeaders(req));
     } catch (err) {
       console.warn("Failed to fetch run costs for brand runs:", err);
     }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -652,7 +652,7 @@ router.get("/campaigns/:id/leads", authenticate, requireOrg, requireUser, async 
     let runMap = new Map<string, RunWithCosts>();
     if (enrichmentRunIds.length > 0) {
       try {
-        runMap = await getRunsBatch(enrichmentRunIds, req.orgId);
+        runMap = await getRunsBatch(enrichmentRunIds, req.orgId, buildInternalHeaders(req));
       } catch (err) {
         console.warn("Failed to fetch lead enrichment run costs:", err);
       }
@@ -716,7 +716,7 @@ router.get("/campaigns/:id/emails", authenticate, requireOrg, requireUser, async
     let runMap = new Map<string, RunWithCosts>();
     if (generationRunIds.length > 0) {
       try {
-        runMap = await getRunsBatch(generationRunIds, req.orgId);
+        runMap = await getRunsBatch(generationRunIds, req.orgId, buildInternalHeaders(req));
       } catch (err) {
         console.warn("Failed to fetch run costs:", err);
       }

--- a/tests/unit/header-forwarding-audit.test.ts
+++ b/tests/unit/header-forwarding-audit.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Regression: ensure all downstream service calls forward required headers
+ * (x-org-id, x-user-id, x-run-id) via buildInternalHeaders(req) or equivalent.
+ *
+ * Gaps fixed:
+ * 1. brand.ts POST /scrape — was missing headers entirely
+ * 2. runs-client — getRun, getRunsBatch, updateRun, addCosts, getRunSummary
+ *    didn't accept caller-provided headers (x-user-id was never forwarded)
+ * 3. auth.ts updateRun — was not forwarding x-user-id
+ * 4. brand.ts/campaigns.ts getRunsBatch calls — were not passing request headers
+ */
+
+const readSrc = (relativePath: string) =>
+  fs.readFileSync(path.join(__dirname, "../..", relativePath), "utf-8");
+
+describe("header forwarding audit", () => {
+  describe("brand.ts — scraping service calls", () => {
+    const src = readSrc("src/routes/brand.ts");
+
+    it("POST /scrape should forward internal headers", () => {
+      // Find the callExternalService block for scraping /scrape POST
+      const scrapingMatch = src.match(
+        /callExternalService\(\s*externalServices\.scraping,\s*"\/scrape",[\s\S]*?\)/
+      );
+      expect(scrapingMatch).not.toBeNull();
+      expect(scrapingMatch![0]).toContain("headers: buildInternalHeaders(req)");
+    });
+
+    it("getRunsBatch should forward internal headers", () => {
+      expect(src).toContain("getRunsBatch(runIds, req.orgId, buildInternalHeaders(req))");
+    });
+  });
+
+  describe("campaigns.ts — getRunsBatch calls", () => {
+    const src = readSrc("src/routes/campaigns.ts");
+
+    it("enrichment run batch should forward internal headers", () => {
+      expect(src).toContain(
+        "getRunsBatch(enrichmentRunIds, req.orgId, buildInternalHeaders(req))"
+      );
+    });
+
+    it("generation run batch should forward internal headers", () => {
+      expect(src).toContain(
+        "getRunsBatch(generationRunIds, req.orgId, buildInternalHeaders(req))"
+      );
+    });
+  });
+
+  describe("auth.ts — updateRun should forward x-user-id", () => {
+    const src = readSrc("src/middleware/auth.ts");
+
+    it("should pass headers with x-user-id to updateRun", () => {
+      // The finish handler should build headers with userId and pass to updateRun
+      expect(src).toContain('headers["x-user-id"] = req.userId');
+      expect(src).toMatch(/updateRun\(run\.id,\s*status,\s*req\.orgId,\s*headers\)/);
+    });
+  });
+
+  describe("runs-client — public functions accept optional headers", () => {
+    const src = readSrc("shared/runs-client/src/index.ts");
+
+    for (const fn of ["createRun", "updateRun", "addCosts", "getRun", "getRunsBatch", "listRuns", "getRunSummary"]) {
+      it(`${fn} should accept an optional headers parameter`, () => {
+        // Each public function should have headers?: Record<string, string> in its signature
+        const fnPattern = new RegExp(
+          `export async function ${fn}\\([\\s\\S]*?headers\\?:\\s*Record<string,\\s*string>`
+        );
+        expect(src).toMatch(fnPattern);
+      });
+    }
+
+    it("should merge caller headers after identity headers", () => {
+      // The pattern { ...identityHeaders(...), ...headers } should appear for merging
+      const mergeCount = (src.match(/\.\.\.identityHeaders\([\s\S]*?\),\s*\.\.\.headers/g) || []).length;
+      expect(mergeCount).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  describe("all route files use buildInternalHeaders for callExternalService", () => {
+    const routeFiles = [
+      "src/routes/campaigns.ts",
+      "src/routes/brand.ts",
+      "src/routes/workflows.ts",
+      "src/routes/leads.ts",
+      "src/routes/chat.ts",
+      "src/routes/keys.ts",
+      "src/routes/qualify.ts",
+      "src/routes/billing.ts",
+      "src/routes/stripe.ts",
+      "src/routes/emails.ts",
+      "src/routes/activity.ts",
+      "src/routes/users.ts",
+    ];
+
+    for (const file of routeFiles) {
+      it(`${file} should import buildInternalHeaders`, () => {
+        const src = readSrc(file);
+        expect(src).toContain("buildInternalHeaders");
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `buildInternalHeaders(req)` to scraping-service `POST /scrape` call in `brand.ts` (was missing all three headers)
- Add optional `headers` param to all `runs-client` public functions (`createRun`, `updateRun`, `addCosts`, `getRun`, `getRunsBatch`, `listRuns`, `getRunSummary`) so callers can forward `x-user-id` and `x-run-id`
- Pass `buildInternalHeaders(req)` through `getRunsBatch` calls in `brand.ts` and `campaigns.ts`
- Forward `x-user-id` in `auth.ts` `updateRun` finish handler

## Test plan
- [x] All 416 tests pass (25 new regression tests added)
- [x] New `header-forwarding-audit.test.ts` verifies all downstream calls forward required headers
- [x] Verified no circular dependency introduced (auth.ts builds headers inline instead of importing `buildInternalHeaders`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)