### PR TITLE
fix: forward downstream HTTP status codes in brand routes

### DIFF
--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -38,7 +38,7 @@ router.post("/brand/scrape", authenticate, async (req: AuthenticatedRequest, res
     res.json(result);
   } catch (error: any) {
     console.error("Brand scrape error:", error.message);
-    res.status(500).json({ error: error.message || "Failed to scrape brand" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to scrape brand" });
   }
 });
 
@@ -70,7 +70,7 @@ router.post("/brands", authenticate, requireOrg, requireUser, async (req: Authen
     res.json(result);
   } catch (error: any) {
     console.error("Brand upsert error:", error.message);
-    res.status(500).json({ error: error.message || "Failed to upsert brand" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to upsert brand" });
   }
 });
 
@@ -97,7 +97,7 @@ router.get("/brand/by-url", authenticate, async (req: AuthenticatedRequest, res)
     res.json(result);
   } catch (error: any) {
     console.error("Get brand error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brand" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand" });
   }
 });
 
@@ -117,7 +117,7 @@ router.get("/brands", authenticate, requireOrg, requireUser, async (req: Authent
     res.json(result);
   } catch (error: any) {
     console.error("Get brands error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brands" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brands" });
   }
 });
 
@@ -135,7 +135,7 @@ router.get("/brands/:id", authenticate, async (req: AuthenticatedRequest, res) =
     res.json(result);
   } catch (error: any) {
     console.error("Get brand by id error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brand" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand" });
   }
 });
 
@@ -253,7 +253,7 @@ router.post("/brand/icp-suggestion", authenticate, requireOrg, requireUser, asyn
         error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
       });
     }
-    res.status(500).json({ error: msg });
+    res.status(error.statusCode || 500).json({ error: msg });
   }
 });
 
@@ -291,7 +291,7 @@ router.get("/brands/costs", authenticate, requireOrg, requireUser, async (req: A
     res.json({ costs });
   } catch (error: any) {
     console.error("Get brands costs error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brands costs" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brands costs" });
   }
 });
 
@@ -322,7 +322,7 @@ router.get("/brands/:id/cost-breakdown", authenticate, requireOrg, requireUser, 
     res.json({ costs: data.costs || [] });
   } catch (error: any) {
     console.error("Get brand cost breakdown error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brand cost breakdown" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand cost breakdown" });
   }
 });
 
@@ -380,7 +380,7 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
     res.json({ runs: enriched });
   } catch (error: any) {
     console.error("Get brand runs error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brand runs" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand runs" });
   }
 });
 
@@ -401,7 +401,7 @@ router.get("/brand/:id", authenticate, async (req: AuthenticatedRequest, res) =>
     res.json(result);
   } catch (error: any) {
     console.error("Get brand error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brand" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand" });
   }
 });
 

--- a/tests/unit/brand-status-forwarding.regression.test.ts
+++ b/tests/unit/brand-status-forwarding.regression.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * Regression test: all brand endpoints must forward the downstream HTTP status
+ * code instead of always returning 500. Previously, a 404 from brand-service
+ * was converted to 500 by api-service, causing retry loops on the frontend.
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+/** Simulate a downstream service returning a specific HTTP error. */
+function mockFetchError(status: number, message: string) {
+  global.fetch = vi.fn().mockImplementation(async () => ({
+    ok: false,
+    status,
+    text: () => Promise.resolve(JSON.stringify({ error: message })),
+  }));
+}
+
+describe("brand routes – downstream status code forwarding", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("GET /v1/brands/:id should forward 404 from brand-service", async () => {
+    mockFetchError(404, "Brand not found");
+    const res = await request(app).get("/v1/brands/non-existent-id");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /v1/brands/:id should forward 500 from brand-service", async () => {
+    mockFetchError(500, "Internal server error");
+    const res = await request(app).get("/v1/brands/some-id");
+    expect(res.status).toBe(500);
+  });
+
+  it("GET /v1/brands/:id/runs should forward 404 from brand-service", async () => {
+    mockFetchError(404, "Brand not found");
+    const res = await request(app).get("/v1/brands/non-existent-id/runs");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /v1/brands should forward 403 from brand-service", async () => {
+    mockFetchError(403, "Forbidden");
+    const res = await request(app).get("/v1/brands");
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /v1/brands/costs should forward 404 from runs-service", async () => {
+    mockFetchError(404, "Not found");
+    const res = await request(app).get("/v1/brands/costs");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /v1/brands/:id/cost-breakdown should forward 404", async () => {
+    mockFetchError(404, "Not found");
+    const res = await request(app).get("/v1/brands/some-id/cost-breakdown");
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- Brand route error handlers were hardcoding `res.status(500)` for all downstream errors, even when brand-service returned 404
- This caused frontend retry loops: 500 is retriable, 404 is not
- Now all catch blocks use `error.statusCode || 500` to forward the downstream status code
- Added regression test covering 404/403/500 forwarding on key brand endpoints

## Test plan
- [x] New regression test `brand-status-forwarding.regression.test.ts` (6 tests)
- [x] All 422 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)