### PR TITLE
feat: add missing dashboard endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -359,6 +359,59 @@
           "campaignIds"
         ]
       },
+      "CampaignRepliesResponse": {
+        "type": "object",
+        "properties": {
+          "replies": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "description": "Lead email address"
+                },
+                "emailsReplied": {
+                  "type": "number",
+                  "description": "Total replies from this lead"
+                },
+                "repliesWillingToMeet": {
+                  "type": "number",
+                  "description": "Willing to meet replies"
+                },
+                "repliesInterested": {
+                  "type": "number",
+                  "description": "Interested replies"
+                },
+                "repliesNotInterested": {
+                  "type": "number",
+                  "description": "Not interested replies"
+                },
+                "repliesOutOfOffice": {
+                  "type": "number",
+                  "description": "Out of office replies"
+                },
+                "repliesUnsubscribe": {
+                  "type": "number",
+                  "description": "Unsubscribe replies"
+                }
+              },
+              "required": [
+                "email",
+                "emailsReplied",
+                "repliesWillingToMeet",
+                "repliesInterested",
+                "repliesNotInterested",
+                "repliesOutOfOffice",
+                "repliesUnsubscribe"
+              ]
+            }
+          }
+        },
+        "required": [
+          "replies"
+        ]
+      },
       "UpsertKeyRequest": {
         "type": "object",
         "properties": {
@@ -517,6 +570,57 @@
         },
         "required": [
           "url"
+        ]
+      },
+      "BrandDeliveryStatsResponse": {
+        "type": "object",
+        "properties": {
+          "emailsSent": {
+            "type": "number"
+          },
+          "emailsDelivered": {
+            "type": "number"
+          },
+          "emailsOpened": {
+            "type": "number"
+          },
+          "emailsClicked": {
+            "type": "number"
+          },
+          "emailsReplied": {
+            "type": "number"
+          },
+          "emailsBounced": {
+            "type": "number"
+          },
+          "repliesWillingToMeet": {
+            "type": "number"
+          },
+          "repliesInterested": {
+            "type": "number"
+          },
+          "repliesNotInterested": {
+            "type": "number"
+          },
+          "repliesOutOfOffice": {
+            "type": "number"
+          },
+          "repliesUnsubscribe": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "emailsSent",
+          "emailsDelivered",
+          "emailsOpened",
+          "emailsClicked",
+          "emailsReplied",
+          "emailsBounced",
+          "repliesWillingToMeet",
+          "repliesInterested",
+          "repliesNotInterested",
+          "repliesOutOfOffice",
+          "repliesUnsubscribe"
         ]
       },
       "BestWorkflowResponse": {
@@ -1720,6 +1824,16 @@
             "in": "query"
           },
           {
+            "schema": {
+              "type": "string",
+              "description": "Filter by status (e.g. 'active', 'stopped', 'all')"
+            },
+            "required": false,
+            "description": "Filter by status (e.g. 'active', 'stopped', 'all')",
+            "name": "status",
+            "in": "query"
+          },
+          {
             "name": "x-org-id",
             "in": "header",
             "required": false,
@@ -2452,6 +2566,82 @@
         "responses": {
           "200": {
             "description": "Campaign emails with generation run data"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/campaigns/{id}/replies": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get campaign replies",
+        "description": "Get email replies for a campaign, grouped by lead email. Returns only leads who have at least one reply, with reply type breakdown.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID"
+            },
+            "required": true,
+            "description": "Campaign ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of reply records per lead",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignRepliesResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -3885,6 +4075,82 @@
         "responses": {
           "200": {
             "description": "Brand extraction runs with cost data"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{brandId}/delivery-stats": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get brand delivery stats",
+        "description": "Get aggregated email delivery statistics for all campaigns under a brand (broadcast only, excludes transactional)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delivery statistics for the brand",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandDeliveryStatsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -750,6 +750,69 @@ router.get("/campaigns/:id/emails", authenticate, requireOrg, requireUser, async
 });
 
 /**
+ * GET /v1/campaigns/:id/replies
+ * Get email replies for a campaign, grouped by lead email.
+ * Returns only leads who have at least one reply, with reply type breakdown.
+ */
+router.get("/campaigns/:id/replies", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+
+    const result = await callExternalService<{
+      groups: Array<{
+        key: string;
+        broadcast: {
+          emailsReplied: number;
+          repliesWillingToMeet: number;
+          repliesInterested: number;
+          repliesNotInterested: number;
+          repliesOutOfOffice: number;
+          repliesUnsubscribe: number;
+        } | null;
+      }>;
+    }>(
+      externalServices.emailGateway,
+      "/stats",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: { campaignId: id, orgId: req.orgId, groupBy: "leadEmail" },
+      }
+    );
+
+    const replies = (result.groups || [])
+      .filter((g) => {
+        const b = g.broadcast;
+        return b && (
+          (b.emailsReplied || 0) > 0 ||
+          (b.repliesWillingToMeet || 0) > 0 ||
+          (b.repliesInterested || 0) > 0 ||
+          (b.repliesNotInterested || 0) > 0 ||
+          (b.repliesOutOfOffice || 0) > 0 ||
+          (b.repliesUnsubscribe || 0) > 0
+        );
+      })
+      .map((g) => {
+        const b = g.broadcast!;
+        return {
+          email: g.key,
+          emailsReplied: b.emailsReplied || 0,
+          repliesWillingToMeet: b.repliesWillingToMeet || 0,
+          repliesInterested: b.repliesInterested || 0,
+          repliesNotInterested: b.repliesNotInterested || 0,
+          repliesOutOfOffice: b.repliesOutOfOffice || 0,
+          repliesUnsubscribe: b.repliesUnsubscribe || 0,
+        };
+      });
+
+    res.json({ replies });
+  } catch (error: any) {
+    console.error("Get campaign replies error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get campaign replies" });
+  }
+});
+
+/**
  * GET /v1/brands/:brandId/delivery-stats
  * Get delivery stats for all campaigns under a brand (single email-gateway call)
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -215,6 +215,7 @@ registry.registerPath({
   request: {
     query: z.object({
       brandId: z.string().optional().describe("Filter by brand ID"),
+      status: z.string().optional().describe("Filter by status (e.g. 'active', 'stopped', 'all')"),
     }),
   },
   responses: {
@@ -418,6 +419,43 @@ registry.registerPath({
   request: { params: CampaignIdParam },
   responses: {
     200: { description: "Campaign emails with generation run data" },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/campaigns/{id}/replies",
+  tags: ["Campaigns"],
+  summary: "Get campaign replies",
+  description:
+    "Get email replies for a campaign, grouped by lead email. Returns only leads who have at least one reply, with reply type breakdown.",
+  security: authed,
+  request: { params: CampaignIdParam },
+  responses: {
+    200: {
+      description: "List of reply records per lead",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              replies: z.array(
+                z.object({
+                  email: z.string().describe("Lead email address"),
+                  emailsReplied: z.number().describe("Total replies from this lead"),
+                  repliesWillingToMeet: z.number().describe("Willing to meet replies"),
+                  repliesInterested: z.number().describe("Interested replies"),
+                  repliesNotInterested: z.number().describe("Not interested replies"),
+                  repliesOutOfOffice: z.number().describe("Out of office replies"),
+                  repliesUnsubscribe: z.number().describe("Unsubscribe replies"),
+                })
+              ),
+            })
+            .openapi("CampaignRepliesResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -901,6 +939,47 @@ registry.registerPath({
   request: { params: BrandIdParam },
   responses: {
     200: { description: "Brand extraction runs with cost data" },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+const BrandIdByBrandIdParam = z.object({
+  brandId: z.string().describe("Brand ID"),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{brandId}/delivery-stats",
+  tags: ["Brand"],
+  summary: "Get brand delivery stats",
+  description:
+    "Get aggregated email delivery statistics for all campaigns under a brand (broadcast only, excludes transactional)",
+  security: authed,
+  request: { params: BrandIdByBrandIdParam },
+  responses: {
+    200: {
+      description: "Delivery statistics for the brand",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              emailsSent: z.number(),
+              emailsDelivered: z.number(),
+              emailsOpened: z.number(),
+              emailsClicked: z.number(),
+              emailsReplied: z.number(),
+              emailsBounced: z.number(),
+              repliesWillingToMeet: z.number(),
+              repliesInterested: z.number(),
+              repliesNotInterested: z.number(),
+              repliesOutOfOffice: z.number(),
+              repliesUnsubscribe: z.number(),
+            })
+            .openapi("BrandDeliveryStatsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },

--- a/tests/unit/campaign-replies.test.ts
+++ b/tests/unit/campaign-replies.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for GET /v1/campaigns/:id/replies
+ * Proxies to email-gateway /stats with groupBy: "leadEmail",
+ * filters for leads with replies, returns reply type breakdown.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockCallExternalService = vi.fn();
+const mockCallService = vi.fn();
+const mockBuildInternalHeaders = vi.fn(() => ({}));
+const mockGetRunsBatch = vi.fn();
+
+vi.mock("../../src/lib/service-client.js", () => ({
+  callExternalService: (...args: unknown[]) => mockCallExternalService(...args),
+  callService: (...args: unknown[]) => mockCallService(...args),
+  externalServices: {
+    emailgen: { url: "http://mock-emailgen", apiKey: "k" },
+    emailGateway: { url: "http://mock-email", apiKey: "k" },
+    replyQualification: { url: "http://mock-rq", apiKey: "k" },
+    lead: { url: "http://mock-lead", apiKey: "k" },
+    campaign: { url: "http://mock-campaign", apiKey: "k" },
+    key: { url: "http://mock-key", apiKey: "k" },
+    scraping: { url: "http://mock-scraping", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
+    brand: { url: "http://mock-brand", apiKey: "k" },
+  },
+  services: {
+    client: "http://mock-client",
+  },
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (_req: any, _res: any, next: any) => {
+    _req.userId = "user1";
+    _req.orgId = "org1";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("../../src/lib/internal-headers.js", () => ({
+  buildInternalHeaders: (...args: unknown[]) => mockBuildInternalHeaders(...args),
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: (...args: unknown[]) => mockGetRunsBatch(...args),
+}));
+
+import express from "express";
+import request from "supertest";
+import campaignsRouter from "../../src/routes/campaigns.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignsRouter);
+  return app;
+}
+
+describe("GET /v1/campaigns/:id/replies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return only leads with replies, filtering out non-repliers", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockImplementation((_service: any, path: string) => {
+      if (path === "/stats") {
+        return Promise.resolve({
+          groups: [
+            {
+              key: "alice@example.com",
+              broadcast: {
+                emailsReplied: 1,
+                repliesWillingToMeet: 0,
+                repliesInterested: 1,
+                repliesNotInterested: 0,
+                repliesOutOfOffice: 0,
+                repliesUnsubscribe: 0,
+              },
+            },
+            {
+              key: "bob@example.com",
+              broadcast: {
+                emailsReplied: 0,
+                repliesWillingToMeet: 0,
+                repliesInterested: 0,
+                repliesNotInterested: 0,
+                repliesOutOfOffice: 0,
+                repliesUnsubscribe: 0,
+              },
+            },
+            {
+              key: "carol@example.com",
+              broadcast: {
+                emailsReplied: 1,
+                repliesWillingToMeet: 0,
+                repliesInterested: 0,
+                repliesNotInterested: 1,
+                repliesOutOfOffice: 0,
+                repliesUnsubscribe: 0,
+              },
+            },
+          ],
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const res = await request(app).get("/v1/campaigns/campaign-123/replies");
+
+    expect(res.status).toBe(200);
+    expect(res.body.replies).toHaveLength(2);
+    expect(res.body.replies[0].email).toBe("alice@example.com");
+    expect(res.body.replies[0].repliesInterested).toBe(1);
+    expect(res.body.replies[1].email).toBe("carol@example.com");
+    expect(res.body.replies[1].repliesNotInterested).toBe(1);
+  });
+
+  it("should return empty replies array when no leads have replied", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({
+      groups: [
+        {
+          key: "alice@example.com",
+          broadcast: {
+            emailsReplied: 0,
+            repliesWillingToMeet: 0,
+            repliesInterested: 0,
+            repliesNotInterested: 0,
+            repliesOutOfOffice: 0,
+            repliesUnsubscribe: 0,
+          },
+        },
+      ],
+    });
+
+    const res = await request(app).get("/v1/campaigns/campaign-123/replies");
+
+    expect(res.status).toBe(200);
+    expect(res.body.replies).toHaveLength(0);
+  });
+
+  it("should return empty replies when groups is empty", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({ groups: [] });
+
+    const res = await request(app).get("/v1/campaigns/campaign-123/replies");
+
+    expect(res.status).toBe(200);
+    expect(res.body.replies).toHaveLength(0);
+  });
+
+  it("should handle null broadcast by filtering out the lead", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({
+      groups: [
+        { key: "alice@example.com", broadcast: null },
+        {
+          key: "bob@example.com",
+          broadcast: {
+            emailsReplied: 1,
+            repliesWillingToMeet: 1,
+            repliesInterested: 0,
+            repliesNotInterested: 0,
+            repliesOutOfOffice: 0,
+            repliesUnsubscribe: 0,
+          },
+        },
+      ],
+    });
+
+    const res = await request(app).get("/v1/campaigns/campaign-123/replies");
+
+    expect(res.status).toBe(200);
+    expect(res.body.replies).toHaveLength(1);
+    expect(res.body.replies[0].email).toBe("bob@example.com");
+    expect(res.body.replies[0].repliesWillingToMeet).toBe(1);
+  });
+
+  it("should call email-gateway with correct params", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({ groups: [] });
+
+    await request(app).get("/v1/campaigns/my-campaign-id/replies");
+
+    expect(mockCallExternalService).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "http://mock-email" }),
+      "/stats",
+      expect.objectContaining({
+        method: "POST",
+        body: { campaignId: "my-campaign-id", orgId: "org1", groupBy: "leadEmail" },
+      })
+    );
+  });
+
+  it("should return 500 when email-gateway fails", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockRejectedValue(new Error("gateway down"));
+
+    const res = await request(app).get("/v1/campaigns/campaign-123/replies");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("gateway down");
+  });
+
+  it("should forward downstream HTTP status codes", async () => {
+    const app = createApp();
+
+    const err = new Error("not found") as any;
+    err.statusCode = 404;
+    mockCallExternalService.mockRejectedValue(err);
+
+    const res = await request(app).get("/v1/campaigns/campaign-123/replies");
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/dashboard-endpoints-openapi.test.ts
+++ b/tests/unit/dashboard-endpoints-openapi.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test: ensures the three dashboard endpoints are properly
+ * documented in the OpenAPI schema (schemas.ts).
+ *
+ * 1. GET /v1/brands/{brandId}/delivery-stats — must be registered
+ * 2. GET /v1/campaigns/{id}/replies — must be registered
+ * 3. GET /v1/campaigns status query param — must be documented
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const schemasPath = path.join(__dirname, "../../src/schemas.ts");
+const content = fs.readFileSync(schemasPath, "utf-8");
+
+describe("Dashboard endpoints OpenAPI documentation", () => {
+  it("should register GET /v1/brands/{brandId}/delivery-stats", () => {
+    expect(content).toContain('path: "/v1/brands/{brandId}/delivery-stats"');
+    expect(content).toContain("BrandDeliveryStatsResponse");
+  });
+
+  it("should register GET /v1/campaigns/{id}/replies", () => {
+    expect(content).toContain('path: "/v1/campaigns/{id}/replies"');
+    expect(content).toContain("CampaignRepliesResponse");
+  });
+
+  it("should document status query param on GET /v1/campaigns", () => {
+    // Find the registerPath block for GET /v1/campaigns and verify status is in the query
+    const listCampaignsMatch = content.match(
+      /registerPath\(\{[^}]*method:\s*"get"[^}]*path:\s*"\/v1\/campaigns"[^]*?query:\s*z\.object\(\{([^}]+)\}/
+    );
+    expect(listCampaignsMatch).not.toBeNull();
+    expect(listCampaignsMatch![1]).toContain("status");
+  });
+});


### PR DESCRIPTION
## Summary
- **GET /v1/brands/{brandId}/delivery-stats**: Route already existed but was missing from the OpenAPI spec. Now registered with full response schema.
- **GET /v1/campaigns/{id}/replies**: New endpoint that proxies to email-gateway `/stats` with `groupBy: "leadEmail"`, filters for leads with replies, and returns per-lead reply type breakdown.
- **GET /v1/campaigns?status=...**: The `status` query param was already implemented in code but undocumented in the OpenAPI spec. Now documented.

## Test plan
- [x] 7 tests for the new replies endpoint (filtering, empty state, null broadcast, error forwarding, correct params)
- [x] 3 regression tests verifying all three endpoints are documented in the OpenAPI schema
- [x] Full test suite passes (432 tests, 59 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)