### PR TITLE
fix: use public stats endpoints in leaderboard

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -61,6 +61,14 @@ export async function authenticate(
 
         req.orgId = resolved.orgId;
         req.userId = resolved.userId;
+      } else if (externalUserId) {
+        // Admin with user context only (e.g. cross-org leaderboard)
+        const userId = await resolveExternalUserId(externalUserId);
+        if (userId) req.userId = userId;
+      } else if (externalOrgId) {
+        // Admin with org context only
+        const orgId = await resolveExternalOrgId(externalOrgId);
+        if (orgId) req.orgId = orgId;
       }
       // Admin without org/user context is valid (e.g. listing all orgs)
 
@@ -155,6 +163,40 @@ async function resolveExternalIds(
     return result;
   } catch (error) {
     console.error("[auth] Failed to resolve external IDs:", (error as Error).message);
+    return null;
+  }
+}
+
+/**
+ * Resolve a single external user ID to internal UUID via client-service.
+ * Used for admin requests with user context but no org context (cross-org views).
+ */
+async function resolveExternalUserId(externalUserId: string): Promise<string | null> {
+  try {
+    const result = await callExternalService<{ user: { id: string } }>(
+      externalServices.client,
+      `/users/by-clerk/${encodeURIComponent(externalUserId)}`
+    );
+    return result.user?.id || null;
+  } catch (error) {
+    console.error("[auth] Failed to resolve external user ID:", (error as Error).message);
+    return null;
+  }
+}
+
+/**
+ * Resolve a single external org ID to internal UUID via client-service.
+ * Used for admin requests with org context but no user context.
+ */
+async function resolveExternalOrgId(externalOrgId: string): Promise<string | null> {
+  try {
+    const result = await callExternalService<{ org: { id: string } }>(
+      externalServices.client,
+      `/orgs/by-clerk/${encodeURIComponent(externalOrgId)}`
+    );
+    return result.org?.id || null;
+  } catch (error) {
+    console.error("[auth] Failed to resolve external org ID:", (error as Error).message);
     return null;
   }
 }

--- a/src/routes/performance.ts
+++ b/src/routes/performance.ts
@@ -121,18 +121,18 @@ function toBroadcastDeliveryStats(b: BroadcastStatsResponse | undefined | null):
   };
 }
 
-/** Fetch broadcast delivery stats from email-gateway.
+/** Fetch broadcast delivery stats from email-gateway (public endpoint, no identity headers).
  *  Only uses broadcast stats (outreach emails).
  *  Transactional stats are transactional/test emails — not relevant. */
-async function fetchBroadcastDeliveryStats(filters: Record<string, string>, headers: Record<string, string> = {}): Promise<DeliveryStats> {
+async function fetchBroadcastDeliveryStats(filters: Record<string, string>): Promise<DeliveryStats> {
   try {
     const result = await callExternalService<{
       transactional: BroadcastStatsResponse;
       broadcast: BroadcastStatsResponse;
     }>(
       externalServices.emailGateway,
-      "/stats",
-      { method: "POST", body: filters, headers }
+      "/stats/public",
+      { method: "POST", body: filters }
     );
 
     return toBroadcastDeliveryStats(result.broadcast);
@@ -141,15 +141,15 @@ async function fetchBroadcastDeliveryStats(filters: Record<string, string>, head
   }
 }
 
-/** Fetch broadcast delivery stats grouped by workflow name. Returns a map of workflowName → stats. */
-async function fetchWorkflowDeliveryStats(headers: Record<string, string> = {}): Promise<Map<string, DeliveryStats>> {
+/** Fetch broadcast delivery stats grouped by workflow name (public endpoint, no identity headers). */
+async function fetchWorkflowDeliveryStats(): Promise<Map<string, DeliveryStats>> {
   try {
     const result = await callExternalService<{
       groups: Array<{ key: string; broadcast: BroadcastStatsResponse }>;
     }>(
       externalServices.emailGateway,
-      "/stats",
-      { method: "POST", body: { type: "broadcast", groupBy: "workflowName" }, headers }
+      "/stats/public",
+      { method: "POST", body: { type: "broadcast", groupBy: "workflowName" } }
     );
 
     const map = new Map<string, DeliveryStats>();
@@ -192,44 +192,27 @@ function instantlyGroupToDeliveryStats(s: InstantlyGroupStats): DeliveryStats {
   };
 }
 
-/** Fetch run IDs grouped by workflow name across all orgs from runs-service. */
-async function fetchRunIdsByWorkflow(orgIds: string[], headers: Record<string, string> = {}): Promise<Record<string, string[]>> {
-  if (orgIds.length === 0) {
-    console.warn(`[leaderboard] fetchRunIdsByWorkflow skipped: orgIds=0`);
+/** Fetch run IDs grouped by workflow name from runs-service (public endpoint, no identity headers). */
+async function fetchRunIdsByWorkflow(): Promise<Record<string, string[]>> {
+  try {
+    const result = await callExternalService<{ groups: Record<string, string[]> }>(
+      externalServices.runs,
+      "/v1/stats/public/run-ids-by-workflow"
+    );
+    const totalRunIds = Object.values(result.groups || {}).reduce((s, ids) => s + ids.length, 0);
+    if (totalRunIds === 0) {
+      console.warn("[leaderboard] fetchRunIdsByWorkflow returned 0 run IDs");
+    }
+    return result.groups || {};
+  } catch (err) {
+    console.warn("[leaderboard] run-ids-by-workflow failed:", (err as Error).message);
     return {};
   }
-
-  const merged: Record<string, string[]> = {};
-
-  await Promise.all(
-    orgIds.map(async (orgId) => {
-      try {
-        const result = await callExternalService<{ groups: Record<string, string[]> }>(
-          externalServices.runs,
-          `/v1/stats/run-ids-by-workflow?orgId=${encodeURIComponent(orgId)}`,
-          { headers: { ...headers, "x-org-id": orgId } }
-        );
-        for (const [workflowName, runIds] of Object.entries(result.groups || {})) {
-          if (!merged[workflowName]) merged[workflowName] = [];
-          merged[workflowName].push(...runIds);
-        }
-      } catch (err) {
-        console.warn(`[leaderboard] run-ids-by-workflow failed for orgId=${orgId}:`, (err as Error).message);
-      }
-    })
-  );
-
-  const totalRunIds = Object.values(merged).reduce((s, ids) => s + ids.length, 0);
-  if (totalRunIds === 0) {
-    console.warn(`[leaderboard] fetchRunIdsByWorkflow returned 0 run IDs across ${orgIds.length} orgs`);
-  }
-  return merged;
 }
 
-/** Fetch grouped stats from instantly-service via POST /stats/grouped. */
+/** Fetch grouped stats from instantly-service via POST /stats/grouped/public (no identity headers). */
 async function fetchInstantlyGroupedStats(
-  runIdsByWorkflow: Record<string, string[]>,
-  headers: Record<string, string> = {}
+  runIdsByWorkflow: Record<string, string[]>
 ): Promise<Map<string, { stats: DeliveryStats; recipients: number }>> {
   const groups: Record<string, { runIds: string[] }> = {};
   for (const [workflowName, runIds] of Object.entries(runIdsByWorkflow)) {
@@ -249,8 +232,8 @@ async function fetchInstantlyGroupedStats(
       }>;
     }>(
       externalServices.instantly,
-      "/stats/grouped",
-      { method: "POST", body: { groups }, headers }
+      "/stats/grouped/public",
+      { method: "POST", body: { groups } }
     );
 
     const map = new Map<string, { stats: DeliveryStats; recipients: number }>();
@@ -269,21 +252,20 @@ async function fetchInstantlyGroupedStats(
   }
 }
 
-/** Fetch aggregate stats from instantly-service for an appId (all orgs combined).
+/** Fetch aggregate stats from instantly-service (public endpoint, no identity headers).
  *  Used as fallback when per-workflow run-id grouping fails. */
-async function fetchInstantlyAggregateStats(headers: Record<string, string> = {}): Promise<DeliveryStats> {
+async function fetchInstantlyAggregateStats(): Promise<DeliveryStats> {
   try {
     const result = await callExternalService<{
       stats: InstantlyGroupStats;
       recipients: number;
     }>(
       externalServices.instantly,
-      "/stats",
-      { method: "POST", body: {}, headers }
+      "/stats/public",
+      { method: "POST", body: {} }
     );
     return instantlyGroupToDeliveryStats(result.stats);
-  } catch (err) {
-    console.warn("[leaderboard] instantly aggregate stats failed:", (err as Error).message);
+  } catch {
     return EMPTY_STATS;
   }
 }
@@ -330,24 +312,22 @@ function applyStatsToWorkflow(wf: WorkflowEntry, stats: DeliveryStats) {
  * Workflows: instantly-service via run-ids-by-workflow → POST /stats/grouped,
  *   with email-gateway groupBy as fallback, then proportional distribution.
  */
-async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[], headers: Record<string, string> = {}, brandOrgMap: Map<string, string> = new Map()): Promise<void> {
+async function enrichWithDeliveryStats(data: LeaderboardData): Promise<void> {
   // Fetch per-brand stats (email-gateway) + workflow stats (instantly-service) in parallel
   const [, instantlyResults] = await Promise.all([
-    // Per-brand stats (email-gateway, unchanged)
+    // Per-brand stats (email-gateway public endpoint)
     Promise.all(
       data.brands.map(async (brand) => {
         if (!brand.brandId) return;
-        const brandOrgId = brandOrgMap.get(brand.brandId);
-        const brandHeaders = brandOrgId ? { ...headers, "x-org-id": brandOrgId } : headers;
-        const stats = await fetchBroadcastDeliveryStats({ brandId: brand.brandId }, brandHeaders);
+        const stats = await fetchBroadcastDeliveryStats({ brandId: brand.brandId });
         if (stats.emailsSent === 0) return;
         applyStatsToBrand(brand, stats);
       })
     ),
-    // Workflow stats via instantly-service (run-ids-by-workflow → POST /stats/grouped)
+    // Workflow stats via instantly-service (run-ids-by-workflow → POST /stats/grouped/public)
     (async () => {
-      const runIdsByWorkflow = await fetchRunIdsByWorkflow(orgIds, headers);
-      return fetchInstantlyGroupedStats(runIdsByWorkflow, headers);
+      const runIdsByWorkflow = await fetchRunIdsByWorkflow();
+      return fetchInstantlyGroupedStats(runIdsByWorkflow);
     })(),
   ]);
 
@@ -362,14 +342,14 @@ async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[], 
     }
   }
   if (!anyWorkflowEnriched && data.workflows.length > 0) {
-    console.warn(`[leaderboard] instantly per-workflow path returned no data (orgIds=${orgIds.length})`);
+    console.warn("[leaderboard] instantly per-workflow path returned no data");
   }
 
   // Fallback 1: instantly aggregate stats distributed proportionally across workflows.
   // This catches cases where run-ids-by-workflow fails (org ID mismatch, auth issue)
   // but instantly-service still has aggregate data.
   if (!anyWorkflowEnriched && data.workflows.length > 0) {
-    const instantlyAggregate = await fetchInstantlyAggregateStats(headers);
+    const instantlyAggregate = await fetchInstantlyAggregateStats();
     if (instantlyAggregate.emailsSent > 0) {
       console.warn("[leaderboard] using instantly aggregate fallback (proportional distribution)");
       const totalCost = data.workflows.reduce((s, w) => s + w.totalCostUsdCents, 0);
@@ -396,7 +376,7 @@ async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[], 
   // Fallback 2: email-gateway groupBy (for workflows not covered by instantly)
   if (!anyWorkflowEnriched && data.workflows.length > 0) {
     console.warn("[leaderboard] falling back to email-gateway groupBy");
-    const workflowStatsMap = await fetchWorkflowDeliveryStats(headers);
+    const workflowStatsMap = await fetchWorkflowDeliveryStats();
     for (const wf of data.workflows) {
       const stats = workflowStatsMap.get(wf.workflowName);
       if (stats && stats.emailsSent > 0) {
@@ -409,7 +389,7 @@ async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[], 
   // Fallback 3: proportional distribution from aggregate email-gateway stats
   if (!anyWorkflowEnriched && data.workflows.length > 0) {
     console.warn("[leaderboard] falling back to email-gateway aggregate (proportional distribution)");
-    const aggregateStats = await fetchBroadcastDeliveryStats({}, headers);
+    const aggregateStats = await fetchBroadcastDeliveryStats({});
     if (aggregateStats.emailsSent > 0) {
       const totalCost = data.workflows.reduce((s, w) => s + w.totalCostUsdCents, 0);
       if (totalCost > 0) {
@@ -453,11 +433,9 @@ async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[], 
 
 /** Get all brands across all orgs from brand-service.
  *  This is more reliable than /campaigns/list which only returns ongoing campaigns. */
-async function fetchAllBrands(headers: Record<string, string> = {}): Promise<{
-  brands: Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }>;
-  orgIds: string[];
-  brandOrgMap: Map<string, string>;
-}> {
+async function fetchAllBrands(headers: Record<string, string> = {}): Promise<
+  Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }>
+> {
   // Get all org IDs from brand-service
   let orgIds: string[];
   try {
@@ -467,10 +445,10 @@ async function fetchAllBrands(headers: Record<string, string> = {}): Promise<{
     orgIds = resp.organization_ids || [];
   } catch (err) {
     console.warn("[leaderboard] Failed to fetch org-ids from brand-service:", (err as Error).message);
-    return { brands: [], orgIds: [], brandOrgMap: new Map() };
+    return [];
   }
 
-  if (orgIds.length === 0) return { brands: [], orgIds: [], brandOrgMap: new Map() };
+  if (orgIds.length === 0) return [];
 
   // Fetch brands for each org in parallel
   const brandArrays = await Promise.all(
@@ -479,28 +457,25 @@ async function fetchAllBrands(headers: Record<string, string> = {}): Promise<{
         const { brands } = await callExternalService<{
           brands: Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }>;
         }>(externalServices.brand, `/brands?orgId=${encodeURIComponent(orgId)}`, { headers: { ...headers, "x-org-id": orgId } });
-        return (brands || []).map((b) => ({ ...b, _orgId: orgId }));
+        return brands || [];
       } catch {
         return [];
       }
     })
   );
 
-  // Deduplicate by brand ID and build brandId → orgId map
+  // Deduplicate by brand ID
   const seen = new Set<string>();
   const allBrands: Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }> = [];
-  const brandOrgMap = new Map<string, string>();
   for (const arr of brandArrays) {
     for (const b of arr) {
       if (!seen.has(b.id)) {
         seen.add(b.id);
-        const { _orgId, ...brand } = b;
-        allBrands.push(brand);
-        brandOrgMap.set(b.id, _orgId);
+        allBrands.push(b);
       }
     }
   }
-  return { brands: allBrands, orgIds, brandOrgMap };
+  return allBrands;
 }
 
 /** Response shape from runs-service /v1/stats/public/leaderboard (costs are strings). */
@@ -515,9 +490,9 @@ interface RunsStatsGroup {
 
 /** Build leaderboard data from brand-service + runs-service public endpoint.
  *  Uses brand-service for brands, runs-service for costs + workflows. */
-async function buildLeaderboardData(headers: Record<string, string> = {}): Promise<{ data: LeaderboardData; orgIds: string[]; brandOrgMap: Map<string, string> }> {
+async function buildLeaderboardData(headers: Record<string, string> = {}): Promise<{ data: LeaderboardData }> {
   // 1. Get brands + workflow stats + brand costs in parallel
-  const [{ brands: allBrands, orgIds, brandOrgMap }, workflowStatsResult, brandCosts] = await Promise.all([
+  const [allBrands, workflowStatsResult, brandCosts] = await Promise.all([
     fetchAllBrands(headers),
     // Workflow stats from runs-service public endpoint
     callExternalService<{ groups: RunsStatsGroup[] }>(
@@ -581,8 +556,6 @@ async function buildLeaderboardData(headers: Record<string, string> = {}): Promi
 
   return {
     data: { brands, workflows, hero: null, updatedAt: new Date().toISOString(), availableCategories, categorySections: [] },
-    orgIds,
-    brandOrgMap,
   };
 }
 
@@ -636,11 +609,11 @@ function buildCategorySections(data: LeaderboardData): CategorySection[] {
 router.get("/performance/leaderboard", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const headers = buildInternalHeaders(req);
-    const { data, orgIds, brandOrgMap } = await buildLeaderboardData(headers);
+    const { data } = await buildLeaderboardData(headers);
 
     // Enrich with delivery stats (instantly-service for workflows, email-gateway for brands)
     try {
-      await enrichWithDeliveryStats(data, orgIds, headers, brandOrgMap);
+      await enrichWithDeliveryStats(data);
     } catch (err) {
       console.warn("Failed to enrich leaderboard with delivery stats:", err);
     }

--- a/tests/unit/brand-service-run-id.regression.test.ts
+++ b/tests/unit/brand-service-run-id.regression.test.ts
@@ -66,11 +66,11 @@ describe("all brand-service calls include internal headers", () => {
     );
 
     // The route handler builds headers from the request and threads them through
-    // buildLeaderboardData → fetchAllBrands → callExternalService(brand, …, { headers })
-    // and enrichWithDeliveryStats → all downstream service calls.
+    // buildLeaderboardData → fetchAllBrands → callExternalService(brand, …, { headers }).
+    // Stats calls use public endpoints (no identity headers).
     expect(src).toContain("buildInternalHeaders(req)");
     expect(src).toContain("buildLeaderboardData(headers)");
-    expect(src).toContain("enrichWithDeliveryStats(data, orgIds, headers, brandOrgMap)");
+    expect(src).toContain("enrichWithDeliveryStats(data)");
   });
 });
 

--- a/tests/unit/performance-leaderboard-stats.regression.test.ts
+++ b/tests/unit/performance-leaderboard-stats.regression.test.ts
@@ -145,12 +145,12 @@ function setupMocks(
       }
       return Promise.resolve({ groups: [] });
     }
-    // Runs-service: /v1/stats/run-ids-by-workflow
-    if (path.startsWith("/v1/stats/run-ids-by-workflow")) {
+    // Runs-service: /v1/stats/public/run-ids-by-workflow
+    if (path.startsWith("/v1/stats/public/run-ids-by-workflow")) {
       return Promise.resolve({ groups: runIdsByWorkflow });
     }
-    // Instantly-service: /stats/grouped
-    if (path === "/stats/grouped") {
+    // Instantly-service: /stats/grouped/public
+    if (path === "/stats/grouped/public") {
       return Promise.resolve(makeInstantlyGroupedResponse(instantlyGroups));
     }
     return null; // Will be handled by per-test overrides
@@ -191,7 +191,7 @@ describe("GET /performance/leaderboard", () => {
       if (result !== null) return result;
 
       // Email-gateway stats for brands
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         if (body.brandId === "brand-1") {
           return Promise.resolve(makeGatewayResponse({ emailsSent: 30, emailsOpened: 15, emailsClicked: 3, emailsReplied: 5 }));
@@ -262,7 +262,7 @@ describe("GET /performance/leaderboard", () => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
 
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve({
           transactional: makeBroadcastStats({ emailsSent: 500, emailsOpened: 300 }),
           broadcast: makeBroadcastStats({ emailsSent: 10, emailsOpened: 5, emailsClicked: 1, emailsReplied: 2 }),
@@ -295,7 +295,7 @@ describe("GET /performance/leaderboard", () => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
 
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve({
           transactional: makeBroadcastStats({ emailsSent: 100, emailsOpened: 50 }),
           broadcast: null,
@@ -334,7 +334,7 @@ describe("GET /performance/leaderboard", () => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
 
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve(makeGatewayResponse({ emailsSent: 10, emailsOpened: 5, emailsClicked: 1, emailsReplied: 2 }));
       }
       return Promise.resolve(null);
@@ -374,7 +374,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve(makeGatewayResponse(null));
       }
       return Promise.resolve(null);
@@ -416,7 +416,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         if (body.brandId) {
           return Promise.resolve(makeGatewayResponse({ emailsSent: 50, emailsOpened: 25, emailsClicked: 5, emailsReplied: 8 }));
@@ -479,7 +479,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         // email-gateway groupBy also returns empty — simulates old emails without workflowName
         if (body.groupBy === "workflowName") {
@@ -538,7 +538,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         // email-gateway groupBy returns data (fallback 1)
         if (body.groupBy === "workflowName") {
@@ -595,7 +595,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         if (body.brandId === "active-brand") {
           return Promise.resolve(makeGatewayResponse({ emailsSent: 10, emailsOpened: 5, emailsClicked: 1, emailsReplied: 1 }));
@@ -645,7 +645,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         // brand-1: 20 sent, 10 opened, 4 replied → costPerOpen=500/10=50, costPerReply=500/4=125
         if (body.brandId === "brand-1") {
@@ -693,7 +693,7 @@ describe("GET /performance/leaderboard", () => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
 
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         if (body.groupBy === "workflowName") {
           // Without appId filter, appId should NOT be in the body
@@ -739,7 +739,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         if (body.groupBy === "workflowName") {
           return Promise.resolve({ groups: [] });
@@ -779,7 +779,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve(makeGatewayResponse(null));
       }
       return Promise.resolve(null);
@@ -789,9 +789,9 @@ describe("GET /performance/leaderboard", () => {
 
     expect(res.status).toBe(200);
 
-    // Verify instantly-service /stats/grouped was called with correct body
+    // Verify instantly-service /stats/grouped/public was called with correct body
     const instantlyCall = mockCallExternalService.mock.calls.find(
-      (call: any[]) => typeof call[1] === "string" && call[1] === "/stats/grouped"
+      (call: any[]) => typeof call[1] === "string" && call[1] === "/stats/grouped/public"
     );
     expect(instantlyCall).toBeDefined();
     expect(instantlyCall![2].body.groups["sales-email-cold-outreach-sienna"].runIds).toEqual(["run-1", "run-2", "run-3"]);
@@ -833,7 +833,7 @@ describe("GET /performance/leaderboard", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve(makeGatewayResponse(null));
       }
       return Promise.resolve(null);
@@ -869,7 +869,7 @@ describe("GET /performance/leaderboard", () => {
       const result = mock(service, path, opts);
       if (result !== null) return result;
 
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         // Distinguish instantly from email-gateway by service URL
         if (service.url === "http://mock-instantly") {
           // Instantly aggregate: 100 sent, 50 opened, 5 positive replies (auto-reply excluded)
@@ -946,7 +946,7 @@ describe("Regression: performance leaderboard must require auth but NOT filter b
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = mock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         const body = opts?.body || {};
         if (body.groupBy === "workflowName") {
           return Promise.resolve(makeGroupedGatewayResponse([
@@ -1008,11 +1008,11 @@ describe("Regression: performance leaderboard must use broadcast-only stats", ()
       "utf-8"
     );
 
-    // Instantly-service integration
+    // Instantly-service integration (public endpoints)
     expect(content).toContain("fetchRunIdsByWorkflow");
     expect(content).toContain("fetchInstantlyGroupedStats");
-    expect(content).toContain("/stats/grouped");
-    expect(content).toContain("/v1/stats/run-ids-by-workflow");
+    expect(content).toContain("/stats/grouped/public");
+    expect(content).toContain("/v1/stats/public/run-ids-by-workflow");
     // Email-gateway fallback still exists
     expect(content).toContain("fetchWorkflowDeliveryStats");
     expect(content).toContain('groupBy: "workflowName"');
@@ -1093,7 +1093,7 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
     vi.restoreAllMocks();
   });
 
-  it("should pass x-org-id header on all callExternalService calls", async () => {
+  it("should use public endpoints without identity headers for stats calls", async () => {
     const app = createApp();
     const brands = [
       { id: "brand-1", domain: "acme.com", name: "Acme", brandUrl: "https://acme.com" },
@@ -1110,13 +1110,12 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = baseMock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve(makeGatewayResponse({ emailsSent: 10, emailsOpened: 5 }));
       }
       return Promise.resolve({});
     });
 
-    // Simulate an authenticated request with x-org-id and x-user-id
     const res = await request(app)
       .get("/performance/leaderboard")
       .set("x-org-id", "admin-org-uuid")
@@ -1124,26 +1123,29 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
 
     expect(res.status).toBe(200);
 
-    // Verify every callExternalService call received headers with x-org-id
-    for (const call of mockCallExternalService.mock.calls) {
+    // Stats calls should use public endpoints (no identity headers)
+    const publicStatsCalls = mockCallExternalService.mock.calls.filter(
+      (c: any) => typeof c[1] === "string" && (
+        c[1] === "/stats/public" ||
+        c[1] === "/stats/grouped/public" ||
+        c[1] === "/v1/stats/public/run-ids-by-workflow"
+      )
+    );
+    expect(publicStatsCalls.length).toBeGreaterThan(0);
+    for (const call of publicStatsCalls) {
       const opts = call[2] as { headers?: Record<string, string> } | undefined;
-      // /org-ids is an internal endpoint that may not need org headers (admin scope)
-      // but all other calls must have headers
-      if (call[1] !== "/org-ids") {
-        expect(opts?.headers).toBeDefined();
-      }
+      expect(opts?.headers?.["x-org-id"]).toBeUndefined();
+      expect(opts?.headers?.["x-user-id"]).toBeUndefined();
     }
 
-    // Specifically verify run-ids-by-workflow passes the per-org x-org-id
-    const runIdsCalls = mockCallExternalService.mock.calls.filter(
-      (c: any) => typeof c[1] === "string" && c[1].includes("/v1/stats/run-ids-by-workflow")
+    // Brand-service calls should still pass headers (brand-service needs per-org headers)
+    const brandsCalls = mockCallExternalService.mock.calls.filter(
+      (c: any) => typeof c[1] === "string" && c[1].startsWith("/brands?orgId=")
     );
-    expect(runIdsCalls.length).toBeGreaterThan(0);
-    for (const call of runIdsCalls) {
+    expect(brandsCalls.length).toBeGreaterThan(0);
+    for (const call of brandsCalls) {
       const opts = call[2] as { headers?: Record<string, string> };
       expect(opts.headers?.["x-org-id"]).toBeDefined();
-      // x-org-id should be the org being queried (from orgIds), not the admin's org
-      expect(opts.headers?.["x-org-id"]).toBe("org-1");
     }
   });
 
@@ -1180,7 +1182,7 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
     }
   });
 
-  it("should pass per-brand x-org-id on email-gateway /stats calls", async () => {
+  it("should use /stats/public without identity headers for per-brand stats", async () => {
     const app = createApp();
     const brands = [
       { id: "brand-1", domain: "acme.com", name: "Acme", brandUrl: "https://acme.com" },
@@ -1190,7 +1192,7 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
     mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
       const result = baseMock(_service, path, opts);
       if (result !== null) return result;
-      if (path === "/stats") {
+      if (path === "/stats/public") {
         return Promise.resolve(makeGatewayResponse({ emailsSent: 10, emailsOpened: 5 }));
       }
       return Promise.resolve({});
@@ -1203,15 +1205,71 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
 
     expect(res.status).toBe(200);
 
-    // Find per-brand email-gateway /stats calls (ones with brandId in body)
+    // Find per-brand email-gateway /stats/public calls (ones with brandId in body)
     const statsCallsWithBrand = mockCallExternalService.mock.calls.filter(
-      (c: any) => typeof c[1] === "string" && c[1] === "/stats" &&
+      (c: any) => typeof c[1] === "string" && c[1] === "/stats/public" &&
         c[2]?.body?.brandId === "brand-1"
     );
-    // Per-brand calls should have x-org-id set to the brand's org
+    expect(statsCallsWithBrand.length).toBeGreaterThan(0);
+    // Public endpoint calls should NOT have x-org-id or x-user-id headers
     for (const call of statsCallsWithBrand) {
       const opts = call[2] as { headers?: Record<string, string> };
-      expect(opts.headers?.["x-org-id"]).toBe("org-1");
+      expect(opts.headers?.["x-org-id"]).toBeUndefined();
+      expect(opts.headers?.["x-user-id"]).toBeUndefined();
+    }
+  });
+
+  it("regression: leaderboard should succeed without identity headers (public landing page)", async () => {
+    // Bug: POST /stats to email-gateway and instantly-service required x-org-id, x-user-id, x-run-id.
+    // The leaderboard is called from the landing page without any user context.
+    // Fix: all stats calls now use /stats/public, /stats/grouped/public, /v1/stats/public/run-ids-by-workflow
+    // which only require X-API-Key (serviceAuth), no identity headers.
+    const app = createApp();
+    const brands = [
+      { id: "brand-1", domain: "acme.com", name: "Acme", brandUrl: "https://acme.com" },
+    ];
+    const workflowGroups: MockRunsGroup[] = [
+      { dimensions: { workflowName: "sales-email-cold-outreach-sienna" }, totalCostInUsdCents: "5000.0000", actualCostInUsdCents: "5000.0000", provisionedCostInUsdCents: "0", cancelledCostInUsdCents: "0", runCount: 10 },
+    ];
+    const runIdsByWorkflow = {
+      "sales-email-cold-outreach-sienna": ["run-1"],
+    };
+    const instantlyGroups = [
+      { key: "sales-email-cold-outreach-sienna", stats: { emailsSent: 30, emailsOpened: 15, emailsReplied: 5 }, recipients: 25 },
+    ];
+
+    const baseMock = setupMocks(brands, [], workflowGroups, runIdsByWorkflow, instantlyGroups);
+    mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
+      const result = baseMock(_service, path, opts);
+      if (result !== null) return result;
+      if (path === "/stats/public") {
+        return Promise.resolve(makeGatewayResponse({ emailsSent: 30, emailsOpened: 15, emailsReplied: 5 }));
+      }
+      return Promise.resolve({});
+    });
+
+    // Call WITHOUT x-org-id and x-user-id — simulates landing page call
+    const res = await request(app).get("/performance/leaderboard");
+
+    expect(res.status).toBe(200);
+    expect(res.body.brands).toHaveLength(1);
+    expect(res.body.brands[0].emailsSent).toBe(30);
+    expect(res.body.workflows).toHaveLength(1);
+    expect(res.body.workflows[0].emailsSent).toBe(30);
+
+    // Verify no identity headers were sent on any stats call
+    const allStatsCalls = mockCallExternalService.mock.calls.filter(
+      (c: any) => typeof c[1] === "string" && (
+        c[1] === "/stats/public" ||
+        c[1] === "/stats/grouped/public" ||
+        c[1] === "/v1/stats/public/run-ids-by-workflow"
+      )
+    );
+    for (const call of allStatsCalls) {
+      const opts = call[2] as { headers?: Record<string, string> };
+      expect(opts?.headers?.["x-org-id"]).toBeUndefined();
+      expect(opts?.headers?.["x-user-id"]).toBeUndefined();
+      expect(opts?.headers?.["x-run-id"]).toBeUndefined();
     }
   });
 });


### PR DESCRIPTION
## Summary
- Switch all leaderboard stats calls to public endpoints (`/stats/public`, `/stats/grouped/public`, `/v1/stats/public/run-ids-by-workflow`) that only require `X-API-Key` — no identity headers
- Fixes `POST /stats failed: Missing required header: x-user-id` errors (31 occurrences in production) when leaderboard is called from the landing page without user context
- Simplify `enrichWithDeliveryStats` and `fetchAllBrands` by removing `orgIds`, `headers`, and `brandOrgMap` parameters that are no longer needed
- Update auth middleware to resolve `x-user-id` and `x-org-id` independently

## Test plan
- [x] All 423 existing tests pass (57 test files)
- [x] Updated existing regression tests to verify public endpoint paths
- [x] Added regression test: leaderboard succeeds without identity headers (simulates landing page)
- [x] Added test: public endpoint calls do NOT send x-org-id/x-user-id/x-run-id headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)