### PR TITLE
revert: undo orgId workaround in leaderboard (#87)

### DIFF
--- a/src/routes/performance.ts
+++ b/src/routes/performance.ts
@@ -192,45 +192,22 @@ function instantlyGroupToDeliveryStats(s: InstantlyGroupStats): DeliveryStats {
   };
 }
 
-/** Fetch run IDs grouped by workflow name from runs-service (public endpoint, no identity headers).
- *  Calls per-org and merges results since the endpoint requires orgId. */
-async function fetchRunIdsByWorkflow(orgIds: string[]): Promise<Record<string, string[]>> {
-  if (orgIds.length === 0) return {};
-
-  const perOrgResults = await Promise.all(
-    orgIds.map(async (orgId) => {
-      try {
-        const result = await callExternalService<{ groups: Record<string, string[]> }>(
-          externalServices.runs,
-          `/v1/stats/public/run-ids-by-workflow?orgId=${encodeURIComponent(orgId)}`
-        );
-        return result.groups || {};
-      } catch (err) {
-        console.warn(`[leaderboard] run-ids-by-workflow failed for org ${orgId}:`, (err as Error).message);
-        return {};
-      }
-    })
-  );
-
-  // Merge per-org results, deduplicating run IDs per workflow
-  const merged: Record<string, Set<string>> = {};
-  for (const groups of perOrgResults) {
-    for (const [workflowName, runIds] of Object.entries(groups)) {
-      if (!merged[workflowName]) merged[workflowName] = new Set();
-      for (const id of runIds) merged[workflowName].add(id);
+/** Fetch run IDs grouped by workflow name from runs-service (public endpoint, no identity headers). */
+async function fetchRunIdsByWorkflow(): Promise<Record<string, string[]>> {
+  try {
+    const result = await callExternalService<{ groups: Record<string, string[]> }>(
+      externalServices.runs,
+      "/v1/stats/public/run-ids-by-workflow"
+    );
+    const totalRunIds = Object.values(result.groups || {}).reduce((s, ids) => s + ids.length, 0);
+    if (totalRunIds === 0) {
+      console.warn("[leaderboard] fetchRunIdsByWorkflow returned 0 run IDs");
     }
+    return result.groups || {};
+  } catch (err) {
+    console.warn("[leaderboard] run-ids-by-workflow failed:", (err as Error).message);
+    return {};
   }
-
-  const result: Record<string, string[]> = {};
-  for (const [workflowName, idSet] of Object.entries(merged)) {
-    result[workflowName] = [...idSet];
-  }
-
-  const totalRunIds = Object.values(result).reduce((s, ids) => s + ids.length, 0);
-  if (totalRunIds === 0) {
-    console.warn("[leaderboard] fetchRunIdsByWorkflow returned 0 run IDs across all orgs");
-  }
-  return result;
 }
 
 /** Fetch grouped stats from instantly-service via POST /stats/grouped/public (no identity headers). */
@@ -335,7 +312,7 @@ function applyStatsToWorkflow(wf: WorkflowEntry, stats: DeliveryStats) {
  * Workflows: instantly-service via run-ids-by-workflow → POST /stats/grouped,
  *   with email-gateway groupBy as fallback, then proportional distribution.
  */
-async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[]): Promise<void> {
+async function enrichWithDeliveryStats(data: LeaderboardData): Promise<void> {
   // Fetch per-brand stats (email-gateway) + workflow stats (instantly-service) in parallel
   const [, instantlyResults] = await Promise.all([
     // Per-brand stats (email-gateway public endpoint)
@@ -349,7 +326,7 @@ async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[]):
     ),
     // Workflow stats via instantly-service (run-ids-by-workflow → POST /stats/grouped/public)
     (async () => {
-      const runIdsByWorkflow = await fetchRunIdsByWorkflow(orgIds);
+      const runIdsByWorkflow = await fetchRunIdsByWorkflow();
       return fetchInstantlyGroupedStats(runIdsByWorkflow);
     })(),
   ]);
@@ -455,12 +432,10 @@ async function enrichWithDeliveryStats(data: LeaderboardData, orgIds: string[]):
 }
 
 /** Get all brands across all orgs from brand-service.
- *  This is more reliable than /campaigns/list which only returns ongoing campaigns.
- *  Also returns the orgIds so callers can use them for per-org queries. */
-async function fetchAllBrands(headers: Record<string, string> = {}): Promise<{
-  brands: Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }>;
-  orgIds: string[];
-}> {
+ *  This is more reliable than /campaigns/list which only returns ongoing campaigns. */
+async function fetchAllBrands(headers: Record<string, string> = {}): Promise<
+  Array<{ id: string; domain: string | null; name: string | null; brandUrl: string | null }>
+> {
   // Get all org IDs from brand-service
   let orgIds: string[];
   try {
@@ -470,10 +445,10 @@ async function fetchAllBrands(headers: Record<string, string> = {}): Promise<{
     orgIds = resp.organization_ids || [];
   } catch (err) {
     console.warn("[leaderboard] Failed to fetch org-ids from brand-service:", (err as Error).message);
-    return { brands: [], orgIds: [] };
+    return [];
   }
 
-  if (orgIds.length === 0) return { brands: [], orgIds: [] };
+  if (orgIds.length === 0) return [];
 
   // Fetch brands for each org in parallel
   const brandArrays = await Promise.all(
@@ -500,7 +475,7 @@ async function fetchAllBrands(headers: Record<string, string> = {}): Promise<{
       }
     }
   }
-  return { brands: allBrands, orgIds };
+  return allBrands;
 }
 
 /** Response shape from runs-service /v1/stats/public/leaderboard (costs are strings). */
@@ -515,9 +490,9 @@ interface RunsStatsGroup {
 
 /** Build leaderboard data from brand-service + runs-service public endpoint.
  *  Uses brand-service for brands, runs-service for costs + workflows. */
-async function buildLeaderboardData(headers: Record<string, string> = {}): Promise<{ data: LeaderboardData; orgIds: string[] }> {
+async function buildLeaderboardData(headers: Record<string, string> = {}): Promise<{ data: LeaderboardData }> {
   // 1. Get brands + workflow stats + brand costs in parallel
-  const [brandResult, workflowStatsResult, brandCosts] = await Promise.all([
+  const [allBrands, workflowStatsResult, brandCosts] = await Promise.all([
     fetchAllBrands(headers),
     // Workflow stats from runs-service public endpoint
     callExternalService<{ groups: RunsStatsGroup[] }>(
@@ -546,8 +521,6 @@ async function buildLeaderboardData(headers: Record<string, string> = {}): Promi
       return new Map<string, number>();
     }),
   ]);
-
-  const { brands: allBrands, orgIds } = brandResult;
 
   // 2. Build brand entries from brand-service data
   const brands: BrandEntry[] = allBrands.map((b) => ({
@@ -583,7 +556,6 @@ async function buildLeaderboardData(headers: Record<string, string> = {}): Promi
 
   return {
     data: { brands, workflows, hero: null, updatedAt: new Date().toISOString(), availableCategories, categorySections: [] },
-    orgIds,
   };
 }
 
@@ -637,11 +609,11 @@ function buildCategorySections(data: LeaderboardData): CategorySection[] {
 router.get("/performance/leaderboard", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const headers = buildInternalHeaders(req);
-    const { data, orgIds } = await buildLeaderboardData(headers);
+    const { data } = await buildLeaderboardData(headers);
 
     // Enrich with delivery stats (instantly-service for workflows, email-gateway for brands)
     try {
-      await enrichWithDeliveryStats(data, orgIds);
+      await enrichWithDeliveryStats(data);
     } catch (err) {
       console.warn("Failed to enrich leaderboard with delivery stats:", err);
     }

--- a/tests/unit/brand-service-run-id.regression.test.ts
+++ b/tests/unit/brand-service-run-id.regression.test.ts
@@ -70,7 +70,7 @@ describe("all brand-service calls include internal headers", () => {
     // Stats calls use public endpoints (no identity headers).
     expect(src).toContain("buildInternalHeaders(req)");
     expect(src).toContain("buildLeaderboardData(headers)");
-    expect(src).toContain("enrichWithDeliveryStats(data, orgIds)");
+    expect(src).toContain("enrichWithDeliveryStats(data)");
   });
 });
 

--- a/tests/unit/performance-leaderboard-stats.regression.test.ts
+++ b/tests/unit/performance-leaderboard-stats.regression.test.ts
@@ -1128,7 +1128,7 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
       (c: any) => typeof c[1] === "string" && (
         c[1] === "/stats/public" ||
         c[1] === "/stats/grouped/public" ||
-        (c[1] as string).startsWith("/v1/stats/public/run-ids-by-workflow")
+        c[1] === "/v1/stats/public/run-ids-by-workflow"
       )
     );
     expect(publicStatsCalls.length).toBeGreaterThan(0);
@@ -1219,47 +1219,6 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
     }
   });
 
-  it("regression: run-ids-by-workflow must pass orgId as query parameter", async () => {
-    // Bug: fetchRunIdsByWorkflow called /v1/stats/public/run-ids-by-workflow without orgId,
-    // but runs-service requires orgId as a query parameter. This caused 400 errors and
-    // forced fallback to proportional distribution (lower quality data).
-    // Fix: iterate over all orgIds and pass orgId as query param per-org.
-    const app = createApp();
-    const brands = [
-      { id: "brand-1", domain: "acme.com", name: "Acme", brandUrl: "https://acme.com" },
-    ];
-    const workflowGroups: MockRunsGroup[] = [
-      { dimensions: { workflowName: "sales-email-cold-outreach-sienna" }, totalCostInUsdCents: "5000", actualCostInUsdCents: "5000", provisionedCostInUsdCents: "0", cancelledCostInUsdCents: "0", runCount: 10 },
-    ];
-    const runIdsByWorkflow = { "sales-email-cold-outreach-sienna": ["run-1"] };
-    const instantlyGroups = [
-      { key: "sales-email-cold-outreach-sienna", stats: { emailsSent: 10, emailsOpened: 5 }, recipients: 8 },
-    ];
-
-    const baseMock = setupMocks(brands, [], workflowGroups, runIdsByWorkflow, instantlyGroups);
-    mockCallExternalService.mockImplementation((_service: any, path: string, opts: any) => {
-      const result = baseMock(_service, path, opts);
-      if (result !== null) return result;
-      if (path === "/stats/public") {
-        return Promise.resolve(makeGatewayResponse({ emailsSent: 10, emailsOpened: 5 }));
-      }
-      return Promise.resolve({});
-    });
-
-    const res = await request(app).get("/performance/leaderboard");
-    expect(res.status).toBe(200);
-
-    // Verify run-ids-by-workflow was called with orgId query parameter
-    const runIdsCalls = mockCallExternalService.mock.calls.filter(
-      (c: any) => typeof c[1] === "string" && (c[1] as string).startsWith("/v1/stats/public/run-ids-by-workflow")
-    );
-    expect(runIdsCalls.length).toBeGreaterThan(0);
-    for (const call of runIdsCalls) {
-      const path = call[1] as string;
-      expect(path).toContain("orgId=");
-    }
-  });
-
   it("regression: leaderboard should succeed without identity headers (public landing page)", async () => {
     // Bug: POST /stats to email-gateway and instantly-service required x-org-id, x-user-id, x-run-id.
     // The leaderboard is called from the landing page without any user context.
@@ -1303,7 +1262,7 @@ describe("leaderboard forwards x-org-id headers to all service calls", () => {
       (c: any) => typeof c[1] === "string" && (
         c[1] === "/stats/public" ||
         c[1] === "/stats/grouped/public" ||
-        (c[1] as string).startsWith("/v1/stats/public/run-ids-by-workflow")
+        c[1] === "/v1/stats/public/run-ids-by-workflow"
       )
     );
     for (const call of allStatsCalls) {


### PR DESCRIPTION
## Summary
- Reverts PR #87 which added a per-org iteration workaround in api-service
- The root cause is in runs-service: `/v1/stats/public/run-ids-by-workflow` requires `orgId` as mandatory, but as a public cross-org endpoint it should make `orgId` optional (like `/v1/stats/public/leaderboard` does)
- The fix belongs in runs-service, not api-service

## Test plan
- [x] All 433 tests pass after revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)