### PR TITLE
fix: remove proportional distribution fallbacks from leaderboard

### DIFF
--- a/src/routes/performance.ts
+++ b/src/routes/performance.ts
@@ -252,23 +252,6 @@ async function fetchInstantlyGroupedStats(
   }
 }
 
-/** Fetch aggregate stats from instantly-service (public endpoint, no identity headers).
- *  Used as fallback when per-workflow run-id grouping fails. */
-async function fetchInstantlyAggregateStats(): Promise<DeliveryStats> {
-  try {
-    const result = await callExternalService<{
-      stats: InstantlyGroupStats;
-      recipients: number;
-    }>(
-      externalServices.instantly,
-      "/stats/public",
-      { method: "POST", body: {} }
-    );
-    return instantlyGroupToDeliveryStats(result.stats);
-  } catch {
-    return EMPTY_STATS;
-  }
-}
 
 function applyStatsToBrand(brand: BrandEntry, stats: DeliveryStats) {
   brand.emailsSent = stats.emailsSent;
@@ -310,7 +293,7 @@ function applyStatsToWorkflow(wf: WorkflowEntry, stats: DeliveryStats) {
  * Enrich leaderboard with delivery stats.
  * Brands: email-gateway (broadcast stats by brandId).
  * Workflows: instantly-service via run-ids-by-workflow → POST /stats/grouped,
- *   with email-gateway groupBy as fallback, then proportional distribution.
+ *   with email-gateway groupBy as fallback.
  */
 async function enrichWithDeliveryStats(data: LeaderboardData): Promise<void> {
   // Fetch per-brand stats (email-gateway) + workflow stats (instantly-service) in parallel
@@ -345,35 +328,7 @@ async function enrichWithDeliveryStats(data: LeaderboardData): Promise<void> {
     console.warn("[leaderboard] instantly per-workflow path returned no data");
   }
 
-  // Fallback 1: instantly aggregate stats distributed proportionally across workflows.
-  // This catches cases where run-ids-by-workflow fails (org ID mismatch, auth issue)
-  // but instantly-service still has aggregate data.
-  if (!anyWorkflowEnriched && data.workflows.length > 0) {
-    const instantlyAggregate = await fetchInstantlyAggregateStats();
-    if (instantlyAggregate.emailsSent > 0) {
-      console.warn("[leaderboard] using instantly aggregate fallback (proportional distribution)");
-      const totalCost = data.workflows.reduce((s, w) => s + w.totalCostUsdCents, 0);
-      if (totalCost > 0) {
-        for (const wf of data.workflows) {
-          const share = wf.totalCostUsdCents / totalCost;
-          const distributed: DeliveryStats = {
-            emailsSent: Math.round(instantlyAggregate.emailsSent * share),
-            emailsOpened: Math.round(instantlyAggregate.emailsOpened * share),
-            emailsClicked: Math.round(instantlyAggregate.emailsClicked * share),
-            emailsReplied: Math.round(instantlyAggregate.emailsReplied * share),
-            emailsBounced: Math.round(instantlyAggregate.emailsBounced * share),
-            repliesInterested: Math.round(instantlyAggregate.repliesInterested * share),
-          };
-          if (distributed.emailsSent > 0) {
-            applyStatsToWorkflow(wf, distributed);
-            anyWorkflowEnriched = true;
-          }
-        }
-      }
-    }
-  }
-
-  // Fallback 2: email-gateway groupBy (for workflows not covered by instantly)
+  // Fallback: email-gateway groupBy (for workflows not covered by instantly)
   if (!anyWorkflowEnriched && data.workflows.length > 0) {
     console.warn("[leaderboard] falling back to email-gateway groupBy");
     const workflowStatsMap = await fetchWorkflowDeliveryStats();
@@ -385,32 +340,6 @@ async function enrichWithDeliveryStats(data: LeaderboardData): Promise<void> {
       }
     }
   }
-
-  // Fallback 3: proportional distribution from aggregate email-gateway stats
-  if (!anyWorkflowEnriched && data.workflows.length > 0) {
-    console.warn("[leaderboard] falling back to email-gateway aggregate (proportional distribution)");
-    const aggregateStats = await fetchBroadcastDeliveryStats({});
-    if (aggregateStats.emailsSent > 0) {
-      const totalCost = data.workflows.reduce((s, w) => s + w.totalCostUsdCents, 0);
-      if (totalCost > 0) {
-        for (const wf of data.workflows) {
-          const share = wf.totalCostUsdCents / totalCost;
-          const distributed: DeliveryStats = {
-            emailsSent: Math.round(aggregateStats.emailsSent * share),
-            emailsOpened: Math.round(aggregateStats.emailsOpened * share),
-            emailsClicked: Math.round(aggregateStats.emailsClicked * share),
-            emailsReplied: Math.round(aggregateStats.emailsReplied * share),
-            emailsBounced: Math.round(aggregateStats.emailsBounced * share),
-            repliesInterested: Math.round(aggregateStats.repliesInterested * share),
-          };
-          if (distributed.emailsSent > 0) {
-            applyStatsToWorkflow(wf, distributed);
-          }
-        }
-      }
-    }
-  }
-
 
   // Recompute hero stats: best $/open and $/reply across brands
   const brandsWithCostPerOpen = data.brands.filter((b) => b.costPerOpenCents !== null && b.costPerOpenCents > 0);
@@ -533,7 +462,7 @@ async function buildLeaderboardData(headers: Record<string, string> = {}): Promi
     costPerOpenCents: null, costPerClickCents: null, costPerReplyCents: null,
   }));
 
-  // 3. Build workflow entries directly from runs-service data (no proportional distribution)
+  // 3. Build workflow entries directly from runs-service data
   const workflows: WorkflowEntry[] = (workflowStatsResult.groups || []).map((g) => {
       const name = g.dimensions.workflowName || "unknown";
       return {

--- a/tests/unit/performance-leaderboard-stats.regression.test.ts
+++ b/tests/unit/performance-leaderboard-stats.regression.test.ts
@@ -12,6 +12,8 @@
  * 6. Workflows use {category}-{channel}-{audienceType}-{signatureName} naming.
  * 7. Per-workflow email stats via instantly-service POST /stats/grouped
  *    (run-ids-by-workflow → grouped stats), with email-gateway fallback.
+ * 10. Removed proportional distribution fallbacks now that runs-service
+ *     supports cross-org run-ids-by-workflow without orgId.
  * 8. emailsReplied = positive replies only (lead_interested). Auto-reply, not-interested, OOO excluded.
  * 9. Recipients count per workflow from instantly-service.
  *
@@ -463,12 +465,11 @@ describe("GET /performance/leaderboard", () => {
     expect(section.brands).toHaveLength(1);
   });
 
-  it("should fall back to email-gateway when instantly-service returns empty, then proportional", async () => {
+  it("should leave workflow stats at zero when both instantly and email-gateway return empty", async () => {
     const app = createApp();
     const brands = [
       { id: "brand-1", domain: "acme.com", name: "Acme", brandUrl: "https://acme.com" },
     ];
-    // Two workflows with different costs — proportional distribution should split by cost share
     const workflowGroups: MockRunsGroup[] = [
       { dimensions: { workflowName: "sales-email-cold-outreach-sienna" }, totalCostInUsdCents: "6000.0000", actualCostInUsdCents: "6000.0000", provisionedCostInUsdCents: "0", cancelledCostInUsdCents: "0", runCount: 30 },
       { dimensions: { workflowName: "sales-email-cold-outreach-darmstadt" }, totalCostInUsdCents: "4000.0000", actualCostInUsdCents: "4000.0000", provisionedCostInUsdCents: "0", cancelledCostInUsdCents: "0", runCount: 20 },
@@ -481,7 +482,7 @@ describe("GET /performance/leaderboard", () => {
       if (result !== null) return result;
       if (path === "/stats/public") {
         const body = opts?.body || {};
-        // email-gateway groupBy also returns empty — simulates old emails without workflowName
+        // email-gateway groupBy also returns empty
         if (body.groupBy === "workflowName") {
           return Promise.resolve({ groups: [] });
         }
@@ -489,11 +490,7 @@ describe("GET /performance/leaderboard", () => {
         if (body.brandId) {
           return Promise.resolve(makeGatewayResponse({ emailsSent: 100, emailsOpened: 50, emailsClicked: 10, emailsReplied: 8 }));
         }
-        // Aggregate stats (fallback)
-        return Promise.resolve(makeGatewayResponse({
-          emailsSent: 100, emailsOpened: 50, emailsClicked: 10, emailsReplied: 8,
-          repliesWillingToMeet: 3, repliesInterested: 2,
-        }));
+        return Promise.resolve(makeGatewayResponse(null));
       }
       return Promise.resolve(null);
     });
@@ -501,27 +498,15 @@ describe("GET /performance/leaderboard", () => {
     const res = await request(app).get("/performance/leaderboard?appId=distribute");
 
     expect(res.status).toBe(200);
-    // Workflows should get proportional stats based on cost share (60% / 40%)
+    // Without proportional fallback, workflows should have 0 email stats
     const sienna = res.body.workflows.find((w: any) => w.workflowName === "sales-email-cold-outreach-sienna");
     expect(sienna).toBeDefined();
-    expect(sienna.emailsSent).toBe(60); // 100 * 0.6
-    expect(sienna.emailsOpened).toBe(30); // 50 * 0.6
-    expect(sienna.emailsReplied).toBe(5); // Math.round(8 * 0.6)
-    expect(sienna.repliesInterested).toBe(3); // Math.round(5 * 0.6)
-    expect(sienna.openRate).toBeGreaterThan(0);
-    expect(sienna.replyRate).toBeGreaterThan(0);
-    expect(sienna.interestedRate).toBeGreaterThan(0);
+    expect(sienna.emailsSent).toBe(0);
+    expect(sienna.emailsOpened).toBe(0);
 
     const darmstadt = res.body.workflows.find((w: any) => w.workflowName === "sales-email-cold-outreach-darmstadt");
     expect(darmstadt).toBeDefined();
-    expect(darmstadt.emailsSent).toBe(40); // 100 * 0.4
-    expect(darmstadt.emailsOpened).toBe(20); // 50 * 0.4
-    expect(darmstadt.emailsReplied).toBe(3); // Math.round(8 * 0.4)
-    expect(darmstadt.repliesInterested).toBe(2); // Math.round(5 * 0.4)
-
-    // Category sections should also have stats from the fallback
-    expect(res.body.categorySections.length).toBe(1);
-    expect(res.body.categorySections[0].stats.emailsSent).toBe(100); // 60 + 40
+    expect(darmstadt.emailsSent).toBe(0);
   });
 
   it("should fall back to email-gateway groupBy when instantly-service returns empty", async () => {
@@ -855,7 +840,7 @@ describe("GET /performance/leaderboard", () => {
     expect(wf.costPerReplyCents).toBe(1333); // Math.round(4000 / 3)
   });
 
-  it("should use instantly aggregate fallback when per-workflow path returns empty", async () => {
+  it("should NOT use proportional distribution — workflows get zero stats when instantly returns empty", async () => {
     const app = createApp();
     const brands = [{ id: "brand-1", domain: "acme.com", name: "Acme", brandUrl: "https://acme.com" }];
     const workflowGroups: MockRunsGroup[] = [
@@ -863,28 +848,21 @@ describe("GET /performance/leaderboard", () => {
       { dimensions: { workflowName: "sales-email-cold-outreach-darmstadt" }, totalCostInUsdCents: "4000.0000", actualCostInUsdCents: "4000.0000", provisionedCostInUsdCents: "0", cancelledCostInUsdCents: "0", runCount: 20 },
     ];
 
-    // Empty run-ids-by-workflow → empty instantly grouped → triggers aggregate fallback
+    // Empty run-ids-by-workflow → empty instantly grouped → NO proportional fallback
     const mock = setupMocks(brands, [], workflowGroups, {}, []);
     mockCallExternalService.mockImplementation((service: any, path: string, opts: any) => {
       const result = mock(service, path, opts);
       if (result !== null) return result;
 
       if (path === "/stats/public") {
-        // Distinguish instantly from email-gateway by service URL
-        if (service.url === "http://mock-instantly") {
-          // Instantly aggregate: 100 sent, 50 opened, 5 positive replies (auto-reply excluded)
-          return Promise.resolve({
-            stats: makeInstantlyStats({
-              emailsSent: 100, emailsOpened: 50, emailsClicked: 8,
-              emailsReplied: 5, repliesAutoReply: 10,
-            }),
-            recipients: 80,
-          });
-        }
         // Email-gateway per-brand stats
         const body = opts?.body || {};
         if (body.brandId) {
           return Promise.resolve(makeGatewayResponse({ emailsSent: 100, emailsOpened: 50 }));
+        }
+        // email-gateway groupBy returns empty
+        if (body.groupBy === "workflowName") {
+          return Promise.resolve({ groups: [] });
         }
         return Promise.resolve(makeGatewayResponse(null));
       }
@@ -894,20 +872,17 @@ describe("GET /performance/leaderboard", () => {
     const res = await request(app).get("/performance/leaderboard?appId=distribute");
 
     expect(res.status).toBe(200);
-    // Workflows get proportional instantly aggregate stats (60%/40% split by cost)
+    // No proportional distribution — workflows have zero email stats
     const sienna = res.body.workflows.find((w: any) => w.workflowName === "sales-email-cold-outreach-sienna");
     expect(sienna).toBeDefined();
-    expect(sienna.emailsSent).toBe(60); // 100 * 0.6
-    expect(sienna.emailsOpened).toBe(30); // 50 * 0.6
-    // Positive replies = 5, sienna gets 60% = 3
-    expect(sienna.emailsReplied).toBe(3); // Math.round(5 * 0.6)
-    expect(sienna.repliesInterested).toBe(3); // Math.round(5 * 0.6)
+    expect(sienna.emailsSent).toBe(0);
+    expect(sienna.emailsOpened).toBe(0);
+    expect(sienna.emailsReplied).toBe(0);
 
     const darmstadt = res.body.workflows.find((w: any) => w.workflowName === "sales-email-cold-outreach-darmstadt");
     expect(darmstadt).toBeDefined();
-    expect(darmstadt.emailsSent).toBe(40); // 100 * 0.4
-    expect(darmstadt.emailsReplied).toBe(2); // Math.round(5 * 0.4)
-    expect(darmstadt.repliesInterested).toBe(2); // Math.round(5 * 0.4)
+    expect(darmstadt.emailsSent).toBe(0);
+    expect(darmstadt.emailsReplied).toBe(0);
   });
 });
 
@@ -1076,6 +1051,24 @@ describe("Regression: performance leaderboard must use broadcast-only stats", ()
     // emailsReplied IS positive replies only, repliesInterested mirrors it
     expect(content).toContain("emailsReplied IS positive replies only");
     expect(content).toContain("repliesInterested mirrors emailsReplied");
+  });
+
+  it("should NOT use proportional distribution fallbacks (cross-org data from runs-service)", () => {
+    const fs = require("fs");
+    const path = require("path");
+    const content = fs.readFileSync(
+      path.join(__dirname, "../../src/routes/performance.ts"),
+      "utf-8"
+    );
+
+    // run-ids-by-workflow is called without orgId — runs-service returns cross-org data
+    expect(content).toContain("/v1/stats/public/run-ids-by-workflow");
+    expect(content).not.toMatch(/run-ids-by-workflow\?orgId/);
+    // No proportional distribution of aggregate stats
+    expect(content).not.toContain("proportional");
+    expect(content).not.toContain("fetchInstantlyAggregateStats");
+    // email-gateway groupBy fallback is kept as a legitimate alternate source
+    expect(content).toContain("fetchWorkflowDeliveryStats");
   });
 });
 


### PR DESCRIPTION
## Summary
- Removes proportional distribution fallbacks (instantly aggregate and email-gateway aggregate) from leaderboard enrichment
- Now that runs-service `GET /v1/stats/public/run-ids-by-workflow` supports cross-org data without `orgId` ([runs-service PR #35](https://github.com/shamanic-technologies/runs-service/pull/35)), the primary path works reliably
- Keeps email-gateway `groupBy` fallback as a legitimate alternate data source
- Removes unused `fetchInstantlyAggregateStats()` function

## Test plan
- [x] Updated regression tests: proportional distribution tests replaced with assertions that workflows get zero stats when no real data is available
- [x] Added source-code assertion: no `proportional` or `fetchInstantlyAggregateStats` in performance.ts, and `run-ids-by-workflow` called without `orgId`
- [x] All 434 tests pass (59 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)