### PR TITLE
fix: make run creation mandatory instead of best-effort

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -84,7 +84,7 @@ export async function authenticate(
       req.authType = "user_key";
     }
 
-    // Create a request run for tracking (best-effort — don't block if runs-service is down)
+    // Create a request run for tracking — mandatory, fail the request if runs-service is down
     if (req.orgId) {
       try {
         const run = await createRun({
@@ -101,11 +101,12 @@ export async function authenticate(
           const headers: Record<string, string> = {};
           if (req.userId) headers["x-user-id"] = req.userId;
           updateRun(run.id, status, req.orgId, headers).catch((e: unknown) =>
-            console.warn("[auth] Failed to update run:", (e as Error).message)
+            console.error("[auth] Failed to close run:", (e as Error).message)
           );
         });
       } catch (err) {
-        console.warn("[auth] Failed to create request run:", (err as Error).message);
+        console.error("[auth] Failed to create request run:", (err as Error).message);
+        return res.status(502).json({ error: "Run tracking unavailable" });
       }
     }
 

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -215,3 +215,52 @@ describe("Auth middleware — error cases", () => {
     expect(mockCall).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("Auth middleware — run creation is mandatory", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_DISTRIBUTE_API_KEY = ADMIN_KEY;
+    app = createApp();
+  });
+
+  it("should return 502 when createRun fails (runs-service down)", async () => {
+    const { createRun } = await import("@distribute/runs-client");
+    vi.mocked(createRun).mockRejectedValueOnce(new Error("Connection refused"));
+
+    // User key auth succeeds
+    mockCall.mockResolvedValueOnce({
+      valid: true,
+      orgId: "org-uuid-direct",
+      userId: "user-uuid-direct",
+    });
+
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("Authorization", "Bearer mcpf_usr_test123");
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("Run tracking unavailable");
+  });
+
+  it("should return 502 when createRun fails for admin auth too", async () => {
+    const { createRun } = await import("@distribute/runs-client");
+    vi.mocked(createRun).mockRejectedValueOnce(new Error("Connection refused"));
+
+    // Admin auth with identity resolution succeeds
+    mockCall.mockResolvedValueOnce({
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+    });
+
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("Authorization", `Bearer ${ADMIN_KEY}`)
+      .set("x-org-id", "org_2clerkOrg")
+      .set("x-user-id", "user_2clerkUser");
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("Run tracking unavailable");
+  });
+});

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -90,6 +90,17 @@ describe("Auth middleware — user key authentication", () => {
   });
 });
 
+describe("Auth middleware — run creation is mandatory (not best-effort)", () => {
+  it("should return 502 when run creation fails, not silently continue", () => {
+    expect(content).toContain("Run tracking unavailable");
+    expect(content).toContain("return res.status(502)");
+  });
+
+  it("should not swallow run creation errors with console.warn", () => {
+    expect(content).not.toContain('console.warn("[auth] Failed to create request run:');
+  });
+});
+
 describe("Auth middleware — requireOrg and requireUser exports", () => {
   it("should export requireOrg middleware", () => {
     expect(content).toContain("export function requireOrg");


### PR DESCRIPTION
## Summary
- Run creation in auth middleware is now **mandatory** — if runs-service is down, requests fail with 502 instead of silently continuing without `x-run-id`
- This fixes silent failures in downstream services (e.g. transactional-email-service) that require `x-run-id` header
- Changed `console.warn` to `console.error` for run closure failures

## Test plan
- [x] Added regression test: 502 returned when `createRun` fails (user key auth)
- [x] Added regression test: 502 returned when `createRun` fails (admin auth)
- [x] Added static test: code no longer contains best-effort `console.warn` for run creation
- [x] All 437 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)