### PR TITLE
Deprecate POST /v1/campaigns/{id}/resume

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2165,8 +2165,9 @@
         "tags": [
           "Campaigns"
         ],
-        "summary": "Resume a campaign",
-        "description": "Resume a stopped campaign",
+        "summary": "Resume a campaign (deprecated)",
+        "description": "**Deprecated.** This endpoint is no longer supported. Create a new campaign instead of resuming a stopped one.",
+        "deprecated": true,
         "security": [
           {
             "bearerAuth": []
@@ -2203,9 +2204,6 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Resumed campaign"
-          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -2216,8 +2214,8 @@
               }
             }
           },
-          "500": {
-            "description": "Internal error",
+          "410": {
+            "description": "Gone — endpoint deprecated",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -311,26 +311,13 @@ router.post("/campaigns/:id/stop", authenticate, requireOrg, requireUser, async 
 
 /**
  * POST /v1/campaigns/:id/resume
- * Resume a stopped campaign
+ * @deprecated — Create a new campaign instead of resuming a stopped one.
  */
-router.post("/campaigns/:id/resume", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const { id } = req.params;
-
-    const result = await callExternalService(
-      externalServices.campaign,
-      `/campaigns/${id}`,
-      {
-        method: "PATCH",
-        headers: buildInternalHeaders(req),
-        body: { status: "activate" },
-      }
-    );
-    res.json(result);
-  } catch (error: any) {
-    console.error("Resume campaign error:", error);
-    res.status(500).json({ error: error.message || "Failed to resume campaign" });
-  }
+router.post("/campaigns/:id/resume", authenticate, requireOrg, requireUser, async (_req: AuthenticatedRequest, res) => {
+  res.status(410).json({
+    error:
+      "This endpoint has been deprecated. Please create a new campaign instead of resuming a stopped one.",
+  });
 });
 
 /**

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -298,14 +298,16 @@ registry.registerPath({
   method: "post",
   path: "/v1/campaigns/{id}/resume",
   tags: ["Campaigns"],
-  summary: "Resume a campaign",
-  description: "Resume a stopped campaign",
+  summary: "Resume a campaign (deprecated)",
+  description:
+    "**Deprecated.** This endpoint is no longer supported. " +
+    "Create a new campaign instead of resuming a stopped one.",
+  deprecated: true,
   security: authed,
   request: { params: CampaignIdParam },
   responses: {
-    200: { description: "Resumed campaign" },
+    410: { description: "Gone — endpoint deprecated", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
-    500: { description: "Internal error", content: errorContent },
   },
 });
 

--- a/tests/unit/campaign-resume-deprecated.test.ts
+++ b/tests/unit/campaign-resume-deprecated.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock auth middleware
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.appId = "distribute";
+    req.authType = "user_key";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+// Mock runs-client
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import campaignRouter from "../../src/routes/campaigns.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignRouter);
+  return app;
+}
+
+describe("POST /v1/campaigns/:id/resume — deprecated", () => {
+  it("returns 410 Gone with deprecation message", async () => {
+    const app = createApp();
+    const res = await request(app).post("/v1/campaigns/camp_123/resume");
+
+    expect(res.status).toBe(410);
+    expect(res.body.error).toMatch(/deprecated/i);
+    expect(res.body.error).toMatch(/new campaign/i);
+  });
+
+  it("is marked deprecated in the OpenAPI spec", async () => {
+    const spec = await import("../../openapi.json");
+    const path = spec.default.paths["/v1/campaigns/{id}/resume"];
+    expect(path).toBeDefined();
+    expect(path.post.deprecated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- The dashboard UI removed the "Resume campaign" button (distribute.you PR #363)
- `POST /v1/campaigns/{id}/resume` now returns **410 Gone** with a message directing callers to create a new campaign instead
- Endpoint marked `deprecated: true` in the OpenAPI spec
- Added regression test covering the 410 response and the OpenAPI deprecated flag

## Note
The `mcpfactory_resume_campaign` MCP tool is defined outside this repo (likely in mcpfactory-service). It should be deprecated separately.

## Test plan
- [x] New test `campaign-resume-deprecated.test.ts` verifies 410 response and OpenAPI deprecated flag
- [x] All 437 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)