### PR TITLE
refactor: split admin/user auth headers, forward profile data

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1477,7 +1477,7 @@
           "externalOrgId": {
             "type": "string",
             "minLength": 1,
-            "description": "External organization ID (e.g. Clerk org ID)"
+            "description": "External organization ID from identity provider"
           },
           "externalUserId": {
             "type": "string",
@@ -1518,7 +1518,7 @@
           },
           "externalId": {
             "type": "string",
-            "description": "External user ID (e.g. Clerk user ID)"
+            "description": "External user ID from identity provider"
           },
           "email": {
             "type": "string",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -10,12 +10,14 @@ export interface AuthenticatedRequest extends Request {
 }
 
 /**
- * Authenticate via Bearer token. Two paths:
+ * Authenticate requests. Two paths:
  *
- * 1. Admin key → Bearer token matches ADMIN_DISTRIBUTE_API_KEY env var (dashboard).
- *    External Clerk IDs from x-org-id / x-user-id are resolved via client-service.
+ * 1. Admin (dashboard) → X-API-Key header matches ADMIN_DISTRIBUTE_API_KEY env var.
+ *    External IDs from x-external-org-id / x-external-user-id are resolved via client-service POST /resolve.
+ *    Optional profile headers (x-email, x-first-name, x-last-name) are forwarded.
  *
- * 2. User key (distrib.usr_*) → validated via key-service. Identity comes from the key itself.
+ * 2. User key (distrib.usr_*) → Authorization: Bearer validated via key-service.
+ *    Identity comes from the key itself.
  */
 export async function authenticate(
   req: AuthenticatedRequest,
@@ -23,57 +25,48 @@ export async function authenticate(
   next: NextFunction
 ) {
   try {
+    const apiKey = req.headers["x-api-key"] as string | undefined;
     const authHeader = req.headers.authorization;
 
-    if (!authHeader?.startsWith("Bearer ")) {
-      return res.status(401).json({ error: "Missing authentication" });
-    }
-
-    const key = authHeader.slice(7);
-
-    // ── Path 1: Admin / dashboard auth ──
-    if (key === process.env.ADMIN_DISTRIBUTE_API_KEY) {
+    if (apiKey) {
+      // ── Path 1: Admin auth via X-API-Key ──
+      if (apiKey !== process.env.ADMIN_DISTRIBUTE_API_KEY) {
+        return res.status(401).json({ error: "Invalid admin key" });
+      }
       req.authType = "admin";
 
-      // Dashboard sends external Clerk IDs → resolve to internal UUIDs
-      const externalOrgId = req.headers["x-org-id"] as string | undefined;
-      const externalUserId = req.headers["x-user-id"] as string | undefined;
+      const externalOrgId = req.headers["x-external-org-id"] as string | undefined;
+      const externalUserId = req.headers["x-external-user-id"] as string | undefined;
 
-      if (externalOrgId && externalUserId) {
-        const resolved = await resolveExternalIds(externalOrgId, externalUserId);
-
-        if (!resolved) {
-          console.error("[auth] Admin identity resolution returned null", {
-            externalOrgId,
-            externalUserId,
-          });
-          return res.status(502).json({ error: "Identity resolution failed" });
-        }
-
-        if (!resolved.orgId || !resolved.userId) {
-          console.error("[auth] Admin identity resolution returned empty IDs", {
-            resolved,
-            externalOrgId,
-            externalUserId,
-          });
-          return res.status(502).json({ error: "Identity resolution returned incomplete data" });
-        }
-
-        req.orgId = resolved.orgId;
-        req.userId = resolved.userId;
-      } else if (externalUserId) {
-        // Admin with user context only (e.g. cross-org leaderboard)
-        const userId = await resolveExternalUserId(externalUserId);
-        if (userId) req.userId = userId;
-      } else if (externalOrgId) {
-        // Admin with org context only
-        const orgId = await resolveExternalOrgId(externalOrgId);
-        if (orgId) req.orgId = orgId;
+      if (!externalOrgId || !externalUserId) {
+        return res.status(400).json({ error: "Admin auth requires both x-external-org-id and x-external-user-id" });
       }
-      // Admin without org/user context is valid (e.g. listing all orgs)
 
-    } else {
-      // ── Path 2: User key auth via key-service ──
+      const resolved = await resolveExternalIds(externalOrgId, externalUserId, req);
+
+      if (!resolved) {
+        console.error("[auth] Admin identity resolution returned null", {
+          externalOrgId,
+          externalUserId,
+        });
+        return res.status(502).json({ error: "Identity resolution failed" });
+      }
+
+      if (!resolved.orgId || !resolved.userId) {
+        console.error("[auth] Admin identity resolution returned empty IDs", {
+          resolved,
+          externalOrgId,
+          externalUserId,
+        });
+        return res.status(502).json({ error: "Identity resolution returned incomplete data" });
+      }
+
+      req.orgId = resolved.orgId;
+      req.userId = resolved.userId;
+
+    } else if (authHeader?.startsWith("Bearer ")) {
+      // ── Path 2: User key auth via Bearer ──
+      const key = authHeader.slice(7);
       const validation = await validateKey(key);
       if (!validation) {
         return res.status(401).json({ error: "Invalid API key" });
@@ -82,6 +75,9 @@ export async function authenticate(
       req.orgId = validation.orgId;
       req.userId = validation.userId;
       req.authType = "user_key";
+
+    } else {
+      return res.status(401).json({ error: "Missing authentication" });
     }
 
     // Create a request run for tracking — mandatory, fail the request if runs-service is down
@@ -143,13 +139,25 @@ async function validateKey(apiKey: string): Promise<{
 }
 
 /**
- * Resolve external org/user IDs to internal UUIDs via client-service POST /resolve
+ * Resolve external org/user IDs to internal UUIDs via client-service POST /resolve.
+ * Forwards optional profile headers (x-email, x-first-name, x-last-name) for non-destructive upsert.
  */
 async function resolveExternalIds(
   externalOrgId: string,
   externalUserId: string,
+  req: Request,
 ): Promise<{ orgId: string; userId: string } | null> {
   try {
+    const body: Record<string, string> = { externalOrgId, externalUserId };
+
+    const email = req.headers["x-email"] as string | undefined;
+    const firstName = req.headers["x-first-name"] as string | undefined;
+    const lastName = req.headers["x-last-name"] as string | undefined;
+
+    if (email) body.email = email;
+    if (firstName) body.firstName = firstName;
+    if (lastName) body.lastName = lastName;
+
     const result = await callExternalService<{
       orgId: string;
       userId: string;
@@ -158,46 +166,12 @@ async function resolveExternalIds(
       "/resolve",
       {
         method: "POST",
-        body: { externalOrgId, externalUserId },
+        body,
       }
     );
     return result;
   } catch (error) {
     console.error("[auth] Failed to resolve external IDs:", (error as Error).message);
-    return null;
-  }
-}
-
-/**
- * Resolve a single external user ID to internal UUID via client-service.
- * Used for admin requests with user context but no org context (cross-org views).
- */
-async function resolveExternalUserId(externalUserId: string): Promise<string | null> {
-  try {
-    const result = await callExternalService<{ user: { id: string } }>(
-      externalServices.client,
-      `/users/by-clerk/${encodeURIComponent(externalUserId)}`
-    );
-    return result.user?.id || null;
-  } catch (error) {
-    console.error("[auth] Failed to resolve external user ID:", (error as Error).message);
-    return null;
-  }
-}
-
-/**
- * Resolve a single external org ID to internal UUID via client-service.
- * Used for admin requests with org context but no user context.
- */
-async function resolveExternalOrgId(externalOrgId: string): Promise<string | null> {
-  try {
-    const result = await callExternalService<{ org: { id: string } }>(
-      externalServices.client,
-      `/orgs/by-clerk/${encodeURIComponent(externalOrgId)}`
-    );
-    return result.org?.id || null;
-  } catch (error) {
-    console.error("[auth] Failed to resolve external org ID:", (error as Error).message);
     return null;
   }
 }
@@ -214,8 +188,8 @@ export function requireOrg(
     console.warn("[auth] requireOrg blocked request", {
       path: req.path,
       authType: req.authType,
-      hasOrgHeader: !!req.headers["x-org-id"],
-      hasUserHeader: !!req.headers["x-user-id"],
+      hasOrgHeader: !!req.headers["x-external-org-id"],
+      hasUserHeader: !!req.headers["x-external-user-id"],
     });
     return res.status(400).json({ error: "Organization context required" });
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1876,7 +1876,7 @@ registry.registerPath({
 
 export const ResolveUserRequestSchema = z
   .object({
-    externalOrgId: z.string().min(1).describe("External organization ID (e.g. Clerk org ID)"),
+    externalOrgId: z.string().min(1).describe("External organization ID from identity provider"),
     externalUserId: z.string().min(1).describe("External user ID — use a generated UUID for anonymous users"),
     email: z.string().email().optional().describe("User email address"),
     firstName: z.string().optional().describe("User first name"),
@@ -1933,7 +1933,7 @@ export const ListUsersQuerySchema = z
 export const ListUsersUserSchema = z
   .object({
     id: z.string().uuid().describe("Internal user UUID"),
-    externalId: z.string().describe("External user ID (e.g. Clerk user ID)"),
+    externalId: z.string().describe("External user ID from identity provider"),
     email: z.string().nullable().describe("User email address"),
     firstName: z.string().nullable().describe("User first name"),
     lastName: z.string().nullable().describe("User last name"),

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -49,7 +49,7 @@ function createApp() {
   return app;
 }
 
-describe("Auth middleware — admin key", () => {
+describe("Auth middleware — admin key via X-API-Key", () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -58,7 +58,7 @@ describe("Auth middleware — admin key", () => {
     app = createApp();
   });
 
-  it("should authenticate with admin key and resolve external IDs via client-service", async () => {
+  it("should authenticate with X-API-Key and resolve external IDs via client-service", async () => {
     mockCall.mockResolvedValueOnce({
       orgId: "org-uuid-123",
       userId: "user-uuid-456",
@@ -68,9 +68,9 @@ describe("Auth middleware — admin key", () => {
 
     const res = await request(app)
       .get("/v1/workflows")
-      .set("Authorization", `Bearer ${ADMIN_KEY}`)
-      .set("x-org-id", "org_2clerkOrg")
-      .set("x-user-id", "user_2clerkUser");
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-org-id", "ext_org_123")
+      .set("x-external-user-id", "ext_user_456");
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -87,49 +87,140 @@ describe("Auth middleware — admin key", () => {
       {
         method: "POST",
         body: {
-          externalOrgId: "org_2clerkOrg",
-          externalUserId: "user_2clerkUser",
+          externalOrgId: "ext_org_123",
+          externalUserId: "ext_user_456",
         },
       },
     );
   });
 
-  it("should allow admin key without org/user headers (admin-only access)", async () => {
+  it("should forward optional profile headers to POST /resolve", async () => {
+    mockCall.mockResolvedValueOnce({
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+    });
+
     const res = await request(app)
-      .get("/v1/me")
-      .set("Authorization", `Bearer ${ADMIN_KEY}`);
+      .get("/v1/workflows")
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-org-id", "ext_org_123")
+      .set("x-external-user-id", "ext_user_456")
+      .set("x-email", "john@example.com")
+      .set("x-first-name", "John")
+      .set("x-last-name", "Doe");
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ orgId: null, userId: null, authType: "admin" });
+    expect(mockCall).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "http://client-service" }),
+      "/resolve",
+      {
+        method: "POST",
+        body: {
+          externalOrgId: "ext_org_123",
+          externalUserId: "ext_user_456",
+          email: "john@example.com",
+          firstName: "John",
+          lastName: "Doe",
+        },
+      },
+    );
+  });
+
+  it("should not include empty profile headers in POST /resolve body", async () => {
+    mockCall.mockResolvedValueOnce({
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+    });
+
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-org-id", "ext_org_123")
+      .set("x-external-user-id", "ext_user_456");
+
+    expect(res.status).toBe(200);
+    expect(mockCall).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "http://client-service" }),
+      "/resolve",
+      {
+        method: "POST",
+        body: {
+          externalOrgId: "ext_org_123",
+          externalUserId: "ext_user_456",
+        },
+      },
+    );
+  });
+
+  it("should return 400 when x-external-org-id is missing", async () => {
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-user-id", "ext_user_456");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Admin auth requires both x-external-org-id and x-external-user-id");
     expect(mockCall).not.toHaveBeenCalled();
   });
 
-  it("should return 502 when client-service resolution fails for admin key", async () => {
+  it("should return 400 when x-external-user-id is missing", async () => {
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-org-id", "ext_org_123");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Admin auth requires both x-external-org-id and x-external-user-id");
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when both external ID headers are missing", async () => {
+    const res = await request(app)
+      .get("/v1/me")
+      .set("X-API-Key", ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Admin auth requires both x-external-org-id and x-external-user-id");
+  });
+
+  it("should return 401 when X-API-Key does not match admin key", async () => {
+    const res = await request(app)
+      .get("/v1/me")
+      .set("X-API-Key", "wrong-key")
+      .set("x-external-org-id", "ext_org_123")
+      .set("x-external-user-id", "ext_user_456");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid admin key");
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("should return 502 when client-service resolution fails", async () => {
     mockCall.mockRejectedValueOnce(new Error("Connection refused"));
 
     const res = await request(app)
       .get("/v1/workflows")
-      .set("Authorization", `Bearer ${ADMIN_KEY}`)
-      .set("x-org-id", "org_2clerkOrg")
-      .set("x-user-id", "user_2clerkUser");
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-org-id", "ext_org_123")
+      .set("x-external-user-id", "ext_user_456");
 
     expect(res.status).toBe(502);
     expect(res.body.error).toBe("Identity resolution failed");
   });
 
-  it("should return 401 when Bearer token does not match admin key and key-service rejects it", async () => {
+  it("should no longer accept admin key via Bearer token", async () => {
     mockCall.mockResolvedValueOnce({ valid: false });
 
     const res = await request(app)
       .get("/v1/me")
-      .set("Authorization", "Bearer wrong-key");
+      .set("Authorization", `Bearer ${ADMIN_KEY}`);
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("Invalid API key");
   });
 });
 
-describe("Auth middleware — user key", () => {
+describe("Auth middleware — user key via Bearer", () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -186,7 +277,7 @@ describe("Auth middleware — error cases", () => {
     app = createApp();
   });
 
-  it("should return 401 when no Authorization header", async () => {
+  it("should return 401 when no authentication header is present", async () => {
     const res = await request(app).get("/v1/me");
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("Missing authentication");
@@ -256,9 +347,9 @@ describe("Auth middleware — run creation is mandatory", () => {
 
     const res = await request(app)
       .get("/v1/workflows")
-      .set("Authorization", `Bearer ${ADMIN_KEY}`)
-      .set("x-org-id", "org_2clerkOrg")
-      .set("x-user-id", "user_2clerkUser");
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-org-id", "ext_org_123")
+      .set("x-external-user-id", "ext_user_456");
 
     expect(res.status).toBe(502);
     expect(res.body.error).toBe("Run tracking unavailable");

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -5,8 +5,14 @@ import * as path from "path";
 const authPath = path.join(__dirname, "../../src/middleware/auth.ts");
 const content = fs.readFileSync(authPath, "utf-8");
 
-describe("Auth middleware — Bearer key authentication", () => {
-  it("should only accept Bearer token authentication", () => {
+describe("Auth middleware — X-API-Key for admin, Bearer for user keys", () => {
+  it("should check X-API-Key header for admin auth", () => {
+    expect(content).toContain('"x-api-key"');
+    expect(content).toContain("ADMIN_DISTRIBUTE_API_KEY");
+    expect(content).toContain("process.env.ADMIN_DISTRIBUTE_API_KEY");
+  });
+
+  it("should accept Bearer token for user key auth", () => {
     expect(content).toContain('authorization');
     expect(content).toContain('startsWith("Bearer ")');
   });
@@ -16,21 +22,67 @@ describe("Auth middleware — Bearer key authentication", () => {
     expect(content).not.toContain("@clerk/backend");
     expect(content).not.toContain("clerkJwt");
   });
+
+  it("should not reference Clerk anywhere", () => {
+    expect(content.toLowerCase()).not.toContain("clerk");
+  });
 });
 
-describe("Auth middleware — admin key authentication", () => {
-  it("should check Bearer token against ADMIN_DISTRIBUTE_API_KEY env var", () => {
-    expect(content).toContain("ADMIN_DISTRIBUTE_API_KEY");
-    expect(content).toContain("process.env.ADMIN_DISTRIBUTE_API_KEY");
+describe("Auth middleware — admin auth requires both external ID headers", () => {
+  it("should read external IDs from x-external-org-id and x-external-user-id headers", () => {
+    expect(content).toContain('"x-external-org-id"');
+    expect(content).toContain('"x-external-user-id"');
+  });
+
+  it("should NOT read from legacy x-org-id / x-user-id for admin identity", () => {
+    // x-org-id and x-user-id should only appear in requireOrg logging, not in admin identity resolution
+    const adminSection = content.split("Path 2")[0]; // everything before user key path
+    expect(adminSection).not.toContain('"x-org-id"');
+    expect(adminSection).not.toContain('"x-user-id"');
+  });
+
+  it("should return 400 when either external ID header is missing", () => {
+    expect(content).toContain("Admin auth requires both x-external-org-id and x-external-user-id");
+  });
+
+  it("should NOT have single-ID resolution functions", () => {
+    expect(content).not.toContain("resolveExternalUserId");
+    expect(content).not.toContain("resolveExternalOrgId");
+    expect(content).not.toContain("by-clerk");
+    expect(content).not.toContain("by-external");
   });
 
   it("should set authType to admin for admin key", () => {
     expect(content).toContain('"admin"');
   });
+});
 
-  it("should resolve external IDs via client-service for admin requests", () => {
-    expect(content).toContain("Admin identity resolution");
-    expect(content).toContain("resolveExternalIds");
+describe("Auth middleware — identity resolution via POST /resolve", () => {
+  it("should resolve external IDs via client-service POST /resolve", () => {
+    expect(content).toContain('"/resolve"');
+    expect(content).toContain("externalServices.client");
+    expect(content).toContain('method: "POST"');
+  });
+
+  it("should forward optional profile headers (x-email, x-first-name, x-last-name)", () => {
+    expect(content).toContain('"x-email"');
+    expect(content).toContain('"x-first-name"');
+    expect(content).toContain('"x-last-name"');
+  });
+
+  it("should NOT set appId on the request", () => {
+    expect(content).not.toContain("req.appId");
+    expect(content).not.toContain("appId?: string");
+  });
+
+  it("should return 502 when identity resolution fails", () => {
+    expect(content).toContain("502");
+    expect(content).toContain("Identity resolution failed");
+  });
+
+  it("should return 502 when identity resolution returns incomplete data", () => {
+    expect(content).toContain("Identity resolution returned incomplete data");
+    expect(content).toContain("!resolved.orgId || !resolved.userId");
   });
 });
 
@@ -46,47 +98,17 @@ describe("Auth middleware — key-service validation (user keys only)", () => {
     expect(content).toContain("encodeURIComponent(apiKey)");
   });
 
-  it("should not have app_key auth type", () => {
-    expect(content).not.toContain('"app_key"');
-    expect(content).not.toContain("app_key");
-  });
-});
-
-describe("Auth middleware — identity resolution", () => {
-  it("should read external IDs from x-org-id and x-user-id headers", () => {
-    expect(content).toContain('"x-org-id"');
-    expect(content).toContain('"x-user-id"');
-  });
-
-  it("should NOT set appId on the request", () => {
-    expect(content).not.toContain("req.appId");
-    expect(content).not.toContain("appId?: string");
-  });
-
-  it("should resolve external IDs via client-service POST /resolve", () => {
-    expect(content).toContain('"/resolve"');
-    expect(content).toContain("externalServices.client");
-    expect(content).toContain('method: "POST"');
-  });
-
-  it("should return 502 when identity resolution fails", () => {
-    expect(content).toContain("502");
-    expect(content).toContain("Identity resolution failed");
-  });
-
-  it("should return 502 when identity resolution returns incomplete data", () => {
-    expect(content).toContain("Identity resolution returned incomplete data");
-    expect(content).toContain("!resolved.orgId || !resolved.userId");
-  });
-});
-
-describe("Auth middleware — user key authentication", () => {
   it("should use orgId directly from key-service for user keys", () => {
     expect(content).toContain("validation.orgId");
   });
 
   it("should set authType to user_key for user key authentication", () => {
     expect(content).toContain('"user_key"');
+  });
+
+  it("should not have app_key auth type", () => {
+    expect(content).not.toContain('"app_key"');
+    expect(content).not.toContain("app_key");
   });
 });
 


### PR DESCRIPTION
## Summary
- Admin auth now uses `X-API-Key` header instead of `Authorization: Bearer` (consistent with service-to-service convention)
- Renamed `x-org-id`/`x-user-id` → `x-external-org-id`/`x-external-user-id` for admin requests
- Admin auth requires both external ID headers (returns 400 if either missing)
- Optional profile headers (`x-email`, `x-first-name`, `x-last-name`) forwarded to client-service POST /resolve
- Deleted single-ID resolution and `/by-clerk/` endpoint calls
- Renamed all "Clerk" references to "external"

## Breaking changes for dashboard
- Switch from `Authorization: Bearer ADMIN_KEY` to `X-API-Key: ADMIN_KEY`
- Rename headers: `x-org-id` → `x-external-org-id`, `x-user-id` → `x-external-user-id`

## Required from client-service
- Make `email` optional on POST /resolve (revert recent required constraint)
- Non-destructive upsert: omitted fields must NOT overwrite existing non-null values
- `/users/by-clerk/` and `/orgs/by-clerk/` can be deprecated (no longer called)

## Test plan
- [x] All 446 tests pass
- [x] OpenAPI spec regenerated
- [x] Admin auth works with X-API-Key, rejects Bearer ADMIN_KEY
- [x] Profile headers forwarded to POST /resolve when present
- [x] Missing external ID headers return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)