### PR TITLE
feat: register postmark-from-address platform key

### DIFF
--- a/src/startup.ts
+++ b/src/startup.ts
@@ -10,6 +10,7 @@ const PLATFORM_KEYS: { provider: string; envVar: string }[] = [
   { provider: "postmark-broadcast-stream", envVar: "POSTMARK_BROADCAST_STREAM_ID" },
   { provider: "postmark-inbound-stream", envVar: "POSTMARK_INBOUND_STREAM_ID" },
   { provider: "postmark-transactional-stream", envVar: "POSTMARK_TRANSACTIONAL_STREAM_ID" },
+  { provider: "postmark-from-address", envVar: "POSTMARK_FROM_ADDRESS" },
   { provider: "stripe", envVar: "STRIPE_SECRET_KEY" },
   { provider: "stripe-webhook", envVar: "STRIPE_WEBHOOK_SECRET" },
 ];

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -24,6 +24,7 @@ function setAllEnvVars() {
   process.env.POSTMARK_BROADCAST_STREAM_ID = "broadcast";
   process.env.POSTMARK_INBOUND_STREAM_ID = "inbound";
   process.env.POSTMARK_TRANSACTIONAL_STREAM_ID = "outbound";
+  process.env.POSTMARK_FROM_ADDRESS = "growth@distribute.you";
   process.env.STRIPE_SECRET_KEY = "sk_test_stripe";
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 }
@@ -38,6 +39,7 @@ function deleteAllEnvVars() {
   delete process.env.POSTMARK_BROADCAST_STREAM_ID;
   delete process.env.POSTMARK_INBOUND_STREAM_ID;
   delete process.env.POSTMARK_TRANSACTIONAL_STREAM_ID;
+  delete process.env.POSTMARK_FROM_ADDRESS;
   delete process.env.STRIPE_SECRET_KEY;
   delete process.env.STRIPE_WEBHOOK_SECRET;
 }
@@ -75,7 +77,7 @@ describe("registerPlatformKeys", () => {
     await registerPlatformKeys();
 
     const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/platform-keys"));
-    expect(platformKeyCalls).toHaveLength(11);
+    expect(platformKeyCalls).toHaveLength(12);
 
     const providers = platformKeyCalls.map((c) => c.body?.provider);
     expect(providers).toContain("anthropic");
@@ -87,6 +89,7 @@ describe("registerPlatformKeys", () => {
     expect(providers).toContain("postmark-broadcast-stream");
     expect(providers).toContain("postmark-inbound-stream");
     expect(providers).toContain("postmark-transactional-stream");
+    expect(providers).toContain("postmark-from-address");
     expect(providers).toContain("stripe");
     expect(providers).toContain("stripe-webhook");
 


### PR DESCRIPTION
## Summary
- Adds `postmark-from-address` to the platform keys registered at startup via key-service
- Required by postmark-service PR #39 which made `from` optional on `/send` and `/send/batch` — when omitted, postmark-service resolves a default sender address from key-service using this provider name
- Follows the existing idempotent upsert pattern; requires `POSTMARK_FROM_ADDRESS` env var in Railway

## Test plan
- [x] Existing startup tests updated and passing (12 platform keys, `postmark-from-address` asserted)
- [ ] Set `POSTMARK_FROM_ADDRESS` env var in Railway before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)