### PR TITLE
feat: deploy campaign email templates at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import emailsRoutes from "./routes/emails.js";
 import stripeRoutes from "./routes/stripe.js";
 import usersRoutes from "./routes/users.js";
 import { apiReference } from "@scalar/express-api-reference";
-import { registerPlatformKeys } from "./startup.js";
+import { registerPlatformKeys, deployEmailTemplates } from "./startup.js";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
@@ -113,6 +113,9 @@ const server = app.listen(Number(PORT), "::", () => {
   registerPlatformKeys().catch((err) => {
     console.error("[api-service] FATAL: Platform key registration failed:", err.message);
     process.exit(1);
+  });
+  deployEmailTemplates().catch((err) => {
+    console.error("[api-service] WARN: Email template deployment failed:", err.message);
   });
 });
 

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,5 +1,7 @@
 import { callExternalService, externalServices } from "./lib/service-client.js";
 
+// ── Platform keys ────────────────────────────────────────────────────────────
+
 const PLATFORM_KEYS: { provider: string; envVar: string }[] = [
   { provider: "anthropic", envVar: "ANTHROPIC_API_KEY" },
   { provider: "apollo", envVar: "APOLLO_API_KEY" },
@@ -35,4 +37,68 @@ export async function registerPlatformKeys(): Promise<void> {
   }
 
   console.log(`[api-service] ${PLATFORM_KEYS.length}/${PLATFORM_KEYS.length} platform keys registered successfully`);
+}
+
+// ── Email templates ──────────────────────────────────────────────────────────
+
+const LOGO_URL = "https://distribute.you/logo-horizontal.jpg";
+const DASHBOARD_URL = "https://dashboard.distribute.you";
+
+function emailLayout(content: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background-color:#f8fafc;font-family:system-ui,-apple-system,sans-serif;">
+  <div style="max-width:600px;margin:0 auto;padding:40px 20px;">
+    <img src="${LOGO_URL}" alt="Distribute" style="width:180px;margin-bottom:30px;" />
+    ${content}
+    <p style="color:#888;font-size:14px;margin-top:40px;padding-top:20px;border-top:1px solid #eee;">
+      Distribute — Your AI-powered outreach platform
+    </p>
+  </div>
+</body>
+</html>`;
+}
+
+const EMAIL_TEMPLATES = [
+  {
+    name: "campaign_created",
+    subject: "Campaign created: {{campaignName}}",
+    htmlBody: emailLayout(`
+      <h1 style="color:#1a1a1a;font-size:24px;margin-bottom:20px;">Campaign created</h1>
+      <p style="color:#4a4a4a;font-size:16px;line-height:1.6;margin-bottom:20px;">
+        Your campaign <strong>{{campaignName}}</strong> has been created and is now live.
+      </p>
+      <p style="margin-bottom:20px;">
+        <a href="${DASHBOARD_URL}" style="display:inline-block;background:#6366f1;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-size:16px;">View in dashboard</a>
+      </p>`),
+    textBody: `Campaign created: {{campaignName}}\n\nYour campaign "{{campaignName}}" has been created and is now live.\n\nView in dashboard: ${DASHBOARD_URL}`,
+  },
+  {
+    name: "campaign_stopped",
+    subject: "Campaign stopped: {{campaignName}}",
+    htmlBody: emailLayout(`
+      <h1 style="color:#1a1a1a;font-size:24px;margin-bottom:20px;">Campaign stopped</h1>
+      <p style="color:#4a4a4a;font-size:16px;line-height:1.6;margin-bottom:20px;">
+        Your campaign <strong>{{campaignName}}</strong> has been stopped.
+      </p>
+      <p style="color:#4a4a4a;font-size:16px;line-height:1.6;margin-bottom:20px;">
+        You can resume it at any time from your dashboard.
+      </p>
+      <p style="margin-bottom:20px;">
+        <a href="${DASHBOARD_URL}" style="display:inline-block;background:#6366f1;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-size:16px;">View in dashboard</a>
+      </p>`),
+    textBody: `Campaign stopped: {{campaignName}}\n\nYour campaign "{{campaignName}}" has been stopped. You can resume it at any time from your dashboard.\n\nView in dashboard: ${DASHBOARD_URL}`,
+  },
+];
+
+export async function deployEmailTemplates(): Promise<void> {
+  console.log("[api-service] Deploying email templates to transactional-email-service...");
+
+  await callExternalService(externalServices.transactionalEmail, "/templates", {
+    method: "PUT",
+    body: { templates: EMAIL_TEMPLATES },
+  });
+
+  console.log(`[api-service] ${EMAIL_TEMPLATES.length} email templates deployed successfully`);
 }

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -12,7 +12,7 @@ vi.mock("@distribute/runs-client", () => ({
   getRunsBatch: vi.fn().mockResolvedValue(new Map()),
 }));
 
-import { registerPlatformKeys } from "../../src/startup.js";
+import { registerPlatformKeys, deployEmailTemplates } from "../../src/startup.js";
 
 function setAllEnvVars() {
   process.env.ANTHROPIC_API_KEY = "sk-ant-test";
@@ -131,5 +131,85 @@ describe("registerPlatformKeys", () => {
     delete process.env.STRIPE_SECRET_KEY;
 
     await expect(registerPlatformKeys()).rejects.toThrow("STRIPE_SECRET_KEY");
+  });
+});
+
+describe("deployEmailTemplates", () => {
+  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown> }>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      fetchCalls.push({ url, method: init?.method, body });
+
+      if (url.includes("/templates")) {
+        return new Response(
+          JSON.stringify({
+            templates: (body?.templates as unknown[])?.map((t: any) => ({ name: t.name, action: "updated" })) ?? [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify({}), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+  });
+
+  it("should deploy campaign_created and campaign_stopped templates via PUT /templates", async () => {
+    await deployEmailTemplates();
+
+    const templateCalls = fetchCalls.filter((c) => c.url.includes("/templates"));
+    expect(templateCalls).toHaveLength(1);
+
+    const call = templateCalls[0]!;
+    expect(call.method).toBe("PUT");
+
+    const templates = call.body?.templates as Array<{ name: string; subject: string; htmlBody: string; textBody: string }>;
+    expect(templates).toHaveLength(2);
+
+    const names = templates.map((t) => t.name);
+    expect(names).toContain("campaign_created");
+    expect(names).toContain("campaign_stopped");
+  });
+
+  it("should use Distribute branding with working logo URL", async () => {
+    await deployEmailTemplates();
+
+    const call = fetchCalls.find((c) => c.url.includes("/templates"))!;
+    const templates = call.body?.templates as Array<{ name: string; htmlBody: string }>;
+
+    for (const tpl of templates) {
+      expect(tpl.htmlBody).toContain("https://distribute.you/logo-horizontal.jpg");
+      expect(tpl.htmlBody).toContain("Distribute");
+      expect(tpl.htmlBody).toContain("https://dashboard.distribute.you");
+      expect(tpl.htmlBody).not.toContain("mcpfactory");
+      expect(tpl.htmlBody).not.toContain("MCP Factory");
+    }
+  });
+
+  it("should include {{campaignName}} interpolation variable", async () => {
+    await deployEmailTemplates();
+
+    const call = fetchCalls.find((c) => c.url.includes("/templates"))!;
+    const templates = call.body?.templates as Array<{ name: string; htmlBody: string; subject: string }>;
+
+    for (const tpl of templates) {
+      expect(tpl.subject).toContain("{{campaignName}}");
+      expect(tpl.htmlBody).toContain("{{campaignName}}");
+    }
+  });
+
+  it("should throw when transactional-email-service returns an error", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => {
+      return new Response(JSON.stringify({ error: "Service unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await expect(deployEmailTemplates()).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Campaign email templates (`campaign_created`, `campaign_stopped`) were hardcoded in transactional-email-service with broken MCP Factory branding (`https://mcpfactory.org/logo-title.jpg` → 404)
- Moved template ownership to api-service: deploys templates via `PUT /templates` at cold start, matching the existing pattern for platform keys
- Uses correct Distribute branding with working logo (`https://distribute.you/logo-horizontal.jpg`) and dashboard link

## Test plan
- [x] 4 new unit tests for `deployEmailTemplates()` (template names, branding, interpolation vars, error handling)
- [x] All 450 existing tests pass
- [ ] After deploy: trigger a campaign stop and verify the email has the Distribute logo and correct branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)