### PR TITLE
feat: deploy 5 additional email templates at startup

### DIFF
--- a/src/routes/activity.ts
+++ b/src/routes/activity.ts
@@ -18,6 +18,7 @@ router.post("/activity", authenticate, requireOrg, requireUser, async (req: Auth
         eventType: "user_active",
         userId: req.userId,
         orgId: req.orgId,
+        metadata: { timestamp: new Date().toISOString() },
       },
     }).catch((err) => console.warn("[activity] Transactional email failed:", err.message));
 

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -61,6 +61,7 @@ function emailLayout(content: string): string {
 }
 
 const EMAIL_TEMPLATES = [
+  // ── Campaign templates (user-facing, branded layout) ───────────────────────
   {
     name: "campaign_created",
     subject: "Campaign created: {{campaignName}}",
@@ -89,6 +90,63 @@ const EMAIL_TEMPLATES = [
         <a href="${DASHBOARD_URL}" style="display:inline-block;background:#6366f1;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-size:16px;">View in dashboard</a>
       </p>`),
     textBody: `Campaign stopped: {{campaignName}}\n\nYour campaign "{{campaignName}}" has been stopped. You can resume it at any time from your dashboard.\n\nView in dashboard: ${DASHBOARD_URL}`,
+  },
+
+  // ── User-facing templates (branded layout) ─────────────────────────────────
+  {
+    name: "waitlist",
+    subject: "Welcome to the Distribute Waitlist!",
+    htmlBody: emailLayout(`
+      <h1 style="color:#1a1a1a;font-size:24px;margin-bottom:20px;">You're on the list!</h1>
+      <p style="color:#4a4a4a;font-size:16px;line-height:1.6;margin-bottom:20px;">
+        Thanks for joining the Distribute waitlist. We'll notify you as soon as we're ready to launch.
+      </p>
+      <p style="color:#4a4a4a;font-size:16px;line-height:1.6;margin-bottom:20px;">
+        In the meantime, you can:
+      </p>
+      <ul style="color:#4a4a4a;font-size:16px;line-height:1.8;margin-bottom:30px;">
+        <li><a href="https://docs.distribute.you" style="color:#6366f1;">Read the documentation</a></li>
+        <li><a href="https://github.com/shamanic-technologies/distribute" style="color:#6366f1;">Star us on GitHub</a></li>
+      </ul>`),
+    textBody: "You're on the list!\n\nThanks for joining the Distribute waitlist. We'll notify you as soon as we're ready to launch.\n\nIn the meantime, you can:\n- Read the documentation: https://docs.distribute.you\n- Star us on GitHub: https://github.com/shamanic-technologies/distribute",
+  },
+  {
+    name: "welcome",
+    subject: "Welcome to Distribute!",
+    htmlBody: emailLayout(`
+      <h1 style="color:#1a1a1a;font-size:24px;margin-bottom:20px;">Welcome aboard!</h1>
+      <p style="color:#4a4a4a;font-size:16px;line-height:1.6;margin-bottom:20px;">
+        Your Distribute account is ready. You can now create campaigns, find leads, and automate your outreach.
+      </p>
+      <p style="color:#4a4a4a;font-size:16px;line-height:1.6;margin-bottom:20px;">
+        Get started:
+      </p>
+      <ul style="color:#4a4a4a;font-size:16px;line-height:1.8;margin-bottom:30px;">
+        <li><a href="${DASHBOARD_URL}" style="color:#6366f1;">Open your dashboard</a></li>
+        <li><a href="https://docs.distribute.you" style="color:#6366f1;">Read the documentation</a></li>
+      </ul>`),
+    textBody: `Welcome aboard!\n\nYour Distribute account is ready. You can now create campaigns, find leads, and automate your outreach.\n\nGet started:\n- Open your dashboard: ${DASHBOARD_URL}\n- Read the documentation: https://docs.distribute.you`,
+  },
+
+  // ── Admin notification templates (plain, no layout) ────────────────────────
+  // Caller must pass { timestamp: new Date().toISOString() } in metadata
+  {
+    name: "signup_notification",
+    subject: "New signup: {{email}}",
+    htmlBody: "<p>New user signed up: <strong>{{email}}</strong> at {{timestamp}}</p>",
+    textBody: "New user signed up: {{email}} at {{timestamp}}",
+  },
+  {
+    name: "signin_notification",
+    subject: "Sign-in: {{email}}",
+    htmlBody: "<p>User signed in: <strong>{{email}}</strong> at {{timestamp}}</p>",
+    textBody: "User signed in: {{email}} at {{timestamp}}",
+  },
+  {
+    name: "user_active",
+    subject: "User active: {{email}}",
+    htmlBody: "<p>User is back: <strong>{{email}}</strong> at {{timestamp}}</p>",
+    textBody: "User is back: {{email}} at {{timestamp}}",
   },
 ];
 

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -158,7 +158,7 @@ describe("deployEmailTemplates", () => {
     });
   });
 
-  it("should deploy campaign_created and campaign_stopped templates via PUT /templates", async () => {
+  it("should deploy all 7 templates via PUT /templates", async () => {
     await deployEmailTemplates();
 
     const templateCalls = fetchCalls.filter((c) => c.url.includes("/templates"));
@@ -168,37 +168,78 @@ describe("deployEmailTemplates", () => {
     expect(call.method).toBe("PUT");
 
     const templates = call.body?.templates as Array<{ name: string; subject: string; htmlBody: string; textBody: string }>;
-    expect(templates).toHaveLength(2);
+    expect(templates).toHaveLength(7);
 
     const names = templates.map((t) => t.name);
     expect(names).toContain("campaign_created");
     expect(names).toContain("campaign_stopped");
+    expect(names).toContain("waitlist");
+    expect(names).toContain("welcome");
+    expect(names).toContain("signup_notification");
+    expect(names).toContain("signin_notification");
+    expect(names).toContain("user_active");
   });
 
-  it("should use Distribute branding with working logo URL", async () => {
+  it("should use Distribute branding on user-facing templates", async () => {
     await deployEmailTemplates();
 
     const call = fetchCalls.find((c) => c.url.includes("/templates"))!;
     const templates = call.body?.templates as Array<{ name: string; htmlBody: string }>;
+    const branded = templates.filter((t) =>
+      ["campaign_created", "campaign_stopped", "waitlist", "welcome"].includes(t.name),
+    );
 
-    for (const tpl of templates) {
+    expect(branded).toHaveLength(4);
+    for (const tpl of branded) {
       expect(tpl.htmlBody).toContain("https://distribute.you/logo-horizontal.jpg");
       expect(tpl.htmlBody).toContain("Distribute");
-      expect(tpl.htmlBody).toContain("https://dashboard.distribute.you");
       expect(tpl.htmlBody).not.toContain("mcpfactory");
       expect(tpl.htmlBody).not.toContain("MCP Factory");
     }
   });
 
-  it("should include {{campaignName}} interpolation variable", async () => {
+  it("should include {{campaignName}} interpolation in campaign templates", async () => {
     await deployEmailTemplates();
 
     const call = fetchCalls.find((c) => c.url.includes("/templates"))!;
     const templates = call.body?.templates as Array<{ name: string; htmlBody: string; subject: string }>;
+    const campaignTemplates = templates.filter((t) => t.name.startsWith("campaign_"));
 
-    for (const tpl of templates) {
+    for (const tpl of campaignTemplates) {
       expect(tpl.subject).toContain("{{campaignName}}");
       expect(tpl.htmlBody).toContain("{{campaignName}}");
+    }
+  });
+
+  it("should include {{timestamp}} interpolation in admin notification templates", async () => {
+    await deployEmailTemplates();
+
+    const call = fetchCalls.find((c) => c.url.includes("/templates"))!;
+    const templates = call.body?.templates as Array<{ name: string; htmlBody: string; textBody: string }>;
+    const adminTemplates = templates.filter((t) =>
+      ["signup_notification", "signin_notification", "user_active"].includes(t.name),
+    );
+
+    expect(adminTemplates).toHaveLength(3);
+    for (const tpl of adminTemplates) {
+      expect(tpl.htmlBody).toContain("{{timestamp}}");
+      expect(tpl.textBody).toContain("{{timestamp}}");
+      expect(tpl.htmlBody).toContain("{{email}}");
+    }
+  });
+
+  it("admin notification templates should not use branded layout", async () => {
+    await deployEmailTemplates();
+
+    const call = fetchCalls.find((c) => c.url.includes("/templates"))!;
+    const templates = call.body?.templates as Array<{ name: string; htmlBody: string }>;
+    const adminTemplates = templates.filter((t) =>
+      ["signup_notification", "signin_notification", "user_active"].includes(t.name),
+    );
+
+    for (const tpl of adminTemplates) {
+      expect(tpl.htmlBody).not.toContain("logo-horizontal.jpg");
+      expect(tpl.htmlBody).not.toContain("<!DOCTYPE html>");
     }
   });
 


### PR DESCRIPTION
## Summary
- Deploys 5 new email templates to transactional-email-service at startup: `waitlist`, `welcome`, `signup_notification`, `signin_notification`, `user_active`
- `waitlist` and `welcome` use the existing Distribute branded layout
- Admin notification templates (`signup_notification`, `signin_notification`, `user_active`) use plain HTML with `{{email}}` and `{{timestamp}}` interpolation
- Updates `POST /v1/activity` to pass `{ timestamp: new Date().toISOString() }` in metadata for the `user_active` event (required since DB templates use `{{timestamp}}` interpolation instead of generating it at render time)

## Context
transactional-email-service #49 removed all hardcoded templates. These 5 were previously built-in and must now be deployed via `PUT /templates` at startup, matching the pattern already used for `campaign_created` and `campaign_stopped` (#97).

## Test plan
- [x] All 7 templates deployed via single PUT call (was 2, now 7)
- [x] User-facing templates use Distribute branding
- [x] Campaign templates include `{{campaignName}}` interpolation
- [x] Admin templates include `{{timestamp}}` and `{{email}}` interpolation
- [x] Admin templates do NOT use branded layout
- [x] Error handling when service is unavailable
- [x] Full test suite passes (452 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)