### PR TITLE
fix: send required identity headers in template deployment

### DIFF
--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { callExternalService, externalServices } from "./lib/service-client.js";
 
 // ── Platform keys ────────────────────────────────────────────────────────────
@@ -155,6 +156,11 @@ export async function deployEmailTemplates(): Promise<void> {
 
   await callExternalService(externalServices.transactionalEmail, "/templates", {
     method: "PUT",
+    headers: {
+      "x-org-id": "00000000-0000-0000-0000-000000000000",
+      "x-user-id": "00000000-0000-0000-0000-000000000000",
+      "x-run-id": randomUUID(),
+    },
     body: { templates: EMAIL_TEMPLATES },
   });
 

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -135,7 +135,7 @@ describe("registerPlatformKeys", () => {
 });
 
 describe("deployEmailTemplates", () => {
-  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown> }>;
+  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown>; headers?: Record<string, string> }>;
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -143,7 +143,8 @@ describe("deployEmailTemplates", () => {
 
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      fetchCalls.push({ url, method: init?.method, body });
+      const headers = init?.headers as Record<string, string> | undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
 
       if (url.includes("/templates")) {
         return new Response(
@@ -241,6 +242,16 @@ describe("deployEmailTemplates", () => {
       expect(tpl.htmlBody).not.toContain("logo-horizontal.jpg");
       expect(tpl.htmlBody).not.toContain("<!DOCTYPE html>");
     }
+  });
+
+  it("should send required identity headers for template deployment", async () => {
+    await deployEmailTemplates();
+
+    const call = fetchCalls.find((c) => c.url.includes("/templates"))!;
+    expect(call.headers).toHaveProperty("x-org-id", "00000000-0000-0000-0000-000000000000");
+    expect(call.headers).toHaveProperty("x-user-id", "00000000-0000-0000-0000-000000000000");
+    expect(call.headers).toHaveProperty("x-run-id");
+    expect(call.headers!["x-run-id"]).toBeTruthy();
   });
 
   it("should throw when transactional-email-service returns an error", async () => {


### PR DESCRIPTION
## Summary
- `deployEmailTemplates()` was calling `PUT /templates` on the transactional-email-service without the required `x-org-id`, `x-user-id`, and `x-run-id` headers
- This caused a silent 400 at startup, so templates were never registered
- All subsequent email sends failed with "No template for event" (user_active, signin_notification, campaign_stopped)
- Fix: pass system identity headers (nil UUID for org/user, random UUID for run-id) in the deployment call

## Test plan
- [x] New test verifies identity headers are sent in template deployment call
- [x] All 455 existing tests pass (61 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)