### PR TITLE
fix: resolve deprecated workflow names before creating campaigns

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1922,6 +1922,26 @@
               }
             }
           },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Workflow is deprecated with no active replacement",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal error",
             "content": {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -5,6 +5,70 @@ import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 import { CreateCampaignRequestSchema, BatchStatsRequestSchema } from "../schemas.js";
 
+interface WorkflowListItem {
+  id: string;
+  name: string;
+  status: "active" | "deprecated";
+  upgradedTo: string | null;
+}
+
+/**
+ * Resolve a workflow name to its active replacement.
+ * If the workflow is deprecated and has an upgrade, follows the chain.
+ * Throws with statusCode 404 if not found, 410 if deprecated with no upgrade.
+ */
+async function resolveActiveWorkflowName(
+  workflowName: string,
+  headers: Record<string, string>,
+): Promise<string> {
+  const result = await callExternalService<{ workflows: WorkflowListItem[] }>(
+    externalServices.workflow,
+    "/workflows?status=all",
+    { headers },
+  );
+  const workflows = result.workflows ?? [];
+  const byName = new Map(workflows.map((w) => [w.name, w]));
+  const byId = new Map(workflows.map((w) => [w.id, w]));
+
+  const wf = byName.get(workflowName);
+  if (!wf) {
+    const err = new Error(`Workflow "${workflowName}" not found`) as Error & { statusCode: number };
+    err.statusCode = 404;
+    throw err;
+  }
+  if (wf.status === "active") return wf.name;
+
+  // Follow the upgrade chain (max 10 hops to prevent loops)
+  let current = wf;
+  for (let i = 0; i < 10; i++) {
+    if (!current.upgradedTo) {
+      const err = new Error(
+        `Workflow "${workflowName}" is deprecated with no replacement`,
+      ) as Error & { statusCode: number };
+      err.statusCode = 410;
+      throw err;
+    }
+    const next = byId.get(current.upgradedTo);
+    if (!next) {
+      const err = new Error(
+        `Workflow "${workflowName}" is deprecated; replacement not found`,
+      ) as Error & { statusCode: number };
+      err.statusCode = 410;
+      throw err;
+    }
+    if (next.status === "active") {
+      console.log(`[api-service] Workflow "${workflowName}" is deprecated, auto-resolved to "${next.name}"`);
+      return next.name;
+    }
+    current = next;
+  }
+  const err = new Error(
+    `Workflow "${workflowName}" has a circular or too-long deprecation chain`,
+  ) as Error & { statusCode: number };
+  err.statusCode = 410;
+  throw err;
+}
+
 const router = Router();
 
 interface EmailGatewayStats {
@@ -136,29 +200,36 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       maxLeads: parsed.data.maxLeads,
     });
 
-    // 1. Upsert brand to get brandId
-    console.log("[api-service] POST /v1/campaigns \u2014 step 1: upserting brand", { brandUrl, orgId: req.orgId });
-    const brandResult = await callExternalService<{ brandId: string }>(
-      externalServices.brand,
-      "/brands",
-      {
-        method: "POST",
-        headers: buildInternalHeaders(req),
-        body: {
-          orgId: req.orgId,
-          url: brandUrl,
-          userId: req.userId,
-        },
-      }
-    );
-    console.log("[api-service] POST /v1/campaigns \u2014 step 1 done: brand upserted", { brandId: brandResult.brandId });
+    // 1. Upsert brand + resolve workflow name in parallel
+    console.log("[api-service] POST /v1/campaigns \u2014 step 1: upserting brand + resolving workflow", { brandUrl, orgId: req.orgId, workflowName: parsed.data.workflowName });
+    const [brandResult, resolvedWorkflowName] = await Promise.all([
+      callExternalService<{ brandId: string }>(
+        externalServices.brand,
+        "/brands",
+        {
+          method: "POST",
+          headers: buildInternalHeaders(req),
+          body: {
+            orgId: req.orgId,
+            url: brandUrl,
+            userId: req.userId,
+          },
+        }
+      ),
+      resolveActiveWorkflowName(parsed.data.workflowName, buildInternalHeaders(req)),
+    ]);
+    console.log("[api-service] POST /v1/campaigns \u2014 step 1 done: brand upserted, workflow resolved", {
+      brandId: brandResult.brandId,
+      requestedWorkflow: parsed.data.workflowName,
+      resolvedWorkflow: resolvedWorkflowName,
+    });
 
     // 2. Forward to campaign-service (run tracking via x-run-id header)
     // Derive `type` from workflowName for campaign-service backward compat
-    const { workflowName, ...restData } = parsed.data;
+    const { workflowName: _requestedWorkflowName, ...restData } = parsed.data;
     const body: Record<string, unknown> = {
       ...restData,
-      workflowName,
+      workflowName: resolvedWorkflowName,
       type: "cold-email-outreach",
       orgId: req.orgId,
       brandId: brandResult.brandId,
@@ -885,4 +956,5 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
   });
 });
 
+export { resolveActiveWorkflowName };
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -245,6 +245,8 @@ registry.registerPath({
       content: errorContent,
     },
     401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Workflow not found", content: errorContent },
+    410: { description: "Workflow is deprecated with no active replacement", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
 });

--- a/tests/unit/brand-service-run-id.regression.test.ts
+++ b/tests/unit/brand-service-run-id.regression.test.ts
@@ -120,6 +120,10 @@ describe("campaign brand upsert sends internal headers", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url: url as string, method: init?.method || "GET", headers, body });
 
+      // Workflow resolution
+      if (typeof url === "string" && url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [{ id: "wf-1", name: "sales-email-cold-outreach-sienna", status: "active", upgradedTo: null }] }) };
+      }
       // Brand upsert response
       if (typeof url === "string" && url.includes("/brands") && init?.method === "POST") {
         return { ok: true, json: () => Promise.resolve({ brandId: "brand_abc" }) };

--- a/tests/unit/campaign-deprecated-workflow.test.ts
+++ b/tests/unit/campaign-deprecated-workflow.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock auth middleware
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.appId = "distribute";
+    req.authType = "user_key";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+// Mock runs-client
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import campaignRouter from "../../src/routes/campaigns.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignRouter);
+  return app;
+}
+
+const validCampaignBody = {
+  name: "Test Campaign",
+  workflowName: "sales-email-cold-outreach-pharaoh",
+  brandUrl: "https://example.com",
+  targetAudience: "CTOs at SaaS startups",
+  targetOutcome: "Book demos",
+  valueForTarget: "Enterprise analytics at startup pricing",
+  urgency: "Limited time offer",
+  scarcity: "10 spots only",
+  riskReversal: "14-day free trial",
+  socialProof: "Used by 100+ companies",
+};
+
+const activeWorkflow = {
+  id: "wf-active-1",
+  name: "sales-email-cold-outreach-pharaoh",
+  status: "active",
+  upgradedTo: null,
+};
+
+const deprecatedWorkflow = {
+  id: "wf-deprecated-1",
+  name: "sales-email-cold-outreach-pharaoh",
+  status: "deprecated",
+  upgradedTo: "wf-active-2",
+};
+
+const replacementWorkflow = {
+  id: "wf-active-2",
+  name: "sales-email-cold-outreach-solstice",
+  status: "active",
+  upgradedTo: null,
+};
+
+describe("POST /v1/campaigns — deprecated workflow resolution", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes through when workflow is active", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [activeWorkflow] }) };
+      }
+      if (url.includes("/brands")) {
+        return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
+      }
+      if (url.includes("/campaigns")) {
+        return { ok: true, json: () => Promise.resolve({ campaign: { id: "camp-1", status: "ongoing" } }) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).post("/v1/campaigns").send(validCampaignBody);
+
+    expect(res.status).toBe(200);
+
+    // Check campaign-service was called with original workflow name
+    const campaignCall = (global.fetch as any).mock.calls.find(
+      (c: any) => c[0].includes("/campaigns") && c[1]?.method === "POST",
+    );
+    const body = JSON.parse(campaignCall[1].body);
+    expect(body.workflowName).toBe("sales-email-cold-outreach-pharaoh");
+  });
+
+  it("auto-resolves deprecated workflow to its active replacement", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/workflows?status=all")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ workflows: [deprecatedWorkflow, replacementWorkflow] }),
+        };
+      }
+      if (url.includes("/brands")) {
+        return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
+      }
+      if (url.includes("/campaigns")) {
+        return { ok: true, json: () => Promise.resolve({ campaign: { id: "camp-1", status: "ongoing" } }) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).post("/v1/campaigns").send(validCampaignBody);
+
+    expect(res.status).toBe(200);
+
+    // Campaign-service should receive the resolved (active) workflow name
+    const campaignCall = (global.fetch as any).mock.calls.find(
+      (c: any) => c[0].includes("/campaigns") && c[1]?.method === "POST",
+    );
+    const body = JSON.parse(campaignCall[1].body);
+    expect(body.workflowName).toBe("sales-email-cold-outreach-solstice");
+  });
+
+  it("returns 404 when workflow name does not exist", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [] }) };
+      }
+      if (url.includes("/brands")) {
+        return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).post("/v1/campaigns").send(validCampaignBody);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("returns 410 when workflow is deprecated with no replacement", async () => {
+    const deadEnd = { ...deprecatedWorkflow, upgradedTo: null };
+
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [deadEnd] }) };
+      }
+      if (url.includes("/brands")) {
+        return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).post("/v1/campaigns").send(validCampaignBody);
+
+    expect(res.status).toBe(410);
+    expect(res.body.error).toMatch(/deprecated/i);
+  });
+
+  it("follows multi-hop upgrade chain to active workflow", async () => {
+    const v1 = { id: "wf-v1", name: "sales-email-cold-outreach-pharaoh", status: "deprecated", upgradedTo: "wf-v2" };
+    const v2 = { id: "wf-v2", name: "sales-email-cold-outreach-interim", status: "deprecated", upgradedTo: "wf-v3" };
+    const v3 = { id: "wf-v3", name: "sales-email-cold-outreach-solstice", status: "active", upgradedTo: null };
+
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [v1, v2, v3] }) };
+      }
+      if (url.includes("/brands")) {
+        return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
+      }
+      if (url.includes("/campaigns")) {
+        return { ok: true, json: () => Promise.resolve({ campaign: { id: "camp-1", status: "ongoing" } }) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).post("/v1/campaigns").send(validCampaignBody);
+
+    expect(res.status).toBe(200);
+
+    const campaignCall = (global.fetch as any).mock.calls.find(
+      (c: any) => c[0].includes("/campaigns") && c[1]?.method === "POST",
+    );
+    const body = JSON.parse(campaignCall[1].body);
+    expect(body.workflowName).toBe("sales-email-cold-outreach-solstice");
+  });
+});

--- a/tests/unit/campaign-duplicate-name.test.ts
+++ b/tests/unit/campaign-duplicate-name.test.ts
@@ -56,6 +56,9 @@ describe("Campaign duplicate name handling (409 Conflict)", () => {
 
   it("POST /v1/campaigns should return 409 when campaign name already exists", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [{ id: "wf-1", name: "sales-email-cold-outreach-v1", status: "active", upgradedTo: null }] }) };
+      }
       if (url.includes("/brands")) {
         return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
       }

--- a/tests/unit/campaign-key-validation.test.ts
+++ b/tests/unit/campaign-key-validation.test.ts
@@ -62,6 +62,9 @@ describe("POST /v1/campaigns — no gateway-level key validation", () => {
 
   it("should forward campaign creation without calling required-providers or org keys", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [{ id: "wf-1", name: "sales-email-cold-outreach-v1", status: "active", upgradedTo: null }] }) };
+      }
       if (url.includes("/brands")) return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
       if (url.includes("/campaigns") && !url.includes("/workflows")) {
         return { ok: true, json: () => Promise.resolve({ campaign: { id: "camp-1", status: "ongoing" } }) };
@@ -83,6 +86,9 @@ describe("POST /v1/campaigns — no gateway-level key validation", () => {
 
   it("should not include keySource in campaign-service request body", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [{ id: "wf-1", name: "sales-email-cold-outreach-v1", status: "active", upgradedTo: null }] }) };
+      }
       if (url.includes("/brands")) return { ok: true, json: () => Promise.resolve({ brandId: "brand-123" }) };
       if (url.includes("/campaigns") && !url.includes("/workflows")) {
         return { ok: true, json: () => Promise.resolve({ campaign: { id: "camp-1", status: "ongoing" } }) };

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -54,6 +54,11 @@ describe("POST /v1/campaigns with targetAudience", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
+      // Workflow resolution
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [{ id: "wf-1", name: "sales-email-cold-outreach-sienna", status: "active", upgradedTo: null }] }) };
+      }
+
       // Brand upsert
       if (url.includes("/brands") && init?.method === "POST") {
         return {
@@ -279,6 +284,9 @@ describe("POST /v1/campaigns with targetAudience", () => {
 
   it("should fail when brand upsert fails", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes("/workflows?status=all")) {
+        return { ok: true, json: () => Promise.resolve({ workflows: [{ id: "wf-1", name: "sales-email-cold-outreach-sienna", status: "active", upgradedTo: null }] }) };
+      }
       if (url.includes("/brands") && init?.method === "POST") {
         return {
           ok: false,


### PR DESCRIPTION
## Summary
- Pre-validates workflow names against workflow-service before creating campaigns
- Auto-resolves deprecated workflows to their active replacement (follows upgrade chain)
- Returns 404 for nonexistent workflows and 410 for deprecated workflows with no replacement
- Prevents campaigns from getting stuck in "ongoing" status with no running workflow

## Test plan
- [x] Active workflow passes through unchanged
- [x] Deprecated workflow auto-resolves to active replacement
- [x] Multi-hop upgrade chain resolves correctly
- [x] Returns 404 for nonexistent workflow names
- [x] Returns 410 for deprecated workflows with no replacement
- [x] All 454 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)