### PR TITLE
feat: PUT /internal/emails/templates for platform template deploy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -58,6 +58,10 @@
     {
       "name": "Billing",
       "description": "Billing, credits, and checkout"
+    },
+    {
+      "name": "Internal",
+      "description": "Platform-level operations (API key auth, no identity headers)"
     }
   ],
   "components": {
@@ -66,6 +70,12 @@
         "type": "http",
         "scheme": "bearer",
         "description": "Bearer token authentication.\n\nUse an API key (`distrib.usr_*`) as your Bearer token. Create one via `POST /v1/api-keys` or in the dashboard.\n\nYour key carries your org and user identity. No extra headers needed."
+      },
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "Platform API key for internal/admin operations.\n\nUsed for cold-start operations (e.g. template deployment) where no user session exists."
       }
     },
     "schemas": {
@@ -5584,6 +5594,84 @@
         "security": [
           {
             "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeployEmailTemplatesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Templates deployed"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          }
+        ]
+      }
+    },
+    "/internal/emails/templates": {
+      "put": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Deploy email templates (platform)",
+        "description": "Platform-level template deployment — no identity headers required. Authenticated by X-API-Key only. Used at cold start when no Clerk session exists. Same body format as PUT /v1/emails/templates.",
+        "security": [
+          {
+            "apiKeyAuth": []
           }
         ],
         "requestBody": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -67,6 +67,7 @@ Authorization: Bearer distrib.usr_abc123...
     { name: "Activity", description: "User activity tracking" },
     { name: "Chat", description: "AI chat with SSE streaming" },
     { name: "Billing", description: "Billing, credits, and checkout" },
+    { name: "Internal", description: "Platform-level operations (API key auth, no identity headers)" },
   ],
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import chatRoutes from "./routes/chat.js";
 import billingRoutes from "./routes/billing.js";
 import { stripeWebhookHandler } from "./routes/billing.js";
 import emailsRoutes from "./routes/emails.js";
+import internalEmailsRoutes from "./routes/internal-emails.js";
 import stripeRoutes from "./routes/stripe.js";
 import usersRoutes from "./routes/users.js";
 import { apiReference } from "@scalar/express-api-reference";
@@ -76,6 +77,9 @@ app.use(
 // Public routes
 app.use(healthRoutes);
 app.use(performanceRoutes);
+
+// Internal platform routes (API key only, no identity)
+app.use("/internal", internalEmailsRoutes);
 
 // Authenticated routes
 app.use("/v1", meRoutes);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -177,6 +177,24 @@ async function resolveExternalIds(
 }
 
 /**
+ * Platform-level auth — validates X-API-Key only.
+ * No identity resolution, no run tracking.
+ * Used for platform operations at cold start (e.g. template deployment).
+ */
+export async function authenticatePlatform(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) {
+  const apiKey = req.headers["x-api-key"] as string | undefined;
+  if (!apiKey || apiKey !== process.env.ADMIN_DISTRIBUTE_API_KEY) {
+    return res.status(401).json({ error: "Invalid or missing platform API key" });
+  }
+  req.authType = "admin";
+  return next();
+}
+
+/**
  * Require organization context
  */
 export function requireOrg(

--- a/src/routes/internal-emails.ts
+++ b/src/routes/internal-emails.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import { authenticatePlatform, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { DeployEmailTemplatesRequestSchema } from "../schemas.js";
+
+const router = Router();
+
+/**
+ * PUT /internal/emails/templates
+ * Platform-level template deployment — no identity headers required.
+ * Authenticated by X-API-Key (ADMIN_DISTRIBUTE_API_KEY) only.
+ * Used by the dashboard at cold start when no Clerk session exists.
+ */
+router.put("/emails/templates", authenticatePlatform, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = DeployEmailTemplatesRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+
+    const result = await callExternalService(
+      externalServices.transactionalEmail,
+      "/templates",
+      {
+        method: "PUT",
+        body: {
+          ...parsed.data,
+        },
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Deploy templates (internal) error:", error);
+    res.status(500).json({ error: error.message || "Failed to deploy templates" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -22,6 +22,18 @@ registry.registerComponent("securitySchemes", "bearerAuth", {
 
 const authed: Record<string, string[]>[] = [{ bearerAuth: [] }];
 
+registry.registerComponent("securitySchemes", "apiKeyAuth", {
+  type: "apiKey",
+  in: "header",
+  name: "X-API-Key",
+  description:
+    "Platform API key for internal/admin operations.\n\n" +
+    "Used for cold-start operations (e.g. template deployment) " +
+    "where no user session exists.",
+});
+
+const platformAuth: Record<string, string[]>[] = [{ apiKeyAuth: [] }];
+
 // ---------------------------------------------------------------------------
 // Common schemas
 // ---------------------------------------------------------------------------
@@ -1636,6 +1648,31 @@ registry.registerPath({
     "Idempotent upsert of email templates. Safe to call on every cold start. " +
     "Templates support {{variable}} interpolation from metadata passed at send time.",
   security: authed,
+  request: {
+    body: {
+      content: { "application/json": { schema: DeployEmailTemplatesRequestSchema } },
+    },
+  },
+  responses: {
+    200: { description: "Templates deployed" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ── Internal (platform-level) ──
+
+registry.registerPath({
+  method: "put",
+  path: "/internal/emails/templates",
+  tags: ["Internal"],
+  summary: "Deploy email templates (platform)",
+  description:
+    "Platform-level template deployment — no identity headers required. " +
+    "Authenticated by X-API-Key only. Used at cold start when no Clerk session exists. " +
+    "Same body format as PUT /v1/emails/templates.",
+  security: platformAuth,
   request: {
     body: {
       content: { "application/json": { schema: DeployEmailTemplatesRequestSchema } },

--- a/tests/unit/internal-emails.test.ts
+++ b/tests/unit/internal-emails.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Do NOT mock auth — we test the real authenticatePlatform middleware
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return {
+    ...actual,
+    // Only keep authenticatePlatform real; stub the others to avoid import issues
+    authenticate: (req: any, _res: any, next: any) => {
+      next();
+    },
+    requireOrg: (_req: any, _res: any, next: any) => {
+      next();
+    },
+    requireUser: (_req: any, _res: any, next: any) => {
+      next();
+    },
+  };
+});
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import internalEmailsRoutes from "../../src/routes/internal-emails.js";
+
+const VALID_API_KEY = "test-admin-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/internal", internalEmailsRoutes);
+  return app;
+}
+
+describe("PUT /internal/emails/templates", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ templates: [{ name: "campaign_created", action: "created" }] }),
+      };
+    });
+    app = createApp();
+  });
+
+  it("should deploy templates with valid API key and no identity headers", async () => {
+    const res = await request(app)
+      .put("/internal/emails/templates")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        templates: [
+          {
+            name: "campaign_created",
+            subject: "Campaign Created",
+            htmlBody: "<h1>Campaign {{campaignName}} created</h1>",
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.templates).toHaveLength(1);
+
+    const deployCall = fetchCalls.find((c) => c.url.includes("/templates"));
+    expect(deployCall).toBeDefined();
+    expect(deployCall!.method).toBe("PUT");
+    expect(deployCall!.body).toMatchObject({
+      templates: [
+        {
+          name: "campaign_created",
+          subject: "Campaign Created",
+          htmlBody: "<h1>Campaign {{campaignName}} created</h1>",
+        },
+      ],
+    });
+    // No identity headers forwarded
+    expect(deployCall!.headers!["x-org-id"]).toBeUndefined();
+    expect(deployCall!.headers!["x-user-id"]).toBeUndefined();
+    expect(deployCall!.headers!["x-run-id"]).toBeUndefined();
+  });
+
+  it("should return 401 without API key", async () => {
+    const res = await request(app)
+      .put("/internal/emails/templates")
+      .send({
+        templates: [
+          { name: "test", subject: "Test", htmlBody: "<p>test</p>" },
+        ],
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 401 with wrong API key", async () => {
+    const res = await request(app)
+      .put("/internal/emails/templates")
+      .set("X-API-Key", "wrong-key")
+      .send({
+        templates: [
+          { name: "test", subject: "Test", htmlBody: "<p>test</p>" },
+        ],
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 400 when templates array is empty", async () => {
+    const res = await request(app)
+      .put("/internal/emails/templates")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ templates: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when templates is missing", async () => {
+    const res = await request(app)
+      .put("/internal/emails/templates")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it("should deploy multiple templates at once", async () => {
+    const templates = [
+      { name: "campaign_created", subject: "Campaign Created", htmlBody: "<h1>Created</h1>" },
+      { name: "campaign_stopped", subject: "Campaign Stopped", htmlBody: "<h1>Stopped</h1>" },
+      { name: "waitlist_welcome", subject: "Welcome", htmlBody: "<h1>Welcome</h1>" },
+    ];
+
+    const res = await request(app)
+      .put("/internal/emails/templates")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ templates });
+
+    expect(res.status).toBe(200);
+
+    const deployCall = fetchCalls.find((c) => c.url.includes("/templates"));
+    expect(deployCall!.body.templates).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `PUT /internal/emails/templates` endpoint authenticated only by `X-API-Key` (no `x-org-id`/`x-user-id` required)
- Adds `authenticatePlatform` middleware for platform-level operations at cold start
- Dashboard can now deploy email templates in `instrumentation.ts` without a Clerk session

## What changed
- `src/middleware/auth.ts` — new `authenticatePlatform` middleware (API key only, no identity resolution, no run tracking)
- `src/routes/internal-emails.ts` — new route file for internal platform endpoints
- `src/index.ts` — mounts `/internal` routes
- `src/schemas.ts` — OpenAPI registration with `apiKeyAuth` security scheme
- `scripts/generate-openapi.ts` — adds "Internal" tag
- `openapi.json` — regenerated
- `tests/unit/internal-emails.test.ts` — 6 tests (valid key, missing key, wrong key, validation errors, multi-template)

## Test plan
- [x] All 455 existing tests pass
- [x] 6 new tests pass covering auth and validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)