### PR TITLE
feat: register cold-email prompt at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import internalEmailsRoutes from "./routes/internal-emails.js";
 import stripeRoutes from "./routes/stripe.js";
 import usersRoutes from "./routes/users.js";
 import { apiReference } from "@scalar/express-api-reference";
-import { registerPlatformKeys } from "./startup.js";
+import { registerPlatformKeys, registerPrompts } from "./startup.js";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
@@ -114,10 +114,12 @@ app.use((err: Error, req: express.Request, res: express.Response, next: express.
 // Listen on :: for Railway private networking (IPv4 & IPv6 support)
 const server = app.listen(Number(PORT), "::", () => {
   console.log(`API Gateway running on port ${PORT}`);
-  registerPlatformKeys().catch((err) => {
-    console.error("[api-service] FATAL: Platform key registration failed:", err.message);
-    process.exit(1);
-  });
+  registerPlatformKeys()
+    .then(() => registerPrompts())
+    .catch((err) => {
+      console.error("[api-service] FATAL: Startup registration failed:", err.message);
+      process.exit(1);
+    });
 });
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -38,3 +38,114 @@ export async function registerPlatformKeys(): Promise<void> {
 
   console.log(`[api-service] ${PLATFORM_KEYS.length}/${PLATFORM_KEYS.length} platform keys registered successfully`);
 }
+
+// ── Prompt registration ─────────────────────────────────────────────────────
+
+const COLD_EMAIL_PROMPT = `Today is ${new Date().toISOString().split("T")[0]}.
+
+You're writing a 3-email cold outreach sequence on behalf of a sales rep. Your job is to get a reply — nothing else matters.
+
+## Output rule
+Always respond with the 3 emails ready to send. Never respond with commentary, suggestions, analysis, or a discussion — only the emails themselves.
+
+## Sequence structure
+- **Email 1 (body):** The initial cold email.
+- **Email 2 (followup1):** A short follow-up sent ~3 days after email 1. Keep it to 2-3 sentences. Same thread — no new subject line.
+- **Email 3 (followup2):** A final follow-up sent ~7 days after email 2. Same thread — no new subject line.
+
+## Cold email frameworks
+Use your judgment to apply or combine these proven frameworks based on the context:
+
+**PAS (Problem-Agitate-Solution):** Identify a problem, amplify its consequences, present the solution. Example: "Managing leads across spreadsheets is slowing your team down. Every hour spent on manual entry is an hour not closing deals. [Product] automates lead capture so your reps focus on selling."
+
+**BAB (Before-After-Bridge):** Describe the current pain (Before), paint the ideal future (After), position the solution as the bridge. Example: "Right now, your SDRs spend 10+ hours weekly researching prospects. Imagine if they had instant access to verified contact data. That's exactly what [Product] delivers."
+
+**AIDA (Attention-Interest-Desire-Action):** Hook attention, build interest with value, create desire, end with CTA. Example: "Companies like [Similar Company] increased response rates by 40%. We help sales teams personalize outreach at scale. Would it be worth a quick look?"
+
+**SPIN (Situation-Problem-Implication-Need-Payoff):** Acknowledge the situation, surface problems, explore implications, highlight payoff. Example: "Noticed [Company] is expanding into EMEA. Scaling outreach to new markets often means hiring more SDRs. What if you could 3x outreach without adding headcount?"
+
+## Industry data (Gong research, 28M+ emails analyzed)
+These findings should inform your choices:
+- Product pitches in cold emails reduce replies by 57%. Leading with the problem you solve instead of features you have performs significantly better.
+- "Interest CTAs" like "thoughts?" or "worth exploring?" generate 2x more replies than "meeting CTAs" like "15 min call Thursday?". Lower friction means higher response rates.
+- Buzzwords in subject lines reduce open rates by 17.9%. Plain, curiosity-driven subject lines outperform clever or jargon-heavy ones.
+- ROI claims, "AI" mentions, and jargon in first touch tend to trigger skepticism rather than interest.
+- Top-performing reps book 8.1x more meetings than average — the gap comes from email quality, not volume.
+
+## Length
+Cold emails must be short. Email 1: max 3-4 sentences. Follow-ups: 1-2 sentences. Every sentence must earn its place — if it doesn't drive a reply, cut it. No backstory, no over-explaining, no filler. Get in, spark curiosity, get out.
+
+## Simplicity
+Write like a human texting a smart friend. Short sentences. Plain words. If a sentence needs to be read twice to be understood, it's too complicated. The contrarian angle should hit instantly — not require a PhD to parse.
+
+## Tone
+Greet the recipient by first name — it's a real email from a real person, not a blog post. Keep it warm, direct, conversational.
+
+## Opening line (Email 1 only)
+Generic compliments ("Your work in X caught my attention", "I've been following your…") pattern-match to template emails and get deleted fast. A contrarian angle works better: a bold, non-obvious observation that challenges something people in the recipient's world take for granted. The best contrarian angle sits at the intersection of (1) what the recipient cares about and (2) why the client's offering exists. If multiple angles are possible, choose the one that resonates most with the recipient's specific role or industry. The tone should feel like a peer sharing an uncomfortable truth, not a salesperson pitching.
+
+## CTA
+Ending with a soft, low-friction ask. "Thoughts?" or "Worth a conversation?" outperform hard asks like "Can we book 15 min Tuesday?" because they let the recipient engage without committing.
+
+## Identity protection
+Keeping the client anonymous increases most of the time conversion.
+
+## Scam filter
+Cold emails live or die on trust. If it looks like a scam or MLM (specific dollar amounts, crypto terminology (tokens, chains, USDT, Web3), "passive income" language) then the user might dismiss. Exact compensation figures can look suspicious, but mentioning when the opportunity is a paid role or paid collaboration can drive interest.
+
+## Urgency
+Urgency, if you have any element about that, drives conversion. Using it in each email is relevant, especially in follow-ups.
+
+## Scarcity
+Scarcity, if you have any element about that, drives conversion. Using it in each email is relevant, especially in follow-ups.
+
+## Social proof
+Social proof, if you have any element about that, drives conversion. Using it in each email is relevant, especially in the main email.
+
+## Value for the audience
+Value for the audience is all the audience wants. Very important to be clear on those, especially on the main email.
+
+## Risk reversal
+Risk reversal, if you have any element about that, drives conversion. Using it in each email is relevant, especially in the follow-ups.
+
+---
+
+Now write the sequence for:
+
+## Recipient
+- Name: {{leadFirstName}} {{leadLastName}}
+- Title: {{leadTitle}}
+- Company: {{leadCompanyName}}
+- Industry: {{leadCompanyIndustry}}
+
+## Client
+- Company: {{clientCompanyName}}`;
+
+const COLD_EMAIL_VARIABLES = [
+  "leadFirstName",
+  "leadLastName",
+  "leadTitle",
+  "leadCompanyName",
+  "leadCompanyIndustry",
+  "clientCompanyName",
+];
+
+export async function registerPrompts(): Promise<void> {
+  console.log("[api-service] Registering prompts with content-generation-service...");
+
+  await callExternalService(externalServices.emailgen, "/prompts", {
+    method: "PUT",
+    headers: {
+      "x-org-id": "system",
+      "x-user-id": "system",
+      "x-run-id": "startup",
+    },
+    body: {
+      type: "cold-email",
+      prompt: COLD_EMAIL_PROMPT,
+      variables: COLD_EMAIL_VARIABLES,
+    },
+  });
+
+  console.log("[api-service] Prompt registered: cold-email");
+}

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -12,7 +12,7 @@ vi.mock("@distribute/runs-client", () => ({
   getRunsBatch: vi.fn().mockResolvedValue(new Map()),
 }));
 
-import { registerPlatformKeys } from "../../src/startup.js";
+import { registerPlatformKeys, registerPrompts } from "../../src/startup.js";
 
 function setAllEnvVars() {
   process.env.ANTHROPIC_API_KEY = "sk-ant-test";
@@ -131,5 +131,91 @@ describe("registerPlatformKeys", () => {
     delete process.env.STRIPE_SECRET_KEY;
 
     await expect(registerPlatformKeys()).rejects.toThrow("STRIPE_SECRET_KEY");
+  });
+});
+
+describe("registerPrompts", () => {
+  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown>; headers?: Record<string, string> }>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const headers = init?.headers as Record<string, string> | undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
+
+      return new Response(JSON.stringify({ type: "cold-email", message: "Prompt registered" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+  });
+
+  it("should call PUT /prompts on content-generation-service with cold-email prompt", async () => {
+    await registerPrompts();
+
+    const promptCalls = fetchCalls.filter((c) => c.url.includes("/prompts"));
+    expect(promptCalls).toHaveLength(1);
+
+    const call = promptCalls[0];
+    expect(call.method).toBe("PUT");
+    expect(call.body).toHaveProperty("type", "cold-email");
+    expect(call.body).toHaveProperty("prompt");
+    expect(call.body).toHaveProperty("variables");
+    expect(call.body!.variables).toEqual([
+      "leadFirstName",
+      "leadLastName",
+      "leadTitle",
+      "leadCompanyName",
+      "leadCompanyIndustry",
+      "clientCompanyName",
+    ]);
+  });
+
+  it("should include identity headers for startup context", async () => {
+    await registerPrompts();
+
+    const call = fetchCalls.find((c) => c.url.includes("/prompts"));
+    expect(call?.headers).toMatchObject({
+      "x-org-id": "system",
+      "x-user-id": "system",
+      "x-run-id": "startup",
+    });
+  });
+
+  it("should include prompt template variables as mustache placeholders", async () => {
+    await registerPrompts();
+
+    const call = fetchCalls.find((c) => c.url.includes("/prompts"));
+    const prompt = call?.body?.prompt as string;
+    expect(prompt).toContain("{{leadFirstName}}");
+    expect(prompt).toContain("{{leadLastName}}");
+    expect(prompt).toContain("{{leadTitle}}");
+    expect(prompt).toContain("{{leadCompanyName}}");
+    expect(prompt).toContain("{{leadCompanyIndustry}}");
+    expect(prompt).toContain("{{clientCompanyName}}");
+  });
+
+  it("should include a resolved date (not a template literal)", async () => {
+    await registerPrompts();
+
+    const call = fetchCalls.find((c) => c.url.includes("/prompts"));
+    const prompt = call?.body?.prompt as string;
+    // Date should be resolved (e.g. "2026-03-12"), not the raw template expression
+    expect(prompt).toMatch(/Today is \d{4}-\d{2}-\d{2}\./);
+    expect(prompt).not.toContain("${");
+  });
+
+  it("should throw when content-generation-service returns an error", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => {
+      return new Response(JSON.stringify({ error: "Service unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await expect(registerPrompts()).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `registerPrompts()` to startup sequence that calls `PUT /prompts` on content-generation-service with the cold-email prompt and its 6 template variables
- Runs after platform key registration — server exits on failure (same behavior as key registration)
- 5 new tests covering prompt body, identity headers, mustache variables, date resolution, and error handling

## Test plan
- [x] All 460 existing tests pass
- [x] 5 new `registerPrompts` tests pass (PUT /prompts call, headers, variables, date, error)
- [ ] Verify prompt registration on deploy by checking content-generation-service logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)