### PR TITLE
fix: use nil UUIDs for prompt registration headers

### DIFF
--- a/src/startup.ts
+++ b/src/startup.ts
@@ -136,8 +136,8 @@ export async function registerPrompts(): Promise<void> {
   await callExternalService(externalServices.emailgen, "/prompts", {
     method: "PUT",
     headers: {
-      "x-org-id": "system",
-      "x-user-id": "system",
+      "x-org-id": "00000000-0000-0000-0000-000000000000",
+      "x-user-id": "00000000-0000-0000-0000-000000000000",
       "x-run-id": "startup",
     },
     body: {

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -179,8 +179,8 @@ describe("registerPrompts", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/prompts"));
     expect(call?.headers).toMatchObject({
-      "x-org-id": "system",
-      "x-user-id": "system",
+      "x-org-id": "00000000-0000-0000-0000-000000000000",
+      "x-user-id": "00000000-0000-0000-0000-000000000000",
       "x-run-id": "startup",
     });
   });


### PR DESCRIPTION
## Summary
- Fixes startup crash from #105 — content-generation-service validates `x-org-id`/`x-user-id` as UUID columns, so `"system"` caused a Postgres cast error
- Uses nil UUIDs (`00000000-0000-0000-0000-000000000000`) for platform-level startup registrations

## Test plan
- [x] Startup tests pass with updated UUID expectations
- [ ] Verify deploy succeeds and prompt registration completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)