### PR TITLE
feat: proxy api-registry endpoints for dashboard LLM chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,7 @@ APOLLO_API_KEY=your-apollo-api-key
 INSTANTLY_API_KEY=your-instantly-api-key
 STRIPE_SECRET_KEY=sk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
+
+# API Registry (service discovery for dashboard LLM chat)
+API_REGISTRY_SERVICE_URL=https://api-registry.distribute.you
+API_REGISTRY_SERVICE_API_KEY=your-api-registry-service-api-key

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import emailsRoutes from "./routes/emails.js";
 import internalEmailsRoutes from "./routes/internal-emails.js";
 import stripeRoutes from "./routes/stripe.js";
 import usersRoutes from "./routes/users.js";
+import platformRoutes from "./routes/platform.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { registerPlatformKeys, registerPlatformPrompts } from "./startup.js";
 import { readFileSync, existsSync } from "fs";
@@ -96,6 +97,7 @@ app.use("/v1", billingRoutes);
 app.use("/v1", emailsRoutes);
 app.use("/v1", stripeRoutes);
 app.use("/v1", usersRoutes);
+app.use("/v1", platformRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -68,6 +68,10 @@ export const externalServices = {
     url: process.env.STRIPE_SERVICE_URL || "http://localhost:3022",
     apiKey: process.env.STRIPE_SERVICE_API_KEY || "",
   },
+  apiRegistry: {
+    url: process.env.API_REGISTRY_SERVICE_URL || "http://localhost:3023",
+    apiKey: process.env.API_REGISTRY_SERVICE_API_KEY || "",
+  },
 };
 
 interface ServiceCallOptions {

--- a/src/routes/platform.ts
+++ b/src/routes/platform.ts
@@ -1,0 +1,63 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+/**
+ * GET /v1/platform/services
+ * List all services from api-registry
+ */
+router.get("/platform/services", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.apiRegistry,
+      "/services",
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("List platform services error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list services" });
+  }
+});
+
+/**
+ * GET /v1/platform/services/:service
+ * Get OpenAPI spec for a specific service from api-registry
+ */
+router.get("/platform/services/:service", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { service } = req.params;
+    const result = await callExternalService(
+      externalServices.apiRegistry,
+      `/openapi/${service}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get platform service spec error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get service spec" });
+  }
+});
+
+/**
+ * GET /v1/platform/llm-context
+ * Get LLM context from api-registry (service descriptions + endpoint summaries for chat)
+ */
+router.get("/platform/llm-context", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.apiRegistry,
+      "/llm-context",
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get platform LLM context error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get LLM context" });
+  }
+});
+
+export default router;

--- a/tests/unit/platform-proxy.test.ts
+++ b/tests/unit/platform-proxy.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const platformRoutePath = path.join(__dirname, "../../src/routes/platform.ts");
+const content = fs.readFileSync(platformRoutePath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const envExamplePath = path.join(__dirname, "../../.env.example");
+const envContent = fs.readFileSync(envExamplePath, "utf-8");
+
+describe("Platform proxy routes", () => {
+  it("should have GET /platform/services endpoint", () => {
+    expect(content).toContain('"/platform/services"');
+    expect(content).toContain("router.get");
+  });
+
+  it("should have GET /platform/services/:service endpoint", () => {
+    expect(content).toContain('"/platform/services/:service"');
+  });
+
+  it("should have GET /platform/llm-context endpoint", () => {
+    expect(content).toContain('"/platform/llm-context"');
+  });
+
+  it("should use authenticate, requireOrg, requireUser on all endpoints", () => {
+    const routeLines = content.split("\n").filter((l) => l.includes("router.get"));
+    expect(routeLines.length).toBe(3);
+    for (const line of routeLines) {
+      expect(line).toContain("authenticate");
+      expect(line).toContain("requireOrg");
+      expect(line).toContain("requireUser");
+    }
+  });
+
+  it("should proxy /platform/services to api-registry /services", () => {
+    expect(content).toContain('"/services"');
+    expect(content).toContain("externalServices.apiRegistry");
+  });
+
+  it("should proxy /platform/services/:service to api-registry /openapi/:service", () => {
+    expect(content).toContain("`/openapi/${service}`");
+  });
+
+  it("should proxy /platform/llm-context to api-registry /llm-context", () => {
+    expect(content).toContain('"/llm-context"');
+  });
+
+  it("should use buildInternalHeaders for identity forwarding", () => {
+    expect(content).toContain("buildInternalHeaders");
+    const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(headerMatches).not.toBeNull();
+    expect(headerMatches!.length).toBe(3);
+  });
+
+  it("should forward upstream status codes on error", () => {
+    expect(content).toContain("error.statusCode || 500");
+  });
+});
+
+describe("API Registry service client config", () => {
+  it("should define apiRegistry in externalServices", () => {
+    expect(serviceClientContent).toContain("apiRegistry:");
+    expect(serviceClientContent).toContain("API_REGISTRY_SERVICE_URL");
+    expect(serviceClientContent).toContain("API_REGISTRY_SERVICE_API_KEY");
+  });
+});
+
+describe("Platform routes are mounted in index.ts", () => {
+  it("should import and mount platform routes", () => {
+    expect(indexContent).toContain("platformRoutes");
+    expect(indexContent).toContain("./routes/platform");
+  });
+});
+
+describe("Environment config", () => {
+  it("should document API_REGISTRY env vars in .env.example", () => {
+    expect(envContent).toContain("API_REGISTRY_SERVICE_URL");
+    expect(envContent).toContain("API_REGISTRY_SERVICE_API_KEY");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 3 proxy routes under `/v1/platform/` that forward to api-registry (`/services`, `/openapi/:service`, `/llm-context`)
- Registers `apiRegistry` in the service client with `API_REGISTRY_SERVICE_URL` and `API_REGISTRY_SERVICE_API_KEY` env vars
- All endpoints require full auth (`authenticate`, `requireOrg`, `requireUser`)

## Test plan
- [x] 12 unit tests covering route definitions, middleware, service client config, env docs, and header forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)