### PR TITLE
feat: add PUT /platform-chat/config endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1083,6 +1083,29 @@
           "message"
         ]
       },
+      "PlatformChatConfigRequest": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "System prompt for the AI assistant"
+          },
+          "mcpServerUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "MCP server URL for tool calling"
+          },
+          "mcpKeyName": {
+            "type": "string",
+            "minLength": 1,
+            "description": "MCP key name for auth resolution"
+          }
+        },
+        "required": [
+          "systemPrompt"
+        ]
+      },
       "SwitchBillingModeRequest": {
         "type": "object",
         "properties": {
@@ -5141,6 +5164,84 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          }
+        ]
+      }
+    },
+    "/platform-chat/config": {
+      "put": {
+        "tags": [
+          "Chat"
+        ],
+        "summary": "Deploy platform-level chat config",
+        "description": "Register or update the global chat configuration (system prompt, MCP server). Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformChatConfigRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Config registered"
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing platform API key",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,9 @@ import internalEmailsRoutes from "./routes/internal-emails.js";
 import stripeRoutes from "./routes/stripe.js";
 import usersRoutes from "./routes/users.js";
 import platformRoutes from "./routes/platform.js";
+import platformChatRoutes from "./routes/platform-chat.js";
 import { apiReference } from "@scalar/express-api-reference";
-import { registerPlatformKeys, registerPlatformPrompts } from "./startup.js";
+import { registerPlatformKeys, registerPlatformPrompts, registerPlatformChatConfig } from "./startup.js";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
@@ -81,6 +82,7 @@ app.use(performanceRoutes);
 
 // Internal platform routes (API key only, no identity)
 app.use("/internal", internalEmailsRoutes);
+app.use("/platform-chat", platformChatRoutes);
 
 // Authenticated routes
 app.use("/v1", meRoutes);
@@ -118,6 +120,7 @@ const server = app.listen(Number(PORT), "::", () => {
   console.log(`API Gateway running on port ${PORT}`);
   registerPlatformKeys()
     .then(() => registerPlatformPrompts())
+    .then(() => registerPlatformChatConfig())
     .catch((err) => {
       console.error("[api-service] FATAL: Startup registration failed:", err.message);
       process.exit(1);

--- a/src/routes/platform-chat.ts
+++ b/src/routes/platform-chat.ts
@@ -1,0 +1,36 @@
+import { Router } from "express";
+import { authenticatePlatform, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { PlatformChatConfigRequestSchema } from "../schemas.js";
+
+const router = Router();
+
+/**
+ * PUT /platform-chat/config
+ * Platform-level chat config deployment — no identity headers required.
+ * Authenticated by X-API-Key (ADMIN_DISTRIBUTE_API_KEY) only.
+ * Used by the dashboard at cold start when no Clerk session exists.
+ */
+router.put("/config", authenticatePlatform, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = PlatformChatConfigRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+
+    const result = await callExternalService(
+      externalServices.chat,
+      "/platform-config",
+      {
+        method: "PUT",
+        body: parsed.data,
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Deploy platform chat config error:", error);
+    res.status(500).json({ error: error.message || "Failed to deploy platform chat config" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1413,6 +1413,41 @@ registry.registerPath({
 });
 
 // ===================================================================
+// PLATFORM CHAT CONFIG
+// ===================================================================
+
+export const PlatformChatConfigRequestSchema = z
+  .object({
+    systemPrompt: z.string().min(1).describe("System prompt for the AI assistant"),
+    mcpServerUrl: z.string().url().optional().describe("MCP server URL for tool calling"),
+    mcpKeyName: z.string().min(1).optional().describe("MCP key name for auth resolution"),
+  })
+  .openapi("PlatformChatConfigRequest");
+
+registry.registerPath({
+  method: "put",
+  path: "/platform-chat/config",
+  tags: ["Chat"],
+  summary: "Deploy platform-level chat config",
+  description:
+    "Register or update the global chat configuration (system prompt, MCP server). " +
+    "Platform-level — no org/user identity required. " +
+    "Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+  security: platformAuth,
+  request: {
+    body: {
+      content: { "application/json": { schema: PlatformChatConfigRequestSchema } },
+    },
+  },
+  responses: {
+    200: { description: "Config registered" },
+    400: { description: "Invalid request", content: errorContent },
+    401: { description: "Invalid or missing platform API key", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
 // BILLING
 // ===================================================================
 

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -130,6 +130,27 @@ const COLD_EMAIL_VARIABLES = [
   "clientCompanyName",
 ];
 
+// ── Platform chat config ──────────────────────────────────────────────────
+
+export async function registerPlatformChatConfig(): Promise<void> {
+  console.log("[api-service] Registering platform chat config with chat-service...");
+
+  await callExternalService(externalServices.chat, "/platform-config", {
+    method: "PUT",
+    body: {
+      systemPrompt:
+        "You are a helpful assistant embedded in a workflow management dashboard. " +
+        "You help users understand their workflows — what each step does, how the DAG is structured, " +
+        "what inputs and outputs are expected, and how to troubleshoot issues. " +
+        "Be concise and practical. When referencing workflow steps, use their names.",
+    },
+  });
+
+  console.log("[api-service] Platform chat config registered");
+}
+
+// ── Platform prompts ────────────────────────────────────────────────────────
+
 export async function registerPlatformPrompts(): Promise<void> {
   console.log("[api-service] Registering platform prompts with content-generation-service...");
 

--- a/tests/unit/platform-chat.test.ts
+++ b/tests/unit/platform-chat.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Do NOT mock auth — we test the real authenticatePlatform middleware
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return {
+    ...actual,
+    authenticate: (req: any, _res: any, next: any) => {
+      next();
+    },
+    requireOrg: (_req: any, _res: any, next: any) => {
+      next();
+    },
+    requireUser: (_req: any, _res: any, next: any) => {
+      next();
+    },
+  };
+});
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import platformChatRoutes from "../../src/routes/platform-chat.js";
+
+const VALID_API_KEY = "test-admin-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/platform-chat", platformChatRoutes);
+  return app;
+}
+
+describe("PUT /platform-chat/config", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ status: "ok" }),
+      };
+    });
+    app = createApp();
+  });
+
+  it("should deploy platform chat config with valid API key and no identity headers", async () => {
+    const res = await request(app)
+      .put("/platform-chat/config")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        systemPrompt: "You are a helpful workflow assistant.",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+
+    const call = fetchCalls.find((c) => c.url.includes("/platform-config"));
+    expect(call).toBeDefined();
+    expect(call!.method).toBe("PUT");
+    expect(call!.body).toMatchObject({
+      systemPrompt: "You are a helpful workflow assistant.",
+    });
+    // No identity headers forwarded
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-user-id"]).toBeUndefined();
+    expect(call!.headers!["x-run-id"]).toBeUndefined();
+  });
+
+  it("should forward optional mcpServerUrl and mcpKeyName", async () => {
+    const res = await request(app)
+      .put("/platform-chat/config")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        systemPrompt: "You are a helpful assistant.",
+        mcpServerUrl: "https://mcp.example.com",
+        mcpKeyName: "dashboard-mcp",
+      });
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/platform-config"));
+    expect(call!.body).toMatchObject({
+      systemPrompt: "You are a helpful assistant.",
+      mcpServerUrl: "https://mcp.example.com",
+      mcpKeyName: "dashboard-mcp",
+    });
+  });
+
+  it("should return 401 without API key", async () => {
+    const res = await request(app)
+      .put("/platform-chat/config")
+      .send({ systemPrompt: "test" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 401 with wrong API key", async () => {
+    const res = await request(app)
+      .put("/platform-chat/config")
+      .set("X-API-Key", "wrong-key")
+      .send({ systemPrompt: "test" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 400 when systemPrompt is missing", async () => {
+    const res = await request(app)
+      .put("/platform-chat/config")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when systemPrompt is empty", async () => {
+    const res = await request(app)
+      .put("/platform-chat/config")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ systemPrompt: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `PUT /platform-chat/config` — platform-level chat config endpoint (API key auth only, no org/user headers)
- Proxies to chat-service at `/platform-config`, following the same pattern as `/internal/emails/templates` and `/platform-prompts`
- Registers a default workflow-viewer system prompt at api-service cold start via `registerPlatformChatConfig()`
- Includes Zod schema validation, OpenAPI spec registration, and 6 unit tests

## Test plan
- [x] 6 new unit tests covering: valid config, optional fields, missing API key, wrong API key, missing systemPrompt, empty systemPrompt
- [x] Full test suite passes (487 tests, 64 files)
- [ ] Verify chat-service supports `PUT /platform-config` endpoint (requires chat-service update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)