### PR TITLE
fix: non-blocking platform chat config at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,11 @@ const server = app.listen(Number(PORT), "::", () => {
   console.log(`API Gateway running on port ${PORT}`);
   registerPlatformKeys()
     .then(() => registerPlatformPrompts())
-    .then(() => registerPlatformChatConfig())
+    .then(() =>
+      registerPlatformChatConfig().catch((err) => {
+        console.warn("[api-service] WARNING: Platform chat config registration failed (chat-service may not be deployed yet):", err.message);
+      })
+    )
     .catch((err) => {
       console.error("[api-service] FATAL: Startup registration failed:", err.message);
       process.exit(1);


### PR DESCRIPTION
## Summary
- Chat-service hasn't deployed `PUT /platform-config` yet, causing api-service to crash at startup with a 404
- Makes `registerPlatformChatConfig()` non-blocking: logs a warning instead of crashing
- Platform keys and prompts registration remain mandatory (fatal on failure)

## Test plan
- [x] Full test suite passes (487 tests)
- [x] api-service starts even when chat-service doesn't have `/platform-config` yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)