### PR TITLE
feat: rename api-service stats routes to match convention

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ app.use(
 
 // Public routes
 app.use(healthRoutes);
-app.use(performanceRoutes);
+app.use("/v1", performanceRoutes);
 
 // Internal platform routes (API key only, no identity)
 app.use("/internal", internalEmailsRoutes);

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -258,11 +258,11 @@ router.post("/brand/icp-suggestion", authenticate, requireOrg, requireUser, asyn
 });
 
 /**
- * GET /v1/brands/costs
+ * GET /v1/brands/stats/costs
  * Get total costs grouped by brandId from runs-service.
  * Returns a map of brandId -> totalCostInUsdCents.
  */
-router.get("/brands/costs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/brands/stats/costs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const orgId = req.orgId!;
 
@@ -296,11 +296,11 @@ router.get("/brands/costs", authenticate, requireOrg, requireUser, async (req: A
 });
 
 /**
- * GET /v1/brands/:id/cost-breakdown
+ * GET /v1/brands/:id/stats/costs
  * Get cost breakdown by cost name for all runs associated with a brand.
- * Uses runs-service as the single source of truth.
+ * Uses runs-service as the single source of truth (groupBy=costName).
  */
-router.get("/brands/:id/cost-breakdown", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/brands/:id/stats/costs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
     const orgId = req.orgId!;

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -412,10 +412,10 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
 });
 
 /**
- * POST /v1/campaigns/batch-stats
+ * POST /v1/campaigns/stats/batch
  * Get stats for multiple campaigns in one call
  */
-router.post("/campaigns/batch-stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.post("/campaigns/stats/batch", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const parsed = BatchStatsRequestSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -691,11 +691,12 @@ router.get("/campaigns/:id/emails", authenticate, requireOrg, requireUser, async
 });
 
 /**
- * GET /v1/campaigns/:id/replies
+ * GET /v1/campaigns/:id/stats/replies
  * Get email replies for a campaign, grouped by lead email.
  * Returns only leads who have at least one reply, with reply type breakdown.
+ * Equivalent to stats with groupBy=leadEmail.
  */
-router.get("/campaigns/:id/replies", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/campaigns/:id/stats/replies", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
 
@@ -757,10 +758,10 @@ router.get("/campaigns/:id/replies", authenticate, requireOrg, requireUser, asyn
 });
 
 /**
- * GET /v1/brands/:brandId/delivery-stats
+ * GET /v1/brands/:brandId/stats
  * Get delivery stats for all campaigns under a brand (single email-gateway call)
  */
-router.get("/brands/:brandId/delivery-stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/brands/:brandId/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { brandId } = req.params;
 

--- a/src/routes/performance.ts
+++ b/src/routes/performance.ts
@@ -433,7 +433,7 @@ function buildCategorySections(data: LeaderboardData): CategorySection[] {
   });
 }
 
-router.get("/performance/leaderboard", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/stats/leaderboard", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const headers = buildInternalHeaders(req);
     const { data } = await buildLeaderboardData(headers);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -134,8 +134,8 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/performance/leaderboard",
-  tags: ["Performance"],
+  path: "/v1/stats/leaderboard",
+  tags: ["Stats"],
   summary: "Get performance leaderboard",
   description:
     "Returns performance leaderboard data including brands, workflows, and hero stats. Requires authentication.",
@@ -371,7 +371,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/campaigns/batch-stats",
+  path: "/v1/campaigns/stats/batch",
   tags: ["Campaigns"],
   summary: "Batch get campaign stats",
   description: "Get stats for multiple campaigns in a single request",
@@ -423,7 +423,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/campaigns/{id}/replies",
+  path: "/v1/campaigns/{id}/stats/replies",
   tags: ["Campaigns"],
   summary: "Get campaign replies",
   description:
@@ -911,7 +911,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/brands/{id}/cost-breakdown",
+  path: "/v1/brands/{id}/stats/costs",
   tags: ["Brand"],
   summary: "Get brand cost breakdown",
   description:
@@ -947,7 +947,7 @@ const BrandIdByBrandIdParam = z.object({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/brands/{brandId}/delivery-stats",
+  path: "/v1/brands/{brandId}/stats",
   tags: ["Brand"],
   summary: "Get brand delivery stats",
   description:


### PR DESCRIPTION
## Summary
Homogenize api-service's own routes to follow the same `/stats` convention we established for all downstream services.

## Breaking changes for frontend

| Avant | Après |
|-------|-------|
| `GET /performance/leaderboard` | `GET /v1/stats/leaderboard` |
| `POST /v1/campaigns/batch-stats` | `POST /v1/campaigns/stats/batch` |
| `GET /v1/campaigns/:id/replies` | `GET /v1/campaigns/:id/stats/replies` |
| `GET /v1/brands/:brandId/delivery-stats` | `GET /v1/brands/:brandId/stats` |
| `GET /v1/brands/costs` | `GET /v1/brands/stats/costs` |
| `GET /v1/brands/:id/cost-breakdown` | `GET /v1/brands/:id/stats/costs` |

Response shapes are unchanged — only paths changed.

## Test plan
- [ ] Frontend must update all route references listed above
- [ ] Leaderboard page: update from `/performance/leaderboard` to `/v1/stats/leaderboard`
- [ ] Campaign detail page: update batch-stats and replies endpoints
- [ ] Brand pages: update delivery-stats, costs, and cost-breakdown endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)