### PR TITLE
fix: add type annotation for implicit any parameter

### DIFF
--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -370,7 +370,7 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
         const withCosts = runMap.get(run.id);
         const allCosts = [
           ...(withCosts?.costs || []),
-          ...(withCosts?.descendantRuns?.flatMap((dr) => dr.costs) || []),
+          ...(withCosts?.descendantRuns?.flatMap((dr: { costs: unknown[] }) => dr.costs) || []),
         ];
         return {
           id: run.id,


### PR DESCRIPTION
## Summary
- Fixes pre-existing `TS7006: Parameter 'dr' implicitly has an 'any' type` error in brand.ts

## Test plan
- [x] `tsc --noEmit` passes (excluding missing workspace package errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)