### PR TITLE
refactor: move brand delivery stats to brand router

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4817,7 +4817,7 @@
         }
       }
     },
-    "/v1/brands/{brandId}/stats": {
+    "/v1/brands/{id}/stats": {
       "get": {
         "tags": [
           "Brand"
@@ -4837,7 +4837,7 @@
             },
             "required": true,
             "description": "Brand ID",
-            "name": "brandId",
+            "name": "id",
             "in": "path"
           },
           {

--- a/src/lib/delivery-stats.ts
+++ b/src/lib/delivery-stats.ts
@@ -1,0 +1,50 @@
+import { AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "./service-client.js";
+import { buildInternalHeaders } from "./internal-headers.js";
+
+interface EmailGatewayStats {
+  emailsSent: number; emailsDelivered: number; emailsOpened: number; emailsClicked: number;
+  emailsReplied: number; emailsBounced: number; repliesWillingToMeet: number;
+  repliesInterested: number; repliesNotInterested: number; repliesOutOfOffice: number;
+  repliesUnsubscribe: number; recipients: number;
+}
+
+/** Fetch delivery stats from email-gateway (aggregates transactional + broadcast). */
+export async function fetchDeliveryStats(
+  filters: { campaignId?: string; brandId?: string },
+  req: AuthenticatedRequest,
+): Promise<Record<string, number> | null> {
+  const orgId = req.orgId!;
+  const params = new URLSearchParams({ orgId });
+  if (filters.campaignId) params.set("campaignId", filters.campaignId);
+  if (filters.brandId) params.set("brandId", filters.brandId);
+  const deliveryResult = await callExternalService<{ transactional: EmailGatewayStats; broadcast: EmailGatewayStats }>(
+    externalServices.emailGateway,
+    `/stats?${params}`,
+    {
+      headers: buildInternalHeaders(req),
+    }
+  ).catch((err) => {
+    console.warn("[delivery-stats] Email-gateway stats failed:", (err as Error).message);
+    return null;
+  });
+
+  // Only use broadcast stats (outreach emails via Instantly).
+  // Transactional stats are transactional/test emails via Postmark — not relevant.
+  const b = (deliveryResult as any)?.broadcast;
+  if (!b) return null;
+
+  return {
+    emailsSent: b.emailsSent || 0,
+    emailsDelivered: b.emailsDelivered || 0,
+    emailsOpened: b.emailsOpened || 0,
+    emailsClicked: b.emailsClicked || 0,
+    emailsReplied: b.emailsReplied || 0,
+    emailsBounced: b.emailsBounced || 0,
+    repliesWillingToMeet: b.repliesWillingToMeet || 0,
+    repliesInterested: b.repliesInterested || 0,
+    repliesNotInterested: b.repliesNotInterested || 0,
+    repliesOutOfOffice: b.repliesOutOfOffice || 0,
+    repliesUnsubscribe: b.repliesUnsubscribe || 0,
+  };
+}

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -4,6 +4,7 @@ import { callExternalService, externalServices } from "../lib/service-client.js"
 import { getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 import { BrandScrapeRequestSchema, BrandUpsertRequestSchema, IcpSuggestionRequestSchema } from "../schemas.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
+import { fetchDeliveryStats } from "../lib/delivery-stats.js";
 
 const router = Router();
 
@@ -330,6 +331,35 @@ router.get("/brands/:id/stats/costs", authenticate, requireOrg, requireUser, asy
   } catch (error: any) {
     console.error("Get brand cost breakdown error:", error);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand cost breakdown" });
+  }
+});
+
+/**
+ * GET /v1/brands/:id/stats
+ * Get delivery stats (email-gateway) for all campaigns under a brand.
+ */
+router.get("/brands/:id/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+
+    const delivery = await fetchDeliveryStats({ brandId: id }, req);
+
+    res.json(delivery ?? {
+      emailsSent: 0,
+      emailsDelivered: 0,
+      emailsOpened: 0,
+      emailsClicked: 0,
+      emailsReplied: 0,
+      emailsBounced: 0,
+      repliesWillingToMeet: 0,
+      repliesInterested: 0,
+      repliesNotInterested: 0,
+      repliesOutOfOffice: 0,
+      repliesUnsubscribe: 0,
+    });
+  } catch (error: any) {
+    console.error("Get brand delivery stats error:", error);
+    res.status(500).json({ error: error.message || "Failed to get brand delivery stats" });
   }
 });
 

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -2,57 +2,11 @@ import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
+import { fetchDeliveryStats } from "../lib/delivery-stats.js";
 import { getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 import { CreateCampaignRequestSchema } from "../schemas.js";
 
 const router = Router();
-
-interface EmailGatewayStats {
-  emailsSent: number; emailsDelivered: number; emailsOpened: number; emailsClicked: number;
-  emailsReplied: number; emailsBounced: number; repliesWillingToMeet: number;
-  repliesInterested: number; repliesNotInterested: number; repliesOutOfOffice: number;
-  repliesUnsubscribe: number; recipients: number;
-}
-
-/** Fetch delivery stats from email-gateway (aggregates transactional + broadcast). */
-async function fetchDeliveryStats(
-  filters: { campaignId?: string; brandId?: string },
-  req: AuthenticatedRequest,
-): Promise<Record<string, number> | null> {
-  const orgId = req.orgId!;
-  const params = new URLSearchParams({ orgId });
-  if (filters.campaignId) params.set("campaignId", filters.campaignId);
-  if (filters.brandId) params.set("brandId", filters.brandId);
-  const deliveryResult = await callExternalService<{ transactional: EmailGatewayStats; broadcast: EmailGatewayStats }>(
-    externalServices.emailGateway,
-    `/stats?${params}`,
-    {
-      headers: buildInternalHeaders(req),
-    }
-  ).catch((err) => {
-    console.warn("[campaigns] Email-gateway stats failed:", (err as Error).message);
-    return null;
-  });
-
-  // Only use broadcast stats (outreach emails via Instantly).
-  // Transactional stats are transactional/test emails via Postmark — not relevant.
-  const b = (deliveryResult as any)?.broadcast;
-  if (!b) return null;
-
-  return {
-    emailsSent: b.emailsSent || 0,
-    emailsDelivered: b.emailsDelivered || 0,
-    emailsOpened: b.emailsOpened || 0,
-    emailsClicked: b.emailsClicked || 0,
-    emailsReplied: b.emailsReplied || 0,
-    emailsBounced: b.emailsBounced || 0,
-    repliesWillingToMeet: b.repliesWillingToMeet || 0,
-    repliesInterested: b.repliesInterested || 0,
-    repliesNotInterested: b.repliesNotInterested || 0,
-    repliesOutOfOffice: b.repliesOutOfOffice || 0,
-    repliesUnsubscribe: b.repliesUnsubscribe || 0,
-  };
-}
 
 /**
  * GET /v1/campaigns
@@ -555,35 +509,6 @@ router.get("/campaigns/:id/emails", authenticate, requireOrg, requireUser, async
   } catch (error: any) {
     console.error("Get campaign emails error:", error);
     res.status(500).json({ error: error.message || "Failed to get campaign emails" });
-  }
-});
-
-/**
- * GET /v1/brands/:brandId/stats
- * Get delivery stats for all campaigns under a brand (single email-gateway call)
- */
-router.get("/brands/:brandId/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const { brandId } = req.params;
-
-    const delivery = await fetchDeliveryStats({ brandId }, req);
-
-    res.json(delivery ?? {
-      emailsSent: 0,
-      emailsDelivered: 0,
-      emailsOpened: 0,
-      emailsClicked: 0,
-      emailsReplied: 0,
-      emailsBounced: 0,
-      repliesWillingToMeet: 0,
-      repliesInterested: 0,
-      repliesNotInterested: 0,
-      repliesOutOfOffice: 0,
-      repliesUnsubscribe: 0,
-    });
-  } catch (error: any) {
-    console.error("Get brand delivery stats error:", error);
-    res.status(500).json({ error: error.message || "Failed to get brand delivery stats" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -875,19 +875,15 @@ registry.registerPath({
   },
 });
 
-const BrandIdByBrandIdParam = z.object({
-  brandId: z.string().describe("Brand ID"),
-});
-
 registry.registerPath({
   method: "get",
-  path: "/v1/brands/{brandId}/stats",
+  path: "/v1/brands/{id}/stats",
   tags: ["Brand"],
   summary: "Get brand delivery stats",
   description:
     "Get aggregated email delivery statistics for all campaigns under a brand (broadcast only, excludes transactional)",
   security: authed,
-  request: { params: BrandIdByBrandIdParam },
+  request: { params: BrandIdParam },
   responses: {
     200: {
       description: "Delivery statistics for the brand",

--- a/tests/unit/brand-delivery-stats.regression.test.ts
+++ b/tests/unit/brand-delivery-stats.regression.test.ts
@@ -4,8 +4,9 @@
  * so each campaign got org-wide totals. With N campaigns, sent/opened were
  * inflated by a factor of N.
  *
- * Fix: GET /v1/brands/:brandId/delivery-stats makes a single email-gateway call
+ * Fix: GET /v1/brands/:id/stats makes a single email-gateway call
  * with brandId filter, returning only broadcast (outreach) stats.
+ * This route now lives in brand.ts (not campaigns.ts).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -55,16 +56,16 @@ vi.mock("@distribute/runs-client", () => ({
 
 import express from "express";
 import request from "supertest";
-import campaignsRouter from "../../src/routes/campaigns.js";
+import brandRouter from "../../src/routes/brand.js";
 
 function createApp() {
   const app = express();
   app.use(express.json());
-  app.use("/v1", campaignsRouter);
+  app.use("/v1", brandRouter);
   return app;
 }
 
-describe("GET /v1/brands/:brandId/stats", () => {
+describe("GET /v1/brands/:id/stats", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -172,41 +173,33 @@ describe("GET /v1/brands/:brandId/stats", () => {
 });
 
 describe("Regression: fetchDeliveryStats must use broadcast only", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("fetchDeliveryStats should only read broadcast stats in source code", () => {
     const fs = require("fs");
     const path = require("path");
     const content = fs.readFileSync(
-      path.join(__dirname, "../../src/routes/campaigns.ts"),
+      path.join(__dirname, "../../src/lib/delivery-stats.ts"),
       "utf-8"
     );
 
-    // The endpoint should exist (renamed from /delivery-stats to /stats)
-    expect(content).toContain("/brands/:brandId/stats");
     // Should only use broadcast, not sum transactional + broadcast
     expect(content).toContain("Only use broadcast stats");
     expect(content).not.toMatch(/sum\(t\?\.emails/);
   });
 
-  it("brand page should use brand-level delivery stats without fallback", () => {
+  it("brand delivery stats route should be in brand.ts, not campaigns.ts", () => {
     const fs = require("fs");
     const path = require("path");
-    const pagePath = path.join(__dirname, "../../../../apps/dashboard/src/app/(dashboard)/brands/[brandId]/workflows/[sectionKey]/page.tsx");
-    if (!fs.existsSync(pagePath)) {
-      // Dashboard file not available in this workspace — skip
-      return;
-    }
-    const content = fs.readFileSync(pagePath, "utf-8");
+    const brandContent = fs.readFileSync(
+      path.join(__dirname, "../../src/routes/brand.ts"),
+      "utf-8"
+    );
+    const campaignsContent = fs.readFileSync(
+      path.join(__dirname, "../../src/routes/campaigns.ts"),
+      "utf-8"
+    );
 
-    expect(content).toContain("getBrandDeliveryStats");
-    // Should NOT fall back to per-campaign sum for delivery stats
-    expect(content).not.toMatch(/brandDelivery\?\.\w+ \?\? campaignTotals\.\w+/);
+    expect(brandContent).toContain('"/brands/:id/stats"');
+    expect(campaignsContent).not.toContain('"/brands/:brandId/stats"');
+    expect(campaignsContent).not.toContain('"/brands/:id/stats"');
   });
 });

--- a/tests/unit/dashboard-endpoints-openapi.test.ts
+++ b/tests/unit/dashboard-endpoints-openapi.test.ts
@@ -2,7 +2,7 @@
  * Regression test: ensures dashboard endpoints are properly
  * documented in the OpenAPI schema (schemas.ts).
  *
- * 1. GET /v1/brands/{brandId}/stats — must be registered
+ * 1. GET /v1/brands/{id}/stats — must be registered
  * 2. GET /v1/campaigns/{id}/stats/replies — removed (no longer registered)
  * 3. GET /v1/campaigns status query param — must be documented
  */
@@ -14,8 +14,8 @@ const schemasPath = path.join(__dirname, "../../src/schemas.ts");
 const content = fs.readFileSync(schemasPath, "utf-8");
 
 describe("Dashboard endpoints OpenAPI documentation", () => {
-  it("should register GET /v1/brands/{brandId}/stats", () => {
-    expect(content).toContain('path: "/v1/brands/{brandId}/stats"');
+  it("should register GET /v1/brands/{id}/stats", () => {
+    expect(content).toContain('path: "/v1/brands/{id}/stats"');
   });
 
   it("should NOT register campaigns replies endpoint (removed)", () => {


### PR DESCRIPTION
## Summary
- Move `GET /v1/brands/:id/stats` (email-gateway delivery stats) from `campaigns.ts` to `brand.ts` — it's a brand route, not a campaign route
- Extract `fetchDeliveryStats` to `src/lib/delivery-stats.ts` (shared by campaigns + brand routers)
- Rename path param from `{brandId}` to `{id}` for consistency with all other brand routes

## Context
The frontend flagged that all stats routes were confusingly named "campaign" even when they call email-gateway for brand-level data. This moves the route to where it semantically belongs.

## Test plan
- [x] All 491 tests pass (64 files)
- [x] Brand delivery stats tests updated to import from brand router
- [x] Regression test verifies route is in brand.ts, not campaigns.ts
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)