### PR TITLE
feat: add GET /v1/campaigns/stats — grouped stats aggregator

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -353,6 +353,97 @@
           "emailsBounced"
         ]
       },
+      "CampaignsBatchStatsResponse": {
+        "type": "object",
+        "properties": {
+          "campaigns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "campaignId": {
+                  "type": "string"
+                },
+                "leadsServed": {
+                  "type": "number"
+                },
+                "leadsBuffered": {
+                  "type": "number"
+                },
+                "leadsSkipped": {
+                  "type": "number"
+                },
+                "emailsGenerated": {
+                  "type": "number"
+                },
+                "emailsSent": {
+                  "type": "number"
+                },
+                "emailsDelivered": {
+                  "type": "number"
+                },
+                "emailsOpened": {
+                  "type": "number"
+                },
+                "emailsClicked": {
+                  "type": "number"
+                },
+                "emailsReplied": {
+                  "type": "number"
+                },
+                "emailsBounced": {
+                  "type": "number"
+                },
+                "repliesWillingToMeet": {
+                  "type": "number"
+                },
+                "repliesInterested": {
+                  "type": "number"
+                },
+                "repliesNotInterested": {
+                  "type": "number"
+                },
+                "repliesOutOfOffice": {
+                  "type": "number"
+                },
+                "repliesUnsubscribe": {
+                  "type": "number"
+                },
+                "totalCostInUsdCents": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "runCount": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "campaignId",
+                "leadsServed",
+                "leadsBuffered",
+                "leadsSkipped",
+                "emailsGenerated",
+                "emailsSent",
+                "emailsDelivered",
+                "emailsOpened",
+                "emailsClicked",
+                "emailsReplied",
+                "emailsBounced",
+                "repliesWillingToMeet",
+                "repliesInterested",
+                "repliesNotInterested",
+                "repliesOutOfOffice",
+                "repliesUnsubscribe",
+                "totalCostInUsdCents",
+                "runCount"
+              ]
+            }
+          }
+        },
+        "required": [
+          "campaigns"
+        ]
+      },
       "UpsertKeyRequest": {
         "type": "object",
         "properties": {
@@ -2625,6 +2716,109 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CampaignStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/campaigns/stats": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get stats for all campaigns (grouped)",
+        "description": "Aggregates stats from email-gateway, lead-service, content-generation, and runs-service using groupBy=campaignId. Returns one entry per campaign. Replaces the old POST /v1/campaigns/stats/batch endpoint.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand ID"
+            },
+            "required": false,
+            "description": "Filter by brand ID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-campaign aggregated statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignsBatchStatsResponse"
                 }
               }
             }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -152,6 +152,143 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
 });
 
 /**
+ * GET /v1/campaigns/stats
+ * Get aggregated stats for all campaigns, grouped by campaignId.
+ * Calls 4 services in parallel with groupBy=campaignId:
+ *   email-gateway, lead-service, content-generation, runs-service.
+ *
+ * Query params:
+ * - brandId: optional, scope to a brand
+ */
+router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const orgId = req.orgId!;
+    const brandId = req.query.brandId as string | undefined;
+    const internalHeaders = buildInternalHeaders(req);
+
+    // Build shared query params
+    const baseParams = new URLSearchParams({ orgId });
+    if (brandId) baseParams.set("brandId", brandId);
+
+    const deliveryParams = new URLSearchParams(baseParams);
+    deliveryParams.set("groupBy", "campaignId");
+
+    const leadParams = new URLSearchParams();
+    if (brandId) leadParams.set("brandId", brandId);
+    leadParams.set("groupBy", "campaignId");
+
+    const emailgenParams = new URLSearchParams();
+    if (brandId) emailgenParams.set("brandId", brandId);
+    emailgenParams.set("groupBy", "campaignId");
+
+    const runsParams = new URLSearchParams({ orgId, groupBy: "campaignId" });
+    if (brandId) runsParams.set("brandId", brandId);
+
+    // 4 parallel calls
+    const [deliveryGroups, leadGroups, emailgenGroups, costGroups] = await Promise.all([
+      callExternalService<{ groups: Array<{ key: string; broadcast: Record<string, number> | null; transactional: Record<string, number> | null }> }>(
+        externalServices.emailGateway,
+        `/stats?${deliveryParams}`,
+        { headers: internalHeaders },
+      ).catch((err) => {
+        console.warn("[campaigns/stats] email-gateway groupBy failed:", (err as Error).message);
+        return null;
+      }),
+      callExternalService<{ groups: Array<{ key: string; served: number; buffered: number; skipped: number }> }>(
+        externalServices.lead,
+        `/stats?${leadParams}`,
+        { headers: internalHeaders },
+      ).catch((err) => {
+        console.warn("[campaigns/stats] lead-service groupBy failed:", (err as Error).message);
+        return null;
+      }),
+      callExternalService<{ groups: Array<{ key: string; stats: { emailsGenerated: number } }> }>(
+        externalServices.emailgen,
+        `/stats?${emailgenParams}`,
+        { headers: internalHeaders },
+      ).catch((err) => {
+        console.warn("[campaigns/stats] content-generation groupBy failed:", (err as Error).message);
+        return null;
+      }),
+      callExternalService<{ groups: Array<{ key: string; totalCostInUsdCents: string; runCount: number }> }>(
+        externalServices.runs,
+        `/v1/stats/costs?${runsParams}`,
+        { headers: internalHeaders },
+      ).catch((err) => {
+        console.warn("[campaigns/stats] runs-service groupBy failed:", (err as Error).message);
+        return null;
+      }),
+    ]);
+
+    // Merge all groups by campaignId
+    const merged = new Map<string, Record<string, unknown>>();
+    const ensure = (id: string) => {
+      if (!merged.has(id)) merged.set(id, { campaignId: id });
+      return merged.get(id)!;
+    };
+
+    // Delivery stats (broadcast only)
+    for (const g of deliveryGroups?.groups ?? []) {
+      const s = ensure(g.key);
+      const b = g.broadcast;
+      s.emailsSent = b?.emailsSent ?? 0;
+      s.emailsDelivered = b?.emailsDelivered ?? 0;
+      s.emailsOpened = b?.emailsOpened ?? 0;
+      s.emailsClicked = b?.emailsClicked ?? 0;
+      s.emailsReplied = b?.emailsReplied ?? 0;
+      s.emailsBounced = b?.emailsBounced ?? 0;
+      s.repliesWillingToMeet = b?.repliesWillingToMeet ?? 0;
+      s.repliesInterested = b?.repliesInterested ?? 0;
+      s.repliesNotInterested = b?.repliesNotInterested ?? 0;
+      s.repliesOutOfOffice = b?.repliesOutOfOffice ?? 0;
+      s.repliesUnsubscribe = b?.repliesUnsubscribe ?? 0;
+    }
+
+    // Lead stats
+    for (const g of leadGroups?.groups ?? []) {
+      const s = ensure(g.key);
+      s.leadsServed = g.served;
+      s.leadsBuffered = g.buffered;
+      s.leadsSkipped = g.skipped;
+    }
+
+    // Emailgen stats
+    for (const g of emailgenGroups?.groups ?? []) {
+      const s = ensure(g.key);
+      s.emailsGenerated = g.stats.emailsGenerated;
+    }
+
+    // Cost stats from runs-service
+    for (const g of costGroups?.groups ?? []) {
+      const s = ensure(g.key);
+      s.totalCostInUsdCents = g.totalCostInUsdCents;
+      s.runCount = g.runCount;
+    }
+
+    // Fill defaults for any missing fields
+    const defaults = {
+      leadsServed: 0, leadsBuffered: 0, leadsSkipped: 0,
+      emailsGenerated: 0,
+      emailsSent: 0, emailsDelivered: 0, emailsOpened: 0, emailsClicked: 0,
+      emailsReplied: 0, emailsBounced: 0,
+      repliesWillingToMeet: 0, repliesInterested: 0, repliesNotInterested: 0,
+      repliesOutOfOffice: 0, repliesUnsubscribe: 0,
+      totalCostInUsdCents: null, runCount: 0,
+    };
+    for (const stats of merged.values()) {
+      for (const [k, v] of Object.entries(defaults)) {
+        if (stats[k] === undefined) stats[k] = v;
+      }
+    }
+
+    res.json({ campaigns: Array.from(merged.values()) });
+  } catch (error: any) {
+    console.error("Get campaigns stats error:", error);
+    res.status(500).json({ error: error.message || "Failed to get campaigns stats" });
+  }
+});
+
+/**
  * GET /v1/campaigns/:id
  * Get a specific campaign
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -362,6 +362,60 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/campaigns/stats",
+  tags: ["Campaigns"],
+  summary: "Get stats for all campaigns (grouped)",
+  description:
+    "Aggregates stats from email-gateway, lead-service, content-generation, and runs-service " +
+    "using groupBy=campaignId. Returns one entry per campaign. " +
+    "Replaces the old POST /v1/campaigns/stats/batch endpoint.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().optional().describe("Filter by brand ID"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Per-campaign aggregated statistics",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              campaigns: z.array(
+                z.object({
+                  campaignId: z.string(),
+                  leadsServed: z.number(),
+                  leadsBuffered: z.number(),
+                  leadsSkipped: z.number(),
+                  emailsGenerated: z.number(),
+                  emailsSent: z.number(),
+                  emailsDelivered: z.number(),
+                  emailsOpened: z.number(),
+                  emailsClicked: z.number(),
+                  emailsReplied: z.number(),
+                  emailsBounced: z.number(),
+                  repliesWillingToMeet: z.number(),
+                  repliesInterested: z.number(),
+                  repliesNotInterested: z.number(),
+                  repliesOutOfOffice: z.number(),
+                  repliesUnsubscribe: z.number(),
+                  totalCostInUsdCents: z.string().nullable(),
+                  runCount: z.number(),
+                }),
+              ),
+            })
+            .openapi("CampaignsBatchStatsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/campaigns/{id}/leads",
   tags: ["Campaigns"],
   summary: "Get campaign leads",

--- a/tests/unit/campaigns-grouped-stats.test.ts
+++ b/tests/unit/campaigns-grouped-stats.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for GET /v1/campaigns/stats?brandId=X
+ * Aggregates stats from 4 services using groupBy=campaignId.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockCallExternalService = vi.fn();
+const mockBuildInternalHeaders = vi.fn(() => ({}));
+
+vi.mock("../../src/lib/service-client.js", () => ({
+  callExternalService: (...args: unknown[]) => mockCallExternalService(...args),
+  callService: vi.fn(),
+  externalServices: {
+    emailgen: { url: "http://mock-emailgen", apiKey: "k" },
+    emailGateway: { url: "http://mock-email-gw", apiKey: "k" },
+    replyQualification: { url: "http://mock-rq", apiKey: "k" },
+    lead: { url: "http://mock-lead", apiKey: "k" },
+    campaign: { url: "http://mock-campaign", apiKey: "k" },
+    key: { url: "http://mock-key", apiKey: "k" },
+    scraping: { url: "http://mock-scraping", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
+    brand: { url: "http://mock-brand", apiKey: "k" },
+    runs: { url: "http://mock-runs", apiKey: "k" },
+  },
+  services: { client: "http://mock-client" },
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (_req: any, _res: any, next: any) => {
+    _req.userId = "user1";
+    _req.orgId = "org1";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("../../src/lib/internal-headers.js", () => ({
+  buildInternalHeaders: (...args: unknown[]) => mockBuildInternalHeaders(...args),
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn(),
+}));
+
+import express from "express";
+import request from "supertest";
+import campaignsRouter from "../../src/routes/campaigns.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignsRouter);
+  return app;
+}
+
+describe("GET /v1/campaigns/stats", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("should merge stats from 4 services grouped by campaignId", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockImplementation((service: any, path: string) => {
+      // email-gateway
+      if (service.url === "http://mock-email-gw") {
+        return Promise.resolve({
+          groups: [
+            {
+              key: "c1",
+              broadcast: { emailsSent: 10, emailsDelivered: 9, emailsOpened: 5, emailsClicked: 2, emailsReplied: 1, emailsBounced: 1, repliesWillingToMeet: 0, repliesInterested: 1, repliesNotInterested: 0, repliesOutOfOffice: 0, repliesUnsubscribe: 0 },
+              transactional: null,
+            },
+            {
+              key: "c2",
+              broadcast: { emailsSent: 20, emailsDelivered: 18, emailsOpened: 12, emailsClicked: 3, emailsReplied: 2, emailsBounced: 2, repliesWillingToMeet: 1, repliesInterested: 0, repliesNotInterested: 1, repliesOutOfOffice: 0, repliesUnsubscribe: 0 },
+              transactional: null,
+            },
+          ],
+        });
+      }
+      // lead-service
+      if (service.url === "http://mock-lead") {
+        return Promise.resolve({
+          groups: [
+            { key: "c1", served: 15, buffered: 3, skipped: 1 },
+            { key: "c2", served: 30, buffered: 5, skipped: 2 },
+          ],
+        });
+      }
+      // content-generation
+      if (service.url === "http://mock-emailgen") {
+        return Promise.resolve({
+          groups: [
+            { key: "c1", stats: { emailsGenerated: 12 } },
+            { key: "c2", stats: { emailsGenerated: 25 } },
+          ],
+        });
+      }
+      // runs-service
+      if (service.url === "http://mock-runs") {
+        return Promise.resolve({
+          groups: [
+            { key: "c1", totalCostInUsdCents: "500", runCount: 15 },
+            { key: "c2", totalCostInUsdCents: "1200", runCount: 30 },
+          ],
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const res = await request(app).get("/v1/campaigns/stats?brandId=brand-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.campaigns).toHaveLength(2);
+
+    const c1 = res.body.campaigns.find((c: any) => c.campaignId === "c1");
+    const c2 = res.body.campaigns.find((c: any) => c.campaignId === "c2");
+
+    // Verify c1
+    expect(c1.leadsServed).toBe(15);
+    expect(c1.emailsGenerated).toBe(12);
+    expect(c1.emailsSent).toBe(10);
+    expect(c1.emailsOpened).toBe(5);
+    expect(c1.emailsReplied).toBe(1);
+    expect(c1.totalCostInUsdCents).toBe("500");
+    expect(c1.runCount).toBe(15);
+
+    // Verify c2
+    expect(c2.leadsServed).toBe(30);
+    expect(c2.emailsGenerated).toBe(25);
+    expect(c2.emailsSent).toBe(20);
+    expect(c2.totalCostInUsdCents).toBe("1200");
+  });
+
+  it("should make exactly 4 service calls", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({ groups: [] });
+
+    await request(app).get("/v1/campaigns/stats?brandId=brand-1");
+
+    expect(mockCallExternalService).toHaveBeenCalledTimes(4);
+  });
+
+  it("should pass brandId filter to all services", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({ groups: [] });
+
+    await request(app).get("/v1/campaigns/stats?brandId=brand-42");
+
+    for (const call of mockCallExternalService.mock.calls) {
+      const path = call[1] as string;
+      expect(path).toContain("brandId=brand-42");
+    }
+  });
+
+  it("should pass groupBy=campaignId to all services", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({ groups: [] });
+
+    await request(app).get("/v1/campaigns/stats");
+
+    for (const call of mockCallExternalService.mock.calls) {
+      const path = call[1] as string;
+      expect(path).toContain("groupBy=campaignId");
+    }
+  });
+
+  it("should fill defaults when some services fail", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockImplementation((service: any) => {
+      // Only lead-service responds
+      if (service.url === "http://mock-lead") {
+        return Promise.resolve({
+          groups: [{ key: "c1", served: 5, buffered: 1, skipped: 0 }],
+        });
+      }
+      return Promise.reject(new Error("service down"));
+    });
+
+    const res = await request(app).get("/v1/campaigns/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body.campaigns).toHaveLength(1);
+
+    const c1 = res.body.campaigns[0];
+    expect(c1.campaignId).toBe("c1");
+    expect(c1.leadsServed).toBe(5);
+    // Defaults for missing services
+    expect(c1.emailsSent).toBe(0);
+    expect(c1.emailsGenerated).toBe(0);
+    expect(c1.totalCostInUsdCents).toBeNull();
+    expect(c1.runCount).toBe(0);
+  });
+
+  it("should return empty array when all services fail", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockRejectedValue(new Error("all down"));
+
+    const res = await request(app).get("/v1/campaigns/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body.campaigns).toEqual([]);
+  });
+
+  it("should use only broadcast stats from email-gateway, not transactional", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockImplementation((service: any) => {
+      if (service.url === "http://mock-email-gw") {
+        return Promise.resolve({
+          groups: [{
+            key: "c1",
+            broadcast: { emailsSent: 5, emailsDelivered: 5, emailsOpened: 3, emailsClicked: 0, emailsReplied: 1, emailsBounced: 0, repliesWillingToMeet: 0, repliesInterested: 0, repliesNotInterested: 0, repliesOutOfOffice: 0, repliesUnsubscribe: 0 },
+            transactional: { emailsSent: 100, emailsDelivered: 95, emailsOpened: 60, emailsClicked: 10, emailsReplied: 20, emailsBounced: 5, repliesWillingToMeet: 0, repliesInterested: 0, repliesNotInterested: 0, repliesOutOfOffice: 0, repliesUnsubscribe: 0 },
+          }],
+        });
+      }
+      return Promise.resolve({ groups: [] });
+    });
+
+    const res = await request(app).get("/v1/campaigns/stats");
+
+    const c1 = res.body.campaigns.find((c: any) => c.campaignId === "c1");
+    // Must be broadcast only, NOT 100 (transactional) or 105 (sum)
+    expect(c1.emailsSent).toBe(5);
+    expect(c1.emailsOpened).toBe(3);
+    expect(c1.emailsReplied).toBe(1);
+  });
+});
+
+describe("Dashboard endpoints OpenAPI — campaigns/stats", () => {
+  it("should register GET /v1/campaigns/stats in schemas.ts", () => {
+    const fs = require("fs");
+    const path = require("path");
+    const content = fs.readFileSync(
+      path.join(__dirname, "../../src/schemas.ts"),
+      "utf-8",
+    );
+    expect(content).toContain('path: "/v1/campaigns/stats"');
+  });
+});

--- a/tests/unit/dashboard-endpoints-openapi.test.ts
+++ b/tests/unit/dashboard-endpoints-openapi.test.ts
@@ -6,6 +6,7 @@
  * 2. GET /v1/runs/stats/costs — must be registered
  * 3. GET /v1/campaigns/{id}/stats/replies — removed (no longer registered)
  * 4. GET /v1/campaigns status query param — must be documented
+ * 5. GET /v1/campaigns/stats — grouped stats aggregator, must be registered
  */
 import { describe, it, expect } from "vitest";
 import fs from "fs";
@@ -32,6 +33,10 @@ describe("Dashboard endpoints OpenAPI documentation", () => {
   it("should NOT register campaigns batch-stats endpoint (removed)", () => {
     expect(content).not.toContain('path: "/v1/campaigns/stats/batch"');
     expect(content).not.toContain("BatchStatsRequest");
+  });
+
+  it("should register GET /v1/campaigns/stats (grouped aggregator)", () => {
+    expect(content).toContain('path: "/v1/campaigns/stats"');
   });
 
   it("should document status query param on GET /v1/campaigns", () => {


### PR DESCRIPTION
## Summary
- Adds `GET /v1/campaigns/stats?brandId=X` — a single endpoint that replaces the old `POST /v1/campaigns/stats/batch` with a cleaner groupBy approach
- Calls 4 services in parallel with `groupBy=campaignId`: email-gateway, lead-service, content-generation, runs-service
- Merges results per campaign and returns `{ campaigns: [...] }` — frontend makes **1 call instead of N**
- Registered in OpenAPI schema with full response type

## Test plan
- [x] 8 unit tests covering: merged stats, 4 service calls, brandId forwarding, groupBy forwarding, partial failures, total failures, broadcast-only filtering
- [x] OpenAPI regression test updated
- [x] Full suite: 65 files, 501 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)