### PR TITLE
docs: add full response schemas to all stats OpenAPI endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -129,6 +129,330 @@
           "error"
         ]
       },
+      "LeaderboardResponse": {
+        "type": "object",
+        "properties": {
+          "brands": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "brandId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "brandUrl": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "brandDomain": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "emailsSent": {
+                  "type": "number"
+                },
+                "emailsOpened": {
+                  "type": "number"
+                },
+                "emailsClicked": {
+                  "type": "number"
+                },
+                "emailsReplied": {
+                  "type": "number"
+                },
+                "totalCostUsdCents": {
+                  "type": "number"
+                },
+                "openRate": {
+                  "type": "number"
+                },
+                "clickRate": {
+                  "type": "number"
+                },
+                "replyRate": {
+                  "type": "number"
+                },
+                "costPerOpenCents": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "costPerClickCents": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "costPerReplyCents": {
+                  "type": "number",
+                  "nullable": true
+                }
+              },
+              "required": [
+                "brandId",
+                "brandUrl",
+                "brandDomain",
+                "emailsSent",
+                "emailsOpened",
+                "emailsClicked",
+                "emailsReplied",
+                "totalCostUsdCents",
+                "openRate",
+                "clickRate",
+                "replyRate",
+                "costPerOpenCents",
+                "costPerClickCents",
+                "costPerReplyCents"
+              ]
+            }
+          },
+          "workflows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "workflowName": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "signatureName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "category": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "sectionKey": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "runCount": {
+                  "type": "number"
+                },
+                "emailsSent": {
+                  "type": "number"
+                },
+                "emailsOpened": {
+                  "type": "number"
+                },
+                "emailsClicked": {
+                  "type": "number"
+                },
+                "emailsReplied": {
+                  "type": "number"
+                },
+                "repliesInterested": {
+                  "type": "number"
+                },
+                "recipients": {
+                  "type": "number"
+                },
+                "totalCostUsdCents": {
+                  "type": "number"
+                },
+                "openRate": {
+                  "type": "number"
+                },
+                "clickRate": {
+                  "type": "number"
+                },
+                "replyRate": {
+                  "type": "number"
+                },
+                "interestedRate": {
+                  "type": "number"
+                },
+                "costPerOpenCents": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "costPerClickCents": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "costPerReplyCents": {
+                  "type": "number",
+                  "nullable": true
+                }
+              },
+              "required": [
+                "workflowName",
+                "displayName",
+                "signatureName",
+                "category",
+                "sectionKey",
+                "runCount",
+                "emailsSent",
+                "emailsOpened",
+                "emailsClicked",
+                "emailsReplied",
+                "repliesInterested",
+                "recipients",
+                "totalCostUsdCents",
+                "openRate",
+                "clickRate",
+                "replyRate",
+                "interestedRate",
+                "costPerOpenCents",
+                "costPerClickCents",
+                "costPerReplyCents"
+              ]
+            }
+          },
+          "hero": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "bestCostPerOpen": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "brandDomain": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "costPerOpenCents": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "brandDomain",
+                  "costPerOpenCents"
+                ]
+              },
+              "bestCostPerReply": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "brandDomain": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "costPerReplyCents": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "brandDomain",
+                  "costPerReplyCents"
+                ]
+              }
+            },
+            "required": [
+              "bestCostPerOpen",
+              "bestCostPerReply"
+            ]
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "availableCategories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "categorySections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string"
+                },
+                "sectionKey": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "stats": {
+                  "type": "object",
+                  "properties": {
+                    "emailsSent": {
+                      "type": "number"
+                    },
+                    "emailsOpened": {
+                      "type": "number"
+                    },
+                    "emailsReplied": {
+                      "type": "number"
+                    },
+                    "repliesInterested": {
+                      "type": "number"
+                    },
+                    "recipients": {
+                      "type": "number"
+                    },
+                    "totalCostUsdCents": {
+                      "type": "number"
+                    },
+                    "openRate": {
+                      "type": "number"
+                    },
+                    "replyRate": {
+                      "type": "number"
+                    },
+                    "interestedRate": {
+                      "type": "number"
+                    },
+                    "costPerOpenCents": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "costPerReplyCents": {
+                      "type": "number",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "emailsSent",
+                    "emailsOpened",
+                    "emailsReplied",
+                    "repliesInterested",
+                    "recipients",
+                    "totalCostUsdCents",
+                    "openRate",
+                    "replyRate",
+                    "interestedRate",
+                    "costPerOpenCents",
+                    "costPerReplyCents"
+                  ]
+                },
+                "workflows": {
+                  "type": "array",
+                  "items": {
+                    "nullable": true
+                  }
+                },
+                "brands": {
+                  "type": "array",
+                  "items": {
+                    "nullable": true
+                  }
+                }
+              },
+              "required": [
+                "category",
+                "sectionKey",
+                "label",
+                "stats",
+                "workflows",
+                "brands"
+              ]
+            }
+          }
+        },
+        "required": [
+          "brands",
+          "workflows",
+          "hero",
+          "updatedAt",
+          "availableCategories",
+          "categorySections"
+        ]
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -312,6 +636,9 @@
           "emailsSent": {
             "type": "number"
           },
+          "emailsDelivered": {
+            "type": "number"
+          },
           "emailsOpened": {
             "type": "number"
           },
@@ -338,6 +665,42 @@
           },
           "repliesUnsubscribe": {
             "type": "number"
+          },
+          "totalCostInUsdCents": {
+            "type": "string",
+            "nullable": true,
+            "description": "Total cost from campaign-service budget tracking"
+          },
+          "costBreakdown": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "costName": {
+                  "type": "string"
+                },
+                "totalCostInUsdCents": {
+                  "type": "string"
+                },
+                "actualCostInUsdCents": {
+                  "type": "string"
+                },
+                "provisionedCostInUsdCents": {
+                  "type": "string"
+                },
+                "totalQuantity": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "costName",
+                "totalCostInUsdCents",
+                "actualCostInUsdCents",
+                "provisionedCostInUsdCents",
+                "totalQuantity"
+              ]
+            },
+            "description": "Per-cost-name breakdown from runs-service"
           }
         },
         "required": [
@@ -653,6 +1016,57 @@
           "repliesNotInterested",
           "repliesOutOfOffice",
           "repliesUnsubscribe"
+        ]
+      },
+      "RunsCostStatsResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dimensions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "description": "Dimension key-value pairs (e.g. { brandId: '...' })"
+                },
+                "totalCostInUsdCents": {
+                  "type": "string"
+                },
+                "actualCostInUsdCents": {
+                  "type": "string"
+                },
+                "provisionedCostInUsdCents": {
+                  "type": "string"
+                },
+                "cancelledCostInUsdCents": {
+                  "type": "string"
+                },
+                "runCount": {
+                  "type": "number"
+                },
+                "totalQuantity": {
+                  "type": "string",
+                  "description": "Present when groupBy includes costName"
+                }
+              },
+              "required": [
+                "dimensions",
+                "totalCostInUsdCents",
+                "actualCostInUsdCents",
+                "provisionedCostInUsdCents",
+                "cancelledCostInUsdCents",
+                "runCount"
+              ]
+            }
+          }
+        },
+        "required": [
+          "groups"
         ]
       },
       "BestWorkflowResponse": {
@@ -1238,6 +1652,36 @@
           "eventType"
         ]
       },
+      "TransactionalEmailStatsResponse": {
+        "type": "object",
+        "properties": {
+          "stats": {
+            "type": "object",
+            "properties": {
+              "totalEmails": {
+                "type": "number",
+                "description": "Total email events"
+              },
+              "sent": {
+                "type": "number",
+                "description": "Successfully sent"
+              },
+              "failed": {
+                "type": "number",
+                "description": "Failed to send"
+              }
+            },
+            "required": [
+              "totalEmails",
+              "sent",
+              "failed"
+            ]
+          }
+        },
+        "required": [
+          "stats"
+        ]
+      },
       "DeployEmailTemplatesRequest": {
         "type": "object",
         "properties": {
@@ -1484,6 +1928,43 @@
           "lineItems",
           "successUrl",
           "cancelUrl"
+        ]
+      },
+      "StripeStatsResponse": {
+        "type": "object",
+        "properties": {
+          "totalPayments": {
+            "type": "number",
+            "description": "Total number of payments"
+          },
+          "totalAmountInCents": {
+            "type": "number",
+            "description": "Total payment amount in cents"
+          },
+          "successCount": {
+            "type": "number",
+            "description": "Successful payments"
+          },
+          "failureCount": {
+            "type": "number",
+            "description": "Failed payments"
+          },
+          "refundCount": {
+            "type": "number",
+            "description": "Refunded payments"
+          },
+          "disputeCount": {
+            "type": "number",
+            "description": "Disputed payments"
+          }
+        },
+        "required": [
+          "totalPayments",
+          "totalAmountInCents",
+          "successCount",
+          "failureCount",
+          "refundCount",
+          "disputeCount"
         ]
       },
       "ResolveUserResponse": {
@@ -1884,7 +2365,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Leaderboard data with brands, workflows, and hero stats"
+            "description": "Leaderboard data with brands, workflows, and hero stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeaderboardResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -5129,7 +5617,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Cost stats grouped by the requested dimension"
+            "description": "Cost stats grouped by the requested dimension",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunsCostStatsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Missing groupBy parameter",
@@ -7226,7 +7721,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Aggregated email stats"
+            "description": "Aggregated email stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionalEmailStatsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -8260,7 +8762,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Aggregated sales stats"
+            "description": "Aggregated sales stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StripeStatsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -141,7 +141,87 @@ registry.registerPath({
     "Returns performance leaderboard data including brands, workflows, and hero stats. Requires authentication.",
   security: authed,
   responses: {
-    200: { description: "Leaderboard data with brands, workflows, and hero stats" },
+    200: {
+      description: "Leaderboard data with brands, workflows, and hero stats",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              brands: z.array(z.object({
+                brandId: z.string().nullable(),
+                brandUrl: z.string().nullable(),
+                brandDomain: z.string().nullable(),
+                emailsSent: z.number(),
+                emailsOpened: z.number(),
+                emailsClicked: z.number(),
+                emailsReplied: z.number(),
+                totalCostUsdCents: z.number(),
+                openRate: z.number(),
+                clickRate: z.number(),
+                replyRate: z.number(),
+                costPerOpenCents: z.number().nullable(),
+                costPerClickCents: z.number().nullable(),
+                costPerReplyCents: z.number().nullable(),
+              })),
+              workflows: z.array(z.object({
+                workflowName: z.string(),
+                displayName: z.string(),
+                signatureName: z.string().nullable(),
+                category: z.string().nullable(),
+                sectionKey: z.string().nullable(),
+                runCount: z.number(),
+                emailsSent: z.number(),
+                emailsOpened: z.number(),
+                emailsClicked: z.number(),
+                emailsReplied: z.number(),
+                repliesInterested: z.number(),
+                recipients: z.number(),
+                totalCostUsdCents: z.number(),
+                openRate: z.number(),
+                clickRate: z.number(),
+                replyRate: z.number(),
+                interestedRate: z.number(),
+                costPerOpenCents: z.number().nullable(),
+                costPerClickCents: z.number().nullable(),
+                costPerReplyCents: z.number().nullable(),
+              })),
+              hero: z.object({
+                bestCostPerOpen: z.object({
+                  brandDomain: z.string().nullable(),
+                  costPerOpenCents: z.number(),
+                }).nullable(),
+                bestCostPerReply: z.object({
+                  brandDomain: z.string().nullable(),
+                  costPerReplyCents: z.number(),
+                }).nullable(),
+              }).nullable(),
+              updatedAt: z.string(),
+              availableCategories: z.array(z.string()),
+              categorySections: z.array(z.object({
+                category: z.string(),
+                sectionKey: z.string(),
+                label: z.string(),
+                stats: z.object({
+                  emailsSent: z.number(),
+                  emailsOpened: z.number(),
+                  emailsReplied: z.number(),
+                  repliesInterested: z.number(),
+                  recipients: z.number(),
+                  totalCostUsdCents: z.number(),
+                  openRate: z.number(),
+                  replyRate: z.number(),
+                  interestedRate: z.number(),
+                  costPerOpenCents: z.number().nullable(),
+                  costPerReplyCents: z.number().nullable(),
+                }),
+                workflows: z.array(z.any()),
+                brands: z.array(z.any()),
+              })),
+            })
+            .openapi("LeaderboardResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },
   },
@@ -341,6 +421,7 @@ registry.registerPath({
               emailsGenerated: z.number(),
               totalCostUsd: z.number().optional(),
               emailsSent: z.number(),
+              emailsDelivered: z.number().optional(),
               emailsOpened: z.number(),
               emailsClicked: z.number(),
               emailsReplied: z.number(),
@@ -350,6 +431,14 @@ registry.registerPath({
               repliesNotInterested: z.number().optional(),
               repliesOutOfOffice: z.number().optional(),
               repliesUnsubscribe: z.number().optional(),
+              totalCostInUsdCents: z.string().nullable().optional().describe("Total cost from campaign-service budget tracking"),
+              costBreakdown: z.array(z.object({
+                costName: z.string(),
+                totalCostInUsdCents: z.string(),
+                actualCostInUsdCents: z.string(),
+                provisionedCostInUsdCents: z.string(),
+                totalQuantity: z.string(),
+              })).optional().describe("Per-cost-name breakdown from runs-service"),
             })
             .openapi("CampaignStatsResponse"),
         },
@@ -980,7 +1069,26 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "Cost stats grouped by the requested dimension" },
+    200: {
+      description: "Cost stats grouped by the requested dimension",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              groups: z.array(z.object({
+                dimensions: z.record(z.string().nullable()).describe("Dimension key-value pairs (e.g. { brandId: '...' })"),
+                totalCostInUsdCents: z.string(),
+                actualCostInUsdCents: z.string(),
+                provisionedCostInUsdCents: z.string(),
+                cancelledCostInUsdCents: z.string(),
+                runCount: z.number(),
+                totalQuantity: z.string().optional().describe("Present when groupBy includes costName"),
+              })),
+            })
+            .openapi("RunsCostStatsResponse"),
+        },
+      },
+    },
     400: { description: "Missing groupBy parameter", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
@@ -1680,7 +1788,22 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "Aggregated email stats" },
+    200: {
+      description: "Aggregated email stats",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              stats: z.object({
+                totalEmails: z.number().describe("Total email events"),
+                sent: z.number().describe("Successfully sent"),
+                failed: z.number().describe("Failed to send"),
+              }),
+            })
+            .openapi("TransactionalEmailStatsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -1949,7 +2072,23 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "Aggregated sales stats" },
+    200: {
+      description: "Aggregated sales stats",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              totalPayments: z.number().describe("Total number of payments"),
+              totalAmountInCents: z.number().describe("Total payment amount in cents"),
+              successCount: z.number().describe("Successful payments"),
+              failureCount: z.number().describe("Failed payments"),
+              refundCount: z.number().describe("Refunded payments"),
+              disputeCount: z.number().describe("Disputed payments"),
+            })
+            .openapi("StripeStatsResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },


### PR DESCRIPTION
## Summary
- **`GET /v1/campaigns/{id}/stats`**: added missing `emailsDelivered`, `totalCostInUsdCents`, `costBreakdown` fields
- **`GET /v1/stats/leaderboard`**: full `LeaderboardResponse` schema (brands, workflows, hero, categorySections)
- **`GET /v1/runs/stats/costs`**: `RunsCostStatsResponse` with groups array, dimensions, cost fields, runCount
- **`GET /v1/emails/stats`**: `TransactionalEmailStatsResponse` (totalEmails, sent, failed) — from transactional-email-service spec
- **`GET /v1/stripe/stats`**: `StripeStatsResponse` (totalPayments, totalAmountInCents, success/failure/refund/dispute counts) — from stripe-service spec

## Test plan
- [x] All 501 tests pass (65 files)
- [x] OpenAPI spec regenerated from schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)