### PR TITLE
fix: read costName from dimensions in runs-service response

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -210,7 +210,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
         console.warn("[campaigns/stats] content-generation groupBy failed:", (err as Error).message);
         return null;
       }),
-      callExternalService<{ groups: Array<{ key: string; totalCostInUsdCents: string; runCount: number }> }>(
+      callExternalService<{ groups: Array<{ dimensions: Record<string, string | null>; totalCostInUsdCents: string; runCount: number }> }>(
         externalServices.runs,
         `/v1/stats/costs?${runsParams}`,
         { headers: internalHeaders },
@@ -260,7 +260,9 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
 
     // Cost stats from runs-service
     for (const g of costGroups?.groups ?? []) {
-      const s = ensure(g.key);
+      const campaignId = g.dimensions.campaignId;
+      if (!campaignId) continue;
+      const s = ensure(campaignId);
       s.totalCostInUsdCents = g.totalCostInUsdCents;
       s.runCount = g.runCount;
     }
@@ -419,7 +421,7 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
         return null;
       }),
       // Full cost breakdown by cost name from runs-service (single source of truth)
-      callExternalService<{ groups: Array<{ key: string; totalCostInUsdCents: string; actualCostInUsdCents: string; provisionedCostInUsdCents: string; totalQuantity: string }> }>(
+      callExternalService<{ groups: Array<{ dimensions: Record<string, string | null>; totalCostInUsdCents: string; actualCostInUsdCents: string; provisionedCostInUsdCents: string; totalQuantity: string }> }>(
         externalServices.runs,
         `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&campaignId=${encodeURIComponent(id)}&groupBy=costName`,
         { headers: internalHeaders }
@@ -486,13 +488,15 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
 
     // Cost breakdown by cost name from runs-service
     if (costBreakdown?.groups) {
-      stats.costBreakdown = costBreakdown.groups.map((g) => ({
-        costName: g.key,
-        totalCostInUsdCents: g.totalCostInUsdCents,
-        actualCostInUsdCents: g.actualCostInUsdCents,
-        provisionedCostInUsdCents: g.provisionedCostInUsdCents,
-        totalQuantity: g.totalQuantity,
-      }));
+      stats.costBreakdown = costBreakdown.groups
+        .filter((g) => g.dimensions.costName != null)
+        .map((g) => ({
+          costName: g.dimensions.costName!,
+          totalCostInUsdCents: g.totalCostInUsdCents,
+          actualCostInUsdCents: g.actualCostInUsdCents,
+          provisionedCostInUsdCents: g.provisionedCostInUsdCents,
+          totalQuantity: g.totalQuantity,
+        }));
     }
 
     res.json(stats);

--- a/tests/unit/campaigns-grouped-stats.test.ts
+++ b/tests/unit/campaigns-grouped-stats.test.ts
@@ -102,8 +102,8 @@ describe("GET /v1/campaigns/stats", () => {
       if (service.url === "http://mock-runs") {
         return Promise.resolve({
           groups: [
-            { key: "c1", totalCostInUsdCents: "500", runCount: 15 },
-            { key: "c2", totalCostInUsdCents: "1200", runCount: 30 },
+            { dimensions: { campaignId: "c1" }, totalCostInUsdCents: "500", runCount: 15 },
+            { dimensions: { campaignId: "c2" }, totalCostInUsdCents: "1200", runCount: 30 },
           ],
         });
       }

--- a/tests/unit/stats-cost-field.regression.test.ts
+++ b/tests/unit/stats-cost-field.regression.test.ts
@@ -5,7 +5,7 @@
  * After PR #116/#117:
  * - The batch stats endpoint (POST /v1/campaigns/stats/batch) was removed
  * - Single campaign stats still includes totalCostInUsdCents from campaign-service /stats/batch-budget
- * - Cost breakdown uses runs-service /v1/stats/costs?groupBy=costName with { groups: [{ key, ... }] } format
+ * - Cost breakdown uses runs-service /v1/stats/costs?groupBy=costName with { groups: [{ dimensions: { costName }, ... }] } format
  */
 import { describe, it, expect } from "vitest";
 import * as fs from "fs";
@@ -33,8 +33,8 @@ describe("Campaign stats endpoints include totalCostInUsdCents", () => {
   it("should use runs-service /v1/stats/costs with groupBy=costName for cost breakdown", () => {
     expect(content).toContain("groupBy=costName");
     expect(content).toContain("externalServices.runs");
-    // Response uses .groups with .key field
+    // Response uses .groups with .dimensions.costName field
     expect(content).toContain("costBreakdown.groups");
-    expect(content).toContain("g.key");
+    expect(content).toContain("g.dimensions.costName");
   });
 });


### PR DESCRIPTION
## Summary
- Runs-service `/v1/stats/costs?groupBy=costName` returns `{ dimensions: { costName: "..." } }`, not `{ key: "..." }`
- The code was reading `g.key` which yielded `undefined`/`null`, causing "Unknown" in the dashboard cost pie chart
- Also fixed `groupBy=campaignId` call which had the same wrong type assertion

## Test plan
- [x] All 501 existing tests pass
- [x] Regression test updated to verify `g.dimensions.costName` pattern
- [x] Grouped stats test updated to use `dimensions: { campaignId }` mock format
- [ ] Verify in staging: `GET /v1/campaigns/{id}/stats` returns non-null `costName` in `costBreakdown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)