### PR TITLE
docs: add response schemas for leads/emails endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -811,6 +811,286 @@
           "campaigns"
         ]
       },
+      "RunCostData": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Run status (e.g. completed, failed)"
+          },
+          "startedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp when the run started"
+          },
+          "completedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp when the run completed"
+          },
+          "totalCostInUsdCents": {
+            "type": "string",
+            "nullable": true,
+            "description": "Total cost in USD cents"
+          },
+          "costs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "costName": {
+                  "type": "string"
+                },
+                "totalCostInUsdCents": {
+                  "type": "string"
+                },
+                "actualCostInUsdCents": {
+                  "type": "string"
+                },
+                "provisionedCostInUsdCents": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "costName",
+                "totalCostInUsdCents",
+                "actualCostInUsdCents",
+                "provisionedCostInUsdCents",
+                "quantity"
+              ]
+            },
+            "description": "Per-cost-name breakdown"
+          },
+          "serviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "taskName": {
+            "type": "string",
+            "nullable": true
+          },
+          "descendantRuns": {
+            "type": "array",
+            "items": {
+              "nullable": true
+            },
+            "description": "Child runs"
+          }
+        },
+        "required": [
+          "status",
+          "startedAt",
+          "completedAt",
+          "totalCostInUsdCents",
+          "costs",
+          "serviceName",
+          "taskName",
+          "descendantRuns"
+        ],
+        "description": "Enrichment run cost data, null if no run"
+      },
+      "CampaignLeadsResponse": {
+        "type": "object",
+        "properties": {
+          "leads": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "externalId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "firstName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "lastName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "emailStatus": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "title": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationDomain": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationIndustry": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationSize": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "linkedinUrl": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Always 'contacted'"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "ISO timestamp (from lead-service servedAt)"
+                },
+                "enrichmentRunId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "enrichmentRun": {
+                  "$ref": "#/components/schemas/RunCostData"
+                }
+              },
+              "required": [
+                "id",
+                "email",
+                "externalId",
+                "firstName",
+                "lastName",
+                "emailStatus",
+                "title",
+                "organizationName",
+                "organizationDomain",
+                "organizationIndustry",
+                "organizationSize",
+                "linkedinUrl",
+                "status",
+                "createdAt",
+                "enrichmentRunId",
+                "enrichmentRun"
+              ]
+            }
+          }
+        },
+        "required": [
+          "leads"
+        ]
+      },
+      "CampaignEmailsResponse": {
+        "type": "object",
+        "properties": {
+          "emails": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Generation ID"
+                },
+                "campaignId": {
+                  "type": "string"
+                },
+                "subject": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Email subject line"
+                },
+                "bodyHtml": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Email body as HTML"
+                },
+                "bodyText": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Email body as plain text"
+                },
+                "sequence": {
+                  "type": "number",
+                  "nullable": true,
+                  "description": "Sequence number in the campaign"
+                },
+                "leadFirstName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadLastName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadCompany": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadTitle": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadIndustry": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "clientCompanyName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "generationRunId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "ISO timestamp"
+                },
+                "generationRun": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/RunCostData"
+                    },
+                    {
+                      "description": "Generation run cost data, null if no run"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "campaignId",
+                "subject",
+                "bodyHtml",
+                "bodyText",
+                "sequence",
+                "leadFirstName",
+                "leadLastName",
+                "leadCompany",
+                "leadTitle",
+                "leadIndustry",
+                "clientCompanyName",
+                "generationRunId",
+                "createdAt",
+                "generationRun"
+              ]
+            }
+          }
+        },
+        "required": [
+          "emails"
+        ]
+      },
       "UpsertKeyRequest": {
         "type": "object",
         "properties": {
@@ -3409,7 +3689,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Campaign leads with enrichment run data"
+            "description": "Campaign leads with enrichment run data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignLeadsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -3505,7 +3792,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Campaign emails with generation run data"
+            "description": "Campaign emails with generation run data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignEmailsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -503,6 +503,29 @@ registry.registerPath({
   },
 });
 
+const RunCostDataSchema = z
+  .object({
+    status: z.string().describe("Run status (e.g. completed, failed)"),
+    startedAt: z.string().nullable().describe("ISO timestamp when the run started"),
+    completedAt: z.string().nullable().describe("ISO timestamp when the run completed"),
+    totalCostInUsdCents: z.string().nullable().describe("Total cost in USD cents"),
+    costs: z
+      .array(
+        z.object({
+          costName: z.string(),
+          totalCostInUsdCents: z.string(),
+          actualCostInUsdCents: z.string(),
+          provisionedCostInUsdCents: z.string(),
+          quantity: z.number(),
+        }),
+      )
+      .describe("Per-cost-name breakdown"),
+    serviceName: z.string().nullable(),
+    taskName: z.string().nullable(),
+    descendantRuns: z.array(z.unknown()).describe("Child runs"),
+  })
+  .openapi("RunCostData");
+
 registry.registerPath({
   method: "get",
   path: "/v1/campaigns/{id}/leads",
@@ -513,7 +536,37 @@ registry.registerPath({
   security: authed,
   request: { params: CampaignIdParam },
   responses: {
-    200: { description: "Campaign leads with enrichment run data" },
+    200: {
+      description: "Campaign leads with enrichment run data",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              leads: z.array(
+                z.object({
+                  id: z.string(),
+                  email: z.string(),
+                  externalId: z.string().nullable(),
+                  firstName: z.string().nullable(),
+                  lastName: z.string().nullable(),
+                  emailStatus: z.string().nullable(),
+                  title: z.string().nullable(),
+                  organizationName: z.string().nullable(),
+                  organizationDomain: z.string().nullable(),
+                  organizationIndustry: z.string().nullable(),
+                  organizationSize: z.string().nullable(),
+                  linkedinUrl: z.string().nullable(),
+                  status: z.string().describe("Always 'contacted'"),
+                  createdAt: z.string().nullable().describe("ISO timestamp (from lead-service servedAt)"),
+                  enrichmentRunId: z.string().nullable(),
+                  enrichmentRun: RunCostDataSchema.nullable().describe("Enrichment run cost data, null if no run"),
+                }),
+              ),
+            })
+            .openapi("CampaignLeadsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -529,7 +582,36 @@ registry.registerPath({
   security: authed,
   request: { params: CampaignIdParam },
   responses: {
-    200: { description: "Campaign emails with generation run data" },
+    200: {
+      description: "Campaign emails with generation run data",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              emails: z.array(
+                z.object({
+                  id: z.string().describe("Generation ID"),
+                  campaignId: z.string(),
+                  subject: z.string().nullable().describe("Email subject line"),
+                  bodyHtml: z.string().nullable().describe("Email body as HTML"),
+                  bodyText: z.string().nullable().describe("Email body as plain text"),
+                  sequence: z.number().nullable().describe("Sequence number in the campaign"),
+                  leadFirstName: z.string().nullable(),
+                  leadLastName: z.string().nullable(),
+                  leadCompany: z.string().nullable(),
+                  leadTitle: z.string().nullable(),
+                  leadIndustry: z.string().nullable(),
+                  clientCompanyName: z.string().nullable(),
+                  generationRunId: z.string().nullable(),
+                  createdAt: z.string().describe("ISO timestamp"),
+                  generationRun: RunCostDataSchema.nullable().describe("Generation run cost data, null if no run"),
+                }),
+              ),
+            })
+            .openapi("CampaignEmailsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },

--- a/tests/unit/campaign-emails-leads-openapi.test.ts
+++ b/tests/unit/campaign-emails-leads-openapi.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression test: ensures campaign leads and emails endpoints
+ * have full response schemas in the OpenAPI spec.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const openapiPath = path.join(__dirname, "../../openapi.json");
+const spec = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+describe("Campaign leads/emails OpenAPI response schemas", () => {
+  it("GET /v1/campaigns/{id}/leads should have a 200 response schema", () => {
+    const endpoint = spec.paths?.["/v1/campaigns/{id}/leads"]?.get;
+    expect(endpoint).toBeDefined();
+    const schema =
+      endpoint.responses?.["200"]?.content?.["application/json"]?.schema;
+    expect(schema).toBeDefined();
+    // Should reference CampaignLeadsResponse or inline leads array
+    const resolved = schema.$ref
+      ? spec.components.schemas[schema.$ref.split("/").pop()!]
+      : schema;
+    expect(resolved.properties?.leads).toBeDefined();
+  });
+
+  it("GET /v1/campaigns/{id}/emails should have a 200 response schema", () => {
+    const endpoint = spec.paths?.["/v1/campaigns/{id}/emails"]?.get;
+    expect(endpoint).toBeDefined();
+    const schema =
+      endpoint.responses?.["200"]?.content?.["application/json"]?.schema;
+    expect(schema).toBeDefined();
+    const resolved = schema.$ref
+      ? spec.components.schemas[schema.$ref.split("/").pop()!]
+      : schema;
+    expect(resolved.properties?.emails).toBeDefined();
+  });
+
+  it("CampaignEmailsResponse should document key email fields", () => {
+    const emailsSchema = spec.components?.schemas?.CampaignEmailsResponse;
+    expect(emailsSchema).toBeDefined();
+    const emailProps =
+      emailsSchema.properties.emails.items.properties;
+    for (const field of [
+      "id",
+      "subject",
+      "bodyHtml",
+      "bodyText",
+      "sequence",
+      "leadFirstName",
+      "leadLastName",
+      "leadCompany",
+      "leadTitle",
+      "leadIndustry",
+      "clientCompanyName",
+      "generationRun",
+      "createdAt",
+    ]) {
+      expect(emailProps).toHaveProperty(field);
+    }
+  });
+
+  it("CampaignLeadsResponse should document key lead fields", () => {
+    const leadsSchema = spec.components?.schemas?.CampaignLeadsResponse;
+    expect(leadsSchema).toBeDefined();
+    const leadProps =
+      leadsSchema.properties.leads.items.properties;
+    for (const field of [
+      "id",
+      "email",
+      "firstName",
+      "lastName",
+      "title",
+      "organizationName",
+      "enrichmentRun",
+    ]) {
+      expect(leadProps).toHaveProperty(field);
+    }
+  });
+
+  it("RunCostData schema should be defined in components", () => {
+    expect(spec.components?.schemas?.RunCostData).toBeDefined();
+    const props = spec.components.schemas.RunCostData.properties;
+    expect(props).toHaveProperty("status");
+    expect(props).toHaveProperty("totalCostInUsdCents");
+    expect(props).toHaveProperty("costs");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds full 200 response schemas for `GET /v1/campaigns/{id}/leads` and `GET /v1/campaigns/{id}/emails` (previously undocumented)
- Creates shared `RunCostData` OpenAPI schema for the run cost attachment pattern used by both endpoints
- Adds regression tests ensuring these schemas stay documented

## Context
These schemas were flagged as missing in an OpenAPI documentation audit. The `CampaignEmailsResponse` schema documents all fields returned by content-generation (id, subject, bodyHtml, bodyText, sequence, leadFirstName, leadLastName, leadCompany, leadTitle, leadIndustry, clientCompanyName, generationRun, createdAt).

**Note:** Two related issues in content-generation are out of scope for this PR:
1. `GET /generations` response — `generations` typed as `object[]` without properties
2. `POST /generate` — `variables` field undocumented (should list recognized keys: leadFirstName, leadLastName, etc.)

## Test plan
- [x] All 513 tests pass (5 new + 508 existing)
- [x] `openapi.json` regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)