### PR TITLE
fix: use POST for /platform-prompts startup registration

### DIFF
--- a/src/startup.ts
+++ b/src/startup.ts
@@ -160,7 +160,7 @@ export async function registerPlatformPrompts(): Promise<void> {
   );
 
   await callExternalService(externalServices.emailgen, "/platform-prompts", {
-    method: "PUT",
+    method: "POST",
     body: {
       type: "cold-email",
       prompt,

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -152,12 +152,12 @@ describe("registerPlatformPrompts", () => {
     });
   });
 
-  it("should call PUT /platform-prompts on content-generation-service", async () => {
+  it("should call POST /platform-prompts on content-generation-service", async () => {
     await registerPlatformPrompts();
 
     const promptCalls = fetchCalls.filter((c) => c.url.includes("/platform-prompts"));
     expect(promptCalls).toHaveLength(1);
-    expect(promptCalls[0].method).toBe("PUT");
+    expect(promptCalls[0].method).toBe("POST");
   });
 
   it("should send cold-email type with all 6 template variables", async () => {


### PR DESCRIPTION
## Summary
- Startup `registerPlatformPrompts()` was calling `PUT /platform-prompts` on content-generation-service, but that endpoint only supports `POST` (idempotent create)
- The 404 ("Not found") caused a FATAL startup crash, making all api-service endpoints return 502
- Changed method from PUT to POST, matching the content-generation-service spec

## Test plan
- [x] Updated startup test to expect POST instead of PUT
- [x] All 9 startup tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)