### PR TITLE
feat: add platform-keys and platform-prompts admin endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2116,6 +2116,52 @@
           "message"
         ]
       },
+      "PlatformKeyRequest": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Provider name (e.g. 'anthropic', 'stripe')"
+          },
+          "apiKey": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The API key value"
+          }
+        },
+        "required": [
+          "provider",
+          "apiKey"
+        ]
+      },
+      "PlatformPromptRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Prompt type (e.g. 'cold-email')"
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The prompt template text"
+          },
+          "variables": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Template variable names (e.g. ['leadFirstName', 'leadLastName'])"
+          }
+        },
+        "required": [
+          "type",
+          "prompt",
+          "variables"
+        ]
+      },
       "PlatformChatConfigRequest": {
         "type": "object",
         "properties": {
@@ -7875,6 +7921,216 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/platform-keys": {
+      "post": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Register a platform key",
+        "description": "Register or update a platform-level API key for a provider. Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformKeyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Key registered"
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing platform API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/platform-prompts": {
+      "put": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Deploy a platform prompt",
+        "description": "Register or update a platform-level prompt template. Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlatformPromptRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Prompt deployed"
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing platform API key",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import stripeRoutes from "./routes/stripe.js";
 import usersRoutes from "./routes/users.js";
 import platformRoutes from "./routes/platform.js";
 import platformChatRoutes from "./routes/platform-chat.js";
+import platformKeysRoutes from "./routes/platform-keys.js";
+import platformPromptsRoutes from "./routes/platform-prompts.js";
 import emailGatewayRoutes from "./routes/email-gateway.js";
 import runsRoutes from "./routes/runs.js";
 import { apiReference } from "@scalar/express-api-reference";
@@ -153,6 +155,8 @@ app.use("/v1", performanceRoutes);
 // Internal platform routes (API key only, no identity)
 app.use("/internal", internalEmailsRoutes);
 app.use("/platform-chat", platformChatRoutes);
+app.use("/platform-keys", platformKeysRoutes);
+app.use("/platform-prompts", platformPromptsRoutes);
 
 // Authenticated routes
 app.use("/v1", meRoutes);

--- a/src/routes/platform-keys.ts
+++ b/src/routes/platform-keys.ts
@@ -1,0 +1,36 @@
+import { Router } from "express";
+import { authenticatePlatform, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { PlatformKeyRequestSchema } from "../schemas.js";
+
+const router = Router();
+
+/**
+ * POST /platform-keys
+ * Platform-level key registration — no identity headers required.
+ * Authenticated by X-API-Key (ADMIN_DISTRIBUTE_API_KEY) only.
+ * Used by the dashboard at cold start when no Clerk session exists.
+ */
+router.post("/", authenticatePlatform, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = PlatformKeyRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+
+    const result = await callExternalService(
+      externalServices.key,
+      "/platform-keys",
+      {
+        method: "POST",
+        body: parsed.data,
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Register platform key error:", error);
+    res.status(500).json({ error: error.message || "Failed to register platform key" });
+  }
+});
+
+export default router;

--- a/src/routes/platform-prompts.ts
+++ b/src/routes/platform-prompts.ts
@@ -1,0 +1,36 @@
+import { Router } from "express";
+import { authenticatePlatform, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { PlatformPromptRequestSchema } from "../schemas.js";
+
+const router = Router();
+
+/**
+ * PUT /platform-prompts
+ * Platform-level prompt deployment — no identity headers required.
+ * Authenticated by X-API-Key (ADMIN_DISTRIBUTE_API_KEY) only.
+ * Used by the dashboard at cold start when no Clerk session exists.
+ */
+router.put("/", authenticatePlatform, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = PlatformPromptRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+
+    const result = await callExternalService(
+      externalServices.emailgen,
+      "/platform-prompts",
+      {
+        method: "PUT",
+        body: parsed.data,
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Deploy platform prompt error:", error);
+    res.status(500).json({ error: error.message || "Failed to deploy platform prompt" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1818,6 +1818,75 @@ registry.registerPath({
 });
 
 // ===================================================================
+// PLATFORM KEYS
+// ===================================================================
+
+export const PlatformKeyRequestSchema = z
+  .object({
+    provider: z.string().min(1).describe("Provider name (e.g. 'anthropic', 'stripe')"),
+    apiKey: z.string().min(1).describe("The API key value"),
+  })
+  .openapi("PlatformKeyRequest");
+
+registry.registerPath({
+  method: "post",
+  path: "/platform-keys",
+  tags: ["Platform"],
+  summary: "Register a platform key",
+  description:
+    "Register or update a platform-level API key for a provider. " +
+    "Platform-level — no org/user identity required. " +
+    "Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+  security: platformAuth,
+  request: {
+    body: {
+      content: { "application/json": { schema: PlatformKeyRequestSchema } },
+    },
+  },
+  responses: {
+    200: { description: "Key registered" },
+    400: { description: "Invalid request", content: errorContent },
+    401: { description: "Invalid or missing platform API key", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
+// PLATFORM PROMPTS
+// ===================================================================
+
+export const PlatformPromptRequestSchema = z
+  .object({
+    type: z.string().min(1).describe("Prompt type (e.g. 'cold-email')"),
+    prompt: z.string().min(1).describe("The prompt template text"),
+    variables: z.array(z.string()).describe("Template variable names (e.g. ['leadFirstName', 'leadLastName'])"),
+  })
+  .openapi("PlatformPromptRequest");
+
+registry.registerPath({
+  method: "put",
+  path: "/platform-prompts",
+  tags: ["Platform"],
+  summary: "Deploy a platform prompt",
+  description:
+    "Register or update a platform-level prompt template. " +
+    "Platform-level — no org/user identity required. " +
+    "Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+  security: platformAuth,
+  request: {
+    body: {
+      content: { "application/json": { schema: PlatformPromptRequestSchema } },
+    },
+  },
+  responses: {
+    200: { description: "Prompt deployed" },
+    400: { description: "Invalid request", content: errorContent },
+    401: { description: "Invalid or missing platform API key", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
 // PLATFORM CHAT CONFIG
 // ===================================================================
 

--- a/tests/unit/platform-keys.test.ts
+++ b/tests/unit/platform-keys.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Do NOT mock auth — we test the real authenticatePlatform middleware
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return {
+    ...actual,
+    authenticate: (req: any, _res: any, next: any) => {
+      next();
+    },
+    requireOrg: (_req: any, _res: any, next: any) => {
+      next();
+    },
+    requireUser: (_req: any, _res: any, next: any) => {
+      next();
+    },
+  };
+});
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import platformKeysRoutes from "../../src/routes/platform-keys.js";
+
+const VALID_API_KEY = "test-admin-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/platform-keys", platformKeysRoutes);
+  return app;
+}
+
+describe("POST /platform-keys", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ status: "ok" }),
+      };
+    });
+    app = createApp();
+  });
+
+  it("should register a platform key with valid API key and no identity headers", async () => {
+    const res = await request(app)
+      .post("/platform-keys")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ provider: "anthropic", apiKey: "sk-ant-123" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+
+    const call = fetchCalls.find((c) => c.url.includes("/platform-keys"));
+    expect(call).toBeDefined();
+    expect(call!.method).toBe("POST");
+    expect(call!.body).toMatchObject({
+      provider: "anthropic",
+      apiKey: "sk-ant-123",
+    });
+    // No identity headers forwarded
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-user-id"]).toBeUndefined();
+    expect(call!.headers!["x-run-id"]).toBeUndefined();
+  });
+
+  it("should return 401 without API key", async () => {
+    const res = await request(app)
+      .post("/platform-keys")
+      .send({ provider: "anthropic", apiKey: "sk-ant-123" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 401 with wrong API key", async () => {
+    const res = await request(app)
+      .post("/platform-keys")
+      .set("X-API-Key", "wrong-key")
+      .send({ provider: "anthropic", apiKey: "sk-ant-123" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 400 when provider is missing", async () => {
+    const res = await request(app)
+      .post("/platform-keys")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ apiKey: "sk-ant-123" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when apiKey is missing", async () => {
+    const res = await request(app)
+      .post("/platform-keys")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ provider: "anthropic" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when provider is empty", async () => {
+    const res = await request(app)
+      .post("/platform-keys")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ provider: "", apiKey: "sk-ant-123" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+});

--- a/tests/unit/platform-prompts.test.ts
+++ b/tests/unit/platform-prompts.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Do NOT mock auth — we test the real authenticatePlatform middleware
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return {
+    ...actual,
+    authenticate: (req: any, _res: any, next: any) => {
+      next();
+    },
+    requireOrg: (_req: any, _res: any, next: any) => {
+      next();
+    },
+    requireUser: (_req: any, _res: any, next: any) => {
+      next();
+    },
+  };
+});
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import platformPromptsRoutes from "../../src/routes/platform-prompts.js";
+
+const VALID_API_KEY = "test-admin-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/platform-prompts", platformPromptsRoutes);
+  return app;
+}
+
+describe("PUT /platform-prompts", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ status: "ok" }),
+      };
+    });
+    app = createApp();
+  });
+
+  it("should deploy a platform prompt with valid API key and no identity headers", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        type: "cold-email",
+        prompt: "You are writing cold emails...",
+        variables: ["leadFirstName", "leadLastName"],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+
+    const call = fetchCalls.find((c) => c.url.includes("/platform-prompts"));
+    expect(call).toBeDefined();
+    expect(call!.method).toBe("PUT");
+    expect(call!.body).toMatchObject({
+      type: "cold-email",
+      prompt: "You are writing cold emails...",
+      variables: ["leadFirstName", "leadLastName"],
+    });
+    // No identity headers forwarded
+    expect(call!.headers!["x-org-id"]).toBeUndefined();
+    expect(call!.headers!["x-user-id"]).toBeUndefined();
+    expect(call!.headers!["x-run-id"]).toBeUndefined();
+  });
+
+  it("should return 401 without API key", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .send({ type: "cold-email", prompt: "test", variables: [] });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 401 with wrong API key", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", "wrong-key")
+      .send({ type: "cold-email", prompt: "test", variables: [] });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid or missing platform API key");
+  });
+
+  it("should return 400 when type is missing", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ prompt: "test", variables: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when prompt is missing", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ type: "cold-email", variables: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when variables is missing", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ type: "cold-email", prompt: "test" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when type is empty", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ type: "", prompt: "test", variables: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /platform-keys` — proxies to key-service, auth via `X-API-Key` (no user session needed)
- Add `PUT /platform-prompts` — proxies to content-generation-service, auth via `X-API-Key`
- Both follow the existing `PUT /platform-chat/config` pattern
- This enables the dashboard to register platform keys and prompts at cold start in `instrumentation.ts`

## Context
First step of migrating startup config registration from api-service to the dashboard. Both sources will coexist during transition (endpoints are idempotent). Once the dashboard is validated in prod, api-service startup registrations will be removed.

## Test plan
- [x] 13 new unit tests (6 for platform-keys, 7 for platform-prompts)
- [x] Full test suite passes (559 tests)
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)