### PR TITLE
feat: add MCP tool server for chat workflow editing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import stripeRoutes from "./routes/stripe.js";
 import usersRoutes from "./routes/users.js";
 import platformRoutes from "./routes/platform.js";
 import platformChatRoutes from "./routes/platform-chat.js";
+import mcpToolsRoutes from "./routes/mcp-tools.js";
 import emailGatewayRoutes from "./routes/email-gateway.js";
 import runsRoutes from "./routes/runs.js";
 import { apiReference } from "@scalar/express-api-reference";
@@ -153,6 +154,7 @@ app.use("/v1", performanceRoutes);
 // Internal platform routes (API key only, no identity)
 app.use("/internal", internalEmailsRoutes);
 app.use("/platform-chat", platformChatRoutes);
+app.use("/internal", mcpToolsRoutes);
 
 // Authenticated routes
 app.use("/v1", meRoutes);

--- a/src/routes/mcp-tools.ts
+++ b/src/routes/mcp-tools.ts
@@ -1,0 +1,275 @@
+import { Router } from "express";
+import { authenticatePlatform, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+
+const router = Router();
+
+// ── MCP tool definitions ────────────────────────────────────────────────────
+
+const MCP_TOOLS = [
+  {
+    name: "getWorkflowDetails",
+    description:
+      "Get full details of a workflow including its DAG (nodes, edges, onError), name, description, tags, and required providers. " +
+      "Use this to understand the structure of a workflow before suggesting changes.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflowId: { type: "string", description: "UUID of the workflow to fetch" },
+      },
+      required: ["workflowId"],
+    },
+  },
+  {
+    name: "getPrompt",
+    description:
+      "Get a prompt template by type (e.g. 'cold-email'). Returns the prompt text with {{variable}} placeholders, " +
+      "the list of expected variables, and version metadata. Use this to understand what a content-generation node uses.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: { type: "string", description: "Prompt type identifier (e.g. 'cold-email', 'cold-email-v2')" },
+      },
+      required: ["type"],
+    },
+  },
+  {
+    name: "validateWorkflow",
+    description:
+      "Validate a workflow DAG for structural correctness and template contract compliance. " +
+      "Returns whether the DAG is valid, any structural errors, and template contract issues " +
+      "(missing variables, unknown variables, unreachable templates). " +
+      "IMPORTANT: You MUST call this after every updateWorkflow call to verify the changes are correct.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflowId: { type: "string", description: "UUID of the workflow to validate" },
+      },
+      required: ["workflowId"],
+    },
+  },
+  {
+    name: "updateWorkflow",
+    description:
+      "Update a workflow's name, description, tags, or DAG. Send only the fields you want to change. " +
+      "When updating the DAG, send the complete dag object (nodes + edges + onError). " +
+      "After calling this, you MUST call validateWorkflow to verify the changes are correct.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflowId: { type: "string", description: "UUID of the workflow to update" },
+        name: { type: "string", description: "New workflow name" },
+        description: { type: "string", description: "New workflow description" },
+        tags: { type: "array", items: { type: "string" }, description: "New tags array" },
+        dag: {
+          type: "object",
+          description: "Complete updated DAG with nodes, edges, and optional onError",
+          properties: {
+            nodes: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string", description: "Unique node ID within the DAG" },
+                  type: { type: "string", description: "Node type (http.call, condition, wait, for-each, script)" },
+                  config: { type: "object", description: "Static parameters for the node" },
+                  inputMapping: { type: "object", description: "Dynamic input references using $ref syntax" },
+                  retries: { type: "integer", description: "Retry count (default 3, set 0 for non-idempotent ops)" },
+                },
+                required: ["id", "type"],
+              },
+            },
+            edges: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  from: { type: "string", description: "Source node ID" },
+                  to: { type: "string", description: "Target node ID" },
+                  condition: { type: "string", description: "JS expression for conditional branching" },
+                },
+                required: ["from", "to"],
+              },
+            },
+            onError: { type: "string", description: "Node ID of the error handler" },
+          },
+          required: ["nodes", "edges"],
+        },
+      },
+      required: ["workflowId"],
+    },
+  },
+  {
+    name: "versionPrompt",
+    description:
+      "Create a new version of a prompt template. The new version gets an auto-incremented type name " +
+      "(e.g. 'cold-email' → 'cold-email-v2'). Use this when the user asks to modify a prompt template. " +
+      "After versioning a prompt, you should call validateWorkflow if the workflow uses this template type.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        sourceType: { type: "string", description: "Type of the prompt to version from (e.g. 'cold-email')" },
+        prompt: { type: "string", description: "New prompt template text with {{variable}} placeholders" },
+        variables: {
+          type: "array",
+          items: { type: "string" },
+          description: "List of expected variable names used in the prompt",
+        },
+      },
+      required: ["sourceType", "prompt", "variables"],
+    },
+  },
+];
+
+// ── Tool execution ──────────────────────────────────────────────────────────
+
+function buildMcpHeaders(req: AuthenticatedRequest): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const orgId = req.headers["x-org-id"] as string | undefined;
+  const userId = req.headers["x-user-id"] as string | undefined;
+  const runId = req.headers["x-run-id"] as string | undefined;
+  if (orgId) headers["x-org-id"] = orgId;
+  if (userId) headers["x-user-id"] = userId;
+  if (runId) headers["x-run-id"] = runId;
+  return headers;
+}
+
+type ToolArgs = Record<string, unknown>;
+
+async function executeGetWorkflowDetails(args: ToolArgs, headers: Record<string, string>): Promise<unknown> {
+  const { workflowId } = args as { workflowId: string };
+  return callExternalService(externalServices.workflow, `/workflows/${workflowId}`, { headers });
+}
+
+async function executeGetPrompt(args: ToolArgs, headers: Record<string, string>): Promise<unknown> {
+  const { type } = args as { type: string };
+  return callExternalService(externalServices.emailgen, `/prompts?type=${encodeURIComponent(type)}`, { headers });
+}
+
+async function executeValidateWorkflow(args: ToolArgs, headers: Record<string, string>): Promise<unknown> {
+  const { workflowId } = args as { workflowId: string };
+  return callExternalService(externalServices.workflow, `/workflows/${workflowId}/validate`, {
+    method: "POST",
+    headers,
+  });
+}
+
+async function executeUpdateWorkflow(args: ToolArgs, headers: Record<string, string>): Promise<unknown> {
+  const { workflowId, ...body } = args as { workflowId: string; [k: string]: unknown };
+  return callExternalService(externalServices.workflow, `/workflows/${workflowId}`, {
+    method: "PUT",
+    headers,
+    body,
+  });
+}
+
+async function executeVersionPrompt(args: ToolArgs, headers: Record<string, string>): Promise<unknown> {
+  const { sourceType, prompt, variables } = args as { sourceType: string; prompt: string; variables: string[] };
+  return callExternalService(externalServices.emailgen, "/prompts", {
+    method: "PUT",
+    headers,
+    body: { sourceType, prompt, variables },
+  });
+}
+
+const TOOL_EXECUTORS: Record<string, (args: ToolArgs, headers: Record<string, string>) => Promise<unknown>> = {
+  getWorkflowDetails: executeGetWorkflowDetails,
+  getPrompt: executeGetPrompt,
+  validateWorkflow: executeValidateWorkflow,
+  updateWorkflow: executeUpdateWorkflow,
+  versionPrompt: executeVersionPrompt,
+};
+
+// ── JSON-RPC helpers ────────────────────────────────────────────────────────
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+function jsonRpcResponse(id: string | number | undefined, result: unknown) {
+  return { jsonrpc: "2.0", id: id ?? null, result };
+}
+
+function jsonRpcError(id: string | number | undefined, code: number, message: string) {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+// ── MCP endpoint ────────────────────────────────────────────────────────────
+
+/**
+ * POST /internal/mcp-tools
+ * MCP Streamable HTTP endpoint — handles JSON-RPC 2.0 requests.
+ * Called by chat-service for tool discovery and execution.
+ * Auth: X-API-Key (ADMIN_DISTRIBUTE_API_KEY).
+ * Identity headers (x-org-id, x-user-id, x-run-id) forwarded to downstream services.
+ */
+router.post("/mcp-tools", authenticatePlatform, async (req: AuthenticatedRequest, res) => {
+  const rpc = req.body as JsonRpcRequest;
+
+  if (!rpc || rpc.jsonrpc !== "2.0" || !rpc.method) {
+    return res.status(400).json(jsonRpcError(rpc?.id, -32600, "Invalid JSON-RPC request"));
+  }
+
+  try {
+    switch (rpc.method) {
+      case "initialize": {
+        return res.json(
+          jsonRpcResponse(rpc.id, {
+            protocolVersion: "2025-03-26",
+            capabilities: { tools: {} },
+            serverInfo: { name: "api-service-mcp-tools", version: "1.0.0" },
+          }),
+        );
+      }
+
+      case "tools/list": {
+        return res.json(jsonRpcResponse(rpc.id, { tools: MCP_TOOLS }));
+      }
+
+      case "tools/call": {
+        const params = rpc.params as { name?: string; arguments?: ToolArgs } | undefined;
+        const toolName = params?.name;
+        const toolArgs = params?.arguments ?? {};
+
+        if (!toolName) {
+          return res.json(jsonRpcError(rpc.id, -32602, "Missing tool name in params.name"));
+        }
+
+        const executor = TOOL_EXECUTORS[toolName];
+        if (!executor) {
+          return res.json(jsonRpcError(rpc.id, -32602, `Unknown tool: ${toolName}`));
+        }
+
+        const headers = buildMcpHeaders(req);
+
+        try {
+          const result = await executor(toolArgs, headers);
+          return res.json(
+            jsonRpcResponse(rpc.id, {
+              content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            }),
+          );
+        } catch (err: any) {
+          return res.json(
+            jsonRpcResponse(rpc.id, {
+              isError: true,
+              content: [{ type: "text", text: err.message || "Tool execution failed" }],
+            }),
+          );
+        }
+      }
+
+      default: {
+        return res.json(jsonRpcError(rpc.id, -32601, `Method not found: ${rpc.method}`));
+      }
+    }
+  } catch (error: any) {
+    console.error("[mcp-tools] Unhandled error:", error.message);
+    return res.status(500).json(jsonRpcError(rpc.id, -32603, "Internal error"));
+  }
+});
+
+export default router;

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -15,6 +15,7 @@ const PLATFORM_KEYS: { provider: string; envVar: string }[] = [
   { provider: "postmark-from-address", envVar: "POSTMARK_FROM_ADDRESS" },
   { provider: "stripe", envVar: "STRIPE_SECRET_KEY" },
   { provider: "stripe-webhook", envVar: "STRIPE_WEBHOOK_SECRET" },
+  { provider: "api-service-mcp", envVar: "ADMIN_DISTRIBUTE_API_KEY" },
 ];
 
 export async function registerPlatformKeys(): Promise<void> {
@@ -132,21 +133,97 @@ const COLD_EMAIL_VARIABLES = [
 
 // ── Platform chat config ──────────────────────────────────────────────────
 
+const WORKFLOW_SYSTEM_PROMPT = `You are an expert workflow editor embedded in a workflow management dashboard.
+You help users understand, modify, and troubleshoot their workflows. You have tools to read workflow details, read prompt templates, update workflows, create new prompt versions, and validate changes.
+
+## How to work
+
+1. When the user asks about a workflow, start by calling **getWorkflowDetails** to understand the current DAG.
+2. If a node references a content-generation template (e.g. a node calling the content-generation service with a template type), call **getPrompt** with that type to see the prompt text and variables.
+3. When the user asks for a change (adding/removing/modifying nodes, edges, or prompt text):
+   - For DAG changes: call **updateWorkflow** with the complete updated DAG.
+   - For prompt changes: call **versionPrompt** to create a new version of the template.
+4. **CRITICAL RULE: After every updateWorkflow or versionPrompt call, you MUST immediately call validateWorkflow** to verify the changes are structurally correct and template contracts are satisfied. Report any validation errors or warnings to the user.
+5. If the user explicitly asks you to validate, call **validateWorkflow**.
+
+## DAG structure reference
+
+A workflow DAG consists of **nodes** (steps), **edges** (execution order), and an optional **onError** handler.
+
+### Node types
+
+- **http.call** — Call any microservice. Config: \`{ service, method, path, body?, query?, headers? }\`. This is the recommended type for all service calls.
+- **condition** — If/then/else branching. Outgoing edges with a \`condition\` field define conditional branches (the target chain only executes when the JS expression is true). Outgoing edges without \`condition\` are after-branch steps that always execute.
+- **wait** — Delay. Config: \`{ seconds }\`.
+- **for-each** — Loop over items. Config: \`{ iterator, parallel?, skipFailures? }\`. Body nodes are nested inside the loop.
+- **script** — Custom JavaScript.
+
+### Node fields
+
+- \`id\` (required): Unique string identifier within the DAG. Used in edges and \$ref input mappings.
+- \`type\` (required): One of the types above.
+- \`config\`: Static parameters. For http.call: \`{ service, method, path, body?, query?, headers? }\`. Special config keys:
+  - \`retries\` (number): Override default retry count.
+  - \`validateResponse\` (\`{ field, equals }\`): Throw error if response[field] !== equals, triggers onError.
+  - \`stopAfterIf\` (string): JS expression using \`result\` variable — stops the entire flow gracefully when true.
+  - \`skipIf\` (string): JS expression — skips only this step when true. Can reference \`results.<node_id>\`.
+- \`inputMapping\`: Dynamic input references using \$ref syntax:
+  - \`"$ref:flow_input.fieldName"\` for workflow execution inputs.
+  - \`"$ref:node-id.output.fieldName"\` for a previous node's output.
+  - Keys in inputMapping override same-named keys in config.
+- \`retries\`: Number of retry attempts (default 3). Set to 0 for non-idempotent operations (emails, queue consumption).
+
+### Edges
+
+- \`from\` (required): Source node ID.
+- \`to\` (required): Target node ID.
+- \`condition\` (optional): JS expression for conditional branching. Only used when source node is type "condition". Expressions can reference \`results.<node_id>.<field>\` or \`flow_input\`.
+
+### onError
+
+Node ID of an error handler that runs when any node fails. Auto-injected parameters: \`failedNodeId\`, \`errorMessage\`. Can access outputs from previously completed nodes via \$ref.
+
+## Available services for http.call
+
+When creating http.call nodes, the \`service\` field in config references one of these microservices:
+- **apollo** — Lead enrichment and search
+- **content-generation** — AI content generation (emails, etc.) using prompt templates
+- **lead** — Lead management (CRUD, search, scoring)
+- **campaign** — Campaign management
+- **scraping** — Web scraping
+- **instantly** — Email sending via Instantly
+- **email-gateway** — Email infrastructure
+- **transactional-email** — Event-triggered transactional emails
+- **key** — API key management
+- **runs** — Execution tracking
+- **stripe** — Payment processing
+- **brand** — Brand management
+- **reply-qualification** — Reply analysis and qualification
+
+## Prompt templates
+
+Prompt templates use \`{{variableName}}\` placeholders. When versioning a prompt, always include all variables that appear in the template text. The version type auto-increments (e.g. cold-email → cold-email-v2).
+
+## Communication style
+
+Be concise and practical. When describing workflow steps, use their node IDs. When showing the DAG structure, present it clearly. Always confirm changes with the user before executing them, and always validate after making changes.`;
+
 export async function registerPlatformChatConfig(): Promise<void> {
   console.log("[api-service] Registering platform chat config with chat-service...");
+
+  const apiServiceUrl = process.env.API_SERVICE_URL || "https://api.distribute.you";
+  const mcpServerUrl = `${apiServiceUrl}/internal/mcp-tools`;
 
   await callExternalService(externalServices.chat, "/platform-config", {
     method: "PUT",
     body: {
-      systemPrompt:
-        "You are a helpful assistant embedded in a workflow management dashboard. " +
-        "You help users understand their workflows — what each step does, how the DAG is structured, " +
-        "what inputs and outputs are expected, and how to troubleshoot issues. " +
-        "Be concise and practical. When referencing workflow steps, use their names.",
+      systemPrompt: WORKFLOW_SYSTEM_PROMPT,
+      mcpServerUrl,
+      mcpKeyName: "api-service-mcp",
     },
   });
 
-  console.log("[api-service] Platform chat config registered");
+  console.log("[api-service] Platform chat config registered (mcpServerUrl: %s)", mcpServerUrl);
 }
 
 // ── Platform prompts ────────────────────────────────────────────────────────

--- a/tests/unit/mcp-tools.test.ts
+++ b/tests/unit/mcp-tools.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock auth — let requests through
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return {
+    ...actual,
+    authenticatePlatform: (_req: any, _res: any, next: any) => {
+      next();
+    },
+  };
+});
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+let fetchResponses: Record<string, unknown> = {};
+
+import mcpToolsRoutes from "../../src/routes/mcp-tools.js";
+
+const VALID_API_KEY = "test-admin-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/internal", mcpToolsRoutes);
+  return app;
+}
+
+function mockFetch(responseOverrides: Record<string, unknown> = {}) {
+  fetchResponses = responseOverrides;
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    const rawHeaders = init?.headers as Record<string, string> | undefined;
+    const headers = rawHeaders ? Object.fromEntries(Object.entries(rawHeaders)) : undefined;
+    fetchCalls.push({ url, method: init?.method, body, headers });
+
+    // Match response by URL pattern
+    for (const [pattern, response] of Object.entries(fetchResponses)) {
+      if (url.includes(pattern)) {
+        return { ok: true, json: () => Promise.resolve(response) };
+      }
+    }
+
+    return { ok: true, json: () => Promise.resolve({ ok: true }) };
+  });
+}
+
+describe("POST /internal/mcp-tools — MCP JSON-RPC", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+    mockFetch();
+    app = createApp();
+  });
+
+  // ── Protocol ──────────────────────────────────────────────────────────────
+
+  it("should return error for non-JSON-RPC request", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ hello: "world" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(-32600);
+  });
+
+  it("should handle initialize", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.jsonrpc).toBe("2.0");
+    expect(res.body.id).toBe(1);
+    expect(res.body.result.protocolVersion).toBe("2025-03-26");
+    expect(res.body.result.capabilities.tools).toBeDefined();
+    expect(res.body.result.serverInfo.name).toBe("api-service-mcp-tools");
+  });
+
+  it("should return error for unknown method", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ jsonrpc: "2.0", id: 2, method: "unknown/method" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.error.code).toBe(-32601);
+  });
+
+  // ── tools/list ────────────────────────────────────────────────────────────
+
+  it("should list all 5 tools", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ jsonrpc: "2.0", id: 3, method: "tools/list" });
+
+    expect(res.status).toBe(200);
+    const tools = res.body.result.tools;
+    expect(tools).toHaveLength(5);
+
+    const names = tools.map((t: { name: string }) => t.name);
+    expect(names).toContain("getWorkflowDetails");
+    expect(names).toContain("getPrompt");
+    expect(names).toContain("validateWorkflow");
+    expect(names).toContain("updateWorkflow");
+    expect(names).toContain("versionPrompt");
+  });
+
+  it("each tool should have name, description, and inputSchema", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ jsonrpc: "2.0", id: 4, method: "tools/list" });
+
+    for (const tool of res.body.result.tools) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe("object");
+    }
+  });
+
+  // ── tools/call — getWorkflowDetails ───────────────────────────────────────
+
+  it("should execute getWorkflowDetails and call workflow-service", async () => {
+    const workflowData = {
+      workflow: { id: "wf-123", name: "Test Workflow", dag: { nodes: [], edges: [] } },
+    };
+    mockFetch({ "/workflows/wf-123": workflowData });
+
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .set("x-org-id", "org-abc")
+      .set("x-user-id", "user-def")
+      .set("x-run-id", "run-ghi")
+      .send({
+        jsonrpc: "2.0",
+        id: 10,
+        method: "tools/call",
+        params: { name: "getWorkflowDetails", arguments: { workflowId: "wf-123" } },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.content).toHaveLength(1);
+    expect(res.body.result.content[0].type).toBe("text");
+
+    const parsed = JSON.parse(res.body.result.content[0].text);
+    expect(parsed.workflow.id).toBe("wf-123");
+
+    // Verify downstream call includes identity headers
+    const call = fetchCalls.find((c) => c.url.includes("/workflows/wf-123"));
+    expect(call).toBeDefined();
+    expect(call!.headers!["x-org-id"]).toBe("org-abc");
+    expect(call!.headers!["x-user-id"]).toBe("user-def");
+    expect(call!.headers!["x-run-id"]).toBe("run-ghi");
+  });
+
+  // ── tools/call — getPrompt ────────────────────────────────────────────────
+
+  it("should execute getPrompt and call content-generation service", async () => {
+    const promptData = {
+      id: "p-1",
+      type: "cold-email",
+      prompt: "Hello {{name}}",
+      variables: ["name"],
+      createdAt: "2025-01-01",
+      updatedAt: "2025-01-01",
+    };
+    mockFetch({ "/prompts?type=cold-email": promptData });
+
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        jsonrpc: "2.0",
+        id: 11,
+        method: "tools/call",
+        params: { name: "getPrompt", arguments: { type: "cold-email" } },
+      });
+
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(res.body.result.content[0].text);
+    expect(parsed.type).toBe("cold-email");
+    expect(parsed.variables).toContain("name");
+  });
+
+  // ── tools/call — validateWorkflow ─────────────────────────────────────────
+
+  it("should execute validateWorkflow with POST to workflow-service", async () => {
+    const validationResult = { valid: true, errors: [] };
+    mockFetch({ "/workflows/wf-123/validate": validationResult });
+
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        jsonrpc: "2.0",
+        id: 12,
+        method: "tools/call",
+        params: { name: "validateWorkflow", arguments: { workflowId: "wf-123" } },
+      });
+
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(res.body.result.content[0].text);
+    expect(parsed.valid).toBe(true);
+
+    const call = fetchCalls.find((c) => c.url.includes("/validate"));
+    expect(call).toBeDefined();
+    expect(call!.method).toBe("POST");
+  });
+
+  // ── tools/call — updateWorkflow ───────────────────────────────────────────
+
+  it("should execute updateWorkflow with PUT to workflow-service", async () => {
+    const updatedWorkflow = { workflow: { id: "wf-123", name: "Updated" } };
+    mockFetch({ "/workflows/wf-123": updatedWorkflow });
+
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        jsonrpc: "2.0",
+        id: 13,
+        method: "tools/call",
+        params: {
+          name: "updateWorkflow",
+          arguments: {
+            workflowId: "wf-123",
+            name: "Updated",
+            dag: { nodes: [{ id: "step1", type: "http.call" }], edges: [] },
+          },
+        },
+      });
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/workflows/wf-123") && c.method === "PUT");
+    expect(call).toBeDefined();
+    expect(call!.body.name).toBe("Updated");
+    expect(call!.body.dag.nodes).toHaveLength(1);
+    // workflowId should NOT be in the body (stripped from args)
+    expect(call!.body.workflowId).toBeUndefined();
+  });
+
+  // ── tools/call — versionPrompt ────────────────────────────────────────────
+
+  it("should execute versionPrompt with PUT to content-generation service", async () => {
+    const newVersion = {
+      id: "p-2",
+      type: "cold-email-v2",
+      prompt: "Hi {{firstName}}",
+      variables: ["firstName"],
+      createdAt: "2025-01-02",
+      updatedAt: "2025-01-02",
+    };
+    mockFetch({ "/prompts": newVersion });
+
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        jsonrpc: "2.0",
+        id: 14,
+        method: "tools/call",
+        params: {
+          name: "versionPrompt",
+          arguments: {
+            sourceType: "cold-email",
+            prompt: "Hi {{firstName}}",
+            variables: ["firstName"],
+          },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(res.body.result.content[0].text);
+    expect(parsed.type).toBe("cold-email-v2");
+
+    const call = fetchCalls.find((c) => c.url.includes("/prompts") && c.method === "PUT");
+    expect(call).toBeDefined();
+    expect(call!.body.sourceType).toBe("cold-email");
+    expect(call!.body.prompt).toBe("Hi {{firstName}}");
+    expect(call!.body.variables).toEqual(["firstName"]);
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  it("should return error for unknown tool name", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        jsonrpc: "2.0",
+        id: 20,
+        method: "tools/call",
+        params: { name: "nonExistentTool", arguments: {} },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.error.code).toBe(-32602);
+    expect(res.body.error.message).toContain("Unknown tool");
+  });
+
+  it("should return error when tool name is missing", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        jsonrpc: "2.0",
+        id: 21,
+        method: "tools/call",
+        params: { arguments: {} },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.error.code).toBe(-32602);
+  });
+
+  it("should return isError when downstream service fails", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(JSON.stringify({ error: "Workflow not found" })),
+    }));
+
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        jsonrpc: "2.0",
+        id: 22,
+        method: "tools/call",
+        params: { name: "getWorkflowDetails", arguments: { workflowId: "missing-id" } },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.isError).toBe(true);
+    expect(res.body.result.content[0].type).toBe("text");
+  });
+});
+
+describe("MCP tools — startup integration", () => {
+  it("startup.ts should reference mcpServerUrl and mcpKeyName", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const startupPath = path.join(__dirname, "../../src/startup.ts");
+    const content = fs.readFileSync(startupPath, "utf-8");
+
+    expect(content).toContain("mcpServerUrl");
+    expect(content).toContain("mcpKeyName");
+    expect(content).toContain("api-service-mcp");
+    expect(content).toContain("/internal/mcp-tools");
+  });
+
+  it("startup.ts should register api-service-mcp platform key", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const startupPath = path.join(__dirname, "../../src/startup.ts");
+    const content = fs.readFileSync(startupPath, "utf-8");
+
+    expect(content).toContain('provider: "api-service-mcp"');
+    expect(content).toContain('envVar: "ADMIN_DISTRIBUTE_API_KEY"');
+  });
+
+  it("index.ts should mount mcp-tools routes at /internal", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const indexPath = path.join(__dirname, "../../src/index.ts");
+    const content = fs.readFileSync(indexPath, "utf-8");
+
+    expect(content).toContain("mcpToolsRoutes");
+    expect(content).toContain("./routes/mcp-tools");
+    expect(content).toContain('"/internal", mcpToolsRoutes');
+  });
+});
+
+describe("System prompt content", () => {
+  it("should include DAG node types reference", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const startupPath = path.join(__dirname, "../../src/startup.ts");
+    const content = fs.readFileSync(startupPath, "utf-8");
+
+    expect(content).toContain("http.call");
+    expect(content).toContain("condition");
+    expect(content).toContain("wait");
+    expect(content).toContain("for-each");
+    expect(content).toContain("script");
+    expect(content).toContain("inputMapping");
+    expect(content).toContain("$ref:");
+    expect(content).toContain("onError");
+  });
+
+  it("should include validation rule", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const startupPath = path.join(__dirname, "../../src/startup.ts");
+    const content = fs.readFileSync(startupPath, "utf-8");
+
+    expect(content).toContain("MUST");
+    expect(content).toContain("validateWorkflow");
+    expect(content).toContain("updateWorkflow");
+  });
+
+  it("should include available services for http.call", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const startupPath = path.join(__dirname, "../../src/startup.ts");
+    const content = fs.readFileSync(startupPath, "utf-8");
+
+    expect(content).toContain("apollo");
+    expect(content).toContain("content-generation");
+    expect(content).toContain("lead");
+    expect(content).toContain("campaign");
+    expect(content).toContain("instantly");
+    expect(content).toContain("stripe");
+  });
+});

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -27,6 +27,7 @@ function setAllEnvVars() {
   process.env.POSTMARK_FROM_ADDRESS = "growth@distribute.you";
   process.env.STRIPE_SECRET_KEY = "sk_test_stripe";
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "admin-test-key";
 }
 
 function deleteAllEnvVars() {
@@ -42,6 +43,7 @@ function deleteAllEnvVars() {
   delete process.env.POSTMARK_FROM_ADDRESS;
   delete process.env.STRIPE_SECRET_KEY;
   delete process.env.STRIPE_WEBHOOK_SECRET;
+  delete process.env.ADMIN_DISTRIBUTE_API_KEY;
 }
 
 describe("registerPlatformKeys", () => {
@@ -77,7 +79,7 @@ describe("registerPlatformKeys", () => {
     await registerPlatformKeys();
 
     const platformKeyCalls = fetchCalls.filter((c) => c.url.includes("/platform-keys"));
-    expect(platformKeyCalls).toHaveLength(12);
+    expect(platformKeyCalls).toHaveLength(13);
 
     const providers = platformKeyCalls.map((c) => c.body?.provider);
     expect(providers).toContain("anthropic");
@@ -92,6 +94,7 @@ describe("registerPlatformKeys", () => {
     expect(providers).toContain("postmark-from-address");
     expect(providers).toContain("stripe");
     expect(providers).toContain("stripe-webhook");
+    expect(providers).toContain("api-service-mcp");
 
     for (const call of platformKeyCalls) {
       expect(call.body).not.toHaveProperty("keySource");


### PR DESCRIPTION
## Summary
- Adds an MCP-compatible JSON-RPC endpoint at `/internal/mcp-tools` with 5 tools: `getWorkflowDetails`, `getPrompt`, `validateWorkflow`, `updateWorkflow`, `versionPrompt`
- Enriches the platform chat system prompt with full DAG node types reference, available services, input mapping syntax, and the mandatory validation rule
- Registers `api-service-mcp` platform key at startup so chat-service can authenticate MCP calls
- Chat-service discovers these tools via `mcpServerUrl` in the platform config — no changes needed on chat-service side

## Test plan
- [x] 19 new tests covering all 5 tools, MCP protocol (initialize, tools/list, tools/call), identity header forwarding, error handling
- [x] All 562 existing tests pass (0 regressions)
- [ ] Verify chat-service connects to the MCP endpoint and discovers tools in staging
- [ ] Test a full chat session: ask about a workflow → modify a node → validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)