### PR TITLE
docs: add SSEErrorEvent to chat OpenAPI spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2097,19 +2097,19 @@
           "message": {
             "type": "string",
             "minLength": 1,
-            "description": "User message text"
+            "description": "The user's chat message"
           },
           "sessionId": {
             "type": "string",
             "format": "uuid",
-            "description": "Session ID for conversation continuity"
+            "description": "UUID of an existing session to continue. Omit to create a new session. When omitted, the service creates a new session and returns its ID in the first SSE event ({\"sessionId\":\"<uuid>\"}). Use that ID in subsequent requests to continue the conversation. If a sessionId is provided but does not exist or belongs to a different org, the stream returns a \"Session not found.\" error and closes."
           },
           "context": {
             "type": "object",
             "additionalProperties": {
               "nullable": true
             },
-            "description": "Additional context for the AI"
+            "description": "Free-form JSON injected into the system prompt for this request only (not stored). Use this to pass dynamic data like workflow IDs, brand URLs, campaign objectives, etc."
           }
         },
         "required": [
@@ -7892,7 +7892,7 @@
           "Chat"
         ],
         "summary": "Stream chat response (SSE)",
-        "description": "Send a message and receive a streamed AI response via Server-Sent Events.",
+        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, **omit `sessionId`**. The first SSE event will be `data: {\"sessionId\":\"<uuid>\"}` — store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** — `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** *(optional)* — `thinking_start` → one or more `thinking_delta` → `thinking_stop`\n3. **Tokens** — `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally\n4. **Tool calls** *(optional, repeatable)* — `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues\n5. **Input request** *(optional)* — `input_request` when the AI needs structured user input\n6. **Buttons** *(optional)* — `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options\n7. **Error** *(optional)* — `{\"type\":\"error\",\"message\":\"...\"}` when the model returns an empty response (e.g. context overflow, safety filter). Always followed by `[DONE]`.\n8. **Done** — `\"[DONE]\"` (always last)\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEToolCallEvent, etc.) for exact payload shapes.",
         "security": [
           {
             "bearerAuth": []
@@ -7909,7 +7909,7 @@
         },
         "responses": {
           "200": {
-            "description": "SSE stream of chat events (tokens, tool calls, buttons)",
+            "description": "SSE stream of chat events. Each `data:` line is a JSON object matching one of the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent), except the final `data: \"[DONE]\"` which is a plain string.",
             "content": {
               "text/event-stream": {
                 "schema": {
@@ -7921,6 +7921,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found (invalid or expired sessionId), or chat config not registered (register via PUT /v1/chat/config or ensure platform config exists)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1861,6 +1861,17 @@ export const SSEButtonsEventSchema = z
   })
   .openapi("SSEButtonsEvent");
 
+export const SSEErrorEventSchema = z
+  .object({
+    type: z.literal("error"),
+    message: z
+      .string()
+      .describe(
+        "Human-readable error message to display to the user (e.g. empty model response, context overflow, safety filter)",
+      ),
+  })
+  .openapi("SSEErrorEvent");
+
 registry.registerPath({
   method: "put",
   path: "/v1/chat/config",
@@ -1904,7 +1915,9 @@ registry.registerPath({
     "then more thinking/tokens as the AI continues\n" +
     "5. **Input request** *(optional)* — `input_request` when the AI needs structured user input\n" +
     '6. **Buttons** *(optional)* — `{"type":"buttons","buttons":[...]}` with quick-reply options\n' +
-    '7. **Done** — `"[DONE]"` (always last)\n\n' +
+    '7. **Error** *(optional)* — `{"type":"error","message":"..."}` when the model returns an empty response ' +
+    "(e.g. context overflow, safety filter). Always followed by `[DONE]`.\n" +
+    '8. **Done** — `"[DONE]"` (always last)\n\n' +
     "See the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEToolCallEvent, etc.) for exact payload shapes.",
   security: authed,
   request: {
@@ -1917,7 +1930,7 @@ registry.registerPath({
       description:
         "SSE stream of chat events. Each `data:` line is a JSON object matching one of the SSE event schemas " +
         "(SSESessionEvent, SSETokenEvent, SSEThinkingStartEvent, SSEThinkingDeltaEvent, SSEThinkingStopEvent, " +
-        'SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent), except the final `data: "[DONE]"` which is a plain string.',
+        'SSEToolCallEvent, SSEToolResultEvent, SSEInputRequestEvent, SSEButtonsEvent, SSEErrorEvent), except the final `data: "[DONE]"` which is a plain string.',
       content: {
         "text/event-stream": {
           schema: z.string().describe("Server-Sent Events stream"),


### PR DESCRIPTION
## Summary
- Add `SSEErrorEvent` schema (`{"type":"error","message":"..."}`) to document the new error event type from chat-service PR #51
- Update SSE event order docs to describe when error events occur (empty model response, context overflow, safety filter)
- Regenerate `openapi.json`

## Test plan
- [x] All 566 tests pass
- [x] `pnpm generate:openapi` succeeds
- [x] Error event appears in endpoint description

🤖 Generated with [Claude Code](https://claude.com/claude-code)