### PR TITLE
chore: remove deprecated mcpServerUrl/mcpKeyName from chat schemas

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2075,16 +2075,6 @@
             "type": "string",
             "minLength": 1,
             "description": "System prompt for the AI assistant"
-          },
-          "mcpServerUrl": {
-            "type": "string",
-            "format": "uri",
-            "description": "MCP server URL for tool calling"
-          },
-          "mcpKeyName": {
-            "type": "string",
-            "minLength": 1,
-            "description": "MCP key name for auth resolution"
           }
         },
         "required": [
@@ -2169,16 +2159,6 @@
             "type": "string",
             "minLength": 1,
             "description": "System prompt for the AI assistant"
-          },
-          "mcpServerUrl": {
-            "type": "string",
-            "format": "uri",
-            "description": "MCP server URL for tool calling"
-          },
-          "mcpKeyName": {
-            "type": "string",
-            "minLength": 1,
-            "description": "MCP key name for auth resolution"
           }
         },
         "required": [
@@ -7787,7 +7767,7 @@
           "Chat"
         ],
         "summary": "Register chat app config",
-        "description": "Register or update app configuration for chat (system prompt, MCP server). Requires app key authentication.",
+        "description": "Register or update app configuration for chat (system prompt). Requires app key authentication.",
         "security": [
           {
             "bearerAuth": []
@@ -8215,7 +8195,7 @@
           "Chat"
         ],
         "summary": "Deploy platform-level chat config",
-        "description": "Register or update the global chat configuration (system prompt, MCP server). Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "description": "Register or update the global chat configuration (system prompt). Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
         "security": [
           {
             "apiKeyAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1756,8 +1756,6 @@ registry.registerPath({
 export const ChatConfigRequestSchema = z
   .object({
     systemPrompt: z.string().min(1).describe("System prompt for the AI assistant"),
-    mcpServerUrl: z.string().url().optional().describe("MCP server URL for tool calling"),
-    mcpKeyName: z.string().min(1).optional().describe("MCP key name for auth resolution"),
   })
   .openapi("ChatConfigRequest");
 
@@ -1878,7 +1876,7 @@ registry.registerPath({
   tags: ["Chat"],
   summary: "Register chat app config",
   description:
-    "Register or update app configuration for chat (system prompt, MCP server). Requires app key authentication.",
+    "Register or update app configuration for chat (system prompt). Requires app key authentication.",
   security: authed,
   request: {
     body: {
@@ -2024,8 +2022,6 @@ registry.registerPath({
 export const PlatformChatConfigRequestSchema = z
   .object({
     systemPrompt: z.string().min(1).describe("System prompt for the AI assistant"),
-    mcpServerUrl: z.string().url().optional().describe("MCP server URL for tool calling"),
-    mcpKeyName: z.string().min(1).optional().describe("MCP key name for auth resolution"),
   })
   .openapi("PlatformChatConfigRequest");
 
@@ -2035,7 +2031,7 @@ registry.registerPath({
   tags: ["Chat"],
   summary: "Deploy platform-level chat config",
   description:
-    "Register or update the global chat configuration (system prompt, MCP server). " +
+    "Register or update the global chat configuration (system prompt). " +
     "Platform-level — no org/user identity required. " +
     "Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
   security: platformAuth,

--- a/tests/unit/chat-proxy.test.ts
+++ b/tests/unit/chat-proxy.test.ts
@@ -94,8 +94,8 @@ describe("Chat OpenAPI schemas", () => {
   it("should define ChatConfigRequestSchema", () => {
     expect(schemaContent).toContain("ChatConfigRequestSchema");
     expect(schemaContent).toContain("systemPrompt");
-    expect(schemaContent).toContain("mcpServerUrl");
-    expect(schemaContent).toContain("mcpKeyName");
+    expect(schemaContent).not.toContain("mcpServerUrl");
+    expect(schemaContent).not.toContain("mcpKeyName");
   });
 
   it("should define ChatMessageRequestSchema with session lifecycle docs", () => {

--- a/tests/unit/platform-chat.test.ts
+++ b/tests/unit/platform-chat.test.ts
@@ -81,7 +81,7 @@ describe("PUT /platform-chat/config", () => {
     expect(call!.headers!["x-run-id"]).toBeUndefined();
   });
 
-  it("should forward optional mcpServerUrl and mcpKeyName", async () => {
+  it("should strip removed mcpServerUrl and mcpKeyName fields", async () => {
     const res = await request(app)
       .put("/platform-chat/config")
       .set("X-API-Key", VALID_API_KEY)
@@ -96,9 +96,9 @@ describe("PUT /platform-chat/config", () => {
     const call = fetchCalls.find((c) => c.url.includes("/platform-config"));
     expect(call!.body).toMatchObject({
       systemPrompt: "You are a helpful assistant.",
-      mcpServerUrl: "https://mcp.example.com",
-      mcpKeyName: "dashboard-mcp",
     });
+    expect(call!.body).not.toHaveProperty("mcpServerUrl");
+    expect(call!.body).not.toHaveProperty("mcpKeyName");
   });
 
   it("should return 401 without API key", async () => {


### PR DESCRIPTION
## Summary
- Removes `mcpServerUrl` and `mcpKeyName` from `ChatConfigRequestSchema` and `PlatformChatConfigRequestSchema`
- chat-service PR #63 dropped these fields — they were silently ignored by Zod (no error, but not stored)
- Updates tests to assert these fields are no longer present
- Regenerates `openapi.json`

## Test plan
- [x] All 566 tests pass
- [x] `openapi.json` regenerated without the removed fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)