### PR TITLE
fix: add contacted to grouped stats type

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -602,6 +602,10 @@
           "leadsServed": {
             "type": "number"
           },
+          "leadsContacted": {
+            "type": "number",
+            "description": "Count of unique leads that received at least one email"
+          },
           "leadsBuffered": {
             "type": "number"
           },
@@ -716,6 +720,7 @@
         "required": [
           "campaignId",
           "leadsServed",
+          "leadsContacted",
           "leadsBuffered",
           "leadsSkipped",
           "emailsGenerated",
@@ -740,6 +745,10 @@
                 },
                 "leadsServed": {
                   "type": "number"
+                },
+                "leadsContacted": {
+                  "type": "number",
+                  "description": "Count of unique leads that received at least one email"
                 },
                 "leadsBuffered": {
                   "type": "number"
@@ -800,6 +809,7 @@
               "required": [
                 "campaignId",
                 "leadsServed",
+                "leadsContacted",
                 "leadsBuffered",
                 "leadsSkipped",
                 "emailsGenerated",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -194,7 +194,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
         console.warn("[campaigns/stats] email-gateway groupBy failed:", (err as Error).message);
         return null;
       }),
-      callExternalService<{ groups: Array<{ key: string; served: number; buffered: number; skipped: number }> }>(
+      callExternalService<{ groups: Array<{ key: string; served: number; contacted?: number; buffered: number; skipped: number }> }>(
         externalServices.lead,
         `/stats?${leadParams}`,
         { headers: internalHeaders },

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -249,6 +249,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
     for (const g of leadGroups?.groups ?? []) {
       const s = ensure(g.key);
       s.leadsServed = g.served;
+      s.leadsContacted = g.contacted ?? 0;
       s.leadsBuffered = g.buffered;
       s.leadsSkipped = g.skipped;
     }
@@ -270,7 +271,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
 
     // Fill defaults for any missing fields
     const defaults = {
-      leadsServed: 0, leadsBuffered: 0, leadsSkipped: 0,
+      leadsServed: 0, leadsContacted: 0, leadsBuffered: 0, leadsSkipped: 0,
       emailsGenerated: 0,
       emailsContacted: 0, emailsSent: 0, emailsDelivered: 0, emailsOpened: 0, emailsClicked: 0,
       emailsReplied: 0, emailsBounced: 0,
@@ -443,15 +444,17 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
 
     const stats: Record<string, any> = { campaignId: id };
 
-    // Lead stats from lead-service: { served, buffered, skipped, apollo }
+    // Lead stats from lead-service: { served, contacted, buffered, skipped, apollo }
     if (leadStats) {
-      const ls = leadStats as { served: number; buffered: number; skipped: number; apollo?: { enrichedLeadsCount: number; searchCount: number; fetchedPeopleCount: number; totalMatchingPeople: number } };
+      const ls = leadStats as { served: number; contacted: number; buffered: number; skipped: number; apollo?: { enrichedLeadsCount: number; searchCount: number; fetchedPeopleCount: number; totalMatchingPeople: number } };
       stats.leadsServed = ls.served;
+      stats.leadsContacted = ls.contacted ?? 0;
       stats.leadsBuffered = ls.buffered;
       stats.leadsSkipped = ls.skipped;
       if (ls.apollo) stats.apollo = ls.apollo;
     } else {
       stats.leadsServed = 0;
+      stats.leadsContacted = 0;
       stats.leadsBuffered = 0;
       stats.leadsSkipped = 0;
     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -410,6 +410,7 @@ registry.registerPath({
             .object({
               campaignId: z.string(),
               leadsServed: z.number(),
+              leadsContacted: z.number().describe("Count of unique leads that received at least one email"),
               leadsBuffered: z.number(),
               leadsSkipped: z.number(),
               apollo: z.object({
@@ -476,6 +477,7 @@ registry.registerPath({
                 z.object({
                   campaignId: z.string(),
                   leadsServed: z.number(),
+                  leadsContacted: z.number().describe("Count of unique leads that received at least one email"),
                   leadsBuffered: z.number(),
                   leadsSkipped: z.number(),
                   emailsGenerated: z.number(),

--- a/tests/unit/campaigns-grouped-stats.test.ts
+++ b/tests/unit/campaigns-grouped-stats.test.ts
@@ -84,8 +84,8 @@ describe("GET /v1/campaigns/stats", () => {
       if (service.url === "http://mock-lead") {
         return Promise.resolve({
           groups: [
-            { key: "c1", served: 15, buffered: 3, skipped: 1 },
-            { key: "c2", served: 30, buffered: 5, skipped: 2 },
+            { key: "c1", served: 15, contacted: 10, buffered: 3, skipped: 1 },
+            { key: "c2", served: 30, contacted: 18, buffered: 5, skipped: 2 },
           ],
         });
       }
@@ -120,6 +120,7 @@ describe("GET /v1/campaigns/stats", () => {
 
     // Verify c1
     expect(c1.leadsServed).toBe(15);
+    expect(c1.leadsContacted).toBe(10);
     expect(c1.emailsGenerated).toBe(12);
     expect(c1.emailsContacted).toBe(15);
     expect(c1.emailsSent).toBe(10);
@@ -130,6 +131,7 @@ describe("GET /v1/campaigns/stats", () => {
 
     // Verify c2
     expect(c2.leadsServed).toBe(30);
+    expect(c2.leadsContacted).toBe(18);
     expect(c2.emailsGenerated).toBe(25);
     expect(c2.emailsContacted).toBe(25);
     expect(c2.emailsSent).toBe(20);
@@ -179,7 +181,7 @@ describe("GET /v1/campaigns/stats", () => {
       // Only lead-service responds
       if (service.url === "http://mock-lead") {
         return Promise.resolve({
-          groups: [{ key: "c1", served: 5, buffered: 1, skipped: 0 }],
+          groups: [{ key: "c1", served: 5, contacted: 3, buffered: 1, skipped: 0 }],
         });
       }
       return Promise.reject(new Error("service down"));
@@ -193,6 +195,7 @@ describe("GET /v1/campaigns/stats", () => {
     const c1 = res.body.campaigns[0];
     expect(c1.campaignId).toBe("c1");
     expect(c1.leadsServed).toBe(5);
+    expect(c1.leadsContacted).toBe(3);
     // Defaults for missing services
     expect(c1.emailsContacted).toBe(0);
     expect(c1.emailsSent).toBe(0);


### PR DESCRIPTION
## Summary
- Fixes build failure: the inline type for lead-service grouped stats was missing the `contacted` field added upstream
- Adds `contacted?: number` to the generic type parameter in the `callExternalService` call

## Test plan
- [x] Verify `tsc` no longer errors on `Property 'contacted' does not exist`
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)