### PR TITLE
feat: add key source preference endpoints aligned with key-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1396,13 +1396,131 @@
       "DeleteKeyResponse": {
         "type": "object",
         "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Provider name"
+          },
           "message": {
             "type": "string",
             "description": "Confirmation message"
           }
         },
         "required": [
+          "provider",
           "message"
+        ]
+      },
+      "KeySourceItem": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Provider name (e.g. 'anthropic', 'openai')"
+          },
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Active key source for this provider"
+          }
+        },
+        "required": [
+          "provider",
+          "keySource"
+        ]
+      },
+      "ListKeySourcesResponse": {
+        "type": "object",
+        "properties": {
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KeySourceItem"
+            }
+          }
+        },
+        "required": [
+          "sources"
+        ]
+      },
+      "GetKeySourceResponse": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Provider name"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Active key source"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether this is the default (no explicit preference set)"
+          }
+        },
+        "required": [
+          "provider",
+          "orgId",
+          "keySource",
+          "isDefault"
+        ]
+      },
+      "SetKeySourceResponse": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Provider name"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Updated key source"
+          },
+          "message": {
+            "type": "string",
+            "description": "Confirmation message"
+          }
+        },
+        "required": [
+          "provider",
+          "orgId",
+          "keySource",
+          "message"
+        ]
+      },
+      "SetKeySourceRequest": {
+        "type": "object",
+        "properties": {
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Key source preference: 'org' (BYOK) or 'platform' (distribute-managed)"
+          }
+        },
+        "required": [
+          "keySource"
         ]
       },
       "ApiKeyItem": {
@@ -6231,6 +6349,322 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DeleteKeyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/keys/sources": {
+      "get": {
+        "tags": [
+          "Keys"
+        ],
+        "summary": "List key source preferences",
+        "description": "List all key source preferences for the organization. Each entry indicates whether the org uses its own key (BYOK) or the platform key for a given provider. Providers not listed default to 'platform'.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key source preferences",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListKeySourcesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/keys/{provider}/source": {
+      "get": {
+        "tags": [
+          "Keys"
+        ],
+        "summary": "Get key source preference",
+        "description": "Get the key source preference for a specific provider. Returns whether the org uses its own key or the platform key.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Provider name"
+            },
+            "required": true,
+            "description": "Provider name",
+            "name": "provider",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key source preference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetKeySourceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Keys"
+        ],
+        "summary": "Set key source preference",
+        "description": "Set the key source preference for a provider. Choose 'org' to use your own BYOK key, or 'platform' to use the distribute-managed key.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Provider name"
+            },
+            "required": true,
+            "description": "Provider name",
+            "name": "provider",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetKeySourceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Key source preference updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetKeySourceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
-import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js";
+import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema, SetKeySourceRequestSchema } from "../schemas.js";
 
 const router = Router();
 
@@ -69,6 +69,76 @@ router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest,
   } catch (error: any) {
     console.error("Delete key error:", error);
     res.status(500).json({ error: error.message || "Failed to delete key" });
+  }
+});
+
+// -----------------------------------------------------------------------
+// Key source preferences — org vs platform (BYOK) management
+// -----------------------------------------------------------------------
+
+/**
+ * GET /v1/keys/sources
+ * List all key source preferences for the organization.
+ */
+router.get("/keys/sources", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    const result = await callExternalService(externalServices.key, "/keys/sources", {
+      headers: buildInternalHeaders(req),
+    });
+    res.json(result);
+  } catch (error: any) {
+    console.error("List key sources error:", error);
+    res.status(500).json({ error: error.message || "Failed to list key sources" });
+  }
+});
+
+/**
+ * GET /v1/keys/:provider/source
+ * Get key source preference for a specific provider.
+ */
+router.get("/keys/:provider/source", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    const { provider } = req.params;
+    const result = await callExternalService(
+      externalServices.key,
+      `/keys/${encodeURIComponent(provider)}/source`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get key source error:", error);
+    res.status(500).json({ error: error.message || "Failed to get key source" });
+  }
+});
+
+/**
+ * PUT /v1/keys/:provider/source
+ * Set key source preference for a specific provider.
+ */
+router.put("/keys/:provider/source", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = SetKeySourceRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+
+    const { provider } = req.params;
+    const result = await callExternalService(
+      externalServices.key,
+      `/keys/${encodeURIComponent(provider)}/source`,
+      {
+        method: "PUT",
+        body: parsed.data,
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Set key source error:", error);
+    res.status(500).json({ error: error.message || "Failed to set key source" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -874,11 +874,127 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
+            provider: z.string().describe("Provider name"),
             message: z.string().describe("Confirmation message"),
           }).openapi("DeleteKeyResponse"),
         },
       },
     },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
+// KEY SOURCE PREFERENCES
+// ===================================================================
+
+const KeySourceEnum = z.enum(["org", "platform"]);
+
+export const SetKeySourceRequestSchema = z
+  .object({
+    keySource: KeySourceEnum.describe("Key source preference: 'org' (BYOK) or 'platform' (distribute-managed)"),
+  })
+  .openapi("SetKeySourceRequest");
+
+const KeySourceItemSchema = z
+  .object({
+    provider: z.string().describe("Provider name (e.g. 'anthropic', 'openai')"),
+    keySource: KeySourceEnum.describe("Active key source for this provider"),
+  })
+  .openapi("KeySourceItem");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/keys/sources",
+  tags: ["Keys"],
+  summary: "List key source preferences",
+  description:
+    "List all key source preferences for the organization. " +
+    "Each entry indicates whether the org uses its own key (BYOK) or the platform key for a given provider. " +
+    "Providers not listed default to 'platform'.",
+  security: authed,
+  responses: {
+    200: {
+      description: "Key source preferences",
+      content: {
+        "application/json": {
+          schema: z.object({
+            sources: z.array(KeySourceItemSchema),
+          }).openapi("ListKeySourcesResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/keys/{provider}/source",
+  tags: ["Keys"],
+  summary: "Get key source preference",
+  description:
+    "Get the key source preference for a specific provider. " +
+    "Returns whether the org uses its own key or the platform key.",
+  security: authed,
+  request: {
+    params: z.object({
+      provider: z.string().describe("Provider name"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Key source preference",
+      content: {
+        "application/json": {
+          schema: z.object({
+            provider: z.string().describe("Provider name"),
+            orgId: z.string().describe("Organization ID"),
+            keySource: KeySourceEnum.describe("Active key source"),
+            isDefault: z.boolean().describe("Whether this is the default (no explicit preference set)"),
+          }).openapi("GetKeySourceResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/keys/{provider}/source",
+  tags: ["Keys"],
+  summary: "Set key source preference",
+  description:
+    "Set the key source preference for a provider. " +
+    "Choose 'org' to use your own BYOK key, or 'platform' to use the distribute-managed key.",
+  security: authed,
+  request: {
+    params: z.object({
+      provider: z.string().describe("Provider name"),
+    }),
+    body: {
+      content: { "application/json": { schema: SetKeySourceRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Key source preference updated",
+      content: {
+        "application/json": {
+          schema: z.object({
+            provider: z.string().describe("Provider name"),
+            orgId: z.string().describe("Organization ID"),
+            keySource: KeySourceEnum.describe("Updated key source"),
+            message: z.string().describe("Confirmation message"),
+          }).openapi("SetKeySourceResponse"),
+        },
+      },
+    },
+    400: { description: "Invalid request", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },

--- a/tests/unit/keys-unified-proxy.test.ts
+++ b/tests/unit/keys-unified-proxy.test.ts
@@ -153,6 +153,106 @@ describe("DELETE /v1/keys/:provider — org keys only", () => {
 });
 
 // -----------------------------------------------------------------------
+// GET /v1/keys/sources
+// -----------------------------------------------------------------------
+
+describe("GET /v1/keys/sources — key source preferences", () => {
+  it("should proxy to key-service /keys/sources", async () => {
+    (global.fetch as any).mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve({ sources: [{ provider: "anthropic", keySource: "org" }] }),
+    }));
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/sources");
+
+    expect(res.status).toBe(200);
+    expect(res.body.sources).toEqual([{ provider: "anthropic", keySource: "org" }]);
+  });
+
+  it("should reject when no org context", async () => {
+    mockAuth.orgId = "";
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/sources");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Organization context required");
+  });
+});
+
+// -----------------------------------------------------------------------
+// GET /v1/keys/:provider/source
+// -----------------------------------------------------------------------
+
+describe("GET /v1/keys/:provider/source — get key source", () => {
+  it("should proxy to key-service /keys/:provider/source", async () => {
+    (global.fetch as any).mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve({ provider: "anthropic", orgId: "org_test456", keySource: "org", isDefault: false }),
+    }));
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/anthropic/source");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ provider: "anthropic", orgId: "org_test456", keySource: "org", isDefault: false });
+  });
+
+  it("should reject when no org context", async () => {
+    mockAuth.orgId = "";
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/anthropic/source");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Organization context required");
+  });
+});
+
+// -----------------------------------------------------------------------
+// PUT /v1/keys/:provider/source
+// -----------------------------------------------------------------------
+
+describe("PUT /v1/keys/:provider/source — set key source", () => {
+  it("should proxy to key-service with validated body", async () => {
+    (global.fetch as any).mockImplementation(async (_url: string, init?: RequestInit) => {
+      fetchCalls.push({ url: _url, method: init?.method, body: init?.body ? JSON.parse(init.body as string) : undefined });
+      return {
+        ok: true,
+        json: () => Promise.resolve({ provider: "anthropic", orgId: "org_test456", keySource: "org", message: "updated" }),
+      };
+    });
+    const app = createApp();
+    const res = await request(app)
+      .put("/v1/keys/anthropic/source")
+      .send({ keySource: "org" });
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.method === "PUT");
+    expect(call!.url).toContain("/keys/anthropic/source");
+    expect(call!.body).toEqual({ keySource: "org" });
+  });
+
+  it("should reject invalid keySource value", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .put("/v1/keys/anthropic/source")
+      .send({ keySource: "invalid" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should reject when no org context", async () => {
+    mockAuth.orgId = "";
+    const app = createApp();
+    const res = await request(app)
+      .put("/v1/keys/anthropic/source")
+      .send({ keySource: "org" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Organization context required");
+  });
+});
+
+// -----------------------------------------------------------------------
 // Decrypt proxy removal
 // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Expose 3 new endpoints for key source preference management: `GET /v1/keys/sources`, `GET /v1/keys/{provider}/source`, `PUT /v1/keys/{provider}/source`
- Fix `DeleteKeyResponse` schema to include `provider` field (matching key-service contract)
- Clients can now manage BYOK vs platform key preferences through the API (needed for Gemini→Anthropic migration)

## Test plan
- [x] 7 new unit tests covering all 3 key source endpoints (happy path + validation + auth)
- [x] All 557 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)