### PR TITLE
fix: align chat OpenAPI schemas with chat-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3010,12 +3010,28 @@
       "ChatConfigResponse": {
         "type": "object",
         "properties": {
-          "message": {
-            "type": "string"
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "The registered system prompt"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp of creation"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO timestamp of last update"
           }
         },
         "required": [
-          "message"
+          "orgId",
+          "systemPrompt",
+          "createdAt",
+          "updatedAt"
         ]
       },
       "ChatConfigRequest": {
@@ -3127,12 +3143,23 @@
       "PlatformChatConfigResponse": {
         "type": "object",
         "properties": {
-          "message": {
-            "type": "string"
+          "systemPrompt": {
+            "type": "string",
+            "description": "The registered system prompt"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp of creation"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO timestamp of last update"
           }
         },
         "required": [
-          "message"
+          "systemPrompt",
+          "createdAt",
+          "updatedAt"
         ]
       },
       "PlatformChatConfigRequest": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2251,6 +2251,10 @@ export const SSEInputRequestEventSchema = z
     label: z.string().describe("Human-readable label/question for the input"),
     placeholder: z.string().optional().describe("Placeholder text for the input field"),
     field: z.string().describe("Identifier for what the input represents"),
+    value: z.string().optional().describe(
+      "Pre-filled value for the input field. When present, the frontend renders the field already populated " +
+      "so the user can confirm with a single click. When absent, the field is empty.",
+    ),
   })
   .openapi("SSEInputRequestEvent");
 
@@ -2297,7 +2301,12 @@ registry.registerPath({
       description: "Config registered",
       content: {
         "application/json": {
-          schema: z.object({ message: z.string() }).openapi("ChatConfigResponse"),
+          schema: z.object({
+            orgId: z.string().describe("Organization ID"),
+            systemPrompt: z.string().describe("The registered system prompt"),
+            createdAt: z.string().describe("ISO timestamp of creation"),
+            updatedAt: z.string().describe("ISO timestamp of last update"),
+          }).openapi("ChatConfigResponse"),
         },
       },
     },
@@ -2475,7 +2484,11 @@ registry.registerPath({
       description: "Config registered",
       content: {
         "application/json": {
-          schema: z.object({ message: z.string() }).openapi("PlatformChatConfigResponse"),
+          schema: z.object({
+            systemPrompt: z.string().describe("The registered system prompt"),
+            createdAt: z.string().describe("ISO timestamp of creation"),
+            updatedAt: z.string().describe("ISO timestamp of last update"),
+          }).openapi("PlatformChatConfigResponse"),
         },
       },
     },

--- a/tests/unit/chat-proxy.test.ts
+++ b/tests/unit/chat-proxy.test.ts
@@ -131,6 +131,34 @@ describe("Chat OpenAPI schemas", () => {
     // The chat endpoint should document text/event-stream
     expect(schemaContent).toContain("text/event-stream");
   });
+
+  it("should include value field on SSEInputRequestEvent (pre-filled input support)", () => {
+    // chat-service sends a value field for pre-filled inputs
+    expect(schemaContent).toContain('value: z.string().optional()');
+  });
+
+  it("should return full config object from PUT /v1/chat/config (not just message)", () => {
+    // chat-service returns { orgId, systemPrompt, createdAt, updatedAt }
+    const configResponseBlock = schemaContent.slice(
+      schemaContent.indexOf('.openapi("ChatConfigResponse")') - 300,
+      schemaContent.indexOf('.openapi("ChatConfigResponse")'),
+    );
+    expect(configResponseBlock).toContain("orgId");
+    expect(configResponseBlock).toContain("systemPrompt");
+    expect(configResponseBlock).toContain("createdAt");
+    expect(configResponseBlock).toContain("updatedAt");
+  });
+
+  it("should return full config object from PUT /platform-chat/config (not just message)", () => {
+    // chat-service returns { systemPrompt, createdAt, updatedAt }
+    const configResponseBlock = schemaContent.slice(
+      schemaContent.indexOf('.openapi("PlatformChatConfigResponse")') - 300,
+      schemaContent.indexOf('.openapi("PlatformChatConfigResponse")'),
+    );
+    expect(configResponseBlock).toContain("systemPrompt");
+    expect(configResponseBlock).toContain("createdAt");
+    expect(configResponseBlock).toContain("updatedAt");
+  });
 });
 
 describe("Chat routes are mounted in index.ts", () => {


### PR DESCRIPTION
## Summary
- Add missing `value` field to `SSEInputRequestEvent` (pre-filled input support from chat-service)
- Fix `ChatConfigResponse` to return full config object (`orgId`, `systemPrompt`, `createdAt`, `updatedAt`) matching chat-service's actual response
- Fix `PlatformChatConfigResponse` similarly (`systemPrompt`, `createdAt`, `updatedAt`)
- Breaking change: response schemas for `PUT /v1/chat/config` and `PUT /platform-chat/config` now reflect the real payload (was incorrectly documented as `{ message }`)

## Test plan
- [x] 3 new regression tests locking the corrected schemas
- [x] All 553 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)