### PR TITLE
fix: forward tracking headers to createRun

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -95,12 +95,17 @@ export async function authenticate(
     // Create a request run for tracking — mandatory, fail the request if runs-service is down
     if (req.orgId) {
       try {
+        const runHeaders: Record<string, string> = {};
+        if (req.brandId) runHeaders["x-brand-id"] = req.brandId;
+        if (req.campaignId) runHeaders["x-campaign-id"] = req.campaignId;
+        if (req.workflowName) runHeaders["x-workflow-name"] = req.workflowName;
+
         const run = await createRun({
           orgId: req.orgId,
           userId: req.userId,
           serviceName: "api-service",
           taskName: `${req.method} ${req.baseUrl}${req.path}`,
-        });
+        }, runHeaders);
         req.runId = run.id;
 
         // Auto-close the run when the response finishes

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -335,6 +335,63 @@ describe("Auth middleware — run creation is mandatory", () => {
     expect(res.body.error).toBe("Run tracking unavailable");
   });
 
+  it("should forward x-brand-id, x-campaign-id, x-workflow-name headers to createRun", async () => {
+    const { createRun } = await import("@distribute/runs-client");
+    const mockCreateRun = vi.mocked(createRun);
+    mockCreateRun.mockResolvedValueOnce({ id: "run-with-context" } as never);
+
+    mockCall.mockResolvedValueOnce({
+      orgId: "org-uuid-123",
+      userId: "user-uuid-456",
+    });
+
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-external-org-id", "ext_org_123")
+      .set("x-external-user-id", "ext_user_456")
+      .set("x-brand-id", "brand-abc")
+      .set("x-campaign-id", "campaign-xyz")
+      .set("x-workflow-name", "my-workflow");
+
+    expect(res.status).toBe(200);
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      {
+        orgId: "org-uuid-123",
+        userId: "user-uuid-456",
+        serviceName: "api-service",
+        taskName: "GET /v1/workflows",
+      },
+      {
+        "x-brand-id": "brand-abc",
+        "x-campaign-id": "campaign-xyz",
+        "x-workflow-name": "my-workflow",
+      },
+    );
+  });
+
+  it("should not include tracking headers when none are provided", async () => {
+    const { createRun } = await import("@distribute/runs-client");
+    const mockCreateRun = vi.mocked(createRun);
+    mockCreateRun.mockResolvedValueOnce({ id: "run-no-context" } as never);
+
+    mockCall.mockResolvedValueOnce({
+      valid: true,
+      orgId: "org-uuid-direct",
+      userId: "user-uuid-direct",
+    });
+
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("Authorization", "Bearer mcpf_usr_test123");
+
+    expect(res.status).toBe(200);
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org-uuid-direct" }),
+      {},
+    );
+  });
+
   it("should return 502 when createRun fails for admin auth too", async () => {
     const { createRun } = await import("@distribute/runs-client");
     vi.mocked(createRun).mockRejectedValueOnce(new Error("Connection refused"));


### PR DESCRIPTION
## Summary
- The auth middleware extracted `x-brand-id`, `x-campaign-id`, and `x-workflow-name` from incoming requests but never forwarded them to runs-service when creating runs
- All runs were missing brand/campaign/workflow context, making cost attribution by brand or campaign impossible
- Fix passes these three values as headers (not body) to `createRun()`, matching runs-service's header fallback mechanism

## Test plan
- [x] Added test: tracking headers are forwarded to `createRun` when present
- [x] Added test: empty headers object when no tracking headers provided
- [x] All 18 auth middleware tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)