### PR TITLE
fix: pass orgId to lead/emailgen in grouped stats

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -173,11 +173,11 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
     const deliveryParams = new URLSearchParams(baseParams);
     deliveryParams.set("groupBy", "campaignId");
 
-    const leadParams = new URLSearchParams();
+    const leadParams = new URLSearchParams({ orgId });
     if (brandId) leadParams.set("brandId", brandId);
     leadParams.set("groupBy", "campaignId");
 
-    const emailgenParams = new URLSearchParams();
+    const emailgenParams = new URLSearchParams({ orgId });
     if (brandId) emailgenParams.set("brandId", brandId);
     emailgenParams.set("groupBy", "campaignId");
 

--- a/tests/unit/campaigns-grouped-stats.test.ts
+++ b/tests/unit/campaigns-grouped-stats.test.ts
@@ -215,6 +215,19 @@ describe("GET /v1/campaigns/stats", () => {
     expect(res.body.campaigns).toEqual([]);
   });
 
+  it("should pass orgId to lead-service and content-generation even without brandId", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({ groups: [] });
+
+    await request(app).get("/v1/campaigns/stats");
+
+    for (const call of mockCallExternalService.mock.calls) {
+      const path = call[1] as string;
+      expect(path).toContain("orgId=org1");
+    }
+  });
+
   it("should use only broadcast stats from email-gateway, not transactional", async () => {
     const app = createApp();
 


### PR DESCRIPTION
## Summary
- `GET /v1/campaigns/stats` was missing `orgId` in query params for lead-service and content-generation calls
- When no `brandId` filter was provided, these calls failed with "At least one filter required: campaignId, brandId, orgId, or runIds"
- Added `orgId` to both `leadParams` and `emailgenParams` (it was already present in `baseParams` for email-gateway and `runsParams` for runs-service)

## Test plan
- [x] Added regression test: verifies all 4 service calls include `orgId` even without `brandId`
- [x] All 9 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)