### PR TITLE
fix: forward marketing fields to brand-service sales profile

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -108,7 +108,28 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
     );
     console.log("[api-service] POST /v1/campaigns \u2014 step 1 done: brand upserted", { brandId: brandResult.brandId });
 
-    // 2. Forward to campaign-service (run tracking via x-run-id header)
+    // 2. Send user-provided marketing fields to brand-service sales profile
+    const { urgency, scarcity, riskReversal, socialProof } = parsed.data;
+    if (urgency || scarcity || riskReversal || socialProof) {
+      console.log("[api-service] POST /v1/campaigns — step 2: updating sales profile", { brandId: brandResult.brandId });
+      await callExternalService(
+        externalServices.brand,
+        `/brands/${brandResult.brandId}/sales-profile`,
+        {
+          method: "POST",
+          headers: buildInternalHeaders(req),
+          body: {
+            ...(urgency && { urgency }),
+            ...(scarcity && { scarcity }),
+            ...(riskReversal && { riskReversal }),
+            ...(socialProof && { socialProof }),
+          },
+        }
+      );
+      console.log("[api-service] POST /v1/campaigns — step 2 done: sales profile updated");
+    }
+
+    // 3. Forward to campaign-service (run tracking via x-run-id header)
     // Derive `type` from workflowName for campaign-service backward compat
     const { workflowName, ...restData } = parsed.data;
     const body: Record<string, unknown> = {
@@ -124,7 +145,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       if (body[key] != null) body[key] = String(body[key]);
     }
 
-    console.log("[api-service] POST /v1/campaigns — step 2: forwarding to campaign-service", {
+    console.log("[api-service] POST /v1/campaigns — step 3: forwarding to campaign-service", {
       brandId: body.brandId,
       workflowName: body.workflowName,
       targetOutcome: body.targetOutcome,
@@ -139,7 +160,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
         body,
       }
     );
-    console.log("[api-service] POST /v1/campaigns \u2014 step 3 done: campaign created", {
+    console.log("[api-service] POST /v1/campaigns \u2014 step 4 done: campaign created", {
       campaignId: (result as any).campaign?.id,
       status: (result as any).campaign?.status,
     });

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -54,6 +54,14 @@ describe("POST /v1/campaigns with targetAudience", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
+      // Sales profile update
+      if (url.includes("/sales-profile") && init?.method === "POST") {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ cached: false, brandId: "brand-uuid-123", profile: {} }),
+        };
+      }
+
       // Brand upsert
       if (url.includes("/brands") && init?.method === "POST") {
         return {
@@ -107,6 +115,15 @@ describe("POST /v1/campaigns with targetAudience", () => {
     expect(brandCall).toBeDefined();
     expect(brandCall!.body!.url).toBe("https://example.com");
     expect(brandCall!.body!.orgId).toBe("org_test456");
+
+    // Verify sales-profile was called with the 4 marketing fields
+    const salesProfileCall = fetchCalls.find((c) => c.url.includes("/sales-profile"));
+    expect(salesProfileCall).toBeDefined();
+    expect(salesProfileCall!.url).toContain("/brands/brand-uuid-123/sales-profile");
+    expect(salesProfileCall!.body!.urgency).toBe("Recruitment closes in 30 days");
+    expect(salesProfileCall!.body!.scarcity).toBe("Only 10 spots available worldwide");
+    expect(salesProfileCall!.body!.riskReversal).toBe("Free trial for 2 weeks, no commitment");
+    expect(salesProfileCall!.body!.socialProof).toBe("Backed by 60 sponsors including Acme, Globex");
 
     // Verify campaign-service received all fields including workflowName and derived type
     const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");


### PR DESCRIPTION
## Summary
- During campaign creation, the 4 marketing fields (`urgency`, `scarcity`, `riskReversal`, `socialProof`) were sent to campaign-service which silently dropped them
- Now api-service forwards these fields to `POST /brands/{brandId}/sales-profile` in brand-service, where they are stored as per-brand data
- This makes them available to workflows via the brand's sales profile (no campaign-service schema changes needed)

## Test plan
- [x] Existing 8 campaign-target-audience tests updated and passing (new assertions for sales-profile call)
- [x] Full test suite: 555 tests passing
- [ ] Verify in staging: create campaign with all 7 fields, confirm GET /brands/{brandId}/sales-profile returns user-provided values

🤖 Generated with [Claude Code](https://claude.com/claude-code)