### PR TITLE
fix: use PUT for brand sales profile upsert

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -116,7 +116,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
         externalServices.brand,
         `/brands/${brandResult.brandId}/sales-profile`,
         {
-          method: "POST",
+          method: "PUT",
           headers: buildInternalHeaders(req),
           body: {
             ...(urgency && { urgency }),

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -55,7 +55,7 @@ describe("POST /v1/campaigns with targetAudience", () => {
       fetchCalls.push({ url, body });
 
       // Sales profile update
-      if (url.includes("/sales-profile") && init?.method === "POST") {
+      if (url.includes("/sales-profile") && init?.method === "PUT") {
         return {
           ok: true,
           json: () => Promise.resolve({ cached: false, brandId: "brand-uuid-123", profile: {} }),


### PR DESCRIPTION
## Summary
- `POST /brands/{id}/sales-profile` returns 409 "Sales profile already exists" when a user creates a second campaign for the same brand
- Changed to `PUT` which is the idempotent upsert endpoint — it replaces stale data with the latest user-provided marketing fields

## Test plan
- [x] 556 tests passing
- [x] Test mock updated to match PUT method
- [ ] Verify in prod: create two campaigns for the same brand URL, confirm second one succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)