### PR TITLE
feat: add POST /v1/content/compose proxy route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4235,6 +4235,57 @@
         "type": "object",
         "properties": {}
       },
+      "ContentComposeResponse": {
+        "type": "object",
+        "properties": {
+          "composedVideoUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the composed video"
+          }
+        },
+        "required": [
+          "composedVideoUrl"
+        ]
+      },
+      "ContentComposeRequest": {
+        "type": "object",
+        "properties": {
+          "videoUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Source video URL"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name to overlay"
+          },
+          "age": {
+            "type": "number",
+            "description": "Age to overlay"
+          },
+          "theme": {
+            "type": "string",
+            "description": "Theme text"
+          },
+          "text": {
+            "type": "string",
+            "description": "Quote text to overlay"
+          },
+          "outputBlobToken": {
+            "type": "string",
+            "description": "Vercel Blob write token for the output"
+          }
+        },
+        "required": [
+          "videoUrl",
+          "name",
+          "age",
+          "theme",
+          "text",
+          "outputBlobToken"
+        ]
+      },
       "LlmEndpointSummary": {
         "type": "object",
         "properties": {
@@ -12577,6 +12628,118 @@
             }
           }
         }
+      }
+    },
+    "/v1/content/compose": {
+      "post": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Compose a personalized video",
+        "description": "Proxy to content-generation-service POST /compose. Composes a personalized video with overlaid text using FFmpeg + sharp, then uploads the result to Vercel Blob.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContentComposeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Composed video URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentComposeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
       }
     },
     "/v1/platform/llm-context": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import platformKeysRoutes from "./routes/platform-keys.js";
 import platformPromptsRoutes from "./routes/platform-prompts.js";
 import emailGatewayRoutes from "./routes/email-gateway.js";
 import runsRoutes from "./routes/runs.js";
+import contentRoutes from "./routes/content.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
@@ -176,6 +177,7 @@ app.use("/v1", usersRoutes);
 app.use("/v1", platformRoutes);
 app.use("/v1", emailGatewayRoutes);
 app.use("/v1", runsRoutes);
+app.use("/v1", contentRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/src/routes/content.ts
+++ b/src/routes/content.ts
@@ -1,0 +1,37 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { ContentComposeRequestSchema } from "../schemas.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+/**
+ * POST /v1/content/compose
+ * Proxy to content-generation-service POST /compose
+ */
+router.post("/content/compose", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = ContentComposeRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+
+    const result = await callExternalService<{ composedVideoUrl: string }>(
+      externalServices.emailgen,
+      "/compose",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: parsed.data,
+      },
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("Content compose error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to compose content" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3429,6 +3429,52 @@ const LlmContextResponseSchema = z
   })
   .openapi("LlmContextResponse");
 
+// ---------------------------------------------------------------------------
+// Content – Compose (proxy to content-generation-service)
+// ---------------------------------------------------------------------------
+export const ContentComposeRequestSchema = z
+  .object({
+    videoUrl: z.string().url().describe("Source video URL"),
+    name: z.string().describe("Name to overlay"),
+    age: z.number().describe("Age to overlay"),
+    theme: z.string().describe("Theme text"),
+    text: z.string().describe("Quote text to overlay"),
+    outputBlobToken: z.string().describe("Vercel Blob write token for the output"),
+  })
+  .openapi("ContentComposeRequest");
+
+export const ContentComposeResponseSchema = z
+  .object({
+    composedVideoUrl: z.string().url().describe("URL of the composed video"),
+  })
+  .openapi("ContentComposeResponse");
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/content/compose",
+  tags: ["Content"],
+  summary: "Compose a personalized video",
+  description:
+    "Proxy to content-generation-service POST /compose. " +
+    "Composes a personalized video with overlaid text using FFmpeg + sharp, " +
+    "then uploads the result to Vercel Blob.",
+  security: authed,
+  request: {
+    body: {
+      content: { "application/json": { schema: ContentComposeRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Composed video URL",
+      content: { "application/json": { schema: ContentComposeResponseSchema } },
+    },
+    400: { description: "Invalid request", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/v1/platform/llm-context",

--- a/tests/unit/content-compose.test.ts
+++ b/tests/unit/content-compose.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import contentRouter from "../../src/routes/content.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", contentRouter);
+  return app;
+}
+
+const validBody = {
+  videoUrl: "https://example.com/video.mp4",
+  name: "Sophie",
+  age: 34,
+  theme: "Loss of Desire",
+  text: "Le texte du quote...",
+  outputBlobToken: "vercel_blob_rw_abc123",
+};
+
+describe("POST /v1/content/compose", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        json: () => Promise.resolve({ composedVideoUrl: "https://blob.vercel.com/composed.mp4" }),
+      };
+    });
+  });
+
+  it("should return composedVideoUrl on success", async () => {
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ composedVideoUrl: "https://blob.vercel.com/composed.mp4" });
+  });
+
+  it("should forward body to content-generation-service /compose", async () => {
+    await request(app)
+      .post("/v1/content/compose")
+      .send(validBody);
+
+    expect(capturedUrl).toContain("/compose");
+    const body = JSON.parse(capturedInit?.body as string);
+    expect(body).toEqual(validBody);
+  });
+
+  it("should forward internal headers (x-org-id, x-user-id, x-run-id)", async () => {
+    await request(app)
+      .post("/v1/content/compose")
+      .send(validBody);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+  });
+
+  it("should send X-API-Key to downstream service", async () => {
+    await request(app)
+      .post("/v1/content/compose")
+      .send(validBody);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["X-API-Key"]).toBeDefined();
+  });
+
+  it("should return 400 when videoUrl is missing", async () => {
+    const { videoUrl, ...noVideo } = validBody;
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send(noVideo);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when videoUrl is invalid", async () => {
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send({ ...validBody, videoUrl: "not-a-url" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when age is not a number", async () => {
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send({ ...validBody, age: "thirty-four" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should forward upstream error status", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve('{"error":"Service unavailable"}'),
+    }));
+
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send(validBody);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toContain("Service unavailable");
+  });
+
+  it("should return 500 when upstream returns unexpected error", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    }));
+
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send(validBody);
+
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /v1/content/compose` proxy route to content-generation-service `/compose`
- Polarity Course admin can call this to compose personalized videos (FFmpeg + sharp + Vercel Blob upload)
- Standard auth (bearer token or admin API key), forwards body as-is, returns `{ composedVideoUrl }` 
- 9 tests covering success, validation, header forwarding, and upstream error propagation

## Test plan
- [x] 9 unit tests pass (validation, proxy forwarding, error handling)
- [x] Full test suite passes (565 tests, 72 files)
- [x] OpenAPI spec regenerated with new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)