### PR TITLE
feat: add portal-sessions proxy and reload_threshold_cents

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3323,6 +3323,11 @@
             "minimum": 0,
             "exclusiveMinimum": true,
             "description": "Auto-reload amount in cents (for payg mode)"
+          },
+          "reload_threshold_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Balance threshold in cents that triggers auto-reload (for payg mode)"
           }
         },
         "required": [
@@ -3412,6 +3417,31 @@
           "success_url",
           "cancel_url",
           "reload_amount_cents"
+        ]
+      },
+      "BillingPortalSessionResponse": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Stripe portal URL to redirect the user to"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      },
+      "CreatePortalSessionRequest": {
+        "type": "object",
+        "properties": {
+          "return_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to redirect after the portal session ends"
+          }
+        },
+        "required": [
+          "return_url"
         ]
       },
       "SendEmailResponse": {
@@ -10727,6 +10757,118 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BillingCheckoutResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/billing/portal-sessions": {
+      "post": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Create Stripe portal session",
+        "description": "Create a Stripe billing portal session for managing payment methods and subscriptions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePortalSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Portal session created with URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingPortalSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No Stripe customer found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -93,4 +93,19 @@ router.post("/billing/checkout-sessions", authenticate, requireOrg, async (req: 
   }
 });
 
+// POST /v1/billing/portal-sessions — create Stripe billing portal session
+router.post("/billing/portal-sessions", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      "/v1/portal-sessions",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message || "Failed to create portal session" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2511,6 +2511,12 @@ export const SwitchBillingModeRequestSchema = z
       .positive()
       .optional()
       .describe("Auto-reload amount in cents (for payg mode)"),
+    reload_threshold_cents: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Balance threshold in cents that triggers auto-reload (for payg mode)"),
   })
   .openapi("SwitchBillingModeRequest");
 
@@ -2533,6 +2539,12 @@ export const CreateCheckoutSessionRequestSchema = z
       .describe("Amount to reload in cents"),
   })
   .openapi("CreateCheckoutSessionRequest");
+
+export const CreatePortalSessionRequestSchema = z
+  .object({
+    return_url: z.string().url().describe("URL to redirect after the portal session ends"),
+  })
+  .openapi("CreatePortalSessionRequest");
 
 registry.registerPath({
   method: "get",
@@ -2706,6 +2718,37 @@ registry.registerPath({
         },
       },
     },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/billing/portal-sessions",
+  tags: ["Billing"],
+  summary: "Create Stripe portal session",
+  description: "Create a Stripe billing portal session for managing payment methods and subscriptions",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: CreatePortalSessionRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Portal session created with URL",
+      content: {
+        "application/json": {
+          schema: z.object({
+            url: z.string().describe("Stripe portal URL to redirect the user to"),
+          }).openapi("BillingPortalSessionResponse"),
+        },
+      },
+    },
+    400: { description: "No Stripe customer found", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },

--- a/tests/unit/billing-proxy.test.ts
+++ b/tests/unit/billing-proxy.test.ts
@@ -44,7 +44,7 @@ describe("Billing proxy routes", () => {
     // Also matches the import line, so total is 7
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    expect(authMatches!.length).toBe(7); // 6 routes + 1 import
+    expect(authMatches!.length).toBe(8); // 7 routes + 1 import
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints (no x-key-source)", () => {
@@ -52,7 +52,7 @@ describe("Billing proxy routes", () => {
     expect(content).not.toContain('"x-key-source"');
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(6);
+    expect(headerMatches!.length).toBe(7);
   });
 
   it("should proxy to externalServices.billing", () => {


### PR DESCRIPTION
## Summary
- Add `POST /v1/billing/portal-sessions` proxy to billing-service for Stripe Customer Portal (payment method management — update/remove card)
- Add `reload_threshold_cents` (optional integer, min 0) to `PATCH /v1/billing/accounts/mode` request body so dashboard can configure auto-reload threshold

## Test plan
- [x] All 560 tests pass
- [x] Route count assertions updated for new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)