### PR TITLE
feat: update billing proxy — drop mode, add auto-reload endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3186,17 +3186,13 @@
             "type": "string",
             "description": "Organization ID"
           },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "byok",
-              "payg"
-            ],
-            "description": "Current billing mode"
-          },
           "balanceCents": {
             "type": "number",
             "description": "Current balance in cents"
+          },
+          "hasAutoReload": {
+            "type": "boolean",
+            "description": "Whether auto-reload is enabled"
           },
           "reloadAmountCents": {
             "type": "number",
@@ -3211,8 +3207,8 @@
         "required": [
           "id",
           "orgId",
-          "mode",
           "balanceCents",
+          "hasAutoReload",
           "reloadAmountCents",
           "createdAt"
         ]
@@ -3220,17 +3216,9 @@
       "BalanceResponse": {
         "type": "object",
         "properties": {
-          "balanceCents": {
+          "balance_cents": {
             "type": "number",
             "description": "Current balance in cents"
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "byok",
-              "payg"
-            ],
-            "description": "Current billing mode"
           },
           "depleted": {
             "type": "boolean",
@@ -3238,8 +3226,7 @@
           }
         },
         "required": [
-          "balanceCents",
-          "mode",
+          "balance_cents",
           "depleted"
         ]
       },
@@ -3286,69 +3273,121 @@
           "transactions"
         ]
       },
-      "SwitchModeResponse": {
+      "ConfigureAutoReloadResponse": {
         "type": "object",
         "properties": {
-          "mode": {
+          "id": {
             "type": "string",
-            "enum": [
-              "byok",
-              "payg"
-            ],
-            "description": "New billing mode"
+            "description": "Account ID"
           },
-          "message": {
+          "orgId": {
             "type": "string",
-            "description": "Confirmation message"
+            "description": "Organization ID"
+          },
+          "balanceCents": {
+            "type": "number",
+            "description": "Current balance in cents"
+          },
+          "hasAutoReload": {
+            "type": "boolean",
+            "description": "Whether auto-reload is enabled"
+          },
+          "reloadAmountCents": {
+            "type": "number",
+            "nullable": true,
+            "description": "Auto-reload amount in cents"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp"
           }
         },
         "required": [
-          "mode",
-          "message"
+          "id",
+          "orgId",
+          "balanceCents",
+          "hasAutoReload",
+          "reloadAmountCents",
+          "createdAt"
         ]
       },
-      "SwitchBillingModeRequest": {
+      "ConfigureAutoReloadRequest": {
         "type": "object",
         "properties": {
-          "mode": {
-            "type": "string",
-            "enum": [
-              "byok",
-              "payg"
-            ],
-            "description": "Billing mode to switch to"
-          },
           "reload_amount_cents": {
             "type": "integer",
             "minimum": 0,
             "exclusiveMinimum": true,
-            "description": "Auto-reload amount in cents (for payg mode)"
+            "description": "Auto-reload amount in cents"
           },
           "reload_threshold_cents": {
             "type": "integer",
             "minimum": 0,
-            "description": "Balance threshold in cents that triggers auto-reload (for payg mode)"
+            "description": "Balance threshold in cents that triggers auto-reload"
           }
         },
         "required": [
-          "mode"
+          "reload_amount_cents"
+        ]
+      },
+      "DisableAutoReloadResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Account ID"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "balanceCents": {
+            "type": "number",
+            "description": "Current balance in cents"
+          },
+          "hasAutoReload": {
+            "type": "boolean",
+            "description": "Whether auto-reload is enabled"
+          },
+          "reloadAmountCents": {
+            "type": "number",
+            "nullable": true,
+            "description": "Auto-reload amount in cents"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp"
+          }
+        },
+        "required": [
+          "id",
+          "orgId",
+          "balanceCents",
+          "hasAutoReload",
+          "reloadAmountCents",
+          "createdAt"
         ]
       },
       "DeductCreditsResponse": {
         "type": "object",
         "properties": {
-          "newBalanceCents": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the deduction succeeded"
+          },
+          "balance_cents": {
             "type": "number",
             "description": "Balance after deduction"
           },
-          "message": {
-            "type": "string",
-            "description": "Confirmation message"
+          "depleted": {
+            "type": "boolean",
+            "description": "True if balance is zero or negative after deduction"
           }
         },
         "required": [
-          "newBalanceCents",
-          "message"
+          "success",
+          "balance_cents",
+          "depleted"
         ]
       },
       "DeductCreditsRequest": {
@@ -10335,7 +10374,7 @@
           "Billing"
         ],
         "summary": "Get account balance",
-        "description": "Quick check of current balance, billing mode, and depletion status",
+        "description": "Quick check of current balance and depletion status",
         "security": [
           {
             "bearerAuth": []
@@ -10515,13 +10554,13 @@
         ]
       }
     },
-    "/v1/billing/accounts/mode": {
+    "/v1/billing/accounts/auto-reload": {
       "patch": {
         "tags": [
           "Billing"
         ],
-        "summary": "Switch billing mode",
-        "description": "Switch between billing modes (byok, payg)",
+        "summary": "Configure auto-reload",
+        "description": "Enable or update auto-reload settings for the billing account. Requires a payment method on file.",
         "security": [
           {
             "bearerAuth": []
@@ -10531,28 +10570,119 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SwitchBillingModeRequest"
+                "$ref": "#/components/schemas/ConfigureAutoReloadRequest"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Mode switched",
+            "description": "Auto-reload configured",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SwitchModeResponse"
+                  "$ref": "#/components/schemas/ConfigureAutoReloadResponse"
                 }
               }
             }
           },
           "400": {
-            "description": "Invalid transition",
+            "description": "No payment method on file",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Disable auto-reload",
+        "description": "Disable auto-reload for the billing account",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Auto-reload disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisableAutoReloadResponse"
                 }
               }
             }

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -51,17 +51,32 @@ router.get("/billing/accounts/transactions", authenticate, requireOrg, async (re
   }
 });
 
-// PATCH /v1/billing/accounts/mode — switch billing mode
-router.patch("/billing/accounts/mode", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// PATCH /v1/billing/accounts/auto-reload — configure auto-reload
+router.patch("/billing/accounts/auto-reload", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.billing,
-      "/v1/accounts/mode",
+      "/v1/accounts/auto-reload",
       { method: "PATCH", body: req.body, headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
-    res.status(500).json({ error: error.message || "Failed to switch billing mode" });
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message || "Failed to configure auto-reload" });
+  }
+});
+
+// DELETE /v1/billing/accounts/auto-reload — disable auto-reload
+router.delete("/billing/accounts/auto-reload", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      "/v1/accounts/auto-reload",
+      { method: "DELETE", headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message || "Failed to disable auto-reload" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2502,23 +2502,21 @@ registry.registerPath({
 // BILLING
 // ===================================================================
 
-export const SwitchBillingModeRequestSchema = z
+export const ConfigureAutoReloadRequestSchema = z
   .object({
-    mode: z.enum(["byok", "payg"]).describe("Billing mode to switch to"),
     reload_amount_cents: z
       .number()
       .int()
       .positive()
-      .optional()
-      .describe("Auto-reload amount in cents (for payg mode)"),
+      .describe("Auto-reload amount in cents"),
     reload_threshold_cents: z
       .number()
       .int()
       .min(0)
       .optional()
-      .describe("Balance threshold in cents that triggers auto-reload (for payg mode)"),
+      .describe("Balance threshold in cents that triggers auto-reload"),
   })
-  .openapi("SwitchBillingModeRequest");
+  .openapi("ConfigureAutoReloadRequest");
 
 export const DeductCreditsRequestSchema = z
   .object({
@@ -2561,8 +2559,8 @@ registry.registerPath({
           schema: z.object({
             id: z.string().describe("Account ID"),
             orgId: z.string().describe("Organization ID"),
-            mode: z.enum(["byok", "payg"]).describe("Current billing mode"),
             balanceCents: z.number().describe("Current balance in cents"),
+            hasAutoReload: z.boolean().describe("Whether auto-reload is enabled"),
             reloadAmountCents: z.number().nullable().describe("Auto-reload amount in cents"),
             createdAt: z.string().describe("ISO timestamp"),
           }).openapi("BillingAccountResponse"),
@@ -2580,7 +2578,7 @@ registry.registerPath({
   tags: ["Billing"],
   summary: "Get account balance",
   description:
-    "Quick check of current balance, billing mode, and depletion status",
+    "Quick check of current balance and depletion status",
   security: authed,
   responses: {
     200: {
@@ -2588,8 +2586,7 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
-            balanceCents: z.number().describe("Current balance in cents"),
-            mode: z.enum(["byok", "payg"]).describe("Current billing mode"),
+            balance_cents: z.number().describe("Current balance in cents"),
             depleted: z.boolean().describe("True if balance is zero or negative"),
           }).openapi("BalanceResponse"),
         },
@@ -2631,31 +2628,63 @@ registry.registerPath({
 
 registry.registerPath({
   method: "patch",
-  path: "/v1/billing/accounts/mode",
+  path: "/v1/billing/accounts/auto-reload",
   tags: ["Billing"],
-  summary: "Switch billing mode",
-  description: "Switch between billing modes (byok, payg)",
+  summary: "Configure auto-reload",
+  description: "Enable or update auto-reload settings for the billing account. Requires a payment method on file.",
   security: authed,
   request: {
     body: {
       content: {
-        "application/json": { schema: SwitchBillingModeRequestSchema },
+        "application/json": { schema: ConfigureAutoReloadRequestSchema },
       },
     },
   },
   responses: {
     200: {
-      description: "Mode switched",
+      description: "Auto-reload configured",
       content: {
         "application/json": {
           schema: z.object({
-            mode: z.enum(["byok", "payg"]).describe("New billing mode"),
-            message: z.string().describe("Confirmation message"),
-          }).openapi("SwitchModeResponse"),
+            id: z.string().describe("Account ID"),
+            orgId: z.string().describe("Organization ID"),
+            balanceCents: z.number().describe("Current balance in cents"),
+            hasAutoReload: z.boolean().describe("Whether auto-reload is enabled"),
+            reloadAmountCents: z.number().nullable().describe("Auto-reload amount in cents"),
+            createdAt: z.string().describe("ISO timestamp"),
+          }).openapi("ConfigureAutoReloadResponse"),
         },
       },
     },
-    400: { description: "Invalid transition", content: errorContent },
+    400: { description: "No payment method on file", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/v1/billing/accounts/auto-reload",
+  tags: ["Billing"],
+  summary: "Disable auto-reload",
+  description: "Disable auto-reload for the billing account",
+  security: authed,
+  responses: {
+    200: {
+      description: "Auto-reload disabled",
+      content: {
+        "application/json": {
+          schema: z.object({
+            id: z.string().describe("Account ID"),
+            orgId: z.string().describe("Organization ID"),
+            balanceCents: z.number().describe("Current balance in cents"),
+            hasAutoReload: z.boolean().describe("Whether auto-reload is enabled"),
+            reloadAmountCents: z.number().nullable().describe("Auto-reload amount in cents"),
+            createdAt: z.string().describe("ISO timestamp"),
+          }).openapi("DisableAutoReloadResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -2681,8 +2710,9 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
-            newBalanceCents: z.number().describe("Balance after deduction"),
-            message: z.string().describe("Confirmation message"),
+            success: z.boolean().describe("Whether the deduction succeeded"),
+            balance_cents: z.number().describe("Balance after deduction"),
+            depleted: z.boolean().describe("True if balance is zero or negative after deduction"),
           }).openapi("DeductCreditsResponse"),
         },
       },

--- a/tests/unit/billing-proxy.test.ts
+++ b/tests/unit/billing-proxy.test.ts
@@ -25,9 +25,19 @@ describe("Billing proxy routes", () => {
     expect(content).toContain('"/billing/accounts/transactions"');
   });
 
-  it("should have PATCH /billing/accounts/mode endpoint", () => {
-    expect(content).toContain('"/billing/accounts/mode"');
+  it("should have PATCH /billing/accounts/auto-reload endpoint", () => {
+    expect(content).toContain('"/billing/accounts/auto-reload"');
     expect(content).toContain("router.patch");
+  });
+
+  it("should have DELETE /billing/accounts/auto-reload endpoint", () => {
+    expect(content).toContain('"/billing/accounts/auto-reload"');
+    expect(content).toContain("router.delete");
+  });
+
+  it("should NOT have PATCH /billing/accounts/mode endpoint", () => {
+    expect(content).not.toContain('"/billing/accounts/mode"');
+    expect(content).not.toContain('"/v1/accounts/mode"');
   });
 
   it("should have POST /billing/credits/deduct endpoint", () => {
@@ -40,11 +50,10 @@ describe("Billing proxy routes", () => {
   });
 
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
-    // Count route definitions using authenticate, requireOrg (6 endpoints, excluding webhook)
-    // Also matches the import line, so total is 7
+    // 9 routes + 1 import = 10
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    expect(authMatches!.length).toBe(8); // 7 routes + 1 import
+    expect(authMatches!.length).toBe(9); // 8 routes + 1 import
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints (no x-key-source)", () => {
@@ -52,7 +61,7 @@ describe("Billing proxy routes", () => {
     expect(content).not.toContain('"x-key-source"');
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(7);
+    expect(headerMatches!.length).toBe(8);
   });
 
   it("should proxy to externalServices.billing", () => {
@@ -63,7 +72,7 @@ describe("Billing proxy routes", () => {
     expect(content).toContain('"/v1/accounts"');
     expect(content).toContain('"/v1/accounts/balance"');
     expect(content).toContain('"/v1/accounts/transactions"');
-    expect(content).toContain('"/v1/accounts/mode"');
+    expect(content).toContain('"/v1/accounts/auto-reload"');
     expect(content).toContain('"/v1/credits/deduct"');
     expect(content).toContain('"/v1/checkout-sessions"');
   });
@@ -89,9 +98,13 @@ describe("Billing OpenAPI schemas", () => {
     expect(schemaContent).toContain('path: "/v1/billing/accounts"');
     expect(schemaContent).toContain('path: "/v1/billing/accounts/balance"');
     expect(schemaContent).toContain('path: "/v1/billing/accounts/transactions"');
-    expect(schemaContent).toContain('path: "/v1/billing/accounts/mode"');
+    expect(schemaContent).toContain('path: "/v1/billing/accounts/auto-reload"');
     expect(schemaContent).toContain('path: "/v1/billing/credits/deduct"');
     expect(schemaContent).toContain('path: "/v1/billing/checkout-sessions"');
+  });
+
+  it("should NOT have accounts/mode path", () => {
+    expect(schemaContent).not.toContain('path: "/v1/billing/accounts/mode"');
   });
 
   it("should use Billing tag", () => {
@@ -99,9 +112,19 @@ describe("Billing OpenAPI schemas", () => {
   });
 
   it("should define request schemas", () => {
-    expect(schemaContent).toContain("SwitchBillingModeRequestSchema");
+    expect(schemaContent).toContain("ConfigureAutoReloadRequestSchema");
+    expect(schemaContent).not.toContain("SwitchBillingModeRequestSchema");
     expect(schemaContent).toContain("DeductCreditsRequestSchema");
     expect(schemaContent).toContain("CreateCheckoutSessionRequestSchema");
+  });
+
+  it("should not have billing_mode in response schemas", () => {
+    // billing_mode / mode enum should not appear in billing response schemas
+    expect(schemaContent).not.toContain('"byok", "payg"');
+  });
+
+  it("should have hasAutoReload in BillingAccountResponse", () => {
+    expect(schemaContent).toContain("hasAutoReload");
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove `PATCH /v1/billing/accounts/mode` (billing_mode concept removed by billing-service PR #21)
- Add `PATCH /v1/billing/accounts/auto-reload` to configure auto-reload
- Add `DELETE /v1/billing/accounts/auto-reload` to disable auto-reload
- Remove `billing_mode` from all response schemas, add `hasAutoReload` to BillingAccount
- Update authorize/balance/deduct response shapes to match new billing-service contract

## Test plan
- [x] All 565 tests pass
- [x] openapi.json regenerated
- [x] Route counts and schema assertions updated in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)