### PR TITLE
docs: add errorSummary to RunCostData schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -768,6 +768,29 @@
           "campaign"
         ]
       },
+      "ErrorSummary": {
+        "type": "object",
+        "properties": {
+          "failedStep": {
+            "type": "string",
+            "description": "Which DAG step failed (e.g. 'fetch_lead', 'generate_email')"
+          },
+          "message": {
+            "type": "string",
+            "description": "Cleaned error message without stack traces"
+          },
+          "rootCause": {
+            "type": "string",
+            "description": "User-friendly root cause (e.g. 'billing-service unavailable')"
+          }
+        },
+        "required": [
+          "failedStep",
+          "message",
+          "rootCause"
+        ],
+        "description": "Structured error summary for failed runs. Contains a user-friendly rootCause, the failedStep, and a cleaned message. Only present when status is 'failed'."
+      },
       "RunCostData": {
         "type": "object",
         "properties": {
@@ -828,6 +851,13 @@
           "taskName": {
             "type": "string",
             "nullable": true
+          },
+          "error": {
+            "type": "string",
+            "description": "Raw error message (for debugging). Only present on failed runs."
+          },
+          "errorSummary": {
+            "$ref": "#/components/schemas/ErrorSummary"
           },
           "descendantRuns": {
             "type": "array",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -363,6 +363,14 @@ export const CreateCampaignRequestSchema = z
 
 // -- Common schemas --
 
+const ErrorSummarySchema = z
+  .object({
+    failedStep: z.string().describe("Which DAG step failed (e.g. 'fetch_lead', 'generate_email')"),
+    message: z.string().describe("Cleaned error message without stack traces"),
+    rootCause: z.string().describe("User-friendly root cause (e.g. 'billing-service unavailable')"),
+  })
+  .openapi("ErrorSummary");
+
 const RunCostDataSchema = z
   .object({
     status: z.string().describe("Run status (e.g. completed, failed)"),
@@ -382,6 +390,10 @@ const RunCostDataSchema = z
       .describe("Per-cost-name breakdown"),
     serviceName: z.string().nullable(),
     taskName: z.string().nullable(),
+    error: z.string().optional().describe("Raw error message (for debugging). Only present on failed runs."),
+    errorSummary: ErrorSummarySchema.optional().describe(
+      "Structured error summary for failed runs. Contains a user-friendly rootCause, the failedStep, and a cleaned message. Only present when status is 'failed'."
+    ),
     descendantRuns: z.array(z.unknown()).describe("Child runs"),
   })
   .openapi("RunCostData");

--- a/tests/unit/openapi-error-summary.test.ts
+++ b/tests/unit/openapi-error-summary.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("OpenAPI spec — ErrorSummary on failed runs", () => {
+  const spec = JSON.parse(
+    readFileSync(resolve(__dirname, "../../openapi.json"), "utf-8"),
+  );
+
+  it("defines the ErrorSummary schema with failedStep, message, rootCause", () => {
+    const errorSummary = spec.components.schemas.ErrorSummary;
+    expect(errorSummary).toBeDefined();
+    expect(errorSummary.properties.failedStep).toBeDefined();
+    expect(errorSummary.properties.message).toBeDefined();
+    expect(errorSummary.properties.rootCause).toBeDefined();
+    expect(errorSummary.required).toEqual(
+      expect.arrayContaining(["failedStep", "message", "rootCause"]),
+    );
+  });
+
+  it("includes error and errorSummary as optional fields on RunCostData", () => {
+    const runCostData = spec.components.schemas.RunCostData;
+    expect(runCostData).toBeDefined();
+    expect(runCostData.properties.errorSummary).toBeDefined();
+    expect(runCostData.properties.error).toBeDefined();
+    // Neither should be required — only present on failed runs
+    expect(runCostData.required).not.toContain("errorSummary");
+    expect(runCostData.required).not.toContain("error");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `ErrorSummary` schema (`failedStep`, `message`, `rootCause`) to the OpenAPI spec
- Adds optional `error` and `errorSummary` fields to `RunCostData` — only present on failed runs
- workflow-service now exposes structured error info (PRs #149 + #150), this documents it for API clients

## Test plan
- [x] `ErrorSummary` schema appears in openapi.json with all 3 required fields
- [x] `error` and `errorSummary` are optional on `RunCostData`
- [x] Unit test validates both constraints
- [x] Build passes, all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)