### PR TITLE
docs: clarify PUT sales-profile refresh bypasses cache

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7839,7 +7839,7 @@
           "Brand"
         ],
         "summary": "Refresh brand sales profile",
-        "description": "Force re-extraction of the sales profile for the brand.",
+        "description": "Force re-extraction of the sales profile for the brand. Always bypasses the 30-day cache and triggers a fresh scraping + AI extraction. Use this when the brand's website has changed and the profile needs updating.",
         "security": [
           {
             "bearerAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1399,7 +1399,7 @@ registry.registerPath({
   tags: ["Brand"],
   summary: "Refresh brand sales profile",
   description:
-    "Force re-extraction of the sales profile for the brand.",
+    "Force re-extraction of the sales profile for the brand. Always bypasses the 30-day cache and triggers a fresh scraping + AI extraction. Use this when the brand's website has changed and the profile needs updating.",
   security: authed,
   request: { params: BrandIdParam },
   responses: {


### PR DESCRIPTION
## Summary
- Updated OpenAPI description for `PUT /v1/brands/:id/sales-profile` to clarify it always bypasses the 30-day cache and triggers fresh scraping + AI extraction.
- Follow-up to PR #157.

## Test plan
- [x] OpenAPI spec regenerated from schemas
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)