### PR TITLE
feat: proxy press-kits-service endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4356,6 +4356,235 @@
         "type": "object",
         "properties": {}
       },
+      "PublicPressKitResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PublicMediaKitLegacyResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitEmailDataResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitOrganizationResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitUpsertOrgRequest": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "orgId"
+        ]
+      },
+      "PressKitShareTokenResponse": {
+        "type": "object",
+        "properties": {
+          "shareToken": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "shareToken"
+        ]
+      },
+      "PressKitOrgExistsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitMediaKitListResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitMediaKitDetailResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitEditResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitEditRequest": {
+        "type": "object",
+        "properties": {
+          "mediaKitId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "instruction": {
+            "type": "string"
+          },
+          "organizationUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mediaKitId",
+          "instruction"
+        ]
+      },
+      "PressKitUpdateMdxResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitUpdateMdxRequest": {
+        "type": "object",
+        "properties": {
+          "mediaKitId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "mdxContent": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mediaKitId",
+          "mdxContent"
+        ]
+      },
+      "PressKitUpdateStatusResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitMediaKitStatus": {
+        "type": "string",
+        "enum": [
+          "drafted",
+          "generating",
+          "validated",
+          "denied",
+          "archived"
+        ]
+      },
+      "PressKitUpdateStatusRequest": {
+        "type": "object",
+        "properties": {
+          "mediaKitId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PressKitMediaKitStatus"
+          },
+          "denialReason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "mediaKitId",
+          "status"
+        ]
+      },
+      "PressKitValidateResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitValidateRequest": {
+        "type": "object",
+        "properties": {
+          "mediaKitId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "mediaKitId"
+        ]
+      },
+      "PressKitCancelDraftResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
+      "PressKitCancelDraftRequest": {
+        "type": "object",
+        "properties": {
+          "mediaKitId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "mediaKitId"
+        ]
+      },
+      "PressKitAdminOrgListResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitAdminDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
+      "PressKitInternalByOrgResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitGenerationDataResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitUpsertGenerationResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitUpsertGenerationRequest": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "mdxContent": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "iconUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "orgId",
+          "mdxContent"
+        ]
+      },
+      "PressKitStaleKitsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitSetupStatusResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitHealthBulkResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "ContentComposeResponse": {
         "type": "object",
         "properties": {
@@ -12911,6 +13140,1730 @@
             }
           }
         }
+      }
+    },
+    "/press-kits/public/{token}": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Get public press kit by share token",
+        "description": "Returns the public-facing press kit for journalists. No authentication required.",
+        "responses": {
+          "200": {
+            "description": "Public press kit data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicPressKitResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/press-kits/public-media-kit/{token}": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Get public media kit (legacy)",
+        "description": "Legacy endpoint for public media kit access by share token. No authentication required.",
+        "responses": {
+          "200": {
+            "description": "Public media kit data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicMediaKitLegacyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/press-kits/email-data/press-kit/{orgId}": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Get press kit data for email templates",
+        "description": "Returns press kit data formatted for use in email templates. No authentication required.",
+        "responses": {
+          "200": {
+            "description": "Email template data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitEmailDataResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/press-kits/organizations": {
+      "post": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Upsert press kit organization",
+        "description": "Create or update an organization in the press-kits service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitUpsertOrgRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Organization upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitOrganizationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/organizations/share-token/{orgId}": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Get organization share token",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Share token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitShareTokenResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/organizations/exists": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Batch check organization existence",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Existence check results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitOrgExistsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/media-kit": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "List media kits",
+        "description": "List media kits, optionally filtered by org_id, organization_id, or title.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Media kits list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitMediaKitListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/media-kit/{id}": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Get media kit by ID",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Media kit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitMediaKitDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/edit-media-kit": {
+      "post": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Initiate media kit generation",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitEditRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generation initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitEditResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/update-mdx": {
+      "post": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Update MDX content",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitUpdateMdxRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitUpdateMdxResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/update-status": {
+      "post": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Update media kit status",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitUpdateStatusRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitUpdateStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/validate": {
+      "post": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Validate media kit",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitValidateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitValidateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/cancel-draft": {
+      "post": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Cancel draft media kit",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitCancelDraftRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Draft cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitCancelDraftResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/admin/organizations": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "List organizations with kit counts (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Admin org list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitAdminOrgListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/admin/organizations/{id}": {
+      "delete": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Delete organization (admin)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitAdminDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/internal/media-kit/by-org/{orgId}": {
+      "get": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Get latest media kit by org (internal)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Media kit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitInternalByOrgResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/internal/generation-data": {
+      "get": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Get generation workflow data (internal)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generation data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitGenerationDataResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/internal/upsert-generation-result": {
+      "post": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Upsert generation result (internal)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitUpsertGenerationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitUpsertGenerationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/clients-media-kits-need-update": {
+      "get": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Get orgs with stale press kits (internal)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stale kits list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitStaleKitsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/media-kit-setup": {
+      "get": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Get media kit setup status (internal)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Setup status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitSetupStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/health/bulk": {
+      "get": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Bulk health check per org (internal)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bulk health",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitHealthBulkResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
       }
     },
     "/v1/content/compose": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import platformPromptsRoutes from "./routes/platform-prompts.js";
 import emailGatewayRoutes from "./routes/email-gateway.js";
 import runsRoutes from "./routes/runs.js";
 import contentRoutes from "./routes/content.js";
+import pressKitsRoutes from "./routes/press-kits.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
@@ -142,6 +143,7 @@ app.use(
 
 // Public routes
 app.use(healthRoutes);
+app.use(pressKitsRoutes); // public press-kit endpoints (no auth)
 
 // Internal platform routes (API key only, no identity)
 app.use("/internal", internalEmailsRoutes);
@@ -170,6 +172,7 @@ app.use("/v1", platformRoutes);
 app.use("/v1", emailGatewayRoutes);
 app.use("/v1", runsRoutes);
 app.use("/v1", contentRoutes);
+app.use("/v1", pressKitsRoutes); // authenticated press-kit endpoints
 
 // 404 handler
 app.use((req, res) => {

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -72,6 +72,10 @@ export const externalServices = {
     url: process.env.API_REGISTRY_SERVICE_URL || "http://localhost:3023",
     apiKey: process.env.API_REGISTRY_SERVICE_API_KEY || "",
   },
+  pressKits: {
+    url: process.env.PRESS_KITS_SERVICE_URL || "https://press-kits.mcpfactory.org",
+    apiKey: process.env.PRESS_KITS_SERVICE_API_KEY || "",
+  },
 };
 
 interface ServiceCallOptions {

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -1,0 +1,316 @@
+import { Router, Request, Response } from "express";
+import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+// ── Public routes (no auth) ─────────────────────────────────────────────────
+
+// GET /press-kits/public/:token — public press kit by share token
+router.get("/press-kits/public/:token", async (req: Request, res: Response) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/public/${encodeURIComponent(req.params.token)}`
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get public press kit" });
+  }
+});
+
+// GET /press-kits/public-media-kit/:token — public media kit (legacy)
+router.get("/press-kits/public-media-kit/:token", async (req: Request, res: Response) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/public-media-kit/${encodeURIComponent(req.params.token)}`
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get public media kit" });
+  }
+});
+
+// GET /press-kits/email-data/press-kit/:orgId — email template data
+router.get("/press-kits/email-data/press-kit/:orgId", async (req: Request, res: Response) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/email-data/press-kit/${encodeURIComponent(req.params.orgId)}`
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get email data" });
+  }
+});
+
+// ── Authenticated routes (mounted at /v1) ────────────────────────────────────
+
+// POST /v1/press-kits/organizations — upsert organization
+router.post("/press-kits/organizations", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/organizations",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to upsert organization" });
+  }
+});
+
+// GET /v1/press-kits/organizations/share-token/:orgId — get share token
+router.get("/press-kits/organizations/share-token/:orgId", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/organizations/share-token/${encodeURIComponent(req.params.orgId)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get share token" });
+  }
+});
+
+// GET /v1/press-kits/organizations/exists — batch check existence
+router.get("/press-kits/organizations/exists", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const qs = req.query.orgIds ? `?orgIds=${encodeURIComponent(req.query.orgIds as string)}` : "";
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/organizations/exists${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to check organizations" });
+  }
+});
+
+// GET /v1/press-kits/media-kit — list media kits
+router.get("/press-kits/media-kit", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.org_id) params.set("org_id", req.query.org_id as string);
+    if (req.query.organization_id) params.set("organization_id", req.query.organization_id as string);
+    if (req.query.title) params.set("title", req.query.title as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/media-kit${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list media kits" });
+  }
+});
+
+// GET /v1/press-kits/media-kit/:id — get media kit by ID
+router.get("/press-kits/media-kit/:id", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/media-kit/${encodeURIComponent(req.params.id)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get media kit" });
+  }
+});
+
+// POST /v1/press-kits/edit-media-kit — initiate media kit generation
+router.post("/press-kits/edit-media-kit", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/edit-media-kit",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to edit media kit" });
+  }
+});
+
+// POST /v1/press-kits/update-mdx — update MDX content
+router.post("/press-kits/update-mdx", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/update-mdx",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to update MDX" });
+  }
+});
+
+// POST /v1/press-kits/update-status — update media kit status
+router.post("/press-kits/update-status", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/update-status",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to update status" });
+  }
+});
+
+// POST /v1/press-kits/validate — validate media kit
+router.post("/press-kits/validate", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/validate",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to validate media kit" });
+  }
+});
+
+// POST /v1/press-kits/cancel-draft — cancel draft media kit
+router.post("/press-kits/cancel-draft", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/cancel-draft",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to cancel draft" });
+  }
+});
+
+// ── Admin routes (authenticated) ─────────────────────────────────────────────
+
+// GET /v1/press-kits/admin/organizations — list orgs with kit counts
+router.get("/press-kits/admin/organizations", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const qs = req.query.search ? `?search=${encodeURIComponent(req.query.search as string)}` : "";
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/admin/organizations${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list admin organizations" });
+  }
+});
+
+// DELETE /v1/press-kits/admin/organizations/:id — delete organization
+router.delete("/press-kits/admin/organizations/:id", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const qs = req.query.confirmName ? `?confirmName=${encodeURIComponent(req.query.confirmName as string)}` : "";
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/admin/organizations/${encodeURIComponent(req.params.id)}${qs}`,
+      { method: "DELETE", headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to delete organization" });
+  }
+});
+
+// ── Internal routes (authenticated, service-to-service) ──────────────────────
+
+// GET /v1/press-kits/internal/media-kit/by-org/:orgId — latest kit by org
+router.get("/press-kits/internal/media-kit/by-org/:orgId", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/internal/media-kit/by-org/${encodeURIComponent(req.params.orgId)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get media kit by org" });
+  }
+});
+
+// GET /v1/press-kits/internal/generation-data — generation workflow data
+router.get("/press-kits/internal/generation-data", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const qs = req.query.orgId ? `?orgId=${encodeURIComponent(req.query.orgId as string)}` : "";
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/internal/generation-data${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get generation data" });
+  }
+});
+
+// POST /v1/press-kits/internal/upsert-generation-result — workflow callback
+router.post("/press-kits/internal/upsert-generation-result", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/internal/upsert-generation-result",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to upsert generation result" });
+  }
+});
+
+// GET /v1/press-kits/clients-media-kits-need-update — stale kits
+router.get("/press-kits/clients-media-kits-need-update", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/clients-media-kits-need-update",
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get stale kits" });
+  }
+});
+
+// GET /v1/press-kits/media-kit-setup — setup status for all orgs
+router.get("/press-kits/media-kit-setup", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/media-kit-setup",
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get setup status" });
+  }
+});
+
+// GET /v1/press-kits/health/bulk — bulk health per org
+router.get("/press-kits/health/bulk", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      "/health/bulk",
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get bulk health" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3501,6 +3501,306 @@ const LlmContextResponseSchema = z
   .openapi("LlmContextResponse");
 
 // ---------------------------------------------------------------------------
+// ===================================================================
+// PRESS KITS (proxy to press-kits-service)
+// ===================================================================
+
+const PressKitMediaKitStatusEnum = z
+  .enum(["drafted", "generating", "validated", "denied", "archived"])
+  .openapi("PressKitMediaKitStatus");
+
+// ── Public endpoints (no auth) ──────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/press-kits/public/{token}",
+  tags: ["Press Kits"],
+  summary: "Get public press kit by share token",
+  description: "Returns the public-facing press kit for journalists. No authentication required.",
+  responses: {
+    200: { description: "Public press kit data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicPressKitResponse") } } },
+    404: { description: "Not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/press-kits/public-media-kit/{token}",
+  tags: ["Press Kits"],
+  summary: "Get public media kit (legacy)",
+  description: "Legacy endpoint for public media kit access by share token. No authentication required.",
+  responses: {
+    200: { description: "Public media kit data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicMediaKitLegacyResponse") } } },
+    404: { description: "Not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/press-kits/email-data/press-kit/{orgId}",
+  tags: ["Press Kits"],
+  summary: "Get press kit data for email templates",
+  description: "Returns press kit data formatted for use in email templates. No authentication required.",
+  responses: {
+    200: { description: "Email template data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitEmailDataResponse") } } },
+  },
+});
+
+// ── Authenticated endpoints ─────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/press-kits/organizations",
+  tags: ["Press Kits"],
+  summary: "Upsert press kit organization",
+  description: "Create or update an organization in the press-kits service.",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({ orgId: z.string(), name: z.string().optional() }).openapi("PressKitUpsertOrgRequest") } } },
+  },
+  responses: {
+    200: { description: "Organization upserted", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitOrganizationResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/organizations/share-token/{orgId}",
+  tags: ["Press Kits"],
+  summary: "Get organization share token",
+  security: authed,
+  responses: {
+    200: { description: "Share token", content: { "application/json": { schema: z.object({ shareToken: z.string().uuid() }).openapi("PressKitShareTokenResponse") } } },
+    404: { description: "Not found", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/organizations/exists",
+  tags: ["Press Kits"],
+  summary: "Batch check organization existence",
+  security: authed,
+  responses: {
+    200: { description: "Existence check results", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitOrgExistsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/media-kit",
+  tags: ["Press Kits"],
+  summary: "List media kits",
+  description: "List media kits, optionally filtered by org_id, organization_id, or title.",
+  security: authed,
+  responses: {
+    200: { description: "Media kits list", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitMediaKitListResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/media-kit/{id}",
+  tags: ["Press Kits"],
+  summary: "Get media kit by ID",
+  security: authed,
+  responses: {
+    200: { description: "Media kit", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitMediaKitDetailResponse") } } },
+    404: { description: "Not found", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/press-kits/edit-media-kit",
+  tags: ["Press Kits"],
+  summary: "Initiate media kit generation",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid(), instruction: z.string(), organizationUrl: z.string().optional() }).openapi("PressKitEditRequest") } } },
+  },
+  responses: {
+    200: { description: "Generation initiated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitEditResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/press-kits/update-mdx",
+  tags: ["Press Kits"],
+  summary: "Update MDX content",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid(), mdxContent: z.string() }).openapi("PressKitUpdateMdxRequest") } } },
+  },
+  responses: {
+    200: { description: "Updated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitUpdateMdxResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/press-kits/update-status",
+  tags: ["Press Kits"],
+  summary: "Update media kit status",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid(), status: PressKitMediaKitStatusEnum, denialReason: z.string().optional() }).openapi("PressKitUpdateStatusRequest") } } },
+  },
+  responses: {
+    200: { description: "Updated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitUpdateStatusResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/press-kits/validate",
+  tags: ["Press Kits"],
+  summary: "Validate media kit",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid() }).openapi("PressKitValidateRequest") } } },
+  },
+  responses: {
+    200: { description: "Validated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitValidateResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/press-kits/cancel-draft",
+  tags: ["Press Kits"],
+  summary: "Cancel draft media kit",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid() }).openapi("PressKitCancelDraftRequest") } } },
+  },
+  responses: {
+    200: { description: "Draft cancelled", content: { "application/json": { schema: z.object({ success: z.boolean() }).openapi("PressKitCancelDraftResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ── Admin endpoints ─────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/admin/organizations",
+  tags: ["Press Kits"],
+  summary: "List organizations with kit counts (admin)",
+  security: authed,
+  responses: {
+    200: { description: "Admin org list", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitAdminOrgListResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/v1/press-kits/admin/organizations/{id}",
+  tags: ["Press Kits"],
+  summary: "Delete organization (admin)",
+  security: authed,
+  responses: {
+    200: { description: "Deleted", content: { "application/json": { schema: z.object({ success: z.boolean() }).openapi("PressKitAdminDeleteResponse") } } },
+    400: { description: "Bad request", content: errorContent },
+    404: { description: "Not found", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+// ── Internal endpoints ──────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/internal/media-kit/by-org/{orgId}",
+  tags: ["Internal"],
+  summary: "Get latest media kit by org (internal)",
+  security: authed,
+  responses: {
+    200: { description: "Media kit", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitInternalByOrgResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/internal/generation-data",
+  tags: ["Internal"],
+  summary: "Get generation workflow data (internal)",
+  security: authed,
+  responses: {
+    200: { description: "Generation data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitGenerationDataResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/press-kits/internal/upsert-generation-result",
+  tags: ["Internal"],
+  summary: "Upsert generation result (internal)",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({ orgId: z.string(), mdxContent: z.string(), title: z.string().optional(), iconUrl: z.string().optional() }).openapi("PressKitUpsertGenerationRequest") } } },
+  },
+  responses: {
+    200: { description: "Upserted", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitUpsertGenerationResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/clients-media-kits-need-update",
+  tags: ["Internal"],
+  summary: "Get orgs with stale press kits (internal)",
+  security: authed,
+  responses: {
+    200: { description: "Stale kits list", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitStaleKitsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/media-kit-setup",
+  tags: ["Internal"],
+  summary: "Get media kit setup status (internal)",
+  security: authed,
+  responses: {
+    200: { description: "Setup status", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitSetupStatusResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/health/bulk",
+  tags: ["Internal"],
+  summary: "Bulk health check per org (internal)",
+  security: authed,
+  responses: {
+    200: { description: "Bulk health", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitHealthBulkResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
 // Content – Compose (proxy to content-generation-service)
 // ---------------------------------------------------------------------------
 export const ContentComposeRequestSchema = z

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/press-kits.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+describe("Press Kits proxy routes", () => {
+  // ── Public endpoints (no auth) ──────────────────────────────────────────
+
+  it("should have public GET /press-kits/public/:token without auth", () => {
+    expect(content).toContain('"/press-kits/public/:token"');
+    // Public route should NOT have authenticate middleware on this line
+    const publicLine = content.split("\n").find((l) => l.includes('"/press-kits/public/:token"'));
+    expect(publicLine).not.toContain("authenticate");
+  });
+
+  it("should have public GET /press-kits/public-media-kit/:token without auth", () => {
+    expect(content).toContain('"/press-kits/public-media-kit/:token"');
+    const publicLine = content.split("\n").find((l) => l.includes('"/press-kits/public-media-kit/:token"'));
+    expect(publicLine).not.toContain("authenticate");
+  });
+
+  it("should have public GET /press-kits/email-data/press-kit/:orgId without auth", () => {
+    expect(content).toContain('"/press-kits/email-data/press-kit/:orgId"');
+    const publicLine = content.split("\n").find((l) => l.includes('"/press-kits/email-data/press-kit/:orgId"'));
+    expect(publicLine).not.toContain("authenticate");
+  });
+
+  // ── Authenticated endpoints ─────────────────────────────────────────────
+
+  it("should have POST /press-kits/organizations with auth", () => {
+    expect(content).toContain('"/press-kits/organizations"');
+    expect(content).toContain("router.post");
+  });
+
+  it("should have GET /press-kits/organizations/share-token/:orgId with auth", () => {
+    expect(content).toContain('"/press-kits/organizations/share-token/:orgId"');
+  });
+
+  it("should have GET /press-kits/organizations/exists with auth", () => {
+    expect(content).toContain('"/press-kits/organizations/exists"');
+  });
+
+  it("should have GET /press-kits/media-kit with auth", () => {
+    expect(content).toContain('"/press-kits/media-kit"');
+  });
+
+  it("should have GET /press-kits/media-kit/:id with auth", () => {
+    expect(content).toContain('"/press-kits/media-kit/:id"');
+  });
+
+  it("should have POST /press-kits/edit-media-kit with auth", () => {
+    expect(content).toContain('"/press-kits/edit-media-kit"');
+  });
+
+  it("should have POST /press-kits/update-mdx with auth", () => {
+    expect(content).toContain('"/press-kits/update-mdx"');
+  });
+
+  it("should have POST /press-kits/update-status with auth", () => {
+    expect(content).toContain('"/press-kits/update-status"');
+  });
+
+  it("should have POST /press-kits/validate with auth", () => {
+    expect(content).toContain('"/press-kits/validate"');
+  });
+
+  it("should have POST /press-kits/cancel-draft with auth", () => {
+    expect(content).toContain('"/press-kits/cancel-draft"');
+  });
+
+  // ── Admin endpoints ───────────────────────────────────────────────────
+
+  it("should have GET /press-kits/admin/organizations with auth", () => {
+    expect(content).toContain('"/press-kits/admin/organizations"');
+  });
+
+  it("should have DELETE /press-kits/admin/organizations/:id with auth", () => {
+    expect(content).toContain('"/press-kits/admin/organizations/:id"');
+    expect(content).toContain("router.delete");
+  });
+
+  // ── Internal endpoints ────────────────────────────────────────────────
+
+  it("should have GET /press-kits/internal/media-kit/by-org/:orgId with auth", () => {
+    expect(content).toContain('"/press-kits/internal/media-kit/by-org/:orgId"');
+  });
+
+  it("should have GET /press-kits/internal/generation-data with auth", () => {
+    expect(content).toContain('"/press-kits/internal/generation-data"');
+  });
+
+  it("should have POST /press-kits/internal/upsert-generation-result with auth", () => {
+    expect(content).toContain('"/press-kits/internal/upsert-generation-result"');
+  });
+
+  it("should have GET /press-kits/clients-media-kits-need-update with auth", () => {
+    expect(content).toContain('"/press-kits/clients-media-kits-need-update"');
+  });
+
+  it("should have GET /press-kits/media-kit-setup with auth", () => {
+    expect(content).toContain('"/press-kits/media-kit-setup"');
+  });
+
+  it("should have GET /press-kits/health/bulk with auth", () => {
+    expect(content).toContain('"/press-kits/health/bulk"');
+  });
+
+  // ── Auth & middleware checks ──────────────────────────────────────────
+
+  it("should use authenticate and requireOrg on all authenticated endpoints", () => {
+    const authMatches = content.match(/authenticate, requireOrg/g);
+    expect(authMatches).not.toBeNull();
+    // 18 authenticated routes + 1 import = 19
+    expect(authMatches!.length).toBe(19);
+  });
+
+  it("should use buildInternalHeaders for all authenticated endpoints", () => {
+    expect(content).toContain("buildInternalHeaders");
+    const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(headerMatches).not.toBeNull();
+    expect(headerMatches!.length).toBe(18);
+  });
+
+  it("should proxy to externalServices.pressKits", () => {
+    expect(content).toContain("externalServices.pressKits");
+  });
+});
+
+describe("Press Kits service client", () => {
+  it("should have pressKits in externalServices", () => {
+    expect(serviceClientContent).toContain("pressKits:");
+    expect(serviceClientContent).toContain("PRESS_KITS_SERVICE_URL");
+    expect(serviceClientContent).toContain("PRESS_KITS_SERVICE_API_KEY");
+  });
+});
+
+describe("Press Kits OpenAPI schemas", () => {
+  it("should register public paths", () => {
+    expect(schemaContent).toContain('path: "/press-kits/public/{token}"');
+    expect(schemaContent).toContain('path: "/press-kits/public-media-kit/{token}"');
+    expect(schemaContent).toContain('path: "/press-kits/email-data/press-kit/{orgId}"');
+  });
+
+  it("should register authenticated paths", () => {
+    expect(schemaContent).toContain('path: "/v1/press-kits/organizations"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/organizations/share-token/{orgId}"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/organizations/exists"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kit"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kit/{id}"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/edit-media-kit"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/update-mdx"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/update-status"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/validate"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/cancel-draft"');
+  });
+
+  it("should register admin paths", () => {
+    expect(schemaContent).toContain('path: "/v1/press-kits/admin/organizations"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/admin/organizations/{id}"');
+  });
+
+  it("should register internal paths", () => {
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/media-kit/by-org/{orgId}"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/generation-data"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/upsert-generation-result"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/clients-media-kits-need-update"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kit-setup"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/health/bulk"');
+  });
+
+  it("should use Press Kits tag for non-internal endpoints", () => {
+    expect(schemaContent).toContain('tags: ["Press Kits"]');
+  });
+
+  it("should use Internal tag for internal endpoints", () => {
+    // Internal press-kit endpoints should use Internal tag
+    const internalPaths = [
+      "/v1/press-kits/internal/media-kit/by-org/{orgId}",
+      "/v1/press-kits/internal/generation-data",
+      "/v1/press-kits/internal/upsert-generation-result",
+      "/v1/press-kits/clients-media-kits-need-update",
+      "/v1/press-kits/media-kit-setup",
+      "/v1/press-kits/health/bulk",
+    ];
+    for (const p of internalPaths) {
+      expect(schemaContent).toContain(`path: "${p}"`);
+    }
+  });
+});
+
+describe("Press Kits routes are mounted in index.ts", () => {
+  it("should import and mount press-kits routes", () => {
+    expect(indexContent).toContain("pressKitsRoutes");
+    expect(indexContent).toContain("./routes/press-kits");
+  });
+
+  it("should mount at root for public endpoints", () => {
+    expect(indexContent).toContain("app.use(pressKitsRoutes)");
+  });
+
+  it("should mount at /v1 for authenticated endpoints", () => {
+    expect(indexContent).toContain('app.use("/v1", pressKitsRoutes)');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 21 proxy routes for the press-kits-service (`https://press-kits.mcpfactory.org`)
- 3 public endpoints (no auth): `/press-kits/public/{token}`, `/press-kits/public-media-kit/{token}`, `/press-kits/email-data/press-kit/{orgId}`
- 10 authenticated endpoints: organizations CRUD, media kit listing/editing/validation
- 2 admin endpoints: org listing with kit counts, org deletion
- 6 internal endpoints: generation workflow data, stale kits, setup status, bulk health
- OpenAPI spec updated with all new paths and schemas
- Env vars: `PRESS_KITS_SERVICE_URL`, `PRESS_KITS_SERVICE_API_KEY`

## Test plan
- [x] 34 unit tests covering all routes, auth middleware, internal headers, OpenAPI schemas, and index mounting
- [x] Full test suite passes (601 tests, 74 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)