### PR TITLE
docs: edit-media-kit accepts orgId

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4419,17 +4419,23 @@
         "properties": {
           "mediaKitId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "ID of an existing media kit to edit (optional if orgId is provided)"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID — auto-finds latest active kit or creates a new one (optional if mediaKitId is provided)"
           },
           "instruction": {
-            "type": "string"
+            "type": "string",
+            "description": "Instructions for the generation"
           },
           "organizationUrl": {
-            "type": "string"
+            "type": "string",
+            "description": "Organization website URL for context"
           }
         },
         "required": [
-          "mediaKitId",
           "instruction"
         ]
       },
@@ -13682,6 +13688,7 @@
           "Press Kits"
         ],
         "summary": "Initiate media kit generation",
+        "description": "Create or edit a media kit. Pass `orgId` to auto-find the latest active kit (or create one from scratch), or pass `mediaKitId` for a targeted edit. At least one of `mediaKitId` or `orgId` is required.",
         "security": [
           {
             "bearerAuth": []
@@ -13703,6 +13710,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PressKitEditResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — at least one of mediaKitId or orgId is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3621,12 +3621,16 @@ registry.registerPath({
   path: "/v1/press-kits/edit-media-kit",
   tags: ["Press Kits"],
   summary: "Initiate media kit generation",
+  description:
+    "Create or edit a media kit. Pass `orgId` to auto-find the latest active kit (or create one from scratch), " +
+    "or pass `mediaKitId` for a targeted edit. At least one of `mediaKitId` or `orgId` is required.",
   security: authed,
   request: {
-    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid(), instruction: z.string(), organizationUrl: z.string().optional() }).openapi("PressKitEditRequest") } } },
+    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid().optional().describe("ID of an existing media kit to edit (optional if orgId is provided)"), orgId: z.string().optional().describe("Organization ID — auto-finds latest active kit or creates a new one (optional if mediaKitId is provided)"), instruction: z.string().describe("Instructions for the generation"), organizationUrl: z.string().optional().describe("Organization website URL for context") }).openapi("PressKitEditRequest") } } },
   },
   responses: {
     200: { description: "Generation initiated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitEditResponse") } } },
+    400: { description: "Bad request — at least one of mediaKitId or orgId is required", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },


### PR DESCRIPTION
## Summary
- Updates OpenAPI spec for `POST /v1/press-kits/edit-media-kit`: `mediaKitId` is now optional, `orgId` added as alternative
- At least one of `mediaKitId` or `orgId` is required
- Adds 400 error response for missing both fields

## Test plan
- [x] Full test suite passes (601 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)