### PR TITLE
feat: support discovery campaigns (outlets & journalists)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1341,6 +1341,195 @@
           "emails"
         ]
       },
+      "DiscoveredOutlet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Outlet record ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Publication / outlet name"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true,
+            "description": "Outlet type (e.g. 'magazine', 'blog', 'newspaper', 'podcast')"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true,
+            "description": "Outlet website URL"
+          },
+          "domainRating": {
+            "type": "number",
+            "nullable": true,
+            "description": "Ahrefs-style domain rating (0-100)"
+          },
+          "monthlyTraffic": {
+            "type": "number",
+            "nullable": true,
+            "description": "Estimated monthly organic traffic"
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Topics / beats covered by this outlet"
+          },
+          "country": {
+            "type": "string",
+            "nullable": true,
+            "description": "Primary country"
+          },
+          "language": {
+            "type": "string",
+            "nullable": true,
+            "description": "Primary language"
+          },
+          "contactEmail": {
+            "type": "string",
+            "nullable": true,
+            "description": "General contact email"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "description": "AI-generated notes on relevance to the brand"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "url",
+          "domainRating",
+          "monthlyTraffic",
+          "topics",
+          "country",
+          "language",
+          "contactEmail",
+          "notes",
+          "createdAt"
+        ]
+      },
+      "DiscoveredOutletsResponse": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscoveredOutlet"
+            }
+          }
+        },
+        "required": [
+          "outlets"
+        ]
+      },
+      "DiscoveredJournalist": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Journalist record ID"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true,
+            "description": "First name"
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Last name"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true,
+            "description": "Email address"
+          },
+          "outletName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Media outlet they write for"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true,
+            "description": "Job title (e.g. 'Senior Reporter')"
+          },
+          "beat": {
+            "type": "string",
+            "nullable": true,
+            "description": "Beat / topic they cover (e.g. 'fintech', 'AI')"
+          },
+          "linkedinUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "LinkedIn profile URL"
+          },
+          "twitterHandle": {
+            "type": "string",
+            "nullable": true,
+            "description": "Twitter / X handle"
+          },
+          "location": {
+            "type": "string",
+            "nullable": true,
+            "description": "City / country"
+          },
+          "domainRating": {
+            "type": "number",
+            "nullable": true,
+            "description": "Outlet domain rating"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "description": "AI-generated notes on relevance to the brand"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp"
+          }
+        },
+        "required": [
+          "id",
+          "firstName",
+          "lastName",
+          "email",
+          "outletName",
+          "title",
+          "beat",
+          "linkedinUrl",
+          "twitterHandle",
+          "location",
+          "domainRating",
+          "notes",
+          "createdAt"
+        ]
+      },
+      "DiscoveredJournalistsResponse": {
+        "type": "object",
+        "properties": {
+          "journalists": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscoveredJournalist"
+            }
+          }
+        },
+        "required": [
+          "journalists"
+        ]
+      },
       "OrgKeyItem": {
         "type": "object",
         "properties": {
@@ -5452,7 +5641,7 @@
           "Campaigns"
         ],
         "summary": "Create a campaign",
-        "description": "Create a new outreach campaign. The `workflowName` field determines which execution pipeline campaign-service uses.",
+        "description": "Create a new campaign. The `workflowName` field determines which execution pipeline campaign-service uses.\n\n**Outreach campaigns** (`sales-email-cold-outreach-*`): require all persuasion fields (urgency, scarcity, riskReversal, socialProof).\n\n**Discovery campaigns** (`outlets-database-discovery-*`, `journalists-database-discovery-*`): only require name, workflowName, brandUrl, and targetAudience. These produce a list of contacts (media outlets or journalists) without sending emails.",
         "security": [
           {
             "bearerAuth": []
@@ -6353,6 +6542,212 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CampaignEmailsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/campaigns/{id}/discovered-outlets": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get discovered outlets",
+        "description": "Get media outlets discovered by an outlets-database-discovery campaign. Returns an empty array if the campaign is still running or is not an outlet-discovery type.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID"
+            },
+            "required": true,
+            "description": "Campaign ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of discovered media outlets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoveredOutletsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/campaigns/{id}/discovered-journalists": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get discovered journalists",
+        "description": "Get journalists discovered by a journalists-database-discovery campaign. Returns an empty array if the campaign is still running or is not a journalist-discovery type.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID"
+            },
+            "required": true,
+            "description": "Campaign ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of discovered journalists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoveredJournalistsResponse"
                 }
               }
             }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -1,10 +1,16 @@
 import { Router } from "express";
+import { z } from "zod";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { fetchDeliveryStats } from "../lib/delivery-stats.js";
 import { getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
-import { CreateCampaignRequestSchema } from "../schemas.js";
+import {
+  CreateCampaignRequestSchema,
+  CreateDiscoveryCampaignRequestSchema,
+  isDiscoveryWorkflow,
+  deriveCampaignType,
+} from "../schemas.js";
 
 const router = Router();
 
@@ -51,16 +57,21 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       body: { ...req.body, brandUrl: req.body.brandUrl },
     });
 
-    const parsed = CreateCampaignRequestSchema.safeParse(req.body);
+    // Detect discovery vs outreach based on workflowName
+    const rawWorkflowName = (req.body.workflowName as string) || "";
+    const discovery = isDiscoveryWorkflow(rawWorkflowName);
+
+    const schema = discovery ? CreateDiscoveryCampaignRequestSchema : CreateCampaignRequestSchema;
+    const parsed = schema.safeParse(req.body);
     if (!parsed.success) {
       const flat = parsed.error.flatten();
       const missingFields = Object.keys(flat.fieldErrors);
       console.warn("[api-service] POST /v1/campaigns \u2014 validation failed", flat);
 
       const fieldGuide: Record<string, { description: string; example: string }> = {
-        name: { description: "A name for your campaign", example: "Q1 SaaS Outreach" },
+        name: { description: "A name for your campaign", example: discovery ? "Q1 Media Discovery" : "Q1 SaaS Outreach" },
         brandUrl: { description: "The URL of the product or service you are promoting", example: "https://acme.com" },
-        targetAudience: { description: "Plain text description of who you want to reach", example: "CTOs at SaaS startups with 10-50 employees in the US" },
+        targetAudience: { description: discovery ? "What kind of outlets or journalists to discover" : "Plain text description of who you want to reach", example: discovery ? "Tech publications covering SaaS and AI" : "CTOs at SaaS startups with 10-50 employees in the US" },
         targetOutcome: { description: "The concrete result you want from this campaign", example: "Book sales demos" },
         valueForTarget: { description: "What your target audience gains by responding to your email", example: "Access to enterprise analytics at startup pricing" },
         urgency: { description: "A time-based constraint that motivates the prospect to act now rather than later", example: "Early-adopter pricing ends March 31st" },
@@ -76,7 +87,9 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       return res.status(400).json({
         error: `Missing or invalid required fields: ${missingFields.join(", ")}.`,
         missingFields: missingFieldDetails,
-        hint: "Every campaign requires all of these fields. Even if you're unsure, provide your best answer — it helps the AI generate better emails.",
+        hint: discovery
+          ? "Discovery campaigns require: name, workflowName, brandUrl, and targetAudience."
+          : "Every campaign requires all of these fields. Even if you're unsure, provide your best answer — it helps the AI generate better emails.",
       });
     }
 
@@ -86,9 +99,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       workflowName: parsed.data.workflowName,
       brandUrl,
       targetAudience: parsed.data.targetAudience?.slice(0, 80) + "...",
-      targetOutcome: parsed.data.targetOutcome,
-      valueForTarget: parsed.data.valueForTarget?.slice(0, 80) + "...",
-      maxLeads: parsed.data.maxLeads,
+      discovery,
     });
 
     // 1. Upsert brand to get brandId
@@ -109,33 +120,38 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
     console.log("[api-service] POST /v1/campaigns \u2014 step 1 done: brand upserted", { brandId: brandResult.brandId });
 
     // 2. Send user-provided marketing fields to brand-service sales profile
-    const { urgency, scarcity, riskReversal, socialProof } = parsed.data;
-    if (urgency || scarcity || riskReversal || socialProof) {
-      console.log("[api-service] POST /v1/campaigns — step 2: updating sales profile", { brandId: brandResult.brandId });
-      await callExternalService(
-        externalServices.brand,
-        `/brands/${brandResult.brandId}/sales-profile`,
-        {
-          method: "PUT",
-          headers: buildInternalHeaders(req),
-          body: {
-            ...(urgency && { urgency }),
-            ...(scarcity && { scarcity }),
-            ...(riskReversal && { riskReversal }),
-            ...(socialProof && { socialProof }),
-          },
-        }
-      );
-      console.log("[api-service] POST /v1/campaigns — step 2 done: sales profile updated");
+    //    (only for outreach campaigns — discovery campaigns don't have these fields)
+    if (!discovery) {
+      const outreachData = parsed.data as z.infer<typeof CreateCampaignRequestSchema>;
+      const { urgency, scarcity, riskReversal, socialProof } = outreachData;
+      if (urgency || scarcity || riskReversal || socialProof) {
+        console.log("[api-service] POST /v1/campaigns — step 2: updating sales profile", { brandId: brandResult.brandId });
+        await callExternalService(
+          externalServices.brand,
+          `/brands/${brandResult.brandId}/sales-profile`,
+          {
+            method: "PUT",
+            headers: buildInternalHeaders(req),
+            body: {
+              ...(urgency && { urgency }),
+              ...(scarcity && { scarcity }),
+              ...(riskReversal && { riskReversal }),
+              ...(socialProof && { socialProof }),
+            },
+          }
+        );
+        console.log("[api-service] POST /v1/campaigns — step 2 done: sales profile updated");
+      }
     }
 
     // 3. Forward to campaign-service (run tracking via x-run-id header)
-    // Derive `type` from workflowName for campaign-service backward compat
+    // Derive `type` from workflowName
     const { workflowName, ...restData } = parsed.data;
+    const campaignType = deriveCampaignType(workflowName);
     const body: Record<string, unknown> = {
       ...restData,
       workflowName,
-      type: "cold-email-outreach",
+      type: campaignType,
       orgId: req.orgId,
       brandId: brandResult.brandId,
     };
@@ -148,8 +164,8 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
     console.log("[api-service] POST /v1/campaigns — step 3: forwarding to campaign-service", {
       brandId: body.brandId,
       workflowName: body.workflowName,
-      targetOutcome: body.targetOutcome,
-      maxLeads: body.maxLeads,
+      type: body.type,
+      discovery,
     });
     const result = await callExternalService(
       externalServices.campaign,
@@ -787,6 +803,46 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
     closed = true;
     clearTimeout(timer);
   });
+});
+
+/**
+ * GET /v1/campaigns/:id/discovered-outlets
+ * Get media outlets discovered by an outlets-database-discovery campaign.
+ * Proxies to campaign-service.
+ */
+router.get("/campaigns/:id/discovered-outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const result = await callExternalService(
+      externalServices.campaign,
+      `/campaigns/${id}/discovered-outlets`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get discovered outlets error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get discovered outlets" });
+  }
+});
+
+/**
+ * GET /v1/campaigns/:id/discovered-journalists
+ * Get journalists discovered by a journalists-database-discovery campaign.
+ * Proxies to campaign-service.
+ */
+router.get("/campaigns/:id/discovered-journalists", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const result = await callExternalService(
+      externalServices.campaign,
+      `/campaigns/${id}/discovered-journalists`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get discovered journalists error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get discovered journalists" });
+  }
 });
 
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -361,6 +361,42 @@ export const CreateCampaignRequestSchema = z
   })
   .openapi("CreateCampaignRequest");
 
+/**
+ * Discovery campaign request — used for outlets-database-discovery and
+ * journalists-database-discovery workflows.  These campaigns produce a
+ * list of contacts (outlets or journalists) rather than sending emails,
+ * so the persuasion fields (urgency, scarcity, etc.) are not required.
+ */
+export const CreateDiscoveryCampaignRequestSchema = z
+  .object({
+    name: z.string().describe("Campaign name"),
+    workflowName: z.string().min(1).describe("Workflow name (e.g. 'outlets-database-discovery-cedar'). Determines which execution pipeline to use."),
+    brandUrl: z.string().min(1).describe("Brand website URL"),
+    targetAudience: z.string().min(1).describe("Plain text description of what kind of outlets or journalists to discover"),
+    maxResults: z.number().int().optional().describe("Maximum number of results to return"),
+    maxBudgetDailyUsd: z.union([z.string(), z.number()]).optional().describe("Max daily budget in USD"),
+    maxBudgetWeeklyUsd: z.union([z.string(), z.number()]).optional().describe("Max weekly budget in USD"),
+    maxBudgetMonthlyUsd: z.union([z.string(), z.number()]).optional().describe("Max monthly budget in USD"),
+    maxBudgetTotalUsd: z.union([z.string(), z.number()]).optional().describe("Max total budget in USD"),
+    endDate: z.string().optional().describe("Campaign end date"),
+  })
+  .openapi("CreateDiscoveryCampaignRequest");
+
+/** Known discovery workflow prefixes and their campaign types. */
+export const DISCOVERY_PREFIXES: Array<{ prefix: string; type: string }> = [
+  { prefix: "outlets-database-discovery-", type: "outlets-database-discovery" },
+  { prefix: "journalists-database-discovery-", type: "journalists-database-discovery" },
+];
+
+export function isDiscoveryWorkflow(workflowName: string): boolean {
+  return DISCOVERY_PREFIXES.some((d) => workflowName.startsWith(d.prefix));
+}
+
+export function deriveCampaignType(workflowName: string): string {
+  const match = DISCOVERY_PREFIXES.find((d) => workflowName.startsWith(d.prefix));
+  return match ? match.type : "cold-email-outreach";
+}
+
 // -- Common schemas --
 
 const ErrorSummarySchema = z
@@ -467,7 +503,10 @@ registry.registerPath({
   tags: ["Campaigns"],
   summary: "Create a campaign",
   description:
-    "Create a new outreach campaign. The `workflowName` field determines which execution pipeline campaign-service uses.",
+    "Create a new campaign. The `workflowName` field determines which execution pipeline campaign-service uses.\n\n" +
+    "**Outreach campaigns** (`sales-email-cold-outreach-*`): require all persuasion fields (urgency, scarcity, riskReversal, socialProof).\n\n" +
+    "**Discovery campaigns** (`outlets-database-discovery-*`, `journalists-database-discovery-*`): only require name, workflowName, brandUrl, and targetAudience. " +
+    "These produce a list of contacts (media outlets or journalists) without sending emails.",
   security: authed,
   request: {
     body: {
@@ -782,6 +821,95 @@ registry.registerPath({
               ),
             })
             .openapi("CampaignEmailsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// -- Discovery result schemas --
+
+const DiscoveredOutletSchema = z
+  .object({
+    id: z.string().describe("Outlet record ID"),
+    name: z.string().describe("Publication / outlet name"),
+    type: z.string().nullable().describe("Outlet type (e.g. 'magazine', 'blog', 'newspaper', 'podcast')"),
+    url: z.string().nullable().describe("Outlet website URL"),
+    domainRating: z.number().nullable().describe("Ahrefs-style domain rating (0-100)"),
+    monthlyTraffic: z.number().nullable().describe("Estimated monthly organic traffic"),
+    topics: z.array(z.string()).describe("Topics / beats covered by this outlet"),
+    country: z.string().nullable().describe("Primary country"),
+    language: z.string().nullable().describe("Primary language"),
+    contactEmail: z.string().nullable().describe("General contact email"),
+    notes: z.string().nullable().describe("AI-generated notes on relevance to the brand"),
+    createdAt: z.string().describe("ISO timestamp"),
+  })
+  .openapi("DiscoveredOutlet");
+
+const DiscoveredJournalistSchema = z
+  .object({
+    id: z.string().describe("Journalist record ID"),
+    firstName: z.string().nullable().describe("First name"),
+    lastName: z.string().nullable().describe("Last name"),
+    email: z.string().nullable().describe("Email address"),
+    outletName: z.string().nullable().describe("Media outlet they write for"),
+    title: z.string().nullable().describe("Job title (e.g. 'Senior Reporter')"),
+    beat: z.string().nullable().describe("Beat / topic they cover (e.g. 'fintech', 'AI')"),
+    linkedinUrl: z.string().nullable().describe("LinkedIn profile URL"),
+    twitterHandle: z.string().nullable().describe("Twitter / X handle"),
+    location: z.string().nullable().describe("City / country"),
+    domainRating: z.number().nullable().describe("Outlet domain rating"),
+    notes: z.string().nullable().describe("AI-generated notes on relevance to the brand"),
+    createdAt: z.string().describe("ISO timestamp"),
+  })
+  .openapi("DiscoveredJournalist");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/campaigns/{id}/discovered-outlets",
+  tags: ["Campaigns"],
+  summary: "Get discovered outlets",
+  description:
+    "Get media outlets discovered by an outlets-database-discovery campaign. " +
+    "Returns an empty array if the campaign is still running or is not an outlet-discovery type.",
+  security: authed,
+  request: { params: CampaignIdParam },
+  responses: {
+    200: {
+      description: "List of discovered media outlets",
+      content: {
+        "application/json": {
+          schema: z
+            .object({ outlets: z.array(DiscoveredOutletSchema) })
+            .openapi("DiscoveredOutletsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/campaigns/{id}/discovered-journalists",
+  tags: ["Campaigns"],
+  summary: "Get discovered journalists",
+  description:
+    "Get journalists discovered by a journalists-database-discovery campaign. " +
+    "Returns an empty array if the campaign is still running or is not a journalist-discovery type.",
+  security: authed,
+  request: { params: CampaignIdParam },
+  responses: {
+    200: {
+      description: "List of discovered journalists",
+      content: {
+        "application/json": {
+          schema: z
+            .object({ journalists: z.array(DiscoveredJournalistSchema) })
+            .openapi("DiscoveredJournalistsResponse"),
         },
       },
     },

--- a/tests/unit/campaign-discovery.test.ts
+++ b/tests/unit/campaign-discovery.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * Tests for discovery campaign creation and result endpoints.
+ * Discovery campaigns (outlets-database-discovery, journalists-database-discovery)
+ * don't require email-specific fields (urgency, scarcity, etc.) and derive their
+ * campaign type from the workflowName prefix.
+ */
+
+// Mock auth middleware
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import campaignRouter from "../../src/routes/campaigns.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignRouter);
+  return app;
+}
+
+describe("Discovery campaign creation", () => {
+  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown> }>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      fetchCalls.push({ url, method: init?.method, body });
+
+      // Brand upsert
+      if (url.includes("/brands") && init?.method === "POST") {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ brandId: "brand-uuid-123" }),
+        };
+      }
+
+      // Campaign creation
+      if (url.includes("/campaigns") && init?.method === "POST") {
+        return {
+          ok: true,
+          json: () => Promise.resolve({
+            campaign: { id: "campaign-disc-1", brandId: "brand-uuid-123", name: body?.name, status: "ongoing" },
+          }),
+        };
+      }
+
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+  });
+
+  it("should create an outlets-database-discovery campaign without email fields", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Tech Media Discovery",
+        workflowName: "outlets-database-discovery-cedar",
+        brandUrl: "https://acme.com",
+        targetAudience: "Tech publications covering SaaS and AI",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.campaign.id).toBe("campaign-disc-1");
+
+    // Verify brand was upserted
+    const brandCall = fetchCalls.find((c) => c.url.includes("/brands") && c.method === "POST");
+    expect(brandCall).toBeDefined();
+    expect(brandCall!.body!.url).toBe("https://acme.com");
+
+    // Verify NO sales-profile update was made (discovery campaigns skip this)
+    const salesProfileCall = fetchCalls.find((c) => c.url.includes("/sales-profile"));
+    expect(salesProfileCall).toBeUndefined();
+
+    // Verify campaign-service received the correct type
+    const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
+    expect(campaignCall).toBeDefined();
+    expect(campaignCall!.body!.type).toBe("outlets-database-discovery");
+    expect(campaignCall!.body!.workflowName).toBe("outlets-database-discovery-cedar");
+    expect(campaignCall!.body!.targetAudience).toBe("Tech publications covering SaaS and AI");
+
+    // Verify email-specific fields are NOT present
+    expect(campaignCall!.body!.urgency).toBeUndefined();
+    expect(campaignCall!.body!.scarcity).toBeUndefined();
+    expect(campaignCall!.body!.riskReversal).toBeUndefined();
+    expect(campaignCall!.body!.socialProof).toBeUndefined();
+  });
+
+  it("should create a journalists-database-discovery campaign without email fields", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Journalist Discovery",
+        workflowName: "journalists-database-discovery-birch",
+        brandUrl: "https://acme.com",
+        targetAudience: "Journalists covering fintech in the US",
+      });
+
+    expect(res.status).toBe(200);
+
+    const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
+    expect(campaignCall!.body!.type).toBe("journalists-database-discovery");
+    expect(campaignCall!.body!.workflowName).toBe("journalists-database-discovery-birch");
+  });
+
+  it("should reject discovery campaign when targetAudience is missing", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Missing Audience",
+        workflowName: "outlets-database-discovery-cedar",
+        brandUrl: "https://acme.com",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("targetAudience");
+    expect(res.body.hint).toContain("Discovery campaigns");
+  });
+
+  it("should reject discovery campaign when brandUrl is missing", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Missing URL",
+        workflowName: "outlets-database-discovery-cedar",
+        targetAudience: "Tech publications",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("brandUrl");
+  });
+
+  it("should still require email fields for non-discovery campaigns", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Test Campaign",
+        workflowName: "sales-email-cold-outreach-sienna",
+        brandUrl: "https://example.com",
+        targetAudience: "CTOs at SaaS",
+        // Missing: targetOutcome, valueForTarget, urgency, scarcity, riskReversal, socialProof
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("targetOutcome");
+    expect(res.body.hint).toContain("AI generate better emails");
+  });
+
+  it("should convert budget numbers to strings for discovery campaigns", async () => {
+    const app = createApp();
+    await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Budget Discovery",
+        workflowName: "outlets-database-discovery-cedar",
+        brandUrl: "https://acme.com",
+        targetAudience: "Tech publications",
+        maxBudgetDailyUsd: 25,
+      });
+
+    const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
+    expect(campaignCall!.body!.maxBudgetDailyUsd).toBe("25");
+  });
+
+  it("should accept optional maxResults for discovery campaigns", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Limited Discovery",
+        workflowName: "outlets-database-discovery-cedar",
+        brandUrl: "https://acme.com",
+        targetAudience: "Tech publications",
+        maxResults: 50,
+      });
+
+    expect(res.status).toBe(200);
+
+    const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
+    expect(campaignCall!.body!.maxResults).toBe(50);
+  });
+});
+
+describe("Discovery result endpoints", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("GET /v1/campaigns/:id/discovered-outlets should proxy to campaign-service", async () => {
+    const mockOutlets = {
+      outlets: [
+        { id: "out-1", name: "TechCrunch", type: "blog", url: "https://techcrunch.com", domainRating: 92 },
+      ],
+    };
+
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/campaigns/camp-1/discovered-outlets")) {
+        return { ok: true, json: () => Promise.resolve(mockOutlets) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/v1/campaigns/camp-1/discovered-outlets");
+
+    expect(res.status).toBe(200);
+    expect(res.body.outlets).toHaveLength(1);
+    expect(res.body.outlets[0].name).toBe("TechCrunch");
+  });
+
+  it("GET /v1/campaigns/:id/discovered-journalists should proxy to campaign-service", async () => {
+    const mockJournalists = {
+      journalists: [
+        { id: "j-1", firstName: "Jane", lastName: "Doe", outletName: "TechCrunch", beat: "AI" },
+      ],
+    };
+
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/campaigns/camp-1/discovered-journalists")) {
+        return { ok: true, json: () => Promise.resolve(mockJournalists) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/v1/campaigns/camp-1/discovered-journalists");
+
+    expect(res.status).toBe(200);
+    expect(res.body.journalists).toHaveLength(1);
+    expect(res.body.journalists[0].firstName).toBe("Jane");
+  });
+
+  it("should return error when campaign-service is unavailable for discovered-outlets", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 502,
+      text: () => Promise.resolve(JSON.stringify({ error: "Service unavailable" })),
+    }));
+
+    const app = createApp();
+    const res = await request(app).get("/v1/campaigns/camp-1/discovered-outlets");
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `outlets-database-discovery` and `journalists-database-discovery` campaign types with a lighter validation schema (no urgency/scarcity/riskReversal/socialProof required)
- Derive campaign `type` from `workflowName` prefix instead of hardcoding `cold-email-outreach`
- Skip sales profile update for discovery campaigns
- Add proxy endpoints: `GET /v1/campaigns/:id/discovered-outlets` and `GET /v1/campaigns/:id/discovered-journalists`
- Define OpenAPI schemas for discovered outlets (name, type, URL, domain rating, traffic, topics, etc.) and journalists (name, email, outlet, beat, LinkedIn, etc.)
- 10 new tests covering creation, validation, result proxying, and error handling

## Test plan
- [x] All 611 existing tests pass (no regressions)
- [x] 10 new tests for discovery campaign creation and result endpoints
- [ ] Integration test once campaign-service implements the discovery workflow backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)