### PR TITLE
feat: rename press-kits endpoints to REST conventions

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4549,14 +4549,6 @@
         "type": "object",
         "properties": {}
       },
-      "PublicMediaKitLegacyResponse": {
-        "type": "object",
-        "properties": {}
-      },
-      "PressKitEmailDataResponse": {
-        "type": "object",
-        "properties": {}
-      },
       "PressKitOrganizationResponse": {
         "type": "object",
         "properties": {}
@@ -4599,22 +4591,13 @@
         "type": "object",
         "properties": {}
       },
-      "PressKitEditResponse": {
+      "PressKitCreateEditResponse": {
         "type": "object",
         "properties": {}
       },
-      "PressKitEditRequest": {
+      "PressKitCreateEditRequest": {
         "type": "object",
         "properties": {
-          "mediaKitId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of an existing media kit to edit (optional if orgId is provided)"
-          },
-          "orgId": {
-            "type": "string",
-            "description": "Organization ID — auto-finds latest active kit or creates a new one (optional if mediaKitId is provided)"
-          },
           "instruction": {
             "type": "string",
             "description": "Instructions for the generation"
@@ -4635,16 +4618,11 @@
       "PressKitUpdateMdxRequest": {
         "type": "object",
         "properties": {
-          "mediaKitId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "mdxContent": {
             "type": "string"
           }
         },
         "required": [
-          "mediaKitId",
           "mdxContent"
         ]
       },
@@ -4665,10 +4643,6 @@
       "PressKitUpdateStatusRequest": {
         "type": "object",
         "properties": {
-          "mediaKitId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "status": {
             "$ref": "#/components/schemas/PressKitMediaKitStatus"
           },
@@ -4677,25 +4651,12 @@
           }
         },
         "required": [
-          "mediaKitId",
           "status"
         ]
       },
       "PressKitValidateResponse": {
         "type": "object",
         "properties": {}
-      },
-      "PressKitValidateRequest": {
-        "type": "object",
-        "properties": {
-          "mediaKitId": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "mediaKitId"
-        ]
       },
       "PressKitCancelDraftResponse": {
         "type": "object",
@@ -4706,18 +4667,6 @@
         },
         "required": [
           "success"
-        ]
-      },
-      "PressKitCancelDraftRequest": {
-        "type": "object",
-        "properties": {
-          "mediaKitId": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "mediaKitId"
         ]
       },
       "PressKitAdminOrgListResponse": {
@@ -4735,7 +4684,7 @@
           "success"
         ]
       },
-      "PressKitInternalByOrgResponse": {
+      "PressKitInternalCurrentResponse": {
         "type": "object",
         "properties": {}
       },
@@ -4750,9 +4699,6 @@
       "PressKitUpsertGenerationRequest": {
         "type": "object",
         "properties": {
-          "orgId": {
-            "type": "string"
-          },
           "mdxContent": {
             "type": "string"
           },
@@ -4764,7 +4710,6 @@
           }
         },
         "required": [
-          "orgId",
           "mdxContent"
         ]
       },
@@ -4777,6 +4722,10 @@
         "properties": {}
       },
       "PressKitHealthBulkResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PressKitEmailDataResponse": {
         "type": "object",
         "properties": {}
       },
@@ -13574,58 +13523,6 @@
         }
       }
     },
-    "/press-kits/public-media-kit/{token}": {
-      "get": {
-        "tags": [
-          "Press Kits"
-        ],
-        "summary": "Get public media kit (legacy)",
-        "description": "Legacy endpoint for public media kit access by share token. No authentication required.",
-        "responses": {
-          "200": {
-            "description": "Public media kit data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PublicMediaKitLegacyResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/press-kits/email-data/press-kit/{orgId}": {
-      "get": {
-        "tags": [
-          "Press Kits"
-        ],
-        "summary": "Get press kit data for email templates",
-        "description": "Returns press kit data formatted for use in email templates. No authentication required.",
-        "responses": {
-          "200": {
-            "description": "Email template data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PressKitEmailDataResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/press-kits/organizations": {
       "post": {
         "tags": [
@@ -13728,7 +13625,7 @@
         ]
       }
     },
-    "/v1/press-kits/organizations/share-token/{orgId}": {
+    "/v1/press-kits/organizations/{orgId}/share-token": {
       "get": {
         "tags": [
           "Press Kits"
@@ -13902,7 +13799,7 @@
         ]
       }
     },
-    "/v1/press-kits/media-kit": {
+    "/v1/press-kits/media-kits": {
       "get": {
         "tags": [
           "Press Kits"
@@ -13983,9 +13880,109 @@
             "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           }
         ]
+      },
+      "post": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Create or edit media kit",
+        "description": "Idempotent create-or-edit. The org is identified via the `x-org-id` header. The service auto-finds the latest active kit or creates a new one.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PressKitCreateEditRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generation initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitCreateEditResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
       }
     },
-    "/v1/press-kits/media-kit/{id}": {
+    "/v1/press-kits/media-kits/{id}": {
       "get": {
         "tags": [
           "Press Kits"
@@ -14077,124 +14074,13 @@
         ]
       }
     },
-    "/v1/press-kits/edit-media-kit": {
-      "post": {
-        "tags": [
-          "Press Kits"
-        ],
-        "summary": "Initiate media kit generation",
-        "description": "Create or edit a media kit. Pass `orgId` to auto-find the latest active kit (or create one from scratch), or pass `mediaKitId` for a targeted edit. At least one of `mediaKitId` or `orgId` is required.",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PressKitEditRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Generation initiated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PressKitEditResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request — at least one of mediaKitId or orgId is required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-name",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          }
-        ]
-      }
-    },
-    "/v1/press-kits/update-mdx": {
-      "post": {
+    "/v1/press-kits/media-kits/{id}/mdx": {
+      "patch": {
         "tags": [
           "Press Kits"
         ],
         "summary": "Update MDX content",
+        "description": "Update the MDX content of a specific media kit. Kit ID is in the URL.",
         "security": [
           {
             "bearerAuth": []
@@ -14230,6 +14116,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal error",
             "content": {
@@ -14290,12 +14186,13 @@
         ]
       }
     },
-    "/v1/press-kits/update-status": {
-      "post": {
+    "/v1/press-kits/media-kits/{id}/status": {
+      "patch": {
         "tags": [
           "Press Kits"
         ],
         "summary": "Update media kit status",
+        "description": "Change the status of a specific media kit. Kit ID is in the URL.",
         "security": [
           {
             "bearerAuth": []
@@ -14331,6 +14228,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal error",
             "content": {
@@ -14391,26 +14298,18 @@
         ]
       }
     },
-    "/v1/press-kits/validate": {
+    "/v1/press-kits/media-kits/{id}/validate": {
       "post": {
         "tags": [
           "Press Kits"
         ],
         "summary": "Validate media kit",
+        "description": "Validate a specific media kit. Kit ID is in the URL, no body required.",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PressKitValidateRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Validated",
@@ -14432,6 +14331,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal error",
             "content": {
@@ -14492,26 +14401,18 @@
         ]
       }
     },
-    "/v1/press-kits/cancel-draft": {
+    "/v1/press-kits/media-kits/{id}/cancel": {
       "post": {
         "tags": [
           "Press Kits"
         ],
         "summary": "Cancel draft media kit",
+        "description": "Cancel a draft media kit. Kit ID is in the URL, no body required.",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PressKitCancelDraftRequest"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Draft cancelled",
@@ -14525,6 +14426,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -14777,12 +14688,13 @@
         ]
       }
     },
-    "/v1/press-kits/internal/media-kit/by-org/{orgId}": {
+    "/v1/press-kits/internal/media-kits/current": {
       "get": {
         "tags": [
           "Internal"
         ],
-        "summary": "Get latest media kit by org (internal)",
+        "summary": "Get latest media kit for org (internal)",
+        "description": "Uses x-org-id header to identify the org. No path param needed.",
         "security": [
           {
             "bearerAuth": []
@@ -14794,7 +14706,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PressKitInternalByOrgResponse"
+                  "$ref": "#/components/schemas/PressKitInternalCurrentResponse"
                 }
               }
             }
@@ -14859,12 +14771,13 @@
         ]
       }
     },
-    "/v1/press-kits/internal/generation-data": {
+    "/v1/press-kits/internal/media-kits/generation-data": {
       "get": {
         "tags": [
           "Internal"
         ],
         "summary": "Get generation workflow data (internal)",
+        "description": "Uses x-org-id header to identify the org.",
         "security": [
           {
             "bearerAuth": []
@@ -14941,7 +14854,7 @@
         ]
       }
     },
-    "/v1/press-kits/internal/upsert-generation-result": {
+    "/v1/press-kits/internal/media-kits/generation-result": {
       "post": {
         "tags": [
           "Internal"
@@ -15032,7 +14945,7 @@
         ]
       }
     },
-    "/v1/press-kits/clients-media-kits-need-update": {
+    "/v1/press-kits/internal/media-kits/stale": {
       "get": {
         "tags": [
           "Internal"
@@ -15114,7 +15027,7 @@
         ]
       }
     },
-    "/v1/press-kits/media-kit-setup": {
+    "/v1/press-kits/internal/media-kits/setup": {
       "get": {
         "tags": [
           "Internal"
@@ -15196,7 +15109,7 @@
         ]
       }
     },
-    "/v1/press-kits/health/bulk": {
+    "/v1/press-kits/internal/health/bulk": {
       "get": {
         "tags": [
           "Internal"
@@ -15214,6 +15127,88 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PressKitHealthBulkResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/press-kits/internal/email-data/{orgId}": {
+      "get": {
+        "tags": [
+          "Internal"
+        ],
+        "summary": "Get press kit data for email templates (internal)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email template data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitEmailDataResponse"
                 }
               }
             }

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -20,32 +20,6 @@ router.get("/press-kits/public/:token", async (req: Request, res: Response) => {
   }
 });
 
-// GET /press-kits/public-media-kit/:token — public media kit (legacy)
-router.get("/press-kits/public-media-kit/:token", async (req: Request, res: Response) => {
-  try {
-    const result = await callExternalService(
-      externalServices.pressKits,
-      `/public-media-kit/${encodeURIComponent(req.params.token)}`
-    );
-    res.json(result);
-  } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get public media kit" });
-  }
-});
-
-// GET /press-kits/email-data/press-kit/:orgId — email template data
-router.get("/press-kits/email-data/press-kit/:orgId", async (req: Request, res: Response) => {
-  try {
-    const result = await callExternalService(
-      externalServices.pressKits,
-      `/email-data/press-kit/${encodeURIComponent(req.params.orgId)}`
-    );
-    res.json(result);
-  } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get email data" });
-  }
-});
-
 // ── Authenticated routes (mounted at /v1) ────────────────────────────────────
 
 // POST /v1/press-kits/organizations — upsert organization
@@ -62,12 +36,12 @@ router.post("/press-kits/organizations", authenticate, requireOrg, async (req: A
   }
 });
 
-// GET /v1/press-kits/organizations/share-token/:orgId — get share token
-router.get("/press-kits/organizations/share-token/:orgId", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/organizations/:orgId/share-token — get share token
+router.get("/press-kits/organizations/:orgId/share-token", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      `/organizations/share-token/${encodeURIComponent(req.params.orgId)}`,
+      `/organizations/${encodeURIComponent(req.params.orgId)}/share-token`,
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -91,8 +65,8 @@ router.get("/press-kits/organizations/exists", authenticate, requireOrg, async (
   }
 });
 
-// GET /v1/press-kits/media-kit — list media kits
-router.get("/press-kits/media-kit", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/media-kits — list media kits
+router.get("/press-kits/media-kits", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
     if (req.query.org_id) params.set("org_id", req.query.org_id as string);
@@ -101,7 +75,7 @@ router.get("/press-kits/media-kit", authenticate, requireOrg, async (req: Authen
     const qs = params.toString() ? `?${params.toString()}` : "";
     const result = await callExternalService(
       externalServices.pressKits,
-      `/media-kit${qs}`,
+      `/media-kits${qs}`,
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -110,12 +84,12 @@ router.get("/press-kits/media-kit", authenticate, requireOrg, async (req: Authen
   }
 });
 
-// GET /v1/press-kits/media-kit/:id — get media kit by ID
-router.get("/press-kits/media-kit/:id", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/media-kits/:id — get media kit by ID
+router.get("/press-kits/media-kits/:id", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      `/media-kit/${encodeURIComponent(req.params.id)}`,
+      `/media-kits/${encodeURIComponent(req.params.id)}`,
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -124,27 +98,27 @@ router.get("/press-kits/media-kit/:id", authenticate, requireOrg, async (req: Au
   }
 });
 
-// POST /v1/press-kits/edit-media-kit — initiate media kit generation
-router.post("/press-kits/edit-media-kit", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// POST /v1/press-kits/media-kits — create or edit media kit (idempotent)
+router.post("/press-kits/media-kits", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/edit-media-kit",
+      "/media-kits",
       { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to edit media kit" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create/edit media kit" });
   }
 });
 
-// POST /v1/press-kits/update-mdx — update MDX content
-router.post("/press-kits/update-mdx", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// PATCH /v1/press-kits/media-kits/:id/mdx — update MDX content
+router.patch("/press-kits/media-kits/:id/mdx", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/update-mdx",
-      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+      `/media-kits/${encodeURIComponent(req.params.id)}/mdx`,
+      { method: "PATCH", body: req.body, headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
@@ -152,13 +126,13 @@ router.post("/press-kits/update-mdx", authenticate, requireOrg, async (req: Auth
   }
 });
 
-// POST /v1/press-kits/update-status — update media kit status
-router.post("/press-kits/update-status", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// PATCH /v1/press-kits/media-kits/:id/status — update media kit status
+router.patch("/press-kits/media-kits/:id/status", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/update-status",
-      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+      `/media-kits/${encodeURIComponent(req.params.id)}/status`,
+      { method: "PATCH", body: req.body, headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
@@ -166,13 +140,13 @@ router.post("/press-kits/update-status", authenticate, requireOrg, async (req: A
   }
 });
 
-// POST /v1/press-kits/validate — validate media kit
-router.post("/press-kits/validate", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// POST /v1/press-kits/media-kits/:id/validate — validate media kit
+router.post("/press-kits/media-kits/:id/validate", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/validate",
-      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+      `/media-kits/${encodeURIComponent(req.params.id)}/validate`,
+      { method: "POST", headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
@@ -180,13 +154,13 @@ router.post("/press-kits/validate", authenticate, requireOrg, async (req: Authen
   }
 });
 
-// POST /v1/press-kits/cancel-draft — cancel draft media kit
-router.post("/press-kits/cancel-draft", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// POST /v1/press-kits/media-kits/:id/cancel — cancel draft media kit
+router.post("/press-kits/media-kits/:id/cancel", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/cancel-draft",
-      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+      `/media-kits/${encodeURIComponent(req.params.id)}/cancel`,
+      { method: "POST", headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
@@ -228,27 +202,26 @@ router.delete("/press-kits/admin/organizations/:id", authenticate, requireOrg, a
 
 // ── Internal routes (authenticated, service-to-service) ──────────────────────
 
-// GET /v1/press-kits/internal/media-kit/by-org/:orgId — latest kit by org
-router.get("/press-kits/internal/media-kit/by-org/:orgId", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/internal/media-kits/current — latest kit for org (uses x-org-id header)
+router.get("/press-kits/internal/media-kits/current", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      `/internal/media-kit/by-org/${encodeURIComponent(req.params.orgId)}`,
+      "/internal/media-kits/current",
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get media kit by org" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get current media kit" });
   }
 });
 
-// GET /v1/press-kits/internal/generation-data — generation workflow data
-router.get("/press-kits/internal/generation-data", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/internal/media-kits/generation-data — generation workflow data (uses x-org-id header)
+router.get("/press-kits/internal/media-kits/generation-data", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
-    const qs = req.query.orgId ? `?orgId=${encodeURIComponent(req.query.orgId as string)}` : "";
     const result = await callExternalService(
       externalServices.pressKits,
-      `/internal/generation-data${qs}`,
+      "/internal/media-kits/generation-data",
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -257,12 +230,12 @@ router.get("/press-kits/internal/generation-data", authenticate, requireOrg, asy
   }
 });
 
-// POST /v1/press-kits/internal/upsert-generation-result — workflow callback
-router.post("/press-kits/internal/upsert-generation-result", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// POST /v1/press-kits/internal/media-kits/generation-result — workflow callback
+router.post("/press-kits/internal/media-kits/generation-result", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/internal/upsert-generation-result",
+      "/internal/media-kits/generation-result",
       { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -271,12 +244,12 @@ router.post("/press-kits/internal/upsert-generation-result", authenticate, requi
   }
 });
 
-// GET /v1/press-kits/clients-media-kits-need-update — stale kits
-router.get("/press-kits/clients-media-kits-need-update", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/internal/media-kits/stale — orgs with stale kits
+router.get("/press-kits/internal/media-kits/stale", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/clients-media-kits-need-update",
+      "/internal/media-kits/stale",
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -285,12 +258,12 @@ router.get("/press-kits/clients-media-kits-need-update", authenticate, requireOr
   }
 });
 
-// GET /v1/press-kits/media-kit-setup — setup status for all orgs
-router.get("/press-kits/media-kit-setup", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/internal/media-kits/setup — setup status for all orgs
+router.get("/press-kits/internal/media-kits/setup", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/media-kit-setup",
+      "/internal/media-kits/setup",
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -299,17 +272,31 @@ router.get("/press-kits/media-kit-setup", authenticate, requireOrg, async (req: 
   }
 });
 
-// GET /v1/press-kits/health/bulk — bulk health per org
-router.get("/press-kits/health/bulk", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/internal/health/bulk — bulk health per org
+router.get("/press-kits/internal/health/bulk", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.pressKits,
-      "/health/bulk",
+      "/internal/health/bulk",
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get bulk health" });
+  }
+});
+
+// GET /v1/press-kits/internal/email-data/:orgId — email template data
+router.get("/press-kits/internal/email-data/:orgId", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/internal/email-data/${encodeURIComponent(req.params.orgId)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get email data" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3651,29 +3651,6 @@ registry.registerPath({
   },
 });
 
-registry.registerPath({
-  method: "get",
-  path: "/press-kits/public-media-kit/{token}",
-  tags: ["Press Kits"],
-  summary: "Get public media kit (legacy)",
-  description: "Legacy endpoint for public media kit access by share token. No authentication required.",
-  responses: {
-    200: { description: "Public media kit data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicMediaKitLegacyResponse") } } },
-    404: { description: "Not found", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "get",
-  path: "/press-kits/email-data/press-kit/{orgId}",
-  tags: ["Press Kits"],
-  summary: "Get press kit data for email templates",
-  description: "Returns press kit data formatted for use in email templates. No authentication required.",
-  responses: {
-    200: { description: "Email template data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitEmailDataResponse") } } },
-  },
-});
-
 // ── Authenticated endpoints ─────────────────────────────────────────────────
 
 registry.registerPath({
@@ -3695,7 +3672,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/organizations/share-token/{orgId}",
+  path: "/v1/press-kits/organizations/{orgId}/share-token",
   tags: ["Press Kits"],
   summary: "Get organization share token",
   security: authed,
@@ -3720,7 +3697,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/media-kit",
+  path: "/v1/press-kits/media-kits",
   tags: ["Press Kits"],
   summary: "List media kits",
   description: "List media kits, optionally filtered by org_id, organization_id, or title.",
@@ -3733,7 +3710,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/media-kit/{id}",
+  path: "/v1/press-kits/media-kits/{id}",
   tags: ["Press Kits"],
   summary: "Get media kit by ID",
   security: authed,
@@ -3746,51 +3723,54 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/press-kits/edit-media-kit",
+  path: "/v1/press-kits/media-kits",
   tags: ["Press Kits"],
-  summary: "Initiate media kit generation",
+  summary: "Create or edit media kit",
   description:
-    "Create or edit a media kit. Pass `orgId` to auto-find the latest active kit (or create one from scratch), " +
-    "or pass `mediaKitId` for a targeted edit. At least one of `mediaKitId` or `orgId` is required.",
+    "Idempotent create-or-edit. The org is identified via the `x-org-id` header. " +
+    "The service auto-finds the latest active kit or creates a new one.",
   security: authed,
   request: {
-    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid().optional().describe("ID of an existing media kit to edit (optional if orgId is provided)"), orgId: z.string().optional().describe("Organization ID — auto-finds latest active kit or creates a new one (optional if mediaKitId is provided)"), instruction: z.string().describe("Instructions for the generation"), organizationUrl: z.string().optional().describe("Organization website URL for context") }).openapi("PressKitEditRequest") } } },
+    body: { content: { "application/json": { schema: z.object({ instruction: z.string().describe("Instructions for the generation"), organizationUrl: z.string().optional().describe("Organization website URL for context") }).openapi("PressKitCreateEditRequest") } } },
   },
   responses: {
-    200: { description: "Generation initiated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitEditResponse") } } },
-    400: { description: "Bad request — at least one of mediaKitId or orgId is required", content: errorContent },
+    200: { description: "Generation initiated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitCreateEditResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
 });
 
 registry.registerPath({
-  method: "post",
-  path: "/v1/press-kits/update-mdx",
+  method: "patch",
+  path: "/v1/press-kits/media-kits/{id}/mdx",
   tags: ["Press Kits"],
   summary: "Update MDX content",
+  description: "Update the MDX content of a specific media kit. Kit ID is in the URL.",
   security: authed,
   request: {
-    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid(), mdxContent: z.string() }).openapi("PressKitUpdateMdxRequest") } } },
+    body: { content: { "application/json": { schema: z.object({ mdxContent: z.string() }).openapi("PressKitUpdateMdxRequest") } } },
   },
   responses: {
     200: { description: "Updated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitUpdateMdxResponse") } } },
+    404: { description: "Not found", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
 });
 
 registry.registerPath({
-  method: "post",
-  path: "/v1/press-kits/update-status",
+  method: "patch",
+  path: "/v1/press-kits/media-kits/{id}/status",
   tags: ["Press Kits"],
   summary: "Update media kit status",
+  description: "Change the status of a specific media kit. Kit ID is in the URL.",
   security: authed,
   request: {
-    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid(), status: PressKitMediaKitStatusEnum, denialReason: z.string().optional() }).openapi("PressKitUpdateStatusRequest") } } },
+    body: { content: { "application/json": { schema: z.object({ status: PressKitMediaKitStatusEnum, denialReason: z.string().optional() }).openapi("PressKitUpdateStatusRequest") } } },
   },
   responses: {
     200: { description: "Updated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitUpdateStatusResponse") } } },
+    404: { description: "Not found", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -3798,15 +3778,14 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/press-kits/validate",
+  path: "/v1/press-kits/media-kits/{id}/validate",
   tags: ["Press Kits"],
   summary: "Validate media kit",
+  description: "Validate a specific media kit. Kit ID is in the URL, no body required.",
   security: authed,
-  request: {
-    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid() }).openapi("PressKitValidateRequest") } } },
-  },
   responses: {
     200: { description: "Validated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitValidateResponse") } } },
+    404: { description: "Not found", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -3814,15 +3793,14 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/press-kits/cancel-draft",
+  path: "/v1/press-kits/media-kits/{id}/cancel",
   tags: ["Press Kits"],
   summary: "Cancel draft media kit",
+  description: "Cancel a draft media kit. Kit ID is in the URL, no body required.",
   security: authed,
-  request: {
-    body: { content: { "application/json": { schema: z.object({ mediaKitId: z.string().uuid() }).openapi("PressKitCancelDraftRequest") } } },
-  },
   responses: {
     200: { description: "Draft cancelled", content: { "application/json": { schema: z.object({ success: z.boolean() }).openapi("PressKitCancelDraftResponse") } } },
+    404: { description: "Not found", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -3860,21 +3838,23 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/internal/media-kit/by-org/{orgId}",
+  path: "/v1/press-kits/internal/media-kits/current",
   tags: ["Internal"],
-  summary: "Get latest media kit by org (internal)",
+  summary: "Get latest media kit for org (internal)",
+  description: "Uses x-org-id header to identify the org. No path param needed.",
   security: authed,
   responses: {
-    200: { description: "Media kit", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitInternalByOrgResponse") } } },
+    200: { description: "Media kit", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitInternalCurrentResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
   },
 });
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/internal/generation-data",
+  path: "/v1/press-kits/internal/media-kits/generation-data",
   tags: ["Internal"],
   summary: "Get generation workflow data (internal)",
+  description: "Uses x-org-id header to identify the org.",
   security: authed,
   responses: {
     200: { description: "Generation data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitGenerationDataResponse") } } },
@@ -3884,12 +3864,12 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/press-kits/internal/upsert-generation-result",
+  path: "/v1/press-kits/internal/media-kits/generation-result",
   tags: ["Internal"],
   summary: "Upsert generation result (internal)",
   security: authed,
   request: {
-    body: { content: { "application/json": { schema: z.object({ orgId: z.string(), mdxContent: z.string(), title: z.string().optional(), iconUrl: z.string().optional() }).openapi("PressKitUpsertGenerationRequest") } } },
+    body: { content: { "application/json": { schema: z.object({ mdxContent: z.string(), title: z.string().optional(), iconUrl: z.string().optional() }).openapi("PressKitUpsertGenerationRequest") } } },
   },
   responses: {
     200: { description: "Upserted", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitUpsertGenerationResponse") } } },
@@ -3899,7 +3879,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/clients-media-kits-need-update",
+  path: "/v1/press-kits/internal/media-kits/stale",
   tags: ["Internal"],
   summary: "Get orgs with stale press kits (internal)",
   security: authed,
@@ -3911,7 +3891,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/media-kit-setup",
+  path: "/v1/press-kits/internal/media-kits/setup",
   tags: ["Internal"],
   summary: "Get media kit setup status (internal)",
   security: authed,
@@ -3923,12 +3903,24 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/health/bulk",
+  path: "/v1/press-kits/internal/health/bulk",
   tags: ["Internal"],
   summary: "Bulk health check per org (internal)",
   security: authed,
   responses: {
     200: { description: "Bulk health", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitHealthBulkResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/internal/email-data/{orgId}",
+  tags: ["Internal"],
+  summary: "Get press kit data for email templates (internal)",
+  security: authed,
+  responses: {
+    200: { description: "Email template data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitEmailDataResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
   },
 });

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -19,21 +19,20 @@ describe("Press Kits proxy routes", () => {
 
   it("should have public GET /press-kits/public/:token without auth", () => {
     expect(content).toContain('"/press-kits/public/:token"');
-    // Public route should NOT have authenticate middleware on this line
     const publicLine = content.split("\n").find((l) => l.includes('"/press-kits/public/:token"'));
     expect(publicLine).not.toContain("authenticate");
   });
 
-  it("should have public GET /press-kits/public-media-kit/:token without auth", () => {
-    expect(content).toContain('"/press-kits/public-media-kit/:token"');
-    const publicLine = content.split("\n").find((l) => l.includes('"/press-kits/public-media-kit/:token"'));
-    expect(publicLine).not.toContain("authenticate");
+  it("should NOT have legacy /press-kits/public-media-kit route (removed upstream)", () => {
+    expect(content).not.toContain("/press-kits/public-media-kit");
   });
 
-  it("should have public GET /press-kits/email-data/press-kit/:orgId without auth", () => {
-    expect(content).toContain('"/press-kits/email-data/press-kit/:orgId"');
-    const publicLine = content.split("\n").find((l) => l.includes('"/press-kits/email-data/press-kit/:orgId"'));
-    expect(publicLine).not.toContain("authenticate");
+  it("should NOT have public /press-kits/email-data route (moved to internal)", () => {
+    // email-data is now internal, not public
+    const publicEmailLine = content.split("\n").find((l) =>
+      l.includes('"/press-kits/email-data/') && !l.includes("internal")
+    );
+    expect(publicEmailLine).toBeUndefined();
   });
 
   // ── Authenticated endpoints ─────────────────────────────────────────────
@@ -43,40 +42,44 @@ describe("Press Kits proxy routes", () => {
     expect(content).toContain("router.post");
   });
 
-  it("should have GET /press-kits/organizations/share-token/:orgId with auth", () => {
-    expect(content).toContain('"/press-kits/organizations/share-token/:orgId"');
+  it("should have GET /press-kits/organizations/:orgId/share-token with auth", () => {
+    expect(content).toContain('"/press-kits/organizations/:orgId/share-token"');
   });
 
   it("should have GET /press-kits/organizations/exists with auth", () => {
     expect(content).toContain('"/press-kits/organizations/exists"');
   });
 
-  it("should have GET /press-kits/media-kit with auth", () => {
-    expect(content).toContain('"/press-kits/media-kit"');
+  it("should have GET /press-kits/media-kits (plural) with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits"');
   });
 
-  it("should have GET /press-kits/media-kit/:id with auth", () => {
-    expect(content).toContain('"/press-kits/media-kit/:id"');
+  it("should have GET /press-kits/media-kits/:id with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits/:id"');
   });
 
-  it("should have POST /press-kits/edit-media-kit with auth", () => {
-    expect(content).toContain('"/press-kits/edit-media-kit"');
+  it("should have POST /press-kits/media-kits (create-or-edit) with auth", () => {
+    const postLine = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/press-kits/media-kits"')
+    );
+    expect(postLine).toBeDefined();
   });
 
-  it("should have POST /press-kits/update-mdx with auth", () => {
-    expect(content).toContain('"/press-kits/update-mdx"');
+  it("should have PATCH /press-kits/media-kits/:id/mdx with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits/:id/mdx"');
+    expect(content).toContain("router.patch");
   });
 
-  it("should have POST /press-kits/update-status with auth", () => {
-    expect(content).toContain('"/press-kits/update-status"');
+  it("should have PATCH /press-kits/media-kits/:id/status with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits/:id/status"');
   });
 
-  it("should have POST /press-kits/validate with auth", () => {
-    expect(content).toContain('"/press-kits/validate"');
+  it("should have POST /press-kits/media-kits/:id/validate with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits/:id/validate"');
   });
 
-  it("should have POST /press-kits/cancel-draft with auth", () => {
-    expect(content).toContain('"/press-kits/cancel-draft"');
+  it("should have POST /press-kits/media-kits/:id/cancel with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits/:id/cancel"');
   });
 
   // ── Admin endpoints ───────────────────────────────────────────────────
@@ -90,30 +93,34 @@ describe("Press Kits proxy routes", () => {
     expect(content).toContain("router.delete");
   });
 
-  // ── Internal endpoints ────────────────────────────────────────────────
+  // ── Internal endpoints (new REST paths) ───────────────────────────────
 
-  it("should have GET /press-kits/internal/media-kit/by-org/:orgId with auth", () => {
-    expect(content).toContain('"/press-kits/internal/media-kit/by-org/:orgId"');
+  it("should have GET /press-kits/internal/media-kits/current with auth", () => {
+    expect(content).toContain('"/press-kits/internal/media-kits/current"');
   });
 
-  it("should have GET /press-kits/internal/generation-data with auth", () => {
-    expect(content).toContain('"/press-kits/internal/generation-data"');
+  it("should have GET /press-kits/internal/media-kits/generation-data with auth", () => {
+    expect(content).toContain('"/press-kits/internal/media-kits/generation-data"');
   });
 
-  it("should have POST /press-kits/internal/upsert-generation-result with auth", () => {
-    expect(content).toContain('"/press-kits/internal/upsert-generation-result"');
+  it("should have POST /press-kits/internal/media-kits/generation-result with auth", () => {
+    expect(content).toContain('"/press-kits/internal/media-kits/generation-result"');
   });
 
-  it("should have GET /press-kits/clients-media-kits-need-update with auth", () => {
-    expect(content).toContain('"/press-kits/clients-media-kits-need-update"');
+  it("should have GET /press-kits/internal/media-kits/stale with auth", () => {
+    expect(content).toContain('"/press-kits/internal/media-kits/stale"');
   });
 
-  it("should have GET /press-kits/media-kit-setup with auth", () => {
-    expect(content).toContain('"/press-kits/media-kit-setup"');
+  it("should have GET /press-kits/internal/media-kits/setup with auth", () => {
+    expect(content).toContain('"/press-kits/internal/media-kits/setup"');
   });
 
-  it("should have GET /press-kits/health/bulk with auth", () => {
-    expect(content).toContain('"/press-kits/health/bulk"');
+  it("should have GET /press-kits/internal/health/bulk with auth", () => {
+    expect(content).toContain('"/press-kits/internal/health/bulk"');
+  });
+
+  it("should have GET /press-kits/internal/email-data/:orgId with auth", () => {
+    expect(content).toContain('"/press-kits/internal/email-data/:orgId"');
   });
 
   // ── Auth & middleware checks ──────────────────────────────────────────
@@ -121,19 +128,46 @@ describe("Press Kits proxy routes", () => {
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    // 18 authenticated routes + 1 import = 19
-    expect(authMatches!.length).toBe(19);
+    // 19 authenticated routes + 1 import = 20
+    expect(authMatches!.length).toBe(20);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(18);
+    expect(headerMatches!.length).toBe(19);
   });
 
   it("should proxy to externalServices.pressKits", () => {
     expect(content).toContain("externalServices.pressKits");
+  });
+
+  // ── Old endpoints removed ─────────────────────────────────────────────
+
+  it("should NOT have old singular /media-kit path (now /media-kits)", () => {
+    // Only /media-kits (plural) should exist, not /media-kit (singular) standalone
+    expect(content).not.toContain('"/press-kits/media-kit"');
+  });
+
+  it("should NOT have old /edit-media-kit path", () => {
+    expect(content).not.toContain("/edit-media-kit");
+  });
+
+  it("should NOT have old /update-mdx path", () => {
+    expect(content).not.toContain('"/press-kits/update-mdx"');
+  });
+
+  it("should NOT have old /update-status path", () => {
+    expect(content).not.toContain('"/press-kits/update-status"');
+  });
+
+  it("should NOT have old /validate standalone path", () => {
+    expect(content).not.toContain('"/press-kits/validate"');
+  });
+
+  it("should NOT have old /cancel-draft standalone path", () => {
+    expect(content).not.toContain('"/press-kits/cancel-draft"');
   });
 });
 
@@ -146,23 +180,33 @@ describe("Press Kits service client", () => {
 });
 
 describe("Press Kits OpenAPI schemas", () => {
-  it("should register public paths", () => {
+  it("should register public path", () => {
     expect(schemaContent).toContain('path: "/press-kits/public/{token}"');
-    expect(schemaContent).toContain('path: "/press-kits/public-media-kit/{token}"');
-    expect(schemaContent).toContain('path: "/press-kits/email-data/press-kit/{orgId}"');
   });
 
-  it("should register authenticated paths", () => {
+  it("should NOT register removed legacy public paths", () => {
+    expect(schemaContent).not.toContain('path: "/press-kits/public-media-kit/{token}"');
+    expect(schemaContent).not.toContain('path: "/press-kits/email-data/press-kit/{orgId}"');
+  });
+
+  it("should register REST authenticated paths", () => {
     expect(schemaContent).toContain('path: "/v1/press-kits/organizations"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/organizations/share-token/{orgId}"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/organizations/{orgId}/share-token"');
     expect(schemaContent).toContain('path: "/v1/press-kits/organizations/exists"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/media-kit"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/media-kit/{id}"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/edit-media-kit"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/update-mdx"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/update-status"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/validate"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/cancel-draft"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}/mdx"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}/status"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}/validate"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}/cancel"');
+  });
+
+  it("should use PATCH for mdx and status updates", () => {
+    // Find the mdx path registration and verify it uses patch
+    const mdxMatch = schemaContent.match(/method: "patch",\s*\n\s*path: "\/v1\/press-kits\/media-kits\/{id}\/mdx"/);
+    expect(mdxMatch).not.toBeNull();
+    const statusMatch = schemaContent.match(/method: "patch",\s*\n\s*path: "\/v1\/press-kits\/media-kits\/{id}\/status"/);
+    expect(statusMatch).not.toBeNull();
   });
 
   it("should register admin paths", () => {
@@ -170,32 +214,27 @@ describe("Press Kits OpenAPI schemas", () => {
     expect(schemaContent).toContain('path: "/v1/press-kits/admin/organizations/{id}"');
   });
 
-  it("should register internal paths", () => {
-    expect(schemaContent).toContain('path: "/v1/press-kits/internal/media-kit/by-org/{orgId}"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/internal/generation-data"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/internal/upsert-generation-result"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/clients-media-kits-need-update"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/media-kit-setup"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/health/bulk"');
+  it("should register new internal paths", () => {
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/media-kits/current"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/media-kits/generation-data"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/media-kits/generation-result"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/media-kits/stale"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/media-kits/setup"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/health/bulk"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/internal/email-data/{orgId}"');
+  });
+
+  it("should NOT have old internal paths", () => {
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/internal/media-kit/by-org/{orgId}"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/internal/generation-data"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/internal/upsert-generation-result"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/clients-media-kits-need-update"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/media-kit-setup"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/health/bulk"');
   });
 
   it("should use Press Kits tag for non-internal endpoints", () => {
     expect(schemaContent).toContain('tags: ["Press Kits"]');
-  });
-
-  it("should use Internal tag for internal endpoints", () => {
-    // Internal press-kit endpoints should use Internal tag
-    const internalPaths = [
-      "/v1/press-kits/internal/media-kit/by-org/{orgId}",
-      "/v1/press-kits/internal/generation-data",
-      "/v1/press-kits/internal/upsert-generation-result",
-      "/v1/press-kits/clients-media-kits-need-update",
-      "/v1/press-kits/media-kit-setup",
-      "/v1/press-kits/health/bulk",
-    ];
-    for (const p of internalPaths) {
-      expect(schemaContent).toContain(`path: "${p}"`);
-    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Renames all press-kits proxy endpoints to match upstream REST rename (press-kits-service PR #8)
- `POST /media-kits` is now idempotent create-or-edit (uses x-org-id header)
- MDX/status updates are now `PATCH /media-kits/:id/mdx` and `PATCH /media-kits/:id/status`
- Validate/cancel take kit ID from URL: `POST /media-kits/:id/validate`, `POST /media-kits/:id/cancel`
- Internal endpoints restructured under `/internal/media-kits/`
- `/email-data` moved from public to internal, `/public-media-kit` legacy route removed

## Test plan
- [x] 42 unit tests covering all new routes, removed old routes, auth, OpenAPI schemas
- [x] Full suite passes (620 tests, 75 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)