### PR TITLE
docs: remove organizationUrl from POST /media-kits

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4601,10 +4601,6 @@
           "instruction": {
             "type": "string",
             "description": "Instructions for the generation"
-          },
-          "organizationUrl": {
-            "type": "string",
-            "description": "Organization website URL for context"
           }
         },
         "required": [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3731,7 +3731,7 @@ registry.registerPath({
     "The service auto-finds the latest active kit or creates a new one.",
   security: authed,
   request: {
-    body: { content: { "application/json": { schema: z.object({ instruction: z.string().describe("Instructions for the generation"), organizationUrl: z.string().optional().describe("Organization website URL for context") }).openapi("PressKitCreateEditRequest") } } },
+    body: { content: { "application/json": { schema: z.object({ instruction: z.string().describe("Instructions for the generation") }).openapi("PressKitCreateEditRequest") } } },
   },
   responses: {
     200: { description: "Generation initiated", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitCreateEditResponse") } } },


### PR DESCRIPTION
## Summary
- Remove `organizationUrl` field from `POST /v1/press-kits/media-kits` request body schema
- Regenerate `openapi.json` to reflect the change
- press-kits-service now resolves organization URL automatically via brand-service using `x-brand-id` header

## Test plan
- [x] All 620 existing tests pass
- [x] `organizationUrl` no longer appears in openapi.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)