### PR TITLE
feat: add layout field to content compose schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4765,6 +4765,15 @@
           "outputBlobToken": {
             "type": "string",
             "description": "Vercel Blob write token for the output"
+          },
+          "layout": {
+            "type": "string",
+            "enum": [
+              "quote-top",
+              "webcam-top"
+            ],
+            "default": "quote-top",
+            "description": "Video layout variant"
           }
         },
         "required": [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3935,6 +3935,7 @@ export const ContentComposeRequestSchema = z
     theme: z.string().describe("Theme text"),
     text: z.string().describe("Quote text to overlay"),
     outputBlobToken: z.string().describe("Vercel Blob write token for the output"),
+    layout: z.enum(["quote-top", "webcam-top"]).default("quote-top").optional().describe("Video layout variant"),
   })
   .openapi("ContentComposeRequest");
 

--- a/tests/unit/content-compose.test.ts
+++ b/tests/unit/content-compose.test.ts
@@ -140,6 +140,32 @@ describe("POST /v1/content/compose", () => {
     expect(res.body.error).toContain("Service unavailable");
   });
 
+  it("should forward layout field to downstream service", async () => {
+    await request(app)
+      .post("/v1/content/compose")
+      .send({ ...validBody, layout: "webcam-top" });
+
+    const body = JSON.parse(capturedInit?.body as string);
+    expect(body.layout).toBe("webcam-top");
+  });
+
+  it("should accept request without layout (optional field)", async () => {
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("should return 400 when layout has invalid value", async () => {
+    const res = await request(app)
+      .post("/v1/content/compose")
+      .send({ ...validBody, layout: "invalid-layout" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
   it("should return 500 when upstream returns unexpected error", async () => {
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: false,


### PR DESCRIPTION
## Summary
- Adds `layout` field (`"quote-top"` | `"webcam-top"`, optional) to `ContentComposeRequest` Zod schema
- Passthrough only — no gateway logic changes, the field flows directly to content-generation-service
- Fixes issue where gateway validation stripped the `layout` field before proxying, causing all requests to fall back to the default layout

## Test plan
- [x] Added test: layout value is forwarded to downstream service
- [x] Added test: request without layout still succeeds (optional field)
- [x] Added test: invalid layout value returns 400
- [x] All 623 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)