### PR TITLE
feat: forward campaign_id filter on GET /v1/press-kits/media-kits

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -13415,7 +13415,7 @@
           "Press Kits"
         ],
         "summary": "List media kits",
-        "description": "List media kits, optionally filtered by org_id, organization_id, or title.",
+        "description": "List media kits, optionally filtered by org_id, organization_id, title, or campaign_id.",
         "security": [
           {
             "bearerAuth": []

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -72,6 +72,7 @@ router.get("/press-kits/media-kits", authenticate, requireOrg, async (req: Authe
     if (req.query.org_id) params.set("org_id", req.query.org_id as string);
     if (req.query.organization_id) params.set("organization_id", req.query.organization_id as string);
     if (req.query.title) params.set("title", req.query.title as string);
+    if (req.query.campaign_id) params.set("campaign_id", req.query.campaign_id as string);
     const qs = params.toString() ? `?${params.toString()}` : "";
     const result = await callExternalService(
       externalServices.pressKits,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3611,7 +3611,7 @@ registry.registerPath({
   path: "/v1/press-kits/media-kits",
   tags: ["Press Kits"],
   summary: "List media kits",
-  description: "List media kits, optionally filtered by org_id, organization_id, or title.",
+  description: "List media kits, optionally filtered by org_id, organization_id, title, or campaign_id.",
   security: authed,
   responses: {
     200: { description: "Media kits list", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitMediaKitListResponse") } } },

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -54,6 +54,10 @@ describe("Press Kits proxy routes", () => {
     expect(content).toContain('"/press-kits/media-kits"');
   });
 
+  it("should forward campaign_id query param on GET /media-kits", () => {
+    expect(content).toContain('params.set("campaign_id"');
+  });
+
   it("should have GET /press-kits/media-kits/:id with auth", () => {
     expect(content).toContain('"/press-kits/media-kits/:id"');
   });


### PR DESCRIPTION
## Summary
- Forward `campaign_id` query parameter on `GET /v1/press-kits/media-kits` proxy route to the upstream press-kits-service
- Update OpenAPI description to document `campaign_id` as a supported filter
- Add regression test for `campaign_id` forwarding

## Context
The press-kits-service already supports `campaign_id` filtering and returns `campaignId` in `MediaKitResponse`. The api-service proxy was the only gap — it forwarded `org_id`, `organization_id`, and `title` but not `campaign_id`.

## Test plan
- [x] Existing press-kits proxy tests pass (44/44)
- [x] New test verifies `campaign_id` is forwarded
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)