### PR TITLE
feat: add campaign outlets and journalists proxy endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1341,6 +1341,103 @@
           "emails"
         ]
       },
+      "CampaignOutletsResponse": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "outletName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "outletUrl": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "outletDomain": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "relevanceScore": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "whyRelevant": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "status": {
+                  "type": "string",
+                  "nullable": true
+                }
+              },
+              "required": [
+                "outletName",
+                "outletUrl",
+                "outletDomain",
+                "relevanceScore",
+                "whyRelevant",
+                "status"
+              ]
+            }
+          }
+        },
+        "required": [
+          "outlets"
+        ]
+      },
+      "CampaignJournalistsResponse": {
+        "type": "object",
+        "properties": {
+          "journalists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "journalistName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "firstName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "lastName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "entityType": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "outletName": {
+                  "type": "string",
+                  "nullable": true
+                }
+              },
+              "required": [
+                "journalistName",
+                "firstName",
+                "lastName",
+                "entityType",
+                "outletName"
+              ]
+            }
+          }
+        },
+        "required": [
+          "journalists"
+        ]
+      },
       "OrgKeyItem": {
         "type": "object",
         "properties": {
@@ -6313,6 +6410,212 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CampaignEmailsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/campaigns/{id}/outlets": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get campaign outlets",
+        "description": "Get discovered outlets for a campaign (proxied from outlet-service)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID"
+            },
+            "required": true,
+            "description": "Campaign ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of outlets discovered for the campaign",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignOutletsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/campaigns/{id}/journalists": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get campaign journalists",
+        "description": "Get discovered journalists for a campaign (proxied from journalist-service)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID"
+            },
+            "required": true,
+            "description": "Campaign ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of journalists discovered for the campaign",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignJournalistsResponse"
                 }
               }
             }

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -76,6 +76,14 @@ export const externalServices = {
     url: process.env.PRESS_KITS_SERVICE_URL || "https://press-kits.mcpfactory.org",
     apiKey: process.env.PRESS_KITS_SERVICE_API_KEY || "",
   },
+  outlet: {
+    url: process.env.OUTLET_SERVICE_URL || "http://localhost:3030",
+    apiKey: process.env.OUTLET_SERVICE_API_KEY || "",
+  },
+  journalist: {
+    url: process.env.JOURNALIST_SERVICE_URL || "http://localhost:3031",
+    apiKey: process.env.JOURNALIST_SERVICE_API_KEY || "",
+  },
 };
 
 interface ServiceCallOptions {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -805,4 +805,48 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
   });
 });
 
+/**
+ * GET /v1/campaigns/:id/outlets
+ * Get discovered outlets for a campaign (proxy to outlet-service)
+ */
+router.get("/campaigns/:id/outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+
+    const result = await callExternalService(
+      externalServices.outlet,
+      `/outlets?campaignId=${encodeURIComponent(id)}`,
+      {
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get campaign outlets error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get campaign outlets" });
+  }
+});
+
+/**
+ * GET /v1/campaigns/:id/journalists
+ * Get discovered journalists for a campaign (proxy to journalist-service)
+ */
+router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+
+    const result = await callExternalService(
+      externalServices.journalist,
+      `/campaign-outlet-journalists?campaignId=${encodeURIComponent(id)}`,
+      {
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get campaign journalists error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get campaign journalists" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -829,6 +829,79 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/campaigns/{id}/outlets",
+  tags: ["Campaigns"],
+  summary: "Get campaign outlets",
+  description:
+    "Get discovered outlets for a campaign (proxied from outlet-service)",
+  security: authed,
+  request: { params: CampaignIdParam },
+  responses: {
+    200: {
+      description: "List of outlets discovered for the campaign",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outlets: z.array(
+                z.object({
+                  id: z.string().optional(),
+                  outletName: z.string().nullable(),
+                  outletUrl: z.string().nullable(),
+                  outletDomain: z.string().nullable(),
+                  relevanceScore: z.number().nullable(),
+                  whyRelevant: z.string().nullable(),
+                  status: z.string().nullable(),
+                }),
+              ),
+            })
+            .openapi("CampaignOutletsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/campaigns/{id}/journalists",
+  tags: ["Campaigns"],
+  summary: "Get campaign journalists",
+  description:
+    "Get discovered journalists for a campaign (proxied from journalist-service)",
+  security: authed,
+  request: { params: CampaignIdParam },
+  responses: {
+    200: {
+      description: "List of journalists discovered for the campaign",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              journalists: z.array(
+                z.object({
+                  id: z.string().optional(),
+                  journalistName: z.string().nullable(),
+                  firstName: z.string().nullable(),
+                  lastName: z.string().nullable(),
+                  entityType: z.string().nullable(),
+                  outletName: z.string().nullable(),
+                }),
+              ),
+            })
+            .openapi("CampaignJournalistsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // PROVIDER KEYS
 // ===================================================================

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const campaignsRoutePath = path.join(__dirname, "../../src/routes/campaigns.ts");
+const content = fs.readFileSync(campaignsRoutePath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+describe("Campaign discovery proxy: outlets", () => {
+  it("should have GET /campaigns/:id/outlets endpoint", () => {
+    expect(content).toContain('"/campaigns/:id/outlets"');
+    expect(content).toContain("router.get");
+  });
+
+  it("should use authenticate, requireOrg, requireUser middleware", () => {
+    const outletsSection = content.slice(
+      content.indexOf('"/campaigns/:id/outlets"'),
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(outletsSection).toContain("authenticate");
+    expect(outletsSection).toContain("requireOrg");
+    expect(outletsSection).toContain("requireUser");
+  });
+
+  it("should proxy to outlet-service with campaignId query param", () => {
+    const outletsSection = content.slice(
+      content.indexOf('"/campaigns/:id/outlets"'),
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(outletsSection).toContain("externalServices.outlet");
+    expect(outletsSection).toContain("/outlets?campaignId=");
+  });
+
+  it("should forward internal headers", () => {
+    const outletsSection = content.slice(
+      content.indexOf('"/campaigns/:id/outlets"'),
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(outletsSection).toContain("buildInternalHeaders(req)");
+  });
+
+  it("should be a read-only GET (no method override)", () => {
+    const outletsSection = content.slice(
+      content.indexOf('"/campaigns/:id/outlets"'),
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(outletsSection).not.toContain('method:');
+  });
+});
+
+describe("Campaign discovery proxy: journalists", () => {
+  it("should have GET /campaigns/:id/journalists endpoint", () => {
+    expect(content).toContain('"/campaigns/:id/journalists"');
+    expect(content).toContain("router.get");
+  });
+
+  it("should use authenticate, requireOrg, requireUser middleware", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("authenticate");
+    expect(journalistsSection).toContain("requireOrg");
+    expect(journalistsSection).toContain("requireUser");
+  });
+
+  it("should proxy to journalist-service with campaignId query param", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("externalServices.journalist");
+    expect(journalistsSection).toContain("/campaign-outlet-journalists?campaignId=");
+  });
+
+  it("should forward internal headers", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("buildInternalHeaders(req)");
+  });
+
+  it("should be a read-only GET (no method override)", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).not.toContain('method: "POST"');
+    expect(journalistsSection).not.toContain('method: "PUT"');
+    expect(journalistsSection).not.toContain('method: "PATCH"');
+    expect(journalistsSection).not.toContain('method: "DELETE"');
+  });
+});
+
+describe("Service client: outlet and journalist services", () => {
+  it("should define outlet service config", () => {
+    expect(serviceClientContent).toContain("OUTLET_SERVICE_URL");
+    expect(serviceClientContent).toContain("OUTLET_SERVICE_API_KEY");
+  });
+
+  it("should define journalist service config", () => {
+    expect(serviceClientContent).toContain("JOURNALIST_SERVICE_URL");
+    expect(serviceClientContent).toContain("JOURNALIST_SERVICE_API_KEY");
+  });
+});
+
+describe("OpenAPI schemas: campaign discovery endpoints", () => {
+  it("should register /v1/campaigns/{id}/outlets path", () => {
+    expect(schemaContent).toContain('path: "/v1/campaigns/{id}/outlets"');
+    expect(schemaContent).toContain('tags: ["Campaigns"]');
+  });
+
+  it("should register /v1/campaigns/{id}/journalists path", () => {
+    expect(schemaContent).toContain('path: "/v1/campaigns/{id}/journalists"');
+  });
+
+  it("should define CampaignOutletsResponse schema", () => {
+    expect(schemaContent).toContain("CampaignOutletsResponse");
+    expect(schemaContent).toContain("outletName");
+    expect(schemaContent).toContain("outletUrl");
+    expect(schemaContent).toContain("outletDomain");
+    expect(schemaContent).toContain("relevanceScore");
+    expect(schemaContent).toContain("whyRelevant");
+  });
+
+  it("should define CampaignJournalistsResponse schema", () => {
+    expect(schemaContent).toContain("CampaignJournalistsResponse");
+    expect(schemaContent).toContain("journalistName");
+    expect(schemaContent).toContain("entityType");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GET /v1/campaigns/{campaignId}/outlets` → proxies to outlet-service `GET /outlets?campaignId={campaignId}`
- Add `GET /v1/campaigns/{campaignId}/journalists` → proxies to journalist-service `GET /campaign-outlet-journalists?campaignId={campaignId}`
- Register outlet-service and journalist-service in service-client config
- Add OpenAPI schemas for both endpoints
- Both endpoints are read-only and forward standard headers (x-org-id, x-user-id, x-run-id)

## Test plan
- [x] 16 new unit tests covering route structure, middleware, service proxying, and OpenAPI schemas
- [x] Full test suite passes (638 tests, 76 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)