### PR TITLE
fix: correct outlets env vars and outletStatus field

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1372,9 +1372,10 @@
                   "type": "string",
                   "nullable": true
                 },
-                "status": {
+                "outletStatus": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "Campaign-level status: open, ended, or denied"
                 }
               },
               "required": [
@@ -1383,7 +1384,7 @@
                 "outletDomain",
                 "relevanceScore",
                 "whyRelevant",
-                "status"
+                "outletStatus"
               ]
             }
           }

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -77,8 +77,8 @@ export const externalServices = {
     apiKey: process.env.PRESS_KITS_SERVICE_API_KEY || "",
   },
   outlet: {
-    url: process.env.OUTLET_SERVICE_URL || "http://localhost:3030",
-    apiKey: process.env.OUTLET_SERVICE_API_KEY || "",
+    url: process.env.OUTLETS_SERVICE_URL || "http://localhost:3030",
+    apiKey: process.env.OUTLETS_SERVICE_API_KEY || "",
   },
   journalist: {
     url: process.env.JOURNALIST_SERVICE_URL || "http://localhost:3031",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -853,7 +853,7 @@ registry.registerPath({
                   outletDomain: z.string().nullable(),
                   relevanceScore: z.number().nullable(),
                   whyRelevant: z.string().nullable(),
-                  status: z.string().nullable(),
+                  outletStatus: z.string().nullable().describe("Campaign-level status: open, ended, or denied"),
                 }),
               ),
             })

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -96,8 +96,8 @@ describe("Campaign discovery proxy: journalists", () => {
 
 describe("Service client: outlet and journalist services", () => {
   it("should define outlet service config", () => {
-    expect(serviceClientContent).toContain("OUTLET_SERVICE_URL");
-    expect(serviceClientContent).toContain("OUTLET_SERVICE_API_KEY");
+    expect(serviceClientContent).toContain("OUTLETS_SERVICE_URL");
+    expect(serviceClientContent).toContain("OUTLETS_SERVICE_API_KEY");
   });
 
   it("should define journalist service config", () => {


### PR DESCRIPTION
## Summary
- Fix env var names to match outlet-service: `OUTLETS_SERVICE_URL` / `OUTLETS_SERVICE_API_KEY` (with S)
- Use `outletStatus` field (campaign-level: open/ended/denied) instead of `status` (global outlet status)

## Test plan
- [x] 16 unit tests pass
- [x] Full suite passes (638 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)