### PR TITLE
fix: journalist proxy uses campaign_id and correct response shape

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1396,47 +1396,80 @@
       "CampaignJournalistsResponse": {
         "type": "object",
         "properties": {
-          "journalists": {
+          "campaignOutletJournalists": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "id": {
+                "campaignId": {
                   "type": "string"
+                },
+                "outletId": {
+                  "type": "string"
+                },
+                "journalistId": {
+                  "type": "string"
+                },
+                "whyRelevant": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "whyNotRelevant": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "relevanceScore": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "createdAt": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "updatedAt": {
+                  "type": "string",
+                  "nullable": true
                 },
                 "journalistName": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "From press_journalists JOIN — available once journalist-service adds the JOIN"
                 },
                 "firstName": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "From press_journalists JOIN"
                 },
                 "lastName": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "From press_journalists JOIN"
                 },
                 "entityType": {
                   "type": "string",
-                  "nullable": true
-                },
-                "outletName": {
-                  "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "From press_journalists JOIN"
                 }
               },
               "required": [
+                "campaignId",
+                "outletId",
+                "journalistId",
+                "whyRelevant",
+                "whyNotRelevant",
+                "relevanceScore",
+                "createdAt",
+                "updatedAt",
                 "journalistName",
                 "firstName",
                 "lastName",
-                "entityType",
-                "outletName"
+                "entityType"
               ]
             }
           }
         },
         "required": [
-          "journalists"
+          "campaignOutletJournalists"
         ]
       },
       "OrgKeyItem": {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -837,7 +837,7 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
 
     const result = await callExternalService(
       externalServices.journalist,
-      `/campaign-outlet-journalists?campaignId=${encodeURIComponent(id)}`,
+      `/campaign-outlet-journalists?campaign_id=${encodeURIComponent(id)}`,
       {
         headers: buildInternalHeaders(req),
       }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -882,14 +882,20 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              journalists: z.array(
+              campaignOutletJournalists: z.array(
                 z.object({
-                  id: z.string().optional(),
-                  journalistName: z.string().nullable(),
-                  firstName: z.string().nullable(),
-                  lastName: z.string().nullable(),
-                  entityType: z.string().nullable(),
-                  outletName: z.string().nullable(),
+                  campaignId: z.string(),
+                  outletId: z.string(),
+                  journalistId: z.string(),
+                  whyRelevant: z.string().nullable(),
+                  whyNotRelevant: z.string().nullable(),
+                  relevanceScore: z.number().nullable(),
+                  createdAt: z.string().nullable(),
+                  updatedAt: z.string().nullable(),
+                  journalistName: z.string().nullable().describe("From press_journalists JOIN — available once journalist-service adds the JOIN"),
+                  firstName: z.string().nullable().describe("From press_journalists JOIN"),
+                  lastName: z.string().nullable().describe("From press_journalists JOIN"),
+                  entityType: z.string().nullable().describe("From press_journalists JOIN"),
                 }),
               ),
             })

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -73,7 +73,7 @@ describe("Campaign discovery proxy: journalists", () => {
       content.indexOf('"/campaigns/:id/journalists"'),
     );
     expect(journalistsSection).toContain("externalServices.journalist");
-    expect(journalistsSection).toContain("/campaign-outlet-journalists?campaignId=");
+    expect(journalistsSection).toContain("/campaign-outlet-journalists?campaign_id=");
   });
 
   it("should forward internal headers", () => {
@@ -125,8 +125,11 @@ describe("OpenAPI schemas: campaign discovery endpoints", () => {
     expect(schemaContent).toContain("whyRelevant");
   });
 
-  it("should define CampaignJournalistsResponse schema", () => {
+  it("should define CampaignJournalistsResponse schema with junction table fields", () => {
     expect(schemaContent).toContain("CampaignJournalistsResponse");
+    expect(schemaContent).toContain("campaignOutletJournalists");
+    expect(schemaContent).toContain("journalistId");
+    expect(schemaContent).toContain("outletId");
     expect(schemaContent).toContain("journalistName");
     expect(schemaContent).toContain("entityType");
   });


### PR DESCRIPTION
## Summary
- Fix query param: `campaign_id` (snake_case) instead of `campaignId` — matches journalist-service convention
- Fix response schema: wrapper is `campaignOutletJournalists` with junction table fields (`campaignId`, `outletId`, `journalistId`, `relevanceScore`, `whyRelevant`, `whyNotRelevant`)
- Journalist detail fields (`journalistName`, `firstName`, `lastName`, `entityType`) included in schema — will be populated once journalist-service adds the `press_journalists` JOIN

## Test plan
- [x] 16 unit tests pass
- [x] Full suite passes (638 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)