### PR TITLE
docs: document 402 response on POST /v1/chat

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10458,6 +10458,16 @@
               }
             }
           },
+          "402": {
+            "description": "Insufficient credits. The organization's credit balance is too low to process this request. Response includes `balance_cents` (current balance) and `required_cents` (minimum needed).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Session not found (invalid or expired sessionId), or chat config not registered (register via PUT /v1/chat/config or ensure platform config exists)",
             "content": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2491,6 +2491,12 @@ registry.registerPath({
       },
     },
     401: { description: "Unauthorized", content: errorContent },
+    402: {
+      description:
+        "Insufficient credits. The organization's credit balance is too low to process this request. " +
+        "Response includes `balance_cents` (current balance) and `required_cents` (minimum needed).",
+      content: errorContent,
+    },
     404: {
       description:
         "Session not found (invalid or expired sessionId), or chat config not registered " +


### PR DESCRIPTION
## Summary
- Added 402 (Insufficient Credits) as a documented response on `POST /v1/chat` in the OpenAPI spec
- Describes `balance_cents` and `required_cents` fields in the error response
- Dashboard team had to discover this empirically (PR #522) — now it's explicit

## Test plan
- [x] `openapi.json` regenerated
- [x] Full test suite passes (639 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)