### PR TITLE
fix: add optional fields to discovery campaign schema

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -379,6 +379,11 @@ export const CreateDiscoveryCampaignRequestSchema = z
     maxBudgetMonthlyUsd: z.union([z.string(), z.number()]).optional().describe("Max monthly budget in USD"),
     maxBudgetTotalUsd: z.union([z.string(), z.number()]).optional().describe("Max total budget in USD"),
     endDate: z.string().optional().describe("Campaign end date"),
+    targetOutcome: z.string().optional().describe("Discovery goal (auto-set for discovery campaigns)"),
+    valueForTarget: z.string().optional().describe("Value proposition (auto-set for discovery campaigns)"),
+    industry: z.string().optional().describe("Industry or sector for outlet discovery"),
+    targetGeo: z.string().optional().describe("Geographic focus for outlet discovery"),
+    angles: z.array(z.string()).optional().describe("PR angles or story hooks (e.g. fundraising, thought leadership)"),
   })
   .openapi("CreateDiscoveryCampaignRequest");
 


### PR DESCRIPTION
## Summary
- Add `targetOutcome` and `valueForTarget` as optional fields to `CreateDiscoveryCampaignRequestSchema` so they pass through to campaign-service (fixes 400 "expected string, received undefined")
- Add `industry`, `targetGeo`, and `angles` as optional fields for discovery-specific inputs from the dashboard

## Context
The discovery Zod schema was stripping `targetOutcome` and `valueForTarget` from the request body because they weren't defined in the schema. Campaign-service still requires these fields, causing a 400 error.

## Test plan
- [ ] Create a discovery campaign from the dashboard — no more 400
- [ ] Create an outreach campaign — unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)