### PR TITLE
feat: add scrapedUrls to sales profile responses

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2162,6 +2162,13 @@
             "type": "string",
             "nullable": true,
             "description": "ISO timestamp when profile expires"
+          },
+          "scrapedUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "URLs that were scraped and analyzed during extraction"
           }
         },
         "required": [
@@ -2175,7 +2182,8 @@
           "keyFeatures",
           "extractionModel",
           "extractedAt",
-          "expiresAt"
+          "expiresAt",
+          "scrapedUrls"
         ]
       },
       "GetSalesProfileResponse": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1364,6 +1364,7 @@ const SalesProfileSchema = z
     extractionModel: z.string().nullable().describe("AI model used for extraction"),
     extractedAt: z.string().describe("ISO timestamp of extraction"),
     expiresAt: z.string().nullable().describe("ISO timestamp when profile expires"),
+    scrapedUrls: z.array(z.string()).describe("URLs that were scraped and analyzed during extraction"),
   })
   .openapi("SalesProfile");
 

--- a/tests/unit/brand-sales-profile-404.regression.test.ts
+++ b/tests/unit/brand-sales-profile-404.regression.test.ts
@@ -43,7 +43,14 @@ describe("GET /v1/brands/:id/sales-profile – read only", () => {
   });
 
   it("should return 200 with profile when it exists", async () => {
-    const profile = { cached: true, brandId: "b-1", profile: { valueProposition: "Test" } };
+    const profile = {
+      cached: true,
+      brandId: "b-1",
+      profile: {
+        valueProposition: "Test",
+        scrapedUrls: ["https://example.com", "https://example.com/about"],
+      },
+    };
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: true,
       json: () => Promise.resolve(profile),
@@ -53,6 +60,7 @@ describe("GET /v1/brands/:id/sales-profile – read only", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(profile);
+    expect(res.body.profile.scrapedUrls).toEqual(["https://example.com", "https://example.com/about"]);
   });
 
   it("should return 404 when no profile exists", async () => {


### PR DESCRIPTION
## Summary
- Adds `scrapedUrls` (string array) to the `SalesProfile` schema, exposing which URLs were scraped during extraction
- Updates tests to cover the new field
- Regenerates `openapi.json`

## Test plan
- [x] Existing sales profile tests pass (9/9)
- [x] OpenAPI spec regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)