### PR TITLE
feat: migrate sales-profile to extract-fields

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2098,61 +2098,20 @@
           "brand"
         ]
       },
-      "SalesProfile": {
+      "ExtractFieldResult": {
         "type": "object",
         "properties": {
-          "valueProposition": {
+          "key": {
             "type": "string",
-            "nullable": true,
-            "description": "Core value proposition"
+            "description": "Field key"
           },
-          "customerPainPoints": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Target pain points"
-          },
-          "callToAction": {
+          "value": {
             "type": "string",
-            "nullable": true,
-            "description": "Primary CTA"
+            "description": "Extracted value"
           },
-          "companyOverview": {
-            "type": "string",
-            "nullable": true,
-            "description": "Company overview"
-          },
-          "competitors": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Known competitors"
-          },
-          "productDifferentiators": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Key differentiators"
-          },
-          "targetAudience": {
-            "type": "string",
-            "nullable": true,
-            "description": "Target audience description"
-          },
-          "keyFeatures": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Key product features"
-          },
-          "extractionModel": {
-            "type": "string",
-            "nullable": true,
-            "description": "AI model used for extraction"
+          "cached": {
+            "type": "boolean",
+            "description": "Whether this result was served from cache"
           },
           "extractedAt": {
             "type": "string",
@@ -2160,63 +2119,67 @@
           },
           "expiresAt": {
             "type": "string",
-            "nullable": true,
-            "description": "ISO timestamp when profile expires"
+            "description": "ISO timestamp when cached result expires"
+          }
+        },
+        "required": [
+          "key",
+          "value",
+          "cached",
+          "extractedAt",
+          "expiresAt"
+        ]
+      },
+      "ExtractFieldsResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "description": "Brand ID"
           },
-          "scrapedUrls": {
+          "results": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/ExtractFieldResult"
             },
-            "description": "URLs that were scraped and analyzed during extraction"
+            "description": "Extraction results"
           }
         },
         "required": [
-          "valueProposition",
-          "customerPainPoints",
-          "callToAction",
-          "companyOverview",
-          "competitors",
-          "productDifferentiators",
-          "targetAudience",
-          "keyFeatures",
-          "extractionModel",
-          "extractedAt",
-          "expiresAt",
-          "scrapedUrls"
+          "brandId",
+          "results"
         ]
       },
-      "GetSalesProfileResponse": {
+      "ExtractFieldRequest": {
         "type": "object",
         "properties": {
-          "profile": {
-            "$ref": "#/components/schemas/SalesProfile"
+          "key": {
+            "type": "string",
+            "description": "Field key (e.g. 'industry', 'valueProposition')"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of what to extract"
           }
         },
         "required": [
-          "profile"
+          "key",
+          "description"
         ]
       },
-      "CreateSalesProfileResponse": {
+      "ExtractFieldsRequest": {
         "type": "object",
         "properties": {
-          "profile": {
-            "$ref": "#/components/schemas/SalesProfile"
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtractFieldRequest"
+            },
+            "description": "Fields to extract"
           }
         },
         "required": [
-          "profile"
-        ]
-      },
-      "RefreshSalesProfileResponse": {
-        "type": "object",
-        "properties": {
-          "profile": {
-            "$ref": "#/components/schemas/SalesProfile"
-          }
-        },
-        "required": [
-          "profile"
+          "fields"
         ]
       },
       "IcpSuggestionResponse": {
@@ -8135,124 +8098,13 @@
         }
       }
     },
-    "/v1/brands/{id}/sales-profile": {
-      "get": {
-        "tags": [
-          "Brand"
-        ],
-        "summary": "Get brand sales profile",
-        "description": "Get the sales profile for a brand. Returns 404 if none exists.",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Brand ID"
-            },
-            "required": true,
-            "description": "Brand ID",
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-name",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Brand sales profile",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetSalesProfileResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Sales profile not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
+    "/v1/brands/{id}/extract-fields": {
       "post": {
         "tags": [
           "Brand"
         ],
-        "summary": "Create brand sales profile",
-        "description": "Trigger AI extraction to create a sales profile for the brand. Returns 409 if a profile already exists.",
+        "summary": "Extract fields from brand",
+        "description": "Generic field extraction: send fields you want with a key and description, and brand-service extracts them via AI. Results are cached 30 days per field. To reproduce the old sales-profile, send the same fields as items in the fields array. For discovery campaigns, send industry, suggestedAngles, suggestedGeo.",
         "security": [
           {
             "bearerAuth": []
@@ -8315,134 +8167,22 @@
             "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExtractFieldsRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Sales profile created",
+            "description": "Extracted field results",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateSalesProfileResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Anthropic API key not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Sales profile already exists",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Brand"
-        ],
-        "summary": "Refresh brand sales profile",
-        "description": "Force re-extraction of the sales profile for the brand. Always bypasses the 30-day cache and triggers a fresh scraping + AI extraction. Use this when the brand's website has changed and the profile needs updating.",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Brand ID"
-            },
-            "required": true,
-            "description": "Brand ID",
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-name",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Sales profile refreshed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RefreshSalesProfileResponse"
+                  "$ref": "#/components/schemas/ExtractFieldsResponse"
                 }
               }
             }
@@ -8598,7 +8338,7 @@
           "Brand"
         ],
         "summary": "Get brand runs",
-        "description": "Get extraction runs for a brand (sales-profile, icp-extraction) enriched with cost data",
+        "description": "Get extraction runs for a brand (extract-fields, icp-extraction) enriched with cost data",
         "security": [
           {
             "bearerAuth": []

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -140,76 +140,25 @@ router.get("/brands/:id", authenticate, async (req: AuthenticatedRequest, res) =
 });
 
 /**
- * GET /v1/brands/:id/sales-profile
- * Read-only: returns the sales profile for a brand, or 404 if none exists.
+ * POST /v1/brands/:id/extract-fields
+ * Generic field extraction: send fields you want with key + description,
+ * brand-service extracts them via AI. Results cached 30 days per field.
  */
-router.get("/brands/:id/sales-profile", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.post("/brands/:id/extract-fields", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.brand,
-      `/brands/${req.params.id}/sales-profile`,
-      { headers: buildInternalHeaders(req) },
-    );
-    res.json(result);
-  } catch (error: any) {
-    console.error("Get brand sales profile error:", error);
-    const statusCode = error.statusCode || 500;
-    if (statusCode === 404) {
-      return res.status(404).json({ error: "Sales profile not found" });
-    }
-    res.status(statusCode).json({ error: error.message || "Failed to get sales profile" });
-  }
-});
-
-/**
- * POST /v1/brands/:id/sales-profile
- * Create: triggers AI extraction for the brand. Returns 409 if a profile already exists.
- */
-router.post("/brands/:id/sales-profile", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const result = await callExternalService(
-      externalServices.brand,
-      `/brands/${req.params.id}/sales-profile`,
+      `/brands/${req.params.id}/extract-fields`,
       {
         method: "POST",
         headers: buildInternalHeaders(req),
+        body: req.body,
       },
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Create brand sales profile error:", error);
-    const msg = error.message || "Failed to create sales profile";
-    if (msg.includes("No Anthropic API key found")) {
-      return res.status(400).json({
-        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
-      });
-    }
-    const statusCode = error.statusCode || 500;
-    if (statusCode === 409) {
-      return res.status(409).json({ error: "Sales profile already exists. Use PUT to refresh." });
-    }
-    res.status(statusCode).json({ error: msg });
-  }
-});
-
-/**
- * PUT /v1/brands/:id/sales-profile
- * Refresh: forces re-extraction of the sales profile.
- */
-router.put("/brands/:id/sales-profile", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const result = await callExternalService(
-      externalServices.brand,
-      `/brands/${req.params.id}/sales-profile?force=true`,
-      {
-        method: "PUT",
-        headers: buildInternalHeaders(req),
-      },
-    );
-    res.json(result);
-  } catch (error: any) {
-    console.error("Refresh brand sales profile error:", error);
-    const msg = error.message || "Failed to refresh sales profile";
+    console.error("Extract fields error:", error);
+    const msg = error.message || "Failed to extract fields";
     if (msg.includes("No Anthropic API key found")) {
       return res.status(400).json({
         error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { z } from "zod";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
@@ -119,33 +118,8 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
     );
     console.log("[api-service] POST /v1/campaigns \u2014 step 1 done: brand upserted", { brandId: brandResult.brandId });
 
-    // 2. Send user-provided marketing fields to brand-service sales profile
-    //    (only for outreach campaigns — discovery campaigns don't have these fields)
-    if (!discovery) {
-      const outreachData = parsed.data as z.infer<typeof CreateCampaignRequestSchema>;
-      const { urgency, scarcity, riskReversal, socialProof } = outreachData;
-      if (urgency || scarcity || riskReversal || socialProof) {
-        console.log("[api-service] POST /v1/campaigns — step 2: updating sales profile", { brandId: brandResult.brandId });
-        await callExternalService(
-          externalServices.brand,
-          `/brands/${brandResult.brandId}/sales-profile`,
-          {
-            method: "PUT",
-            headers: buildInternalHeaders(req),
-            body: {
-              ...(urgency && { urgency }),
-              ...(scarcity && { scarcity }),
-              ...(riskReversal && { riskReversal }),
-              ...(socialProof && { socialProof }),
-            },
-          }
-        );
-        console.log("[api-service] POST /v1/campaigns — step 2 done: sales profile updated");
-      }
-    }
-
-    // 3. Forward to campaign-service (run tracking via x-run-id header)
-    // Derive `type` from workflowName
+    // 2. Forward to campaign-service (run tracking via x-run-id header)
+    //    Derive `type` from workflowName
     const { workflowName, ...restData } = parsed.data;
     const campaignType = deriveCampaignType(workflowName);
     const body: Record<string, unknown> = {
@@ -168,7 +142,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       if (body[key] != null) body[key] = String(body[key]);
     }
 
-    console.log("[api-service] POST /v1/campaigns — step 3: forwarding to campaign-service", {
+    console.log("[api-service] POST /v1/campaigns — step 2: forwarding to campaign-service", {
       brandId: body.brandId,
       workflowName: body.workflowName,
       type: body.type,
@@ -183,7 +157,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
         body,
       }
     );
-    console.log("[api-service] POST /v1/campaigns \u2014 step 4 done: campaign created", {
+    console.log("[api-service] POST /v1/campaigns \u2014 step 2 done: campaign created", {
       campaignId: (result as any).campaign?.id,
       status: (result as any).campaign?.status,
     });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1351,22 +1351,18 @@ const BrandDetailSchema = BrandSummarySchema.extend({
   categories: z.string().nullable().describe("Brand categories"),
 }).openapi("BrandDetail");
 
-const SalesProfileSchema = z
-  .object({
-    valueProposition: z.string().nullable().describe("Core value proposition"),
-    customerPainPoints: z.array(z.string()).describe("Target pain points"),
-    callToAction: z.string().nullable().describe("Primary CTA"),
-    companyOverview: z.string().nullable().describe("Company overview"),
-    competitors: z.array(z.string()).describe("Known competitors"),
-    productDifferentiators: z.array(z.string()).describe("Key differentiators"),
-    targetAudience: z.string().nullable().describe("Target audience description"),
-    keyFeatures: z.array(z.string()).describe("Key product features"),
-    extractionModel: z.string().nullable().describe("AI model used for extraction"),
-    extractedAt: z.string().describe("ISO timestamp of extraction"),
-    expiresAt: z.string().nullable().describe("ISO timestamp when profile expires"),
-    scrapedUrls: z.array(z.string()).describe("URLs that were scraped and analyzed during extraction"),
-  })
-  .openapi("SalesProfile");
+const ExtractFieldRequestSchema = z.object({
+  key: z.string().describe("Field key (e.g. 'industry', 'valueProposition')"),
+  description: z.string().describe("Description of what to extract"),
+}).openapi("ExtractFieldRequest");
+
+const ExtractFieldResultSchema = z.object({
+  key: z.string().describe("Field key"),
+  value: z.string().describe("Extracted value"),
+  cached: z.boolean().describe("Whether this result was served from cache"),
+  extractedAt: z.string().describe("ISO timestamp of extraction"),
+  expiresAt: z.string().describe("ISO timestamp when cached result expires"),
+}).openapi("ExtractFieldResult");
 
 registry.registerPath({
   method: "post",
@@ -1469,69 +1465,34 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: "get",
-  path: "/v1/brands/{id}/sales-profile",
-  tags: ["Brand"],
-  summary: "Get brand sales profile",
-  description:
-    "Get the sales profile for a brand. Returns 404 if none exists.",
-  security: authed,
-  request: { params: BrandIdParam },
-  responses: {
-    200: {
-      description: "Brand sales profile",
-      content: {
-        "application/json": {
-          schema: z.object({ profile: SalesProfileSchema }).openapi("GetSalesProfileResponse"),
-        },
-      },
-    },
-    401: { description: "Unauthorized", content: errorContent },
-    404: { description: "Sales profile not found", content: errorContent },
-    500: { description: "Internal error", content: errorContent },
-  },
-});
-
-registry.registerPath({
   method: "post",
-  path: "/v1/brands/{id}/sales-profile",
+  path: "/v1/brands/{id}/extract-fields",
   tags: ["Brand"],
-  summary: "Create brand sales profile",
+  summary: "Extract fields from brand",
   description:
-    "Trigger AI extraction to create a sales profile for the brand. Returns 409 if a profile already exists.",
+    "Generic field extraction: send fields you want with a key and description, and brand-service extracts them via AI. Results are cached 30 days per field. To reproduce the old sales-profile, send the same fields as items in the fields array. For discovery campaigns, send industry, suggestedAngles, suggestedGeo.",
   security: authed,
-  request: { params: BrandIdParam },
-  responses: {
-    200: {
-      description: "Sales profile created",
+  request: {
+    params: BrandIdParam,
+    body: {
       content: {
         "application/json": {
-          schema: z.object({ profile: SalesProfileSchema }).openapi("CreateSalesProfileResponse"),
+          schema: z.object({
+            fields: z.array(ExtractFieldRequestSchema).describe("Fields to extract"),
+          }).openapi("ExtractFieldsRequest"),
         },
       },
     },
-    400: { description: "Anthropic API key not configured", content: errorContent },
-    401: { description: "Unauthorized", content: errorContent },
-    409: { description: "Sales profile already exists", content: errorContent },
-    500: { description: "Internal error", content: errorContent },
   },
-});
-
-registry.registerPath({
-  method: "put",
-  path: "/v1/brands/{id}/sales-profile",
-  tags: ["Brand"],
-  summary: "Refresh brand sales profile",
-  description:
-    "Force re-extraction of the sales profile for the brand. Always bypasses the 30-day cache and triggers a fresh scraping + AI extraction. Use this when the brand's website has changed and the profile needs updating.",
-  security: authed,
-  request: { params: BrandIdParam },
   responses: {
     200: {
-      description: "Sales profile refreshed",
+      description: "Extracted field results",
       content: {
         "application/json": {
-          schema: z.object({ profile: SalesProfileSchema }).openapi("RefreshSalesProfileResponse"),
+          schema: z.object({
+            brandId: z.string().describe("Brand ID"),
+            results: z.array(ExtractFieldResultSchema).describe("Extraction results"),
+          }).openapi("ExtractFieldsResponse"),
         },
       },
     },
@@ -1617,7 +1578,7 @@ registry.registerPath({
   tags: ["Brand"],
   summary: "Get brand runs",
   description:
-    "Get extraction runs for a brand (sales-profile, icp-extraction) enriched with cost data",
+    "Get extraction runs for a brand (extract-fields, icp-extraction) enriched with cost data",
   security: authed,
   request: { params: BrandIdParam },
   responses: {

--- a/tests/unit/brand-sales-profile-404.regression.test.ts
+++ b/tests/unit/brand-sales-profile-404.regression.test.ts
@@ -3,10 +3,9 @@ import request from "supertest";
 import express from "express";
 
 /**
- * Sales profile endpoints (refactored):
- *   GET  /v1/brands/:id/sales-profile  → 200 if exists, 404 if not
- *   POST /v1/brands/:id/sales-profile  → 200 on extraction, 409 if exists, 400 on missing key
- *   PUT  /v1/brands/:id/sales-profile  → 200 on refresh, 400 on missing key
+ * POST /v1/brands/:id/extract-fields
+ * Generic field extraction proxy to brand-service.
+ * Replaces the old GET/POST/PUT sales-profile endpoints.
  */
 
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -34,7 +33,7 @@ function buildApp() {
   return app;
 }
 
-describe("GET /v1/brands/:id/sales-profile – read only", () => {
+describe("POST /v1/brands/:id/extract-fields", () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -42,125 +41,56 @@ describe("GET /v1/brands/:id/sales-profile – read only", () => {
     app = buildApp();
   });
 
-  it("should return 200 with profile when it exists", async () => {
-    const profile = {
-      cached: true,
+  it("should return 200 with extracted results", async () => {
+    const response = {
       brandId: "b-1",
-      profile: {
-        valueProposition: "Test",
-        scrapedUrls: ["https://example.com", "https://example.com/about"],
-      },
+      results: [
+        { key: "industry", value: "SaaS", cached: true, extractedAt: "2026-03-01T00:00:00Z", expiresAt: "2026-03-31T00:00:00Z" },
+        { key: "valueProposition", value: "All-in-one platform", cached: false, extractedAt: "2026-03-23T00:00:00Z", expiresAt: "2026-04-22T00:00:00Z" },
+      ],
     };
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: true,
-      json: () => Promise.resolve(profile),
+      json: () => Promise.resolve(response),
     }));
 
-    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
+    const res = await request(app)
+      .post("/v1/brands/some-brand-id/extract-fields")
+      .send({
+        fields: [
+          { key: "industry", description: "Brand sector" },
+          { key: "valueProposition", description: "Core value proposition" },
+        ],
+      });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(profile);
-    expect(res.body.profile.scrapedUrls).toEqual(["https://example.com", "https://example.com/about"]);
+    expect(res.body.brandId).toBe("b-1");
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.results[0].key).toBe("industry");
+    expect(res.body.results[0].cached).toBe(true);
   });
 
-  it("should return 404 when no profile exists", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 404,
-      text: () => Promise.resolve('{"error":"Sales profile not found"}'),
-    }));
-
-    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
-
-    expect(res.status).toBe(404);
-    expect(res.body.error).toContain("not found");
-  });
-
-  it("should return 500 for genuine server errors", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 500,
-      text: () => Promise.resolve('{"error":"Internal server error"}'),
-    }));
-
-    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
-
-    expect(res.status).toBe(500);
-  });
-});
-
-describe("POST /v1/brands/:id/sales-profile – create", () => {
-  let app: express.Express;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    app = buildApp();
-  });
-
-  it("should return 200 on successful extraction", async () => {
-    const profile = { cached: false, brandId: "b-1", profile: { valueProposition: "New" } };
+  it("should forward the request body to brand-service", async () => {
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: true,
-      json: () => Promise.resolve(profile),
+      json: () => Promise.resolve({ brandId: "b-1", results: [] }),
     }));
 
-    const res = await request(app).post("/v1/brands/some-brand-id/sales-profile");
+    const fields = [
+      { key: "industry", description: "Brand sector" },
+      { key: "suggestedAngles", description: "PR angles" },
+    ];
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual(profile);
-  });
+    await request(app)
+      .post("/v1/brands/some-brand-id/extract-fields")
+      .send({ fields });
 
-  it("should return 409 when profile already exists", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 409,
-      text: () => Promise.resolve('{"error":"Sales profile already exists"}'),
-    }));
-
-    const res = await request(app).post("/v1/brands/some-brand-id/sales-profile");
-
-    expect(res.status).toBe(409);
-    expect(res.body.error).toContain("already exists");
-  });
-
-  it("should return 400 when Anthropic key is missing", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 400,
-      text: () => Promise.resolve('{"error":"No Anthropic API key found"}'),
-    }));
-
-    const res = await request(app).post("/v1/brands/some-brand-id/sales-profile");
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain("Anthropic API key not configured");
-  });
-});
-
-describe("PUT /v1/brands/:id/sales-profile – refresh", () => {
-  let app: express.Express;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    app = buildApp();
-  });
-
-  it("should return 200 on successful refresh and pass ?force=true to brand-service", async () => {
-    const profile = { cached: false, brandId: "b-1", profile: { valueProposition: "Refreshed" } };
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: true,
-      json: () => Promise.resolve(profile),
-    }));
-
-    const res = await request(app).put("/v1/brands/some-brand-id/sales-profile");
-
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual(profile);
-
-    // Verify ?force=true is sent to brand-service
     const fetchCall = (global.fetch as any).mock.calls[0];
     const url = typeof fetchCall[0] === "string" ? fetchCall[0] : fetchCall[0].url;
-    expect(url).toContain("/brands/some-brand-id/sales-profile?force=true");
+    expect(url).toContain("/brands/some-brand-id/extract-fields");
+
+    const body = JSON.parse(fetchCall[1].body);
+    expect(body.fields).toEqual(fields);
   });
 
   it("should return 400 when Anthropic key is missing", async () => {
@@ -170,7 +100,9 @@ describe("PUT /v1/brands/:id/sales-profile – refresh", () => {
       text: () => Promise.resolve('{"error":"No Anthropic API key found"}'),
     }));
 
-    const res = await request(app).put("/v1/brands/some-brand-id/sales-profile");
+    const res = await request(app)
+      .post("/v1/brands/some-brand-id/extract-fields")
+      .send({ fields: [{ key: "industry", description: "Brand sector" }] });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Anthropic API key not configured");
@@ -183,8 +115,15 @@ describe("PUT /v1/brands/:id/sales-profile – refresh", () => {
       text: () => Promise.resolve('{"error":"Internal server error"}'),
     }));
 
-    const res = await request(app).put("/v1/brands/some-brand-id/sales-profile");
+    const res = await request(app)
+      .post("/v1/brands/some-brand-id/extract-fields")
+      .send({ fields: [{ key: "industry", description: "Brand sector" }] });
 
     expect(res.status).toBe(500);
+  });
+
+  it("should return 404 for old sales-profile endpoints", async () => {
+    const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
+    expect(res.status).toBe(404);
   });
 });

--- a/tests/unit/campaign-discovery.test.ts
+++ b/tests/unit/campaign-discovery.test.ts
@@ -93,9 +93,9 @@ describe("Discovery campaign creation", () => {
     expect(brandCall).toBeDefined();
     expect(brandCall!.body!.url).toBe("https://acme.com");
 
-    // Verify NO sales-profile update was made (discovery campaigns skip this)
-    const salesProfileCall = fetchCalls.find((c) => c.url.includes("/sales-profile"));
-    expect(salesProfileCall).toBeUndefined();
+    // Verify NO extract-fields or sales-profile call was made
+    const extractCall = fetchCalls.find((c) => c.url.includes("/extract-fields") || c.url.includes("/sales-profile"));
+    expect(extractCall).toBeUndefined();
 
     // Verify campaign-service received the correct type
     const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -54,14 +54,6 @@ describe("POST /v1/campaigns with targetAudience", () => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
       fetchCalls.push({ url, body });
 
-      // Sales profile update
-      if (url.includes("/sales-profile") && init?.method === "PUT") {
-        return {
-          ok: true,
-          json: () => Promise.resolve({ cached: false, brandId: "brand-uuid-123", profile: {} }),
-        };
-      }
-
       // Brand upsert
       if (url.includes("/brands") && init?.method === "POST") {
         return {
@@ -116,15 +108,9 @@ describe("POST /v1/campaigns with targetAudience", () => {
     expect(brandCall!.body!.url).toBe("https://example.com");
     expect(brandCall!.body!.orgId).toBe("org_test456");
 
-    // Verify sales-profile was called with the 4 marketing fields
-    const salesProfileCall = fetchCalls.find((c) => c.url.includes("/sales-profile"));
-    expect(salesProfileCall).toBeDefined();
-    expect(salesProfileCall!.url).toContain("/brands/brand-uuid-123/sales-profile");
-    expect(salesProfileCall!.url).not.toContain("force=true"); // campaign creation uses cache, not force re-extraction
-    expect(salesProfileCall!.body!.urgency).toBe("Recruitment closes in 30 days");
-    expect(salesProfileCall!.body!.scarcity).toBe("Only 10 spots available worldwide");
-    expect(salesProfileCall!.body!.riskReversal).toBe("Free trial for 2 weeks, no commitment");
-    expect(salesProfileCall!.body!.socialProof).toBe("Backed by 60 sponsors including Acme, Globex");
+    // sales-profile is no longer called — marketing fields go directly to campaign-service
+    const salesProfileCall = fetchCalls.find((c) => c.url.includes("/sales-profile") || c.url.includes("/extract-fields"));
+    expect(salesProfileCall).toBeUndefined();
 
     // Verify campaign-service received all fields including workflowName and derived type
     const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");

--- a/tests/unit/json-parse-error.regression.test.ts
+++ b/tests/unit/json-parse-error.regression.test.ts
@@ -54,7 +54,7 @@ describe("callExternalService – malformed JSON response handling", () => {
       json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
     }));
 
-    const res = await request(app).get("/v1/brands/test-brand/sales-profile");
+    const res = await request(app).get("/v1/brands/test-brand");
 
     expect(res.status).toBe(500);
     // The fix ensures callExternalService logs the error before re-throwing
@@ -70,7 +70,7 @@ describe("callExternalService – malformed JSON response handling", () => {
       json: () => Promise.reject(new SyntaxError("Unexpected token '<'")),
     }));
 
-    const res = await request(app).get("/v1/brands/test-brand/sales-profile");
+    const res = await request(app).get("/v1/brands/test-brand");
 
     expect(res.status).toBe(500);
     expect(consoleErrorSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Replaces `GET/POST/PUT /brands/:id/sales-profile` with `POST /brands/:id/extract-fields` — generic AI field extraction (brand-service PR #77)
- Removes the sales-profile PUT call from campaign creation flow (marketing fields already go to campaign-service)
- Updates OpenAPI spec and all affected tests (637/637 pass)

## Test plan
- [x] All 76 test files pass (637 tests)
- [x] OpenAPI spec regenerated
- [ ] Verify dashboard calls extract-fields instead of sales-profile after their migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)