### PR TITLE
feat: add sourceUrls to extract-fields response

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2120,6 +2120,14 @@
           "expiresAt": {
             "type": "string",
             "description": "ISO timestamp when cached result expires"
+          },
+          "sourceUrls": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "URLs scraped to extract this field. Null for pre-existing extractions."
           }
         },
         "required": [
@@ -2127,7 +2135,8 @@
           "value",
           "cached",
           "extractedAt",
-          "expiresAt"
+          "expiresAt",
+          "sourceUrls"
         ]
       },
       "ExtractFieldsResponse": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1362,6 +1362,7 @@ const ExtractFieldResultSchema = z.object({
   cached: z.boolean().describe("Whether this result was served from cache"),
   extractedAt: z.string().describe("ISO timestamp of extraction"),
   expiresAt: z.string().describe("ISO timestamp when cached result expires"),
+  sourceUrls: z.array(z.string()).nullable().describe("URLs scraped to extract this field. Null for pre-existing extractions."),
 }).openapi("ExtractFieldResult");
 
 registry.registerPath({


### PR DESCRIPTION
## Summary
- Adds `sourceUrls` (nullable string array) to `ExtractFieldResult` schema
- New extractions return the URLs that were scraped; pre-existing extractions return `null`
- OpenAPI spec regenerated

## Test plan
- [x] 637/637 tests pass
- [x] OpenAPI spec updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)