### PR TITLE
fix: type extract-fields value as string|array|object

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2106,8 +2106,24 @@
             "description": "Field key"
           },
           "value": {
-            "type": "string",
-            "description": "Extracted value"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "nullable": true
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "nullable": true
+                }
+              }
+            ],
+            "description": "Extracted value. Can be a string, an array (e.g. targetAudience returns a list of segments), or a structured object (e.g. socialProof returns an object with metrics, ecosystemSupport, etc.) depending on the field key."
           },
           "cached": {
             "type": "boolean",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1358,7 +1358,11 @@ const ExtractFieldRequestSchema = z.object({
 
 const ExtractFieldResultSchema = z.object({
   key: z.string().describe("Field key"),
-  value: z.string().describe("Extracted value"),
+  value: z.union([
+    z.string(),
+    z.array(z.unknown()),
+    z.record(z.unknown()),
+  ]).describe("Extracted value. Can be a string, an array (e.g. targetAudience returns a list of segments), or a structured object (e.g. socialProof returns an object with metrics, ecosystemSupport, etc.) depending on the field key."),
   cached: z.boolean().describe("Whether this result was served from cache"),
   extractedAt: z.string().describe("ISO timestamp of extraction"),
   expiresAt: z.string().describe("ISO timestamp when cached result expires"),


### PR DESCRIPTION
## Summary
- Changes `ExtractFieldResult.value` from `string` to `anyOf: [string, array, object]`
- Adds description documenting the possible shapes per field key
- OpenAPI spec regenerated

Fixes a bug where dashboard consumers treated all values as strings, causing arrays/objects to render as empty.

## Test plan
- [x] 637/637 tests pass
- [x] OpenAPI spec reflects `anyOf` union

🤖 Generated with [Claude Code](https://claude.com/claude-code)