### PR TITLE
feat: add x-feature-slug header support

### DIFF
--- a/src/lib/internal-headers.ts
+++ b/src/lib/internal-headers.ts
@@ -9,6 +9,7 @@ import { AuthenticatedRequest } from "../middleware/auth.js";
  * - x-campaign-id: Campaign ID from workflow-service (when available)
  * - x-brand-id: Brand ID from workflow-service (when available)
  * - x-workflow-name: Workflow name from workflow-service (when available)
+ * - x-feature-slug: Feature slug for tracking (when available)
  */
 export function buildInternalHeaders(req: AuthenticatedRequest): Record<string, string> {
   const headers: Record<string, string> = {};
@@ -18,5 +19,6 @@ export function buildInternalHeaders(req: AuthenticatedRequest): Record<string, 
   if (req.campaignId) headers["x-campaign-id"] = req.campaignId;
   if (req.brandId) headers["x-brand-id"] = req.brandId;
   if (req.workflowName) headers["x-workflow-name"] = req.workflowName;
+  if (req.featureSlug) headers["x-feature-slug"] = req.featureSlug;
   return headers;
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -11,6 +11,7 @@ export interface AuthenticatedRequest extends Request {
   campaignId?: string;
   brandId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }
 
 /**
@@ -88,9 +89,11 @@ export async function authenticate(
     const campaignId = req.headers["x-campaign-id"] as string | undefined;
     const brandId = req.headers["x-brand-id"] as string | undefined;
     const workflowName = req.headers["x-workflow-name"] as string | undefined;
+    const featureSlug = req.headers["x-feature-slug"] as string | undefined;
     if (campaignId) req.campaignId = campaignId;
     if (brandId) req.brandId = brandId;
     if (workflowName) req.workflowName = workflowName;
+    if (featureSlug) req.featureSlug = featureSlug;
 
     // Create a request run for tracking — mandatory, fail the request if runs-service is down
     if (req.orgId) {
@@ -99,6 +102,7 @@ export async function authenticate(
         if (req.brandId) runHeaders["x-brand-id"] = req.brandId;
         if (req.campaignId) runHeaders["x-campaign-id"] = req.campaignId;
         if (req.workflowName) runHeaders["x-workflow-name"] = req.workflowName;
+        if (req.featureSlug) runHeaders["x-feature-slug"] = req.featureSlug;
 
         const run = await createRun({
           orgId: req.orgId,

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -335,7 +335,7 @@ describe("Auth middleware — run creation is mandatory", () => {
     expect(res.body.error).toBe("Run tracking unavailable");
   });
 
-  it("should forward x-brand-id, x-campaign-id, x-workflow-name headers to createRun", async () => {
+  it("should forward x-brand-id, x-campaign-id, x-workflow-name, x-feature-slug headers to createRun", async () => {
     const { createRun } = await import("@distribute/runs-client");
     const mockCreateRun = vi.mocked(createRun);
     mockCreateRun.mockResolvedValueOnce({ id: "run-with-context" } as never);
@@ -352,7 +352,8 @@ describe("Auth middleware — run creation is mandatory", () => {
       .set("x-external-user-id", "ext_user_456")
       .set("x-brand-id", "brand-abc")
       .set("x-campaign-id", "campaign-xyz")
-      .set("x-workflow-name", "my-workflow");
+      .set("x-workflow-name", "my-workflow")
+      .set("x-feature-slug", "press-outreach");
 
     expect(res.status).toBe(200);
     expect(mockCreateRun).toHaveBeenCalledWith(
@@ -366,6 +367,7 @@ describe("Auth middleware — run creation is mandatory", () => {
         "x-brand-id": "brand-abc",
         "x-campaign-id": "campaign-xyz",
         "x-workflow-name": "my-workflow",
+        "x-feature-slug": "press-outreach",
       },
     );
   });

--- a/tests/unit/header-forwarding-audit.test.ts
+++ b/tests/unit/header-forwarding-audit.test.ts
@@ -75,12 +75,16 @@ describe("header forwarding audit", () => {
     it("should extract x-workflow-name from incoming request", () => {
       expect(src).toContain('req.headers["x-workflow-name"]');
     });
+
+    it("should extract x-feature-slug from incoming request", () => {
+      expect(src).toContain('req.headers["x-feature-slug"]');
+    });
   });
 
   describe("internal-headers.ts — workflow tracking headers forwarding", () => {
     const src = readSrc("src/lib/internal-headers.ts");
 
-    for (const header of ["x-campaign-id", "x-brand-id", "x-workflow-name"]) {
+    for (const header of ["x-campaign-id", "x-brand-id", "x-workflow-name", "x-feature-slug"]) {
       it(`should forward ${header} to downstream services`, () => {
         expect(src).toContain(`headers["${header}"]`);
       });


### PR DESCRIPTION
## Summary
- Accept `x-feature-slug` header on all authenticated endpoints (via auth middleware)
- Propagate it to downstream service-to-service calls (via `buildInternalHeaders`)
- Forward it to runs-service on run creation (for tracking)
- Follows the exact same pattern as `x-campaign-id`, `x-brand-id`, `x-workflow-name`

## Test plan
- [x] Auth middleware test updated: verifies `x-feature-slug` is forwarded to `createRun`
- [x] Header forwarding audit test updated: verifies extraction and propagation
- [x] All 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)