### PR TITLE
feat: proxy features-service endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4918,6 +4918,42 @@
           "_usage",
           "services"
         ]
+      },
+      "FeaturesListResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "FeatureResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "FeatureInputsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "FeaturePrefillResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "FeaturePrefillRequest": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "description": "Brand UUID to prefill from"
+          }
+        },
+        "required": [
+          "brandId"
+        ]
+      },
+      "FeaturesBatchUpsertResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "FeaturesBatchUpsertRequest": {
+        "type": "object",
+        "properties": {}
       }
     },
     "parameters": {}
@@ -16318,6 +16354,642 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/features": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "List features",
+        "description": "List available features with optional filters. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by status"
+            },
+            "required": false,
+            "description": "Filter by status",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by category"
+            },
+            "required": false,
+            "description": "Filter by category",
+            "name": "category",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by channel"
+            },
+            "required": false,
+            "description": "Filter by channel",
+            "name": "channel",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by audience type"
+            },
+            "required": false,
+            "description": "Filter by audience type",
+            "name": "audienceType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by implementation status ('true' or 'false')"
+            },
+            "required": false,
+            "description": "Filter by implementation status ('true' or 'false')",
+            "name": "implemented",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of features",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturesListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Batch upsert features",
+        "description": "Idempotent batch upsert of feature definitions. Used for cold-start registration. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeaturesBatchUpsertRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upsert result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturesBatchUpsertResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/features/{slug}": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Get feature by slug",
+        "description": "Get a single feature definition by its slug. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "slug",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/{slug}/inputs": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Get feature input schema",
+        "description": "Get the input schema (required and optional fields) for a feature. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "slug",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature input schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureInputsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/{slug}/prefill": {
+      "post": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Prefill feature form from brand",
+        "description": "Prefill the 'New Campaign' form for a feature using brand data. Features-service calls brand-service internally to extract values. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "slug",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeaturePrefillRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Prefilled feature inputs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturePrefillResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import emailGatewayRoutes from "./routes/email-gateway.js";
 import runsRoutes from "./routes/runs.js";
 import contentRoutes from "./routes/content.js";
 import pressKitsRoutes from "./routes/press-kits.js";
+import featuresRoutes from "./routes/features.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
@@ -173,6 +174,7 @@ app.use("/v1", emailGatewayRoutes);
 app.use("/v1", runsRoutes);
 app.use("/v1", contentRoutes);
 app.use("/v1", pressKitsRoutes); // authenticated press-kit endpoints
+app.use("/v1", featuresRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -84,6 +84,10 @@ export const externalServices = {
     url: process.env.JOURNALIST_SERVICE_URL || "http://localhost:3031",
     apiKey: process.env.JOURNALIST_SERVICE_API_KEY || "",
   },
+  features: {
+    url: process.env.FEATURES_SERVICE_URL || "http://localhost:3032",
+    apiKey: process.env.FEATURES_SERVICE_API_KEY || "",
+  },
 };
 
 interface ServiceCallOptions {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -1,0 +1,111 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+/**
+ * GET /v1/features
+ * List features with optional filters
+ */
+router.get("/features", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["status", "category", "channel", "audienceType", "implemented"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/features${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("List features error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list features" });
+  }
+});
+
+/**
+ * GET /v1/features/:slug
+ * Get a single feature by slug
+ */
+router.get("/features/:slug", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get feature error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature" });
+  }
+});
+
+/**
+ * GET /v1/features/:slug/inputs
+ * Get input schema for a feature
+ */
+router.get("/features/:slug/inputs", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}/inputs`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get feature inputs error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature inputs" });
+  }
+});
+
+/**
+ * POST /v1/features/:slug/prefill
+ * Prefill feature form using brand data. Called by dashboard for "New Campaign".
+ */
+router.post("/features/:slug/prefill", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}/prefill`,
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Prefill feature error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to prefill feature" });
+  }
+});
+
+/**
+ * PUT /v1/features
+ * Batch upsert features (cold-start registration)
+ */
+router.put("/features", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      "/features",
+      {
+        method: "PUT",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Batch upsert features error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to upsert features" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4009,3 +4009,112 @@ registry.registerPath({
     500: { description: "Internal error", content: errorContent },
   },
 });
+
+// ===================================================================
+// FEATURES (proxy to features-service)
+// ===================================================================
+
+const FeaturePrefillRequestSchema = z
+  .object({
+    brandId: z.string().describe("Brand UUID to prefill from"),
+  })
+  .openapi("FeaturePrefillRequest");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/features",
+  tags: ["Features"],
+  summary: "List features",
+  description:
+    "List available features with optional filters. " +
+    "Proxied from features-service.",
+  security: authed,
+  request: {
+    query: z.object({
+      status: z.string().optional().describe("Filter by status"),
+      category: z.string().optional().describe("Filter by category"),
+      channel: z.string().optional().describe("Filter by channel"),
+      audienceType: z.string().optional().describe("Filter by audience type"),
+      implemented: z.string().optional().describe("Filter by implementation status ('true' or 'false')"),
+    }),
+  },
+  responses: {
+    200: { description: "List of features", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturesListResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/{slug}",
+  tags: ["Features"],
+  summary: "Get feature by slug",
+  description: "Get a single feature definition by its slug. Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ slug: z.string().describe("Feature slug") }),
+  },
+  responses: {
+    200: { description: "Feature details", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/{slug}/inputs",
+  tags: ["Features"],
+  summary: "Get feature input schema",
+  description: "Get the input schema (required and optional fields) for a feature. Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ slug: z.string().describe("Feature slug") }),
+  },
+  responses: {
+    200: { description: "Feature input schema", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureInputsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/features/{slug}/prefill",
+  tags: ["Features"],
+  summary: "Prefill feature form from brand",
+  description:
+    "Prefill the 'New Campaign' form for a feature using brand data. " +
+    "Features-service calls brand-service internally to extract values. Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ slug: z.string().describe("Feature slug") }),
+    body: { content: { "application/json": { schema: FeaturePrefillRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Prefilled feature inputs", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturePrefillResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/features",
+  tags: ["Features"],
+  summary: "Batch upsert features",
+  description: "Idempotent batch upsert of feature definitions. Used for cold-start registration. Proxied from features-service.",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturesBatchUpsertRequest") } } },
+  },
+  responses: {
+    200: { description: "Upsert result", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturesBatchUpsertResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/features.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+describe("Features proxy routes", () => {
+  it("should have GET /features with auth", () => {
+    expect(content).toContain('"/features"');
+    expect(content).toContain("router.get");
+  });
+
+  it("should forward query params on GET /features", () => {
+    for (const param of ["status", "category", "channel", "audienceType", "implemented"]) {
+      expect(content).toContain(`"${param}"`);
+    }
+  });
+
+  it("should have GET /features/:slug with auth", () => {
+    expect(content).toContain('"/features/:slug"');
+  });
+
+  it("should have GET /features/:slug/inputs with auth", () => {
+    expect(content).toContain('"/features/:slug/inputs"');
+  });
+
+  it("should have POST /features/:slug/prefill with auth + requireOrg + requireUser", () => {
+    expect(content).toContain('"/features/:slug/prefill"');
+    const prefillLine = content.split("\n").find((l) =>
+      l.includes('"/features/:slug/prefill"')
+    );
+    expect(prefillLine).toContain("authenticate");
+    expect(prefillLine).toContain("requireOrg");
+    expect(prefillLine).toContain("requireUser");
+  });
+
+  it("should have PUT /features for batch upsert with auth", () => {
+    expect(content).toContain("router.put");
+    const putLine = content.split("\n").find((l) =>
+      l.includes("router.put") && l.includes('"/features"')
+    );
+    expect(putLine).toBeDefined();
+    expect(putLine).toContain("authenticate");
+  });
+
+  it("should use buildInternalHeaders for all endpoints", () => {
+    expect(content).toContain("buildInternalHeaders");
+    const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(headerMatches).not.toBeNull();
+    expect(headerMatches!.length).toBe(5);
+  });
+
+  it("should proxy to externalServices.features", () => {
+    expect(content).toContain("externalServices.features");
+  });
+});
+
+describe("Features service client", () => {
+  it("should have features in externalServices", () => {
+    expect(serviceClientContent).toContain("features:");
+    expect(serviceClientContent).toContain("FEATURES_SERVICE_URL");
+    expect(serviceClientContent).toContain("FEATURES_SERVICE_API_KEY");
+  });
+});
+
+describe("Features OpenAPI schemas", () => {
+  it("should register GET /v1/features", () => {
+    expect(schemaContent).toContain('path: "/v1/features"');
+  });
+
+  it("should register GET /v1/features/{slug}", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{slug}"');
+  });
+
+  it("should register GET /v1/features/{slug}/inputs", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{slug}/inputs"');
+  });
+
+  it("should register POST /v1/features/{slug}/prefill", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{slug}/prefill"');
+  });
+
+  it("should register PUT /v1/features for batch upsert", () => {
+    const putMatch = schemaContent.match(/method: "put",\s*\n\s*path: "\/v1\/features"/);
+    expect(putMatch).not.toBeNull();
+  });
+
+  it("should use Features tag", () => {
+    expect(schemaContent).toContain('tags: ["Features"]');
+  });
+
+  it("should define FeaturePrefillRequest schema with brandId", () => {
+    expect(schemaContent).toContain("FeaturePrefillRequest");
+    expect(schemaContent).toContain("brandId");
+  });
+});
+
+describe("Features routes are mounted in index.ts", () => {
+  it("should import and mount features routes", () => {
+    expect(indexContent).toContain("featuresRoutes");
+    expect(indexContent).toContain("./routes/features");
+  });
+
+  it("should mount at /v1", () => {
+    expect(indexContent).toContain('app.use("/v1", featuresRoutes)');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `features` to `externalServices` (`FEATURES_SERVICE_URL` / `FEATURES_SERVICE_API_KEY`)
- Proxy 5 endpoints from features-service:
  - `GET /v1/features` — list with filters (status, category, channel, audienceType, implemented)
  - `GET /v1/features/:slug` — get feature by slug
  - `GET /v1/features/:slug/inputs` — get input schema
  - `POST /v1/features/:slug/prefill` — prefill form from brand (requires org+user)
  - `PUT /v1/features` — batch upsert (cold-start)
- OpenAPI spec with `Features` tag and `FeaturePrefillRequest` schema
- 18 tests covering routes, service client, OpenAPI schemas, and index mounting

## Test plan
- [x] All 659 tests pass (78 files)
- [x] OpenAPI spec regenerated with all 5 features endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)