### PR TITLE
docs: typed response schemas for prefill endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4931,9 +4931,71 @@
         "type": "object",
         "properties": {}
       },
-      "FeaturePrefillResponse": {
+      "FeaturePrefillFullValue": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "value": {
+            "nullable": true,
+            "description": "The prefilled value (string, object, or null)"
+          },
+          "cached": {
+            "type": "boolean",
+            "description": "Whether this value was served from cache"
+          },
+          "sourceUrls": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "URLs used to extract this value, or null"
+          }
+        },
+        "required": [
+          "cached",
+          "sourceUrls"
+        ]
+      },
+      "FeaturePrefillFullResponse": {
+        "type": "object",
+        "properties": {
+          "prefilled": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FeaturePrefillFullValue"
+            },
+            "description": "Map of field name to rich prefill object with value, cached flag, and source URLs"
+          }
+        },
+        "required": [
+          "prefilled"
+        ]
+      },
+      "FeaturePrefillTextResponse": {
+        "type": "object",
+        "properties": {
+          "prefilled": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Map of field name to flat string value (or null)"
+          }
+        },
+        "required": [
+          "prefilled"
+        ]
+      },
+      "FeaturePrefillResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/FeaturePrefillFullResponse"
+          },
+          {
+            "$ref": "#/components/schemas/FeaturePrefillTextResponse"
+          }
+        ]
       },
       "FeaturePrefillRequest": {
         "type": "object",
@@ -16964,7 +17026,7 @@
         },
         "responses": {
           "200": {
-            "description": "Prefilled feature inputs",
+            "description": "Prefilled feature inputs. Shape depends on `format` query param.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4020,6 +4020,30 @@ const FeaturePrefillRequestSchema = z
   })
   .openapi("FeaturePrefillRequest");
 
+const FeaturePrefillFullValueSchema = z
+  .object({
+    value: z.any().describe("The prefilled value (string, object, or null)"),
+    cached: z.boolean().describe("Whether this value was served from cache"),
+    sourceUrls: z.array(z.string()).nullable().describe("URLs used to extract this value, or null"),
+  })
+  .openapi("FeaturePrefillFullValue");
+
+const FeaturePrefillFullResponseSchema = z
+  .object({
+    prefilled: z
+      .record(z.string(), FeaturePrefillFullValueSchema)
+      .describe("Map of field name to rich prefill object with value, cached flag, and source URLs"),
+  })
+  .openapi("FeaturePrefillFullResponse");
+
+const FeaturePrefillTextResponseSchema = z
+  .object({
+    prefilled: z
+      .record(z.string(), z.string().nullable())
+      .describe("Map of field name to flat string value (or null)"),
+  })
+  .openapi("FeaturePrefillTextResponse");
+
 registry.registerPath({
   method: "get",
   path: "/v1/features",
@@ -4102,7 +4126,14 @@ registry.registerPath({
     body: { content: { "application/json": { schema: FeaturePrefillRequestSchema } } },
   },
   responses: {
-    200: { description: "Prefilled feature inputs", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturePrefillResponse") } } },
+    200: {
+      description: "Prefilled feature inputs. Shape depends on `format` query param.",
+      content: {
+        "application/json": {
+          schema: z.union([FeaturePrefillFullResponseSchema, FeaturePrefillTextResponseSchema]).openapi("FeaturePrefillResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     500: { description: "Internal error", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -100,6 +100,15 @@ describe("Features OpenAPI schemas", () => {
     expect(schemaContent).toContain("format:");
   });
 
+  it("should define typed response schemas for both prefill formats", () => {
+    expect(schemaContent).toContain("FeaturePrefillFullResponse");
+    expect(schemaContent).toContain("FeaturePrefillTextResponse");
+    expect(schemaContent).toContain("FeaturePrefillFullValue");
+    // full format fields
+    expect(schemaContent).toContain("cached");
+    expect(schemaContent).toContain("sourceUrls");
+  });
+
   it("should register PUT /v1/features for batch upsert", () => {
     const putMatch = schemaContent.match(/method: "put",\s*\n\s*path: "\/v1\/features"/);
     expect(putMatch).not.toBeNull();


### PR DESCRIPTION
## Summary
- Replaces empty `FeaturePrefillResponse` schema with two typed schemas documenting both `format` modes
- `format=full` (default): `{ prefilled: { [key]: { value, cached, sourceUrls } } }`
- `format=text`: `{ prefilled: { [key]: string | null } }`
- Adds test coverage for response schema definitions

## Test plan
- [x] 21/21 unit tests pass
- [x] OpenAPI spec regenerated with full schema definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)