### PR TITLE
fix: log fetch error cause and full URL

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -133,7 +133,8 @@ export async function callExternalService<T>(
 
     return await response.json();
   } catch (error: any) {
-    console.error(`[callExternalService] ${method} ${path} failed:`, error.message);
+    const cause = error.cause ? ` (cause: ${error.cause?.code || error.cause?.message || error.cause})` : "";
+    console.error(`[callExternalService] ${method} ${url} failed: ${error.message}${cause}`);
     throw error;
   }
 }

--- a/tests/unit/service-client-error-handling.test.ts
+++ b/tests/unit/service-client-error-handling.test.ts
@@ -42,6 +42,24 @@ describe("callExternalService error handling", () => {
     );
   });
 
+  it("should log fetch cause when fetch itself fails (e.g. DNS/network)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const networkError = new TypeError("fetch failed");
+    (networkError as any).cause = { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND badhost" };
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(networkError));
+
+    await expect(callExternalService(service, "/resolve", { method: "POST" })).rejects.toThrow("fetch failed");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("(cause: ENOTFOUND)"),
+    );
+    // Should log the full URL, not just the path
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("http://localhost:9999/resolve"),
+    );
+  });
+
   it("should use status code when JSON has no error field", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- Surfaces `error.cause` (e.g. `ENOTFOUND`, `ECONNREFUSED`) in `callExternalService` log lines — previously only showed the unhelpful "fetch failed"
- Logs the full URL instead of just the path, so we can see which host/env var is involved
- Adds regression test for network-level fetch failures

## Context
Production logs show repeated `fetch failed` across all downstream services with no indication of the root cause. This makes it impossible to distinguish between DNS failures, missing env vars, and Railway networking issues.

## Test plan
- [x] Existing service-client tests pass
- [x] New test verifies cause code and full URL appear in error log

🤖 Generated with [Claude Code](https://claude.com/claude-code)