### PR TITLE
docs: add typed OpenAPI schemas for features endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -66,6 +66,10 @@
     {
       "name": "Platform",
       "description": "Service discovery and platform configuration"
+    },
+    {
+      "name": "Features",
+      "description": "Feature definitions — inputs, outputs, charts, and metadata"
     }
   ],
   "components": {
@@ -4886,17 +4890,460 @@
           "services"
         ]
       },
+      "FeatureInput": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Input field key"
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "text",
+              "textarea",
+              "number",
+              "select"
+            ],
+            "description": "Input field type"
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "Placeholder text"
+          },
+          "description": {
+            "type": "string",
+            "description": "Help text for the field"
+          },
+          "extractKey": {
+            "type": "string",
+            "description": "Brand extraction key used by prefill"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Options for select-type inputs"
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "type",
+          "placeholder",
+          "description",
+          "extractKey"
+        ]
+      },
+      "FeatureOutput": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Output metric key"
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "count",
+              "rate",
+              "currency",
+              "percentage"
+            ],
+            "description": "Output metric type"
+          },
+          "displayOrder": {
+            "type": "integer",
+            "description": "Display order in UI"
+          },
+          "showInCampaignRow": {
+            "type": "boolean",
+            "description": "Show in campaign row summary"
+          },
+          "showInFunnel": {
+            "type": "boolean",
+            "description": "Show in funnel chart"
+          },
+          "funnelOrder": {
+            "type": "integer",
+            "description": "Order in funnel visualization"
+          },
+          "numeratorKey": {
+            "type": "string",
+            "description": "Key for rate numerator"
+          },
+          "denominatorKey": {
+            "type": "string",
+            "description": "Key for rate denominator"
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "type",
+          "displayOrder",
+          "showInCampaignRow",
+          "showInFunnel"
+        ]
+      },
+      "WorkflowColumn": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Column key"
+          },
+          "label": {
+            "type": "string",
+            "description": "Column label"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "rate",
+              "currency",
+              "count"
+            ],
+            "description": "Column data type"
+          },
+          "numeratorKey": {
+            "type": "string",
+            "description": "Key for rate numerator"
+          },
+          "denominatorKey": {
+            "type": "string",
+            "description": "Key for rate denominator"
+          },
+          "sortDirection": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "description": "Default sort direction"
+          },
+          "displayOrder": {
+            "type": "integer",
+            "description": "Display order"
+          },
+          "defaultSort": {
+            "type": "boolean",
+            "description": "Whether this column is the default sort"
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "type",
+          "sortDirection",
+          "displayOrder"
+        ]
+      },
+      "FeatureChart": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "funnel-bar"
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "displayOrder": {
+                "type": "integer"
+              },
+              "steps": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "statsField": {
+                      "type": "string"
+                    },
+                    "rateBasedOn": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "label",
+                    "statsField",
+                    "rateBasedOn"
+                  ]
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "key",
+              "type",
+              "title",
+              "displayOrder",
+              "steps"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "breakdown-bar"
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "displayOrder": {
+                "type": "integer"
+              },
+              "segments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "statsField": {
+                      "type": "string"
+                    },
+                    "color": {
+                      "type": "string",
+                      "enum": [
+                        "green",
+                        "blue",
+                        "red",
+                        "gray",
+                        "orange"
+                      ]
+                    },
+                    "sentiment": {
+                      "type": "string",
+                      "enum": [
+                        "positive",
+                        "neutral",
+                        "negative"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "label",
+                    "statsField",
+                    "color",
+                    "sentiment"
+                  ]
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "key",
+              "type",
+              "title",
+              "displayOrder",
+              "segments"
+            ]
+          }
+        ]
+      },
+      "Feature": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Unique feature slug"
+          },
+          "name": {
+            "type": "string",
+            "description": "Feature name"
+          },
+          "description": {
+            "type": "string",
+            "description": "Feature description"
+          },
+          "icon": {
+            "type": "string",
+            "description": "Icon identifier"
+          },
+          "category": {
+            "type": "string",
+            "description": "Feature category"
+          },
+          "channel": {
+            "type": "string",
+            "description": "Communication channel"
+          },
+          "audienceType": {
+            "type": "string",
+            "description": "Target audience type"
+          },
+          "implemented": {
+            "type": "boolean",
+            "description": "Whether the feature is implemented"
+          },
+          "displayOrder": {
+            "type": "integer",
+            "description": "Display order"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "deprecated"
+            ],
+            "description": "Feature status"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeatureInput"
+            },
+            "description": "Input field definitions"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeatureOutput"
+            },
+            "description": "Output metric definitions"
+          },
+          "workflowColumns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowColumn"
+            },
+            "description": "Workflow table columns"
+          },
+          "charts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeatureChart"
+            },
+            "description": "Chart configurations"
+          },
+          "resultComponent": {
+            "type": "string",
+            "nullable": true,
+            "description": "Custom result component name"
+          },
+          "defaultWorkflowName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Default workflow name"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO timestamp"
+          }
+        },
+        "required": [
+          "slug",
+          "name",
+          "description",
+          "icon",
+          "category",
+          "channel",
+          "audienceType",
+          "implemented",
+          "displayOrder",
+          "status",
+          "inputs",
+          "outputs"
+        ]
+      },
       "FeaturesListResponse": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "features": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Feature"
+            },
+            "description": "Array of feature definitions"
+          }
+        },
+        "required": [
+          "features"
+        ]
       },
       "FeatureResponse": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "feature": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Feature"
+              },
+              {
+                "description": "Feature definition"
+              }
+            ]
+          }
+        },
+        "required": [
+          "feature"
+        ]
       },
       "FeatureInputsResponse": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Feature slug"
+          },
+          "name": {
+            "type": "string",
+            "description": "Feature name"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeatureInput"
+            },
+            "description": "Input field definitions"
+          }
+        },
+        "required": [
+          "slug",
+          "name",
+          "inputs"
+        ]
       },
       "FeaturePrefillFullValue": {
         "type": "object",
@@ -4978,11 +5425,139 @@
       },
       "FeaturesBatchUpsertResponse": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "features": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Feature"
+                },
+                {
+                  "nullable": true
+                }
+              ]
+            },
+            "description": "Upserted features (null entries indicate failures)"
+          }
+        },
+        "required": [
+          "features"
+        ]
       },
       "FeaturesBatchUpsertRequest": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Feature name"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Feature description"
+                },
+                "icon": {
+                  "type": "string",
+                  "description": "Icon identifier"
+                },
+                "category": {
+                  "type": "string",
+                  "description": "Feature category"
+                },
+                "channel": {
+                  "type": "string",
+                  "description": "Communication channel"
+                },
+                "audienceType": {
+                  "type": "string",
+                  "description": "Target audience type"
+                },
+                "implemented": {
+                  "type": "boolean",
+                  "description": "Whether the feature is implemented"
+                },
+                "displayOrder": {
+                  "type": "integer",
+                  "description": "Display order"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "draft",
+                    "deprecated"
+                  ],
+                  "description": "Feature status"
+                },
+                "inputs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FeatureInput"
+                  },
+                  "description": "Input field definitions"
+                },
+                "outputs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FeatureOutput"
+                  },
+                  "description": "Output metric definitions"
+                },
+                "workflowColumns": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowColumn"
+                  },
+                  "description": "Workflow table columns"
+                },
+                "charts": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FeatureChart"
+                  },
+                  "description": "Chart configurations"
+                },
+                "resultComponent": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Custom result component name"
+                },
+                "defaultWorkflowName": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Default workflow name"
+                },
+                "slug": {
+                  "type": "string",
+                  "description": "Feature slug (auto-generated from name if omitted)"
+                }
+              },
+              "required": [
+                "name",
+                "description",
+                "icon",
+                "category",
+                "channel",
+                "audienceType",
+                "implemented",
+                "displayOrder",
+                "status",
+                "inputs",
+                "outputs"
+              ]
+            },
+            "minItems": 1,
+            "description": "Array of features to upsert"
+          }
+        },
+        "required": [
+          "features"
+        ]
       }
     },
     "parameters": {}

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -69,6 +69,7 @@ Authorization: Bearer distrib.usr_abc123...
     { name: "Billing", description: "Billing, credits, and checkout" },
     { name: "Internal", description: "Platform-level operations (API key auth, no identity headers)" },
     { name: "Platform", description: "Service discovery and platform configuration" },
+    { name: "Features", description: "Feature definitions — inputs, outputs, charts, and metadata" },
   ],
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3981,6 +3981,94 @@ registry.registerPath({
 // FEATURES (proxy to features-service)
 // ===================================================================
 
+// --- Shared sub-schemas for features ---
+
+const FeatureInputSchema = z.object({
+  key: z.string().describe("Input field key"),
+  label: z.string().describe("Human-readable label"),
+  type: z.enum(["text", "textarea", "number", "select"]).describe("Input field type"),
+  placeholder: z.string().describe("Placeholder text"),
+  description: z.string().describe("Help text for the field"),
+  extractKey: z.string().describe("Brand extraction key used by prefill"),
+  options: z.array(z.string()).optional().describe("Options for select-type inputs"),
+}).openapi("FeatureInput");
+
+const FeatureOutputSchema = z.object({
+  key: z.string().describe("Output metric key"),
+  label: z.string().describe("Human-readable label"),
+  type: z.enum(["count", "rate", "currency", "percentage"]).describe("Output metric type"),
+  displayOrder: z.number().int().describe("Display order in UI"),
+  showInCampaignRow: z.boolean().describe("Show in campaign row summary"),
+  showInFunnel: z.boolean().describe("Show in funnel chart"),
+  funnelOrder: z.number().int().optional().describe("Order in funnel visualization"),
+  numeratorKey: z.string().optional().describe("Key for rate numerator"),
+  denominatorKey: z.string().optional().describe("Key for rate denominator"),
+}).openapi("FeatureOutput");
+
+const WorkflowColumnSchema = z.object({
+  key: z.string().describe("Column key"),
+  label: z.string().describe("Column label"),
+  type: z.enum(["rate", "currency", "count"]).describe("Column data type"),
+  numeratorKey: z.string().optional().describe("Key for rate numerator"),
+  denominatorKey: z.string().optional().describe("Key for rate denominator"),
+  sortDirection: z.enum(["asc", "desc"]).describe("Default sort direction"),
+  displayOrder: z.number().int().describe("Display order"),
+  defaultSort: z.boolean().optional().describe("Whether this column is the default sort"),
+}).openapi("WorkflowColumn");
+
+const FunnelBarStepSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  statsField: z.string(),
+  rateBasedOn: z.string().nullable(),
+});
+
+const BreakdownBarSegmentSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  statsField: z.string(),
+  color: z.enum(["green", "blue", "red", "gray", "orange"]),
+  sentiment: z.enum(["positive", "neutral", "negative"]),
+});
+
+const FeatureChartSchema = z.union([
+  z.object({
+    key: z.string(),
+    type: z.literal("funnel-bar"),
+    title: z.string(),
+    displayOrder: z.number().int(),
+    steps: z.array(FunnelBarStepSchema).min(1),
+  }),
+  z.object({
+    key: z.string(),
+    type: z.literal("breakdown-bar"),
+    title: z.string(),
+    displayOrder: z.number().int(),
+    segments: z.array(BreakdownBarSegmentSchema).min(1),
+  }),
+]).openapi("FeatureChart");
+
+const FeatureObjectSchema = z.object({
+  slug: z.string().describe("Unique feature slug"),
+  name: z.string().describe("Feature name"),
+  description: z.string().describe("Feature description"),
+  icon: z.string().describe("Icon identifier"),
+  category: z.string().describe("Feature category"),
+  channel: z.string().describe("Communication channel"),
+  audienceType: z.string().describe("Target audience type"),
+  implemented: z.boolean().describe("Whether the feature is implemented"),
+  displayOrder: z.number().int().describe("Display order"),
+  status: z.enum(["active", "draft", "deprecated"]).describe("Feature status"),
+  inputs: z.array(FeatureInputSchema).describe("Input field definitions"),
+  outputs: z.array(FeatureOutputSchema).describe("Output metric definitions"),
+  workflowColumns: z.array(WorkflowColumnSchema).optional().describe("Workflow table columns"),
+  charts: z.array(FeatureChartSchema).optional().describe("Chart configurations"),
+  resultComponent: z.string().nullable().optional().describe("Custom result component name"),
+  defaultWorkflowName: z.string().nullable().optional().describe("Default workflow name"),
+  createdAt: z.string().optional().describe("ISO timestamp"),
+  updatedAt: z.string().optional().describe("ISO timestamp"),
+}).openapi("Feature");
+
 const FeaturePrefillRequestSchema = z
   .object({
     brandId: z.string().describe("Brand UUID to prefill from"),
@@ -4030,7 +4118,7 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "List of features", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturesListResponse") } } },
+    200: { description: "List of features", content: { "application/json": { schema: z.object({ features: z.array(FeatureObjectSchema).describe("Array of feature definitions") }).openapi("FeaturesListResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
@@ -4047,7 +4135,7 @@ registry.registerPath({
     params: z.object({ slug: z.string().describe("Feature slug") }),
   },
   responses: {
-    200: { description: "Feature details", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureResponse") } } },
+    200: { description: "Feature details", content: { "application/json": { schema: z.object({ feature: FeatureObjectSchema.describe("Feature definition") }).openapi("FeatureResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     500: { description: "Internal error", content: errorContent },
@@ -4065,7 +4153,7 @@ registry.registerPath({
     params: z.object({ slug: z.string().describe("Feature slug") }),
   },
   responses: {
-    200: { description: "Feature input schema", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureInputsResponse") } } },
+    200: { description: "Feature input schema", content: { "application/json": { schema: z.object({ slug: z.string().describe("Feature slug"), name: z.string().describe("Feature name"), inputs: z.array(FeatureInputSchema).describe("Input field definitions") }).openapi("FeatureInputsResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     500: { description: "Internal error", content: errorContent },
@@ -4115,10 +4203,10 @@ registry.registerPath({
   description: "Idempotent batch upsert of feature definitions. Used for cold-start registration. Proxied from features-service.",
   security: authed,
   request: {
-    body: { content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturesBatchUpsertRequest") } } },
+    body: { content: { "application/json": { schema: z.object({ features: z.array(FeatureObjectSchema.omit({ slug: true, createdAt: true, updatedAt: true }).extend({ slug: z.string().optional().describe("Feature slug (auto-generated from name if omitted)") })).min(1).describe("Array of features to upsert") }).openapi("FeaturesBatchUpsertRequest") } } },
   },
   responses: {
-    200: { description: "Upsert result", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturesBatchUpsertResponse") } } },
+    200: { description: "Upsert result", content: { "application/json": { schema: z.object({ features: z.array(FeatureObjectSchema.nullable()).describe("Upserted features (null entries indicate failures)") }).openapi("FeaturesBatchUpsertResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },


### PR DESCRIPTION
## Summary
- Fill in 5 empty feature schemas (FeatureResponse, FeaturesListResponse, FeatureInputsResponse, FeaturesBatchUpsertRequest, FeaturesBatchUpsertResponse) with full typed definitions matching features-service
- Add reusable component schemas: Feature, FeatureInput, FeatureOutput, WorkflowColumn, FeatureChart
- Add missing "Features" tag to the OpenAPI tags list

## Test plan
- [x] `pnpm build` passes (includes `tsc` + `generate:openapi`)
- [x] `pnpm test` — 77/78 test files pass, 1 pre-existing failure (json-parse-error.regression.test.ts, unrelated)
- [x] Verified all 5 previously empty schemas now have properties via openapi.json inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)