### PR TITLE
fix: forward featureSlug query param on ranked workflows

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5145,6 +5145,16 @@
             "description": "Filter by brand ID",
             "name": "brandId",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug (e.g. 'pr-cold-email-outreach')"
+            },
+            "required": false,
+            "description": "Filter by feature slug (e.g. 'pr-cold-email-outreach')",
+            "name": "featureSlug",
+            "in": "query"
           }
         ],
         "responses": {
@@ -5295,6 +5305,16 @@
             "required": false,
             "description": "Filter by brand ID",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug (e.g. 'pr-cold-email-outreach')"
+            },
+            "required": false,
+            "description": "Filter by feature slug (e.g. 'pr-cold-email-outreach')",
+            "name": "featureSlug",
             "in": "query"
           },
           {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -92,7 +92,7 @@ function buildWorkflowParams(query: Record<string, unknown>, keys: string[]): UR
   return params;
 }
 
-const RANKED_PARAMS = ["category", "channel", "audienceType", "objective", "limit", "groupBy", "brandId"];
+const RANKED_PARAMS = ["category", "channel", "audienceType", "objective", "limit", "groupBy", "brandId", "featureSlug"];
 const BEST_PARAMS = ["by", "orgId"];
 
 // ---------------------------------------------------------------------------

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -140,6 +140,7 @@ const rankedQueryParams = z.object({
   limit: z.string().optional().describe("Max results (default 10, max 100)"),
   groupBy: z.string().optional().describe("'section' to group by category-channel-audienceType, 'brand' to group by brand"),
   brandId: z.string().optional().describe("Filter by brand ID"),
+  featureSlug: z.string().optional().describe("Filter by feature slug (e.g. 'pr-cold-email-outreach')"),
 });
 
 const bestQueryParams = z.object({

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -61,6 +61,10 @@ describe("Workflow proxy routes", () => {
     expect(content).toContain('"/public/workflows/best"');
   });
 
+  it("should forward featureSlug query param on ranked endpoints", () => {
+    expect(content).toContain('"featureSlug"');
+  });
+
   it("should not expose appId as a query param", () => {
     // appId is no longer a public-facing query param — it's resolved from auth
     const listStart = content.indexOf('"/workflows"');


### PR DESCRIPTION
## Summary
- Add `featureSlug` to `RANKED_PARAMS` in `src/routes/workflows.ts` so it gets forwarded to workflow-service on `GET /v1/workflows/ranked`
- Add `featureSlug` to `rankedQueryParams` Zod schema in `src/schemas.ts` for OpenAPI documentation
- Add regression test verifying featureSlug is present in ranked endpoint config

## Context
The dashboard's "Create Campaign" page sends `?featureSlug=pr-cold-email-outreach` to filter workflows by feature, but api-service was silently dropping the param — returning all workflows unfiltered.

## Test plan
- [x] Existing tests pass (4 pre-existing failures in `json-parse-error.regression.test.ts` unrelated to this change)
- [x] New test verifies `featureSlug` is forwarded on ranked endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)