### PR TITLE
feat: proxy features-service stats endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4976,6 +4976,18 @@
           "brandId"
         ]
       },
+      "StatsRegistryResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "GlobalStatsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "FeatureStatsResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "FeaturesBatchUpsertResponse": {
         "type": "object",
         "properties": {}
@@ -17018,6 +17030,392 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FeaturePrefillResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/stats/registry": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Stats key registry",
+        "description": "Public dictionary of stats keys with label and type per key. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stats key registry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsRegistryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/features/stats": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Global stats cross-features",
+        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Group dimension(s), comma-separated: featureSlug, workflowName, brandId, campaignId"
+            },
+            "required": false,
+            "description": "Group dimension(s), comma-separated: featureSlug, workflowName, brandId, campaignId",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand UUID"
+            },
+            "required": false,
+            "description": "Filter by brand UUID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Global stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/{featureSlug}/stats": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Feature stats",
+        "description": "Stats for a specific feature, groupable by workflowName, brandId, or campaignId. Supports optional brandId, campaignId, and workflowName filters. Requires x-org-id. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "featureSlug",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Group dimension: workflowName | brandId | campaignId"
+            },
+            "required": false,
+            "description": "Group dimension: workflowName | brandId | campaignId",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand UUID"
+            },
+            "required": false,
+            "description": "Filter by brand UUID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign UUID"
+            },
+            "required": false,
+            "description": "Filter by campaign UUID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow name"
+            },
+            "required": false,
+            "description": "Filter by workflow name",
+            "name": "workflowName",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureStatsResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -29,6 +29,47 @@ router.get("/features", authenticate, async (req: AuthenticatedRequest, res) => 
 });
 
 /**
+ * GET /v1/features/stats/registry
+ * Public dictionary of stats keys (label + type per key)
+ */
+router.get("/features/stats/registry", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      "/stats/registry",
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Stats registry error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get stats registry" });
+  }
+});
+
+/**
+ * GET /v1/features/stats
+ * Global stats cross-features, groupable by featureSlug/workflowName/brandId/campaignId
+ */
+router.get("/features/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["groupBy", "brandId"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/stats${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Global stats error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get global stats" });
+  }
+});
+
+/**
  * GET /v1/features/:slug
  * Get a single feature by slug
  */
@@ -61,6 +102,29 @@ router.get("/features/:slug/inputs", authenticate, async (req: AuthenticatedRequ
   } catch (error: any) {
     console.error("Get feature inputs error:", error.message);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature inputs" });
+  }
+});
+
+/**
+ * GET /v1/features/:slug/stats
+ * Stats for a specific feature, groupable by workflowName/brandId/campaignId
+ */
+router.get("/features/:slug/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["groupBy", "brandId", "campaignId", "workflowName"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}/stats${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Feature stats error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature stats" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4109,6 +4109,66 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/v1/features/stats/registry",
+  tags: ["Features"],
+  summary: "Stats key registry",
+  description: "Public dictionary of stats keys with label and type per key. Proxied from features-service.",
+  security: authed,
+  responses: {
+    200: { description: "Stats key registry", content: { "application/json": { schema: z.object({}).passthrough().openapi("StatsRegistryResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/stats",
+  tags: ["Features"],
+  summary: "Global stats cross-features",
+  description:
+    "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+  security: authed,
+  request: {
+    query: z.object({
+      groupBy: z.string().optional().describe("Group dimension(s), comma-separated: featureSlug, workflowName, brandId, campaignId"),
+      brandId: z.string().optional().describe("Filter by brand UUID"),
+    }),
+  },
+  responses: {
+    200: { description: "Global stats", content: { "application/json": { schema: z.object({}).passthrough().openapi("GlobalStatsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/{featureSlug}/stats",
+  tags: ["Features"],
+  summary: "Feature stats",
+  description:
+    "Stats for a specific feature, groupable by workflowName, brandId, or campaignId. Supports optional brandId, campaignId, and workflowName filters. Requires x-org-id. Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ featureSlug: z.string().describe("Feature slug") }),
+    query: z.object({
+      groupBy: z.string().optional().describe("Group dimension: workflowName | brandId | campaignId"),
+      brandId: z.string().optional().describe("Filter by brand UUID"),
+      campaignId: z.string().optional().describe("Filter by campaign UUID"),
+      workflowName: z.string().optional().describe("Filter by workflow name"),
+    }),
+  },
+  responses: {
+    200: { description: "Feature stats", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureStatsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "put",
   path: "/v1/features",
   tags: ["Features"],

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -62,11 +62,55 @@ describe("Features proxy routes", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(5);
+    expect(headerMatches!.length).toBe(8);
   });
 
   it("should proxy to externalServices.features", () => {
     expect(content).toContain("externalServices.features");
+  });
+
+  it("should have GET /features/stats/registry with auth", () => {
+    expect(content).toContain('"/features/stats/registry"');
+    const line = content.split("\n").find((l) =>
+      l.includes('"/features/stats/registry"')
+    );
+    expect(line).toContain("authenticate");
+  });
+
+  it("should have GET /features/stats with auth + requireOrg", () => {
+    expect(content).toContain('"/features/stats"');
+    const line = content.split("\n").find((l) =>
+      l.includes('router.get') && l.includes('"/features/stats"')
+    );
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+  });
+
+  it("should forward groupBy and brandId on GET /features/stats", () => {
+    expect(content).toContain('"groupBy"');
+    expect(content).toContain('"brandId"');
+  });
+
+  it("should have GET /features/:slug/stats with auth + requireOrg", () => {
+    expect(content).toContain('"/features/:slug/stats"');
+    const line = content.split("\n").find((l) =>
+      l.includes('"/features/:slug/stats"')
+    );
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+  });
+
+  it("should forward groupBy, brandId, campaignId, workflowName on GET /features/:slug/stats", () => {
+    expect(content).toContain('"campaignId"');
+    expect(content).toContain('"workflowName"');
+  });
+
+  it("should register static routes before parameterized :slug route", () => {
+    const registryIdx = content.indexOf('"/features/stats/registry"');
+    const globalStatsIdx = content.indexOf('"/features/stats"');
+    const slugIdx = content.indexOf('"/features/:slug"');
+    expect(registryIdx).toBeLessThan(slugIdx);
+    expect(globalStatsIdx).toBeLessThan(slugIdx);
   });
 });
 
@@ -121,6 +165,22 @@ describe("Features OpenAPI schemas", () => {
   it("should define FeaturePrefillRequest schema with brandId", () => {
     expect(schemaContent).toContain("FeaturePrefillRequest");
     expect(schemaContent).toContain("brandId");
+  });
+
+  it("should register GET /v1/features/stats/registry", () => {
+    expect(schemaContent).toContain('path: "/v1/features/stats/registry"');
+  });
+
+  it("should register GET /v1/features/stats", () => {
+    expect(schemaContent).toContain('path: "/v1/features/stats"');
+  });
+
+  it("should register GET /v1/features/{featureSlug}/stats", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/stats"');
+  });
+
+  it("should document groupBy query param on stats endpoints", () => {
+    expect(schemaContent).toContain("groupBy:");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds 3 new proxy routes for features-service stats endpoints: `GET /v1/features/stats/registry`, `GET /v1/features/stats`, `GET /v1/features/:slug/stats`
- Registers OpenAPI schemas for all three new endpoints with proper query param documentation
- Static routes (`/features/stats/*`) placed before parameterized `/:slug` route to prevent Express mismatching
- Updates tests to cover new endpoints (31 tests passing)

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit/features-proxy.test.ts` — 31/31)
- [x] Route ordering verified: static stats routes registered before `:slug` param route
- [x] OpenAPI spec regenerated with `npm run generate:openapi`
- [ ] Verify proxy works end-to-end once features-service is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)