### PR TITLE
fix: correct JOURNALIST_SERVICE env vars to JOURNALISTS_SERVICE

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -81,8 +81,8 @@ export const externalServices = {
     apiKey: process.env.OUTLETS_SERVICE_API_KEY || "",
   },
   journalist: {
-    url: process.env.JOURNALIST_SERVICE_URL || "http://localhost:3031",
-    apiKey: process.env.JOURNALIST_SERVICE_API_KEY || "",
+    url: process.env.JOURNALISTS_SERVICE_URL || "http://localhost:3031",
+    apiKey: process.env.JOURNALISTS_SERVICE_API_KEY || "",
   },
   features: {
     url: process.env.FEATURES_SERVICE_URL || "http://localhost:3032",

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -101,8 +101,8 @@ describe("Service client: outlet and journalist services", () => {
   });
 
   it("should define journalist service config", () => {
-    expect(serviceClientContent).toContain("JOURNALIST_SERVICE_URL");
-    expect(serviceClientContent).toContain("JOURNALIST_SERVICE_API_KEY");
+    expect(serviceClientContent).toContain("JOURNALISTS_SERVICE_URL");
+    expect(serviceClientContent).toContain("JOURNALISTS_SERVICE_API_KEY");
   });
 });
 


### PR DESCRIPTION
## Summary
- The Railway env vars are named `JOURNALISTS_SERVICE_URL` and `JOURNALISTS_SERVICE_API_KEY` (with 's'), but the code was reading `JOURNALIST_SERVICE_URL`/`API_KEY` (without 's')
- This caused the journalist service client to fall back to `localhost:3031`, failing with ECONNREFUSED in production
- Fixes the Gate Check block on workflow `pr-email-cold-outreach-baobab` (`fetch_brand` step)

## Test plan
- [x] Existing tests updated and passing
- [ ] Deploy and verify campaign journalist endpoints no longer return ECONNREFUSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)