### PR TITLE
fix: disable Node 20 requestTimeout for long SSE streams

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,14 @@ const server = app.listen(Number(PORT), "::", () => {
   console.log(`API Gateway running on port ${PORT}`);
 });
 
+// ── HTTP timeouts ────────────────────────────────────────────────────────────
+// Node 20 defaults requestTimeout to 5 min (300 000 ms), which kills long-lived
+// SSE streams (e.g. chat sessions with LLM tool-calling that can run 30-60 min).
+// Disable it so streaming endpoints are not prematurely terminated.
+server.requestTimeout = 0;       // no limit on how long a request can take
+server.headersTimeout = 60_000;  // 60 s to receive headers (guard against slowloris)
+server.keepAliveTimeout = 72_000; // slightly above typical LB idle timeout (60 s)
+
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
 // Railway sends SIGTERM before stopping a container. Without this handler,
 // the process dies immediately — killing in-flight requests and causing 500s.

--- a/tests/unit/graceful-shutdown.test.ts
+++ b/tests/unit/graceful-shutdown.test.ts
@@ -36,4 +36,23 @@ describe("graceful shutdown", () => {
   it("should export the server instance for testability", () => {
     expect(indexSrc).toContain("export { server }");
   });
+
+  it("should disable requestTimeout for long-lived SSE streams", () => {
+    expect(indexSrc).toContain("server.requestTimeout = 0");
+  });
+
+  it("should set headersTimeout to guard against slowloris", () => {
+    const match = indexSrc.match(/server\.headersTimeout\s*=\s*(\d[\d_]*)/);
+    expect(match).not.toBeNull();
+    const ms = Number(match![1].replace(/_/g, ""));
+    expect(ms).toBeGreaterThanOrEqual(30_000);
+    expect(ms).toBeLessThanOrEqual(120_000);
+  });
+
+  it("should set keepAliveTimeout above typical LB idle timeout", () => {
+    const match = indexSrc.match(/server\.keepAliveTimeout\s*=\s*(\d[\d_]*)/);
+    expect(match).not.toBeNull();
+    const ms = Number(match![1].replace(/_/g, ""));
+    expect(ms).toBeGreaterThan(60_000);
+  });
 });


### PR DESCRIPTION
## Summary
- Node 20 defaults `server.requestTimeout` to 5 minutes, which silently kills long-running SSE connections (e.g. LLM chat sessions with tool-calling that can run 30–60 min)
- Set `requestTimeout = 0` (no limit) so streaming endpoints are not prematurely terminated
- Explicitly configure `headersTimeout` (60s) and `keepAliveTimeout` (72s) for security and LB compatibility

## Test plan
- [x] Existing graceful shutdown tests pass
- [x] Added 3 new regression tests verifying timeout configuration
- [ ] Deploy and verify long-running chat sessions are no longer killed after 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)