### PR TITLE
feat: add createFeature MCP tool with charts/entities

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4988,6 +4988,14 @@
         "type": "object",
         "properties": {}
       },
+      "FeatureCreateResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "FeatureCreateRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "FeaturesBatchUpsertResponse": {
         "type": "object",
         "properties": {}
@@ -16567,6 +16575,135 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Create a single feature",
+        "description": "Create a new feature definition with inputs, outputs, charts, and entities. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeatureCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created feature",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — feature with this name already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       },
       "put": {
         "tags": [

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -153,6 +153,28 @@ router.post("/features/:slug/prefill", authenticate, requireOrg, requireUser, as
 });
 
 /**
+ * POST /v1/features
+ * Create a single feature
+ */
+router.post("/features", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      "/features",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.status(201).json(result);
+  } catch (error: any) {
+    console.error("Create feature error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create feature" });
+  }
+});
+
+/**
  * PUT /v1/features
  * Batch upsert features (cold-start registration)
  */

--- a/src/routes/mcp-tools.ts
+++ b/src/routes/mcp-tools.ts
@@ -100,6 +100,102 @@ const MCP_TOOLS = [
     },
   },
   {
+    name: "createFeature",
+    description:
+      "Create a new feature definition. A feature defines what a campaign type can do: its inputs (form fields), " +
+      "outputs (metrics from the stats registry), charts (funnel-bar or breakdown-bar visualizations), " +
+      "and entities (detail tabs like leads, companies, emails). " +
+      "Charts must have at least 1 item. Entities must have at least 1 item. " +
+      "Use GET /stats/registry to discover valid stats keys for outputs and chart steps/segments.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string", description: "Display name (e.g. 'Cold Email Outreach')" },
+        description: { type: "string", description: "What this feature does" },
+        icon: { type: "string", description: "Lucide icon name (e.g. 'envelope', 'globe', 'megaphone')" },
+        category: { type: "string", description: "Feature category (e.g. 'sales', 'pr', 'discovery')" },
+        channel: { type: "string", description: "Communication channel (e.g. 'email', 'phone', 'linkedin', 'database')" },
+        audienceType: { type: "string", description: "Form layout type (e.g. 'cold-outreach', 'discovery')" },
+        implemented: { type: "boolean", description: "Whether the feature is implemented (default true)" },
+        displayOrder: { type: "integer", description: "Sort order in the UI (default 0)" },
+        status: { type: "string", enum: ["active", "draft", "deprecated"], description: "Feature status (default 'active')" },
+        inputs: {
+          type: "array",
+          description: "Input fields for the campaign creation form (min 1)",
+          items: {
+            type: "object",
+            properties: {
+              key: { type: "string", description: "Unique input key" },
+              label: { type: "string", description: "Display label" },
+              type: { type: "string", enum: ["text", "textarea", "number", "select"], description: "Input type" },
+              placeholder: { type: "string", description: "Placeholder text" },
+              description: { type: "string", description: "Help text for the input" },
+              extractKey: { type: "string", description: "Key used for data extraction" },
+              options: { type: "array", items: { type: "string" }, description: "Options for select type" },
+            },
+            required: ["key", "label", "type", "placeholder", "description", "extractKey"],
+          },
+        },
+        outputs: {
+          type: "array",
+          description: "Output metrics — stats keys from the registry with display config (min 1)",
+          items: {
+            type: "object",
+            properties: {
+              key: { type: "string", description: "Stats registry key" },
+              displayOrder: { type: "integer", description: "Sort order" },
+              defaultSort: { type: "boolean", description: "Whether this is the default sort column" },
+              sortDirection: { type: "string", enum: ["asc", "desc"], description: "Default sort direction" },
+            },
+            required: ["key", "displayOrder"],
+          },
+        },
+        charts: {
+          type: "array",
+          description: "Chart visualizations (min 1). Two types: funnel-bar (steps, min 2) and breakdown-bar (segments, min 2)",
+          items: {
+            type: "object",
+            properties: {
+              key: { type: "string", description: "Unique chart key" },
+              type: { type: "string", enum: ["funnel-bar", "breakdown-bar"], description: "Chart type" },
+              title: { type: "string", description: "Chart title" },
+              displayOrder: { type: "integer", description: "Sort order" },
+              steps: {
+                type: "array",
+                description: "For funnel-bar: ordered steps (min 2). Each step references a stats registry key.",
+                items: {
+                  type: "object",
+                  properties: { key: { type: "string", description: "Stats registry key" } },
+                  required: ["key"],
+                },
+              },
+              segments: {
+                type: "array",
+                description: "For breakdown-bar: segments (min 2). Each segment has a stats key, color, and sentiment.",
+                items: {
+                  type: "object",
+                  properties: {
+                    key: { type: "string", description: "Stats registry key" },
+                    color: { type: "string", enum: ["green", "blue", "red", "gray", "orange"], description: "Segment color" },
+                    sentiment: { type: "string", enum: ["positive", "neutral", "negative"], description: "Segment sentiment" },
+                  },
+                  required: ["key", "color", "sentiment"],
+                },
+              },
+            },
+            required: ["key", "type", "title", "displayOrder"],
+          },
+        },
+        entities: {
+          type: "array",
+          description: "Entity types shown in campaign detail sidebar (e.g. ['leads', 'companies', 'emails']). Min 1.",
+          items: { type: "string" },
+        },
+      },
+      required: ["name", "description", "icon", "category", "channel", "audienceType", "inputs", "outputs", "charts", "entities"],
+    },
+  },
+  {
     name: "versionPrompt",
     description:
       "Create a new version of a prompt template. The new version gets an auto-incremented type name " +
@@ -163,6 +259,14 @@ async function executeUpdateWorkflow(args: ToolArgs, headers: Record<string, str
   });
 }
 
+async function executeCreateFeature(args: ToolArgs, headers: Record<string, string>): Promise<unknown> {
+  return callExternalService(externalServices.features, "/features", {
+    method: "POST",
+    headers,
+    body: args,
+  });
+}
+
 async function executeVersionPrompt(args: ToolArgs, headers: Record<string, string>): Promise<unknown> {
   const { sourceType, prompt, variables } = args as { sourceType: string; prompt: string; variables: string[] };
   return callExternalService(externalServices.emailgen, "/prompts", {
@@ -177,6 +281,7 @@ const TOOL_EXECUTORS: Record<string, (args: ToolArgs, headers: Record<string, st
   getPrompt: executeGetPrompt,
   validateWorkflow: executeValidateWorkflow,
   updateWorkflow: executeUpdateWorkflow,
+  createFeature: executeCreateFeature,
   versionPrompt: executeVersionPrompt,
 };
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4169,6 +4169,25 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "post",
+  path: "/v1/features",
+  tags: ["Features"],
+  summary: "Create a single feature",
+  description: "Create a new feature definition with inputs, outputs, charts, and entities. Proxied from features-service.",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureCreateRequest") } } },
+  },
+  responses: {
+    201: { description: "Created feature", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureCreateResponse") } } },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    409: { description: "Conflict — feature with this name already exists", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "put",
   path: "/v1/features",
   tags: ["Features"],

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -49,6 +49,20 @@ describe("Features proxy routes", () => {
     expect(content).toContain("?format=");
   });
 
+  it("should have POST /features with auth + requireOrg + requireUser", () => {
+    const postLine = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/features"')
+    );
+    expect(postLine).toBeDefined();
+    expect(postLine).toContain("authenticate");
+    expect(postLine).toContain("requireOrg");
+    expect(postLine).toContain("requireUser");
+  });
+
+  it("should return 201 on POST /features", () => {
+    expect(content).toContain("res.status(201)");
+  });
+
   it("should have PUT /features for batch upsert with auth", () => {
     expect(content).toContain("router.put");
     const putLine = content.split("\n").find((l) =>
@@ -62,7 +76,7 @@ describe("Features proxy routes", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(8);
+    expect(headerMatches!.length).toBe(9);
   });
 
   it("should proxy to externalServices.features", () => {

--- a/tests/unit/mcp-tools.test.ts
+++ b/tests/unit/mcp-tools.test.ts
@@ -102,7 +102,7 @@ describe("POST /internal/mcp-tools — MCP JSON-RPC", () => {
 
   // ── tools/list ────────────────────────────────────────────────────────────
 
-  it("should list all 5 tools", async () => {
+  it("should list all 6 tools", async () => {
     const res = await request(app)
       .post("/internal/mcp-tools")
       .set("X-API-Key", VALID_API_KEY)
@@ -110,13 +110,14 @@ describe("POST /internal/mcp-tools — MCP JSON-RPC", () => {
 
     expect(res.status).toBe(200);
     const tools = res.body.result.tools;
-    expect(tools).toHaveLength(5);
+    expect(tools).toHaveLength(6);
 
     const names = tools.map((t: { name: string }) => t.name);
     expect(names).toContain("getWorkflowDetails");
     expect(names).toContain("getPrompt");
     expect(names).toContain("validateWorkflow");
     expect(names).toContain("updateWorkflow");
+    expect(names).toContain("createFeature");
     expect(names).toContain("versionPrompt");
   });
 
@@ -296,6 +297,93 @@ describe("POST /internal/mcp-tools — MCP JSON-RPC", () => {
     expect(call!.body.sourceType).toBe("cold-email");
     expect(call!.body.prompt).toBe("Hi {{firstName}}");
     expect(call!.body.variables).toEqual(["firstName"]);
+  });
+
+  // ── tools/call — createFeature ─────────────────────────────────────────────
+
+  it("should execute createFeature with POST to features-service", async () => {
+    const createdFeature = {
+      feature: {
+        id: "feat-uuid",
+        slug: "cold-email-outreach",
+        name: "Cold Email Outreach",
+        charts: [
+          { key: "email-funnel", type: "funnel-bar", title: "Email Funnel", displayOrder: 0, steps: [{ key: "emails_sent" }, { key: "emails_opened" }] },
+        ],
+        entities: ["leads", "emails"],
+      },
+    };
+    mockFetch({ "/features": createdFeature });
+
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .set("x-org-id", "org-abc")
+      .set("x-user-id", "user-def")
+      .set("x-run-id", "run-ghi")
+      .send({
+        jsonrpc: "2.0",
+        id: 15,
+        method: "tools/call",
+        params: {
+          name: "createFeature",
+          arguments: {
+            name: "Cold Email Outreach",
+            description: "Send cold emails to prospects",
+            icon: "envelope",
+            category: "sales",
+            channel: "email",
+            audienceType: "cold-outreach",
+            inputs: [{ key: "targetAudience", label: "Target Audience", type: "textarea", placeholder: "Describe your audience", description: "Who to target", extractKey: "target_audience" }],
+            outputs: [{ key: "emails_sent", displayOrder: 0 }],
+            charts: [
+              { key: "email-funnel", type: "funnel-bar", title: "Email Funnel", displayOrder: 0, steps: [{ key: "emails_sent" }, { key: "emails_opened" }] },
+            ],
+            entities: ["leads", "emails"],
+          },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.isError).toBeUndefined();
+
+    const parsed = JSON.parse(res.body.result.content[0].text);
+    expect(parsed.feature.slug).toBe("cold-email-outreach");
+    expect(parsed.feature.charts).toHaveLength(1);
+    expect(parsed.feature.entities).toEqual(["leads", "emails"]);
+
+    // Verify downstream call
+    const call = fetchCalls.find((c) => c.url.includes("/features") && c.method === "POST");
+    expect(call).toBeDefined();
+    expect(call!.body.name).toBe("Cold Email Outreach");
+    expect(call!.body.charts).toHaveLength(1);
+    expect(call!.body.entities).toEqual(["leads", "emails"]);
+    expect(call!.headers!["x-org-id"]).toBe("org-abc");
+    expect(call!.headers!["x-user-id"]).toBe("user-def");
+    expect(call!.headers!["x-run-id"]).toBe("run-ghi");
+  });
+
+  it("createFeature tool schema should include charts and entities as required", async () => {
+    const res = await request(app)
+      .post("/internal/mcp-tools")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({ jsonrpc: "2.0", id: 16, method: "tools/list" });
+
+    const tool = res.body.result.tools.find((t: { name: string }) => t.name === "createFeature");
+    expect(tool).toBeDefined();
+    expect(tool.inputSchema.required).toContain("charts");
+    expect(tool.inputSchema.required).toContain("entities");
+    expect(tool.inputSchema.properties.charts).toBeDefined();
+    expect(tool.inputSchema.properties.entities).toBeDefined();
+
+    // Verify chart types are documented
+    const chartItems = tool.inputSchema.properties.charts.items;
+    expect(chartItems.properties.type.enum).toEqual(["funnel-bar", "breakdown-bar"]);
+
+    // Verify segment colors and sentiments are documented
+    const segments = chartItems.properties.segments.items;
+    expect(segments.properties.color.enum).toContain("green");
+    expect(segments.properties.sentiment.enum).toContain("positive");
   });
 
   // ── Error handling ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `createFeature` MCP tool to `/internal/mcp-tools` so the chat-service LLM can create features with the full schema (inputs, outputs, charts, entities)
- Added `POST /v1/features` proxy route to features-service
- Added OpenAPI schema registration for the new endpoint
- Charts support both `funnel-bar` (with steps) and `breakdown-bar` (with segments including color and sentiment)

## Root cause
The LLM in chat-service could not create features because no `createFeature` tool existed in the MCP tools endpoint. The features-service `POST /features` requires `charts` and `entities` as mandatory fields, but there was no tool exposing those parameters.

## Test plan
- [x] MCP tool listed in `tools/list` (6 tools now)
- [x] `createFeature` tool schema includes `charts` and `entities` as required
- [x] Tool execution POSTs to features-service with correct body and identity headers
- [x] `POST /v1/features` proxy route with auth + requireOrg + requireUser
- [x] All 49 MCP + features proxy tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)