### PR TITLE
fix: forward featureSlug query param on GET /v1/workflows

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -173,6 +173,11 @@
           "signatureName": {
             "type": "string",
             "description": "Human-readable name for this DAG variant"
+          },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true,
+            "description": "Feature slug this workflow belongs to"
           }
         },
         "required": [
@@ -9498,6 +9503,16 @@
             "required": false,
             "description": "Filter workflows by human expert ID",
             "name": "humanId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug"
+            },
+            "required": false,
+            "description": "Filter by feature slug",
+            "name": "featureSlug",
             "in": "query"
           },
           {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -155,6 +155,7 @@ router.get("/workflows", authenticate, requireOrg, requireUser, async (req: Auth
     if (req.query.channel) params.set("channel", req.query.channel as string);
     if (req.query.audienceType) params.set("audienceType", req.query.audienceType as string);
     if (req.query.humanId) params.set("humanId", req.query.humanId as string);
+    if (req.query.featureSlug) params.set("featureSlug", req.query.featureSlug as string);
 
     const result = await callExternalService<{ workflows: Array<{ id: string; [key: string]: unknown }> }>(
       externalServices.workflow,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -173,6 +173,7 @@ const WorkflowMetadataSchema = z
     audienceType: z.string().describe("Audience type (e.g. 'cold-outreach')"),
     signature: z.string().describe("SHA-256 hash of the canonical DAG"),
     signatureName: z.string().describe("Human-readable name for this DAG variant"),
+    featureSlug: z.string().nullable().optional().describe("Feature slug this workflow belongs to"),
   })
   .openapi("WorkflowMetadata");
 
@@ -1749,6 +1750,7 @@ registry.registerPath({
       channel: z.string().optional().describe("Filter by channel (e.g. 'email')"),
       audienceType: z.string().optional().describe("Filter by audience type (e.g. 'cold-outreach')"),
       humanId: z.string().optional().describe("Filter workflows by human expert ID"),
+      featureSlug: z.string().optional().describe("Filter by feature slug"),
     }),
   },
   responses: {

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -81,6 +81,15 @@ describe("Workflow proxy routes", () => {
 
     expect(listBlock).toContain("humanId");
   });
+
+  it("should forward featureSlug query param on GET /workflows", () => {
+    const listStart = content.indexOf('router.get("/workflows"');
+    const rankedStart = content.indexOf('router.get("/workflows/ranked"');
+    const listBlock = content.slice(listStart, rankedStart);
+
+    expect(listBlock).toContain('req.query.featureSlug');
+    expect(listBlock).toContain('params.set("featureSlug"');
+  });
 });
 
 describe("Workflow proxy routes — new endpoints", () => {
@@ -158,6 +167,22 @@ describe("Workflow schemas — ranked and best endpoints", () => {
       content.indexOf('path: "/v1/workflows/{id}"')
     );
     expect(listSection).toContain("humanId");
+  });
+
+  it("should include featureSlug query param on GET /v1/workflows", () => {
+    const listSection = content.slice(
+      content.indexOf('path: "/v1/workflows"'),
+      content.indexOf('path: "/v1/workflows/{id}"')
+    );
+    expect(listSection).toContain("featureSlug");
+  });
+
+  it("should include featureSlug in WorkflowMetadata schema", () => {
+    const metaSection = content.slice(
+      content.indexOf("WorkflowMetadataSchema"),
+      content.indexOf(".openapi(\"WorkflowMetadata\")")
+    );
+    expect(metaSection).toContain("featureSlug");
   });
 });
 


### PR DESCRIPTION
## Summary
- Forward `featureSlug` query param from `GET /v1/workflows` to workflow-service
- Add `featureSlug` to `WorkflowMetadata` response schema
- Add `featureSlug` to OpenAPI query param spec
- Add regression tests

Fixes dashboard inability to filter workflows by feature — was falling back to category filtering which is too broad.

## Test plan
- [x] Existing tests pass (27/27 in workflows-proxy)
- [x] New regression tests for featureSlug forwarding and schema inclusion
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)