### PR TITLE
fix: align workflow schemas with workflow-service breaking changes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -166,6 +166,10 @@
             "type": "string",
             "description": "Audience type (e.g. 'cold-outreach')"
           },
+          "featureSlug": {
+            "type": "string",
+            "description": "Feature slug this workflow belongs to (e.g. 'pr-cold-email-outreach')"
+          },
           "signature": {
             "type": "string",
             "description": "SHA-256 hash of the canonical DAG"
@@ -173,11 +177,6 @@
           "signatureName": {
             "type": "string",
             "description": "Human-readable name for this DAG variant"
-          },
-          "featureSlug": {
-            "type": "string",
-            "nullable": true,
-            "description": "Feature slug this workflow belongs to"
           }
         },
         "required": [
@@ -185,9 +184,7 @@
           "name",
           "displayName",
           "createdForBrandId",
-          "category",
-          "channel",
-          "audienceType",
+          "featureSlug",
           "signature",
           "signatureName"
         ]
@@ -2610,17 +2607,9 @@
                 "type": "string",
                 "description": "Auto-generated workflow name"
               },
-              "category": {
+              "featureSlug": {
                 "type": "string",
-                "description": "Workflow category"
-              },
-              "channel": {
-                "type": "string",
-                "description": "Communication channel"
-              },
-              "audienceType": {
-                "type": "string",
-                "description": "Audience type"
+                "description": "Feature slug this workflow belongs to"
               },
               "signature": {
                 "type": "string",
@@ -2652,9 +2641,7 @@
             "required": [
               "id",
               "name",
-              "category",
-              "channel",
-              "audienceType",
+              "featureSlug",
               "signature",
               "signatureName",
               "action",
@@ -5099,7 +5086,7 @@
           "Workflows"
         ],
         "summary": "Ranked workflows (public)",
-        "description": "Public ranked workflows by performance. Supports groupBy=section and groupBy=brand. No authentication required.",
+        "description": "Public ranked workflows by performance. Supports groupBy=feature and groupBy=brand. No authentication required.",
         "parameters": [
           {
             "schema": {
@@ -5154,10 +5141,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "'section' to group by category-channel-audienceType, 'brand' to group by brand"
+              "description": "'feature' to group by featureSlug, 'brand' to group by brand"
             },
             "required": false,
-            "description": "'section' to group by category-channel-audienceType, 'brand' to group by brand",
+            "description": "'feature' to group by featureSlug, 'brand' to group by brand",
             "name": "groupBy",
             "in": "query"
           },
@@ -5255,7 +5242,7 @@
           "Workflows"
         ],
         "summary": "Ranked workflows",
-        "description": "Workflows ranked by performance, scoped to the authenticated org. Supports groupBy=section and groupBy=brand.",
+        "description": "Workflows ranked by performance, scoped to the authenticated org. Supports groupBy=feature and groupBy=brand.",
         "security": [
           {
             "bearerAuth": []
@@ -5315,10 +5302,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "'section' to group by category-channel-audienceType, 'brand' to group by brand"
+              "description": "'feature' to group by featureSlug, 'brand' to group by brand"
             },
             "required": false,
-            "description": "'section' to group by category-channel-audienceType, 'brand' to group by brand",
+            "description": "'feature' to group by featureSlug, 'brand' to group by brand",
             "name": "groupBy",
             "in": "query"
           },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -138,7 +138,7 @@ const rankedQueryParams = z.object({
   audienceType: z.string().optional().describe("Filter by audience type (e.g. 'cold-outreach')"),
   objective: z.string().optional().describe("Optimization objective ('replies' or 'clicks')"),
   limit: z.string().optional().describe("Max results (default 10, max 100)"),
-  groupBy: z.string().optional().describe("'section' to group by category-channel-audienceType, 'brand' to group by brand"),
+  groupBy: z.string().optional().describe("'feature' to group by featureSlug, 'brand' to group by brand"),
   brandId: z.string().optional().describe("Filter by brand ID"),
   featureSlug: z.string().optional().describe("Filter by feature slug (e.g. 'pr-cold-email-outreach')"),
 });
@@ -168,12 +168,12 @@ const WorkflowMetadataSchema = z
     name: z.string().describe("Workflow name"),
     displayName: z.string().nullable().describe("Stable display name for the workflow family"),
     createdForBrandId: z.string().nullable().describe("Brand ID that created this workflow"),
-    category: z.string().describe("Workflow category (e.g. 'sales', 'pr')"),
-    channel: z.string().describe("Communication channel (e.g. 'email')"),
-    audienceType: z.string().describe("Audience type (e.g. 'cold-outreach')"),
+    category: z.string().optional().describe("Workflow category (e.g. 'sales', 'pr')"),
+    channel: z.string().optional().describe("Communication channel (e.g. 'email')"),
+    audienceType: z.string().optional().describe("Audience type (e.g. 'cold-outreach')"),
+    featureSlug: z.string().describe("Feature slug this workflow belongs to (e.g. 'pr-cold-email-outreach')"),
     signature: z.string().describe("SHA-256 hash of the canonical DAG"),
     signatureName: z.string().describe("Human-readable name for this DAG variant"),
-    featureSlug: z.string().nullable().optional().describe("Feature slug this workflow belongs to"),
   })
   .openapi("WorkflowMetadata");
 
@@ -267,7 +267,7 @@ registry.registerPath({
   path: "/v1/public/workflows/ranked",
   tags: ["Workflows"],
   summary: "Ranked workflows (public)",
-  description: "Public ranked workflows by performance. Supports groupBy=section and groupBy=brand. No authentication required.",
+  description: "Public ranked workflows by performance. Supports groupBy=feature and groupBy=brand. No authentication required.",
   request: { query: rankedQueryParams },
   responses: publicRankedResponse,
 });
@@ -288,7 +288,7 @@ registry.registerPath({
   path: "/v1/workflows/ranked",
   tags: ["Workflows"],
   summary: "Ranked workflows",
-  description: "Workflows ranked by performance, scoped to the authenticated org. Supports groupBy=section and groupBy=brand.",
+  description: "Workflows ranked by performance, scoped to the authenticated org. Supports groupBy=feature and groupBy=brand.",
   security: authed,
   request: { query: rankedQueryParams },
   responses: { ...rankedResponse, 401: { description: "Unauthorized", content: errorContent } },
@@ -1872,9 +1872,7 @@ registry.registerPath({
               workflow: z.object({
                 id: z.string().describe("Workflow ID"),
                 name: z.string().describe("Auto-generated workflow name"),
-                category: z.string().describe("Workflow category"),
-                channel: z.string().describe("Communication channel"),
-                audienceType: z.string().describe("Audience type"),
+                featureSlug: z.string().describe("Feature slug this workflow belongs to"),
                 signature: z.string().describe("SHA-256 hash of the canonical DAG"),
                 signatureName: z.string().describe("Human-readable name for this DAG variant"),
                 action: z.enum(["created", "updated"]).describe("Whether the workflow was created or updated"),

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -184,6 +184,38 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     );
     expect(metaSection).toContain("featureSlug");
   });
+
+  it("should have category/channel/audienceType as optional in WorkflowMetadata", () => {
+    const metaSection = content.slice(
+      content.indexOf("WorkflowMetadataSchema"),
+      content.indexOf(".openapi(\"WorkflowMetadata\")")
+    );
+    // Each of these fields should have .optional()
+    const categoryLine = metaSection.slice(metaSection.indexOf("category:"), metaSection.indexOf("channel:"));
+    expect(categoryLine).toContain(".optional()");
+    const channelLine = metaSection.slice(metaSection.indexOf("channel:"), metaSection.indexOf("audienceType:"));
+    expect(channelLine).toContain(".optional()");
+    const audienceLine = metaSection.slice(metaSection.indexOf("audienceType:"), metaSection.indexOf("featureSlug:"));
+    expect(audienceLine).toContain(".optional()");
+  });
+
+  it("should use groupBy=feature instead of groupBy=section in ranked query params", () => {
+    const start = content.indexOf("const rankedQueryParams");
+    const end = content.indexOf("});", start) + 3;
+    const rankedSection = content.slice(start, end);
+    expect(rankedSection).toContain("feature");
+    expect(rankedSection).not.toContain("'section'");
+  });
+
+  it("should include featureSlug in GenerateWorkflowResponse instead of category/channel/audienceType", () => {
+    const genSection = content.slice(
+      content.indexOf("GenerateWorkflowResponse"),
+      content.indexOf("GenerateWorkflowResponse") + 500
+    );
+    expect(genSection).not.toContain("category");
+    expect(genSection).not.toContain("channel");
+    expect(genSection).not.toContain("audienceType");
+  });
 });
 
 describe("Workflow routes are mounted in index.ts", () => {


### PR DESCRIPTION
## Summary
- `category`/`channel`/`audienceType` now optional in `WorkflowMetadata` schema (workflow-service no longer guarantees them)
- `featureSlug` now required in `WorkflowMetadata` (was nullable/optional)
- `groupBy=section` → `groupBy=feature` in ranked query params and OpenAPI descriptions
- `GenerateWorkflowResponse` returns `featureSlug` instead of `category`/`channel`/`audienceType`
- Regression tests for all schema changes

Follows workflow-service PR #162 breaking changes.

## Test plan
- [x] 30/30 workflow proxy tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)