### PR TITLE
fix: remove deprecated workflow filters, add featureSlug to generate

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2717,6 +2717,11 @@
       "GenerateWorkflowRequest": {
         "type": "object",
         "properties": {
+          "featureSlug": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Feature slug for the generated workflow (e.g. 'pr-cold-email-outreach')"
+          },
           "description": {
             "type": "string",
             "minLength": 10,
@@ -2754,6 +2759,7 @@
           }
         },
         "required": [
+          "featureSlug",
           "description"
         ]
       },
@@ -5091,36 +5097,6 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by category (e.g. 'sales', 'pr')"
-            },
-            "required": false,
-            "description": "Filter by category (e.g. 'sales', 'pr')",
-            "name": "category",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by channel (e.g. 'email')"
-            },
-            "required": false,
-            "description": "Filter by channel (e.g. 'email')",
-            "name": "channel",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by audience type (e.g. 'cold-outreach')"
-            },
-            "required": false,
-            "description": "Filter by audience type (e.g. 'cold-outreach')",
-            "name": "audienceType",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
               "description": "Optimization objective ('replies' or 'clicks')"
             },
             "required": false,
@@ -5249,36 +5225,6 @@
           }
         ],
         "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by category (e.g. 'sales', 'pr')"
-            },
-            "required": false,
-            "description": "Filter by category (e.g. 'sales', 'pr')",
-            "name": "category",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by channel (e.g. 'email')"
-            },
-            "required": false,
-            "description": "Filter by channel (e.g. 'email')",
-            "name": "channel",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by audience type (e.g. 'cold-outreach')"
-            },
-            "required": false,
-            "description": "Filter by audience type (e.g. 'cold-outreach')",
-            "name": "audienceType",
-            "in": "query"
-          },
           {
             "schema": {
               "type": "string",
@@ -9445,43 +9391,13 @@
           "Workflows"
         ],
         "summary": "List workflows",
-        "description": "List available workflows from the workflow-service, optionally filtered by category, channel, or audience type",
+        "description": "List available workflows from the workflow-service, optionally filtered by featureSlug or humanId",
         "security": [
           {
             "bearerAuth": []
           }
         ],
         "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by category (e.g. 'sales', 'pr')"
-            },
-            "required": false,
-            "description": "Filter by category (e.g. 'sales', 'pr')",
-            "name": "category",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by channel (e.g. 'email')"
-            },
-            "required": false,
-            "description": "Filter by channel (e.g. 'email')",
-            "name": "channel",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by audience type (e.g. 'cold-outreach')"
-            },
-            "required": false,
-            "description": "Filter by audience type (e.g. 'cold-outreach')",
-            "name": "audienceType",
-            "in": "query"
-          },
           {
             "schema": {
               "type": "string",
@@ -9495,10 +9411,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by feature slug"
+              "description": "Filter by feature slug (e.g. 'pr-cold-email-outreach')"
             },
             "required": false,
-            "description": "Filter by feature slug",
+            "description": "Filter by feature slug (e.g. 'pr-cold-email-outreach')",
             "name": "featureSlug",
             "in": "query"
           },

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -92,7 +92,7 @@ function buildWorkflowParams(query: Record<string, unknown>, keys: string[]): UR
   return params;
 }
 
-const RANKED_PARAMS = ["category", "channel", "audienceType", "objective", "limit", "groupBy", "brandId", "featureSlug"];
+const RANKED_PARAMS = ["objective", "limit", "groupBy", "brandId", "featureSlug"];
 const BEST_PARAMS = ["by", "orgId"];
 
 // ---------------------------------------------------------------------------
@@ -151,9 +151,6 @@ router.get("/workflows", authenticate, requireOrg, requireUser, async (req: Auth
     const params = new URLSearchParams();
 
     if (req.query.orgId) params.set("orgId", req.query.orgId as string);
-    if (req.query.category) params.set("category", req.query.category as string);
-    if (req.query.channel) params.set("channel", req.query.channel as string);
-    if (req.query.audienceType) params.set("audienceType", req.query.audienceType as string);
     if (req.query.humanId) params.set("humanId", req.query.humanId as string);
     if (req.query.featureSlug) params.set("featureSlug", req.query.featureSlug as string);
 
@@ -479,7 +476,7 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
       });
     }
 
-    const { description, hints, style } = parsed.data;
+    const { featureSlug, description, hints, style } = parsed.data;
 
     const result = await callExternalService(
       externalServices.workflow,
@@ -490,6 +487,7 @@ router.post("/workflows/generate", authenticate, requireOrg, requireUser, async 
         body: {
           orgId: req.orgId,
           userId: req.userId,
+          featureSlug,
           description,
           hints,
           ...(style && { style }),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -133,9 +133,6 @@ registry.registerPath({
 // ===================================================================
 
 const rankedQueryParams = z.object({
-  category: z.string().optional().describe("Filter by category (e.g. 'sales', 'pr')"),
-  channel: z.string().optional().describe("Filter by channel (e.g. 'email')"),
-  audienceType: z.string().optional().describe("Filter by audience type (e.g. 'cold-outreach')"),
   objective: z.string().optional().describe("Optimization objective ('replies' or 'clicks')"),
   limit: z.string().optional().describe("Max results (default 10, max 100)"),
   groupBy: z.string().optional().describe("'feature' to group by featureSlug, 'brand' to group by brand"),
@@ -1742,15 +1739,12 @@ registry.registerPath({
   tags: ["Workflows"],
   summary: "List workflows",
   description:
-    "List available workflows from the workflow-service, optionally filtered by category, channel, or audience type",
+    "List available workflows from the workflow-service, optionally filtered by featureSlug or humanId",
   security: authed,
   request: {
     query: z.object({
-      category: z.string().optional().describe("Filter by category (e.g. 'sales', 'pr')"),
-      channel: z.string().optional().describe("Filter by channel (e.g. 'email')"),
-      audienceType: z.string().optional().describe("Filter by audience type (e.g. 'cold-outreach')"),
       humanId: z.string().optional().describe("Filter workflows by human expert ID"),
-      featureSlug: z.string().optional().describe("Filter by feature slug"),
+      featureSlug: z.string().optional().describe("Filter by feature slug (e.g. 'pr-cold-email-outreach')"),
     }),
   },
   responses: {
@@ -1824,6 +1818,10 @@ export const WorkflowStyleSchema = z
 
 export const GenerateWorkflowRequestSchema = z
   .object({
+    featureSlug: z
+      .string()
+      .min(1)
+      .describe("Feature slug for the generated workflow (e.g. 'pr-cold-email-outreach')"),
     description: z
       .string()
       .min(10)

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -90,6 +90,32 @@ describe("Workflow proxy routes", () => {
     expect(listBlock).toContain('req.query.featureSlug');
     expect(listBlock).toContain('params.set("featureSlug"');
   });
+
+  it("should not forward category/channel/audienceType on GET /workflows", () => {
+    const listStart = content.indexOf('router.get("/workflows"');
+    const rankedStart = content.indexOf('router.get("/workflows/ranked"');
+    const listBlock = content.slice(listStart, rankedStart);
+
+    expect(listBlock).not.toContain('req.query.category');
+    expect(listBlock).not.toContain('req.query.channel');
+    expect(listBlock).not.toContain('req.query.audienceType');
+  });
+
+  it("should not include category/channel/audienceType in RANKED_PARAMS", () => {
+    const rankedLine = content.slice(
+      content.indexOf("RANKED_PARAMS"),
+      content.indexOf("];", content.indexOf("RANKED_PARAMS")) + 2
+    );
+    expect(rankedLine).not.toContain('"category"');
+    expect(rankedLine).not.toContain('"channel"');
+    expect(rankedLine).not.toContain('"audienceType"');
+  });
+
+  it("should forward featureSlug in POST /workflows/generate body", () => {
+    const genStart = content.indexOf('"/workflows/generate"');
+    const genBlock = content.slice(genStart, genStart + 500);
+    expect(genBlock).toContain("featureSlug");
+  });
 });
 
 describe("Workflow proxy routes — new endpoints", () => {
@@ -205,6 +231,33 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     const rankedSection = content.slice(start, end);
     expect(rankedSection).toContain("feature");
     expect(rankedSection).not.toContain("'section'");
+  });
+
+  it("should not include category/channel/audienceType in rankedQueryParams", () => {
+    const start = content.indexOf("const rankedQueryParams");
+    const end = content.indexOf("});", start) + 3;
+    const rankedSection = content.slice(start, end);
+    expect(rankedSection).not.toContain("category");
+    expect(rankedSection).not.toContain("channel");
+    expect(rankedSection).not.toContain("audienceType");
+  });
+
+  it("should not include category/channel/audienceType in GET /v1/workflows query params", () => {
+    const listSection = content.slice(
+      content.indexOf('path: "/v1/workflows"'),
+      content.indexOf('path: "/v1/workflows/{id}"')
+    );
+    expect(listSection).not.toContain("category");
+    expect(listSection).not.toContain("channel");
+    expect(listSection).not.toContain("audienceType");
+  });
+
+  it("should require featureSlug in GenerateWorkflowRequestSchema", () => {
+    const start = content.indexOf("GenerateWorkflowRequestSchema");
+    const end = content.indexOf(".openapi(\"GenerateWorkflowRequest\")", start);
+    const genSchema = content.slice(start, end);
+    expect(genSchema).toContain("featureSlug");
+    expect(genSchema).toContain(".min(1)");
   });
 
   it("should include featureSlug in GenerateWorkflowResponse instead of category/channel/audienceType", () => {


### PR DESCRIPTION
## Summary
Completes alignment with workflow-service PR #162 breaking changes:

- **Removed** `category`/`channel`/`audienceType` query param forwarding on `GET /v1/workflows` — workflow-service no longer supports these filters
- **Removed** `category`/`channel`/`audienceType` from `RANKED_PARAMS` (affects `/ranked` and `/public/workflows/ranked`)
- **Removed** `category`/`channel`/`audienceType` from OpenAPI query param schemas for both list and ranked endpoints
- **Added** `featureSlug` (required, `.min(1)`) to `GenerateWorkflowRequestSchema` — workflow-service now requires it on `POST /workflows/generate`
- **Added** `featureSlug` forwarding in the generate route body

## Test plan
- [x] 36/36 workflow proxy tests pass
- [x] Regression tests for all removed params and new featureSlug requirement
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)