### PR TITLE
feat: proxy missing key-service endpoints for dashboard

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1537,6 +1537,204 @@
           "message"
         ]
       },
+      "KeySourcePreference": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Provider name"
+          },
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Key source preference"
+          }
+        },
+        "required": [
+          "provider",
+          "keySource"
+        ]
+      },
+      "ListKeySourcesResponse": {
+        "type": "object",
+        "properties": {
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KeySourcePreference"
+            }
+          }
+        },
+        "required": [
+          "sources"
+        ]
+      },
+      "GetKeySourceResponse": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Provider name"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Key source preference"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether this is the default (no explicit preference set)"
+          }
+        },
+        "required": [
+          "provider",
+          "orgId",
+          "keySource",
+          "isDefault"
+        ]
+      },
+      "SetKeySourceResponse": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Provider name"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization ID"
+          },
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Key source preference"
+          },
+          "message": {
+            "type": "string",
+            "description": "Confirmation message"
+          }
+        },
+        "required": [
+          "provider",
+          "orgId",
+          "keySource",
+          "message"
+        ]
+      },
+      "SetKeySourceRequest": {
+        "type": "object",
+        "properties": {
+          "keySource": {
+            "type": "string",
+            "enum": [
+              "org",
+              "platform"
+            ],
+            "description": "Whether to use the org's own key or the platform key"
+          }
+        },
+        "required": [
+          "keySource"
+        ]
+      },
+      "ProviderRequirementsResponse": {
+        "type": "object",
+        "properties": {
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "service": {
+                  "type": "string",
+                  "description": "Service name"
+                },
+                "method": {
+                  "type": "string",
+                  "description": "HTTP method"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "Endpoint path"
+                },
+                "provider": {
+                  "type": "string",
+                  "description": "Required provider"
+                }
+              },
+              "required": [
+                "service",
+                "method",
+                "path",
+                "provider"
+              ]
+            },
+            "description": "Per-endpoint provider requirements"
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Unique list of all required providers"
+          }
+        },
+        "required": [
+          "requirements",
+          "providers"
+        ]
+      },
+      "ProviderRequirementsRequest": {
+        "type": "object",
+        "properties": {
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "service": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Service name"
+                },
+                "method": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "HTTP method"
+                },
+                "path": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Endpoint path"
+                }
+              },
+              "required": [
+                "service",
+                "method",
+                "path"
+              ]
+            },
+            "minItems": 1,
+            "description": "List of service endpoints to check"
+          }
+        },
+        "required": [
+          "endpoints"
+        ]
+      },
       "ApiKeyItem": {
         "type": "object",
         "properties": {
@@ -7268,6 +7466,470 @@
             }
           }
         }
+      }
+    },
+    "/v1/keys/sources": {
+      "get": {
+        "tags": [
+          "Keys"
+        ],
+        "summary": "List key source preferences",
+        "description": "List all explicit key source preferences for the organization. Providers not listed default to 'platform'.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key source preferences",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListKeySourcesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/keys/{provider}/source": {
+      "get": {
+        "tags": [
+          "Keys"
+        ],
+        "summary": "Get key source preference",
+        "description": "Get the current key source preference for a provider. Returns 'platform' with isDefault=true if no explicit preference is set.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Provider name"
+            },
+            "required": true,
+            "description": "Provider name",
+            "name": "provider",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key source preference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetKeySourceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Keys"
+        ],
+        "summary": "Set key source preference",
+        "description": "Set whether the org uses its own key or the platform key for a given provider. If switching to 'org', an org key must already be stored.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Provider name"
+            },
+            "required": true,
+            "description": "Provider name",
+            "name": "provider",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetKeySourceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Key source preference saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetKeySourceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or no org key stored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/keys/provider-requirements": {
+      "post": {
+        "tags": [
+          "Keys"
+        ],
+        "summary": "Query provider requirements",
+        "description": "Given a list of service endpoints, returns which third-party providers each endpoint needs. Used to determine which keys are required before execution.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderRequirementsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Provider requirements for the given endpoints",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderRequirementsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/api-keys": {

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
-import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema } from "../schemas.js";
+import { UpsertKeyRequestSchema, CreateApiKeyRequestSchema, SetKeySourceRequestSchema, ProviderRequirementsRequestSchema } from "../schemas.js";
 
 const router = Router();
 
@@ -69,6 +69,105 @@ router.delete("/keys/:provider", authenticate, async (req: AuthenticatedRequest,
   } catch (error: any) {
     console.error("Delete key error:", error);
     res.status(500).json({ error: error.message || "Failed to delete key" });
+  }
+});
+
+// -----------------------------------------------------------------------
+// Key source preferences — org vs platform key selection
+// -----------------------------------------------------------------------
+
+/**
+ * GET /v1/keys/sources
+ * List all key source preferences for the org.
+ */
+router.get("/keys/sources", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    const result = await callExternalService(externalServices.key, "/keys/sources", {
+      headers: buildInternalHeaders(req),
+    });
+    res.json(result);
+  } catch (error: any) {
+    console.error("List key sources error:", error);
+    res.status(500).json({ error: error.message || "Failed to list key sources" });
+  }
+});
+
+/**
+ * GET /v1/keys/:provider/source
+ * Get key source preference for a provider.
+ */
+router.get("/keys/:provider/source", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    const { provider } = req.params;
+    const result = await callExternalService(
+      externalServices.key,
+      `/keys/${encodeURIComponent(provider)}/source`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get key source error:", error);
+    res.status(500).json({ error: error.message || "Failed to get key source" });
+  }
+});
+
+/**
+ * PUT /v1/keys/:provider/source
+ * Set key source preference for a provider.
+ */
+router.put("/keys/:provider/source", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = SetKeySourceRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    const { provider } = req.params;
+    const result = await callExternalService(
+      externalServices.key,
+      `/keys/${encodeURIComponent(provider)}/source`,
+      {
+        method: "PUT",
+        body: parsed.data,
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Set key source error:", error);
+    res.status(500).json({ error: error.message || "Failed to set key source" });
+  }
+});
+
+// -----------------------------------------------------------------------
+// Provider requirements — which providers are needed for given endpoints
+// -----------------------------------------------------------------------
+
+/**
+ * POST /v1/keys/provider-requirements
+ * Query which providers are needed for a set of endpoints.
+ */
+router.post("/keys/provider-requirements", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = ProviderRequirementsRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+    }
+    const result = await callExternalService(
+      externalServices.key,
+      "/provider-requirements",
+      {
+        method: "POST",
+        body: parsed.data,
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Provider requirements error:", error);
+    res.status(500).json({ error: error.message || "Failed to query provider requirements" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -986,6 +986,174 @@ registry.registerPath({
 });
 
 // ===================================================================
+// KEY SOURCE PREFERENCES
+// ===================================================================
+
+export const SetKeySourceRequestSchema = z
+  .object({
+    keySource: z
+      .enum(["org", "platform"])
+      .describe("Whether to use the org's own key or the platform key"),
+  })
+  .openapi("SetKeySourceRequest");
+
+const KeySourcePreferenceSchema = z
+  .object({
+    provider: z.string().describe("Provider name"),
+    keySource: z.enum(["org", "platform"]).describe("Key source preference"),
+  })
+  .openapi("KeySourcePreference");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/keys/sources",
+  tags: ["Keys"],
+  summary: "List key source preferences",
+  description:
+    "List all explicit key source preferences for the organization. Providers not listed default to 'platform'.",
+  security: authed,
+  responses: {
+    200: {
+      description: "Key source preferences",
+      content: {
+        "application/json": {
+          schema: z.object({
+            sources: z.array(KeySourcePreferenceSchema),
+          }).openapi("ListKeySourcesResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/keys/{provider}/source",
+  tags: ["Keys"],
+  summary: "Get key source preference",
+  description:
+    "Get the current key source preference for a provider. Returns 'platform' with isDefault=true if no explicit preference is set.",
+  security: authed,
+  request: {
+    params: z.object({
+      provider: z.string().describe("Provider name"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Key source preference",
+      content: {
+        "application/json": {
+          schema: z.object({
+            provider: z.string().describe("Provider name"),
+            orgId: z.string().describe("Organization ID"),
+            keySource: z.enum(["org", "platform"]).describe("Key source preference"),
+            isDefault: z.boolean().describe("Whether this is the default (no explicit preference set)"),
+          }).openapi("GetKeySourceResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/keys/{provider}/source",
+  tags: ["Keys"],
+  summary: "Set key source preference",
+  description:
+    "Set whether the org uses its own key or the platform key for a given provider. If switching to 'org', an org key must already be stored.",
+  security: authed,
+  request: {
+    params: z.object({
+      provider: z.string().describe("Provider name"),
+    }),
+    body: {
+      content: { "application/json": { schema: SetKeySourceRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Key source preference saved",
+      content: {
+        "application/json": {
+          schema: z.object({
+            provider: z.string().describe("Provider name"),
+            orgId: z.string().describe("Organization ID"),
+            keySource: z.enum(["org", "platform"]).describe("Key source preference"),
+            message: z.string().describe("Confirmation message"),
+          }).openapi("SetKeySourceResponse"),
+        },
+      },
+    },
+    400: { description: "Invalid request or no org key stored", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
+// PROVIDER REQUIREMENTS
+// ===================================================================
+
+export const ProviderRequirementsRequestSchema = z
+  .object({
+    endpoints: z
+      .array(
+        z.object({
+          service: z.string().min(1).describe("Service name"),
+          method: z.string().min(1).describe("HTTP method"),
+          path: z.string().min(1).describe("Endpoint path"),
+        })
+      )
+      .min(1)
+      .describe("List of service endpoints to check"),
+  })
+  .openapi("ProviderRequirementsRequest");
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/keys/provider-requirements",
+  tags: ["Keys"],
+  summary: "Query provider requirements",
+  description:
+    "Given a list of service endpoints, returns which third-party providers each endpoint needs. Used to determine which keys are required before execution.",
+  security: authed,
+  request: {
+    body: {
+      content: { "application/json": { schema: ProviderRequirementsRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Provider requirements for the given endpoints",
+      content: {
+        "application/json": {
+          schema: z.object({
+            requirements: z.array(
+              z.object({
+                service: z.string().describe("Service name"),
+                method: z.string().describe("HTTP method"),
+                path: z.string().describe("Endpoint path"),
+                provider: z.string().describe("Required provider"),
+              })
+            ).describe("Per-endpoint provider requirements"),
+            providers: z.array(z.string()).describe("Unique list of all required providers"),
+          }).openapi("ProviderRequirementsResponse"),
+        },
+      },
+    },
+    400: { description: "Invalid request", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
 // API KEYS
 // ===================================================================
 

--- a/tests/unit/key-source-preferences.test.ts
+++ b/tests/unit/key-source-preferences.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+let mockAuth = {
+  userId: "user_test123",
+  orgId: "org_test456",
+  authType: "user_key" as "user_key" | "admin",
+};
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = mockAuth.userId;
+    req.orgId = mockAuth.orgId;
+    req.authType = mockAuth.authType;
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+import keysRoutes from "../../src/routes/keys.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", keysRoutes);
+  return app;
+}
+
+function mockFetchWith(response: any) {
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    fetchCalls.push({ url, method: init?.method, body });
+    return { ok: true, json: () => Promise.resolve(response) };
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fetchCalls = [];
+  mockAuth = { userId: "user_test123", orgId: "org_test456", authType: "user_key" };
+  mockFetchWith({});
+});
+
+// -----------------------------------------------------------------------
+// GET /v1/keys/sources
+// -----------------------------------------------------------------------
+
+describe("GET /v1/keys/sources", () => {
+  it("should proxy to key-service /keys/sources", async () => {
+    mockFetchWith({ sources: [{ provider: "openai", keySource: "org" }] });
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/sources");
+
+    expect(res.status).toBe(200);
+    expect(res.body.sources).toEqual([{ provider: "openai", keySource: "org" }]);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toContain("/keys/sources");
+  });
+
+  it("should reject when no org context", async () => {
+    mockAuth.orgId = "";
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/sources");
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// GET /v1/keys/:provider/source
+// -----------------------------------------------------------------------
+
+describe("GET /v1/keys/:provider/source", () => {
+  it("should proxy to key-service /keys/:provider/source", async () => {
+    mockFetchWith({ provider: "openai", orgId: "org_test456", keySource: "platform", isDefault: true });
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/openai/source");
+
+    expect(res.status).toBe(200);
+    expect(res.body.keySource).toBe("platform");
+    expect(fetchCalls[0].url).toContain("/keys/openai/source");
+  });
+
+  it("should reject when no org context", async () => {
+    mockAuth.orgId = "";
+    const app = createApp();
+    const res = await request(app).get("/v1/keys/openai/source");
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// PUT /v1/keys/:provider/source
+// -----------------------------------------------------------------------
+
+describe("PUT /v1/keys/:provider/source", () => {
+  it("should proxy to key-service with keySource in body", async () => {
+    mockFetchWith({ provider: "openai", orgId: "org_test456", keySource: "org", message: "saved" });
+    const app = createApp();
+    const res = await request(app)
+      .put("/v1/keys/openai/source")
+      .send({ keySource: "org" });
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.method === "PUT");
+    expect(call!.url).toContain("/keys/openai/source");
+    expect(call!.body).toEqual({ keySource: "org" });
+  });
+
+  it("should reject invalid keySource value", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .put("/v1/keys/openai/source")
+      .send({ keySource: "invalid" });
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should reject missing keySource", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .put("/v1/keys/openai/source")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should reject when no org context", async () => {
+    mockAuth.orgId = "";
+    const app = createApp();
+    const res = await request(app)
+      .put("/v1/keys/openai/source")
+      .send({ keySource: "org" });
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// POST /v1/keys/provider-requirements
+// -----------------------------------------------------------------------
+
+describe("POST /v1/keys/provider-requirements", () => {
+  it("should proxy to key-service /provider-requirements", async () => {
+    const reqBody = {
+      endpoints: [{ service: "email-gateway", method: "POST", path: "/send" }],
+    };
+    mockFetchWith({
+      requirements: [{ service: "email-gateway", method: "POST", path: "/send", provider: "postmark" }],
+      providers: ["postmark"],
+    });
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/keys/provider-requirements")
+      .send(reqBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.providers).toEqual(["postmark"]);
+    const call = fetchCalls.find((c) => c.method === "POST");
+    expect(call!.url).toContain("/provider-requirements");
+    expect(call!.body).toEqual(reqBody);
+  });
+
+  it("should reject empty endpoints array", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/keys/provider-requirements")
+      .send({ endpoints: [] });
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("should reject missing endpoints field", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/keys/provider-requirements")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 missing key-service proxy endpoints that were never exposed through api-service
- **Key source preferences**: `GET /v1/keys/sources`, `GET /v1/keys/:provider/source`, `PUT /v1/keys/:provider/source` — let the dashboard manage org vs platform key selection per provider
- **Provider requirements**: `POST /v1/keys/provider-requirements` — query which providers are needed for a set of endpoints

## Test plan
- [x] 11 new unit tests covering all 4 endpoints (happy path + validation + org context checks)
- [x] Existing key proxy tests still pass (9/9)
- [x] TypeScript build passes
- [x] OpenAPI spec auto-regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)