### PR TITLE
feat: proxy PUT /features/:slug for dashboard

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5090,6 +5090,14 @@
         "type": "object",
         "properties": {}
       },
+      "UpdateFeatureResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdateFeatureRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "FeatureInputsResponse": {
         "type": "object",
         "properties": {}
@@ -17496,6 +17504,155 @@
           },
           "404": {
             "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Update feature by slug",
+        "description": "Update a single feature definition by its slug. All fields are optional — only provided fields are updated. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "slug",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFeatureRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated feature",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateFeatureResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (e.g. slug collision)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -175,6 +175,28 @@ router.post("/features", authenticate, requireOrg, requireUser, async (req: Auth
 });
 
 /**
+ * PUT /v1/features/:slug
+ * Update a single feature by slug
+ */
+router.put("/features/:slug", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}`,
+      {
+        method: "PUT",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Update feature error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to update feature" });
+  }
+});
+
+/**
  * PUT /v1/features
  * Batch upsert features (cold-start registration)
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4222,6 +4222,29 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "put",
+  path: "/v1/features/{slug}",
+  tags: ["Features"],
+  summary: "Update feature by slug",
+  description: "Update a single feature definition by its slug. All fields are optional — only provided fields are updated. Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ slug: z.string().describe("Feature slug") }),
+    body: {
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("UpdateFeatureRequest") } },
+    },
+  },
+  responses: {
+    200: { description: "Updated feature", content: { "application/json": { schema: z.object({}).passthrough().openapi("UpdateFeatureResponse") } } },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    409: { description: "Conflict (e.g. slug collision)", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "get",
   path: "/v1/features/{slug}/inputs",
   tags: ["Features"],

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -66,17 +66,27 @@ describe("Features proxy routes", () => {
   it("should have PUT /features for batch upsert with auth", () => {
     expect(content).toContain("router.put");
     const putLine = content.split("\n").find((l) =>
-      l.includes("router.put") && l.includes('"/features"')
+      l.includes("router.put") && l.includes('"/features"') && !l.includes(":slug")
     );
     expect(putLine).toBeDefined();
     expect(putLine).toContain("authenticate");
+  });
+
+  it("should have PUT /features/:slug with auth + requireOrg + requireUser", () => {
+    const putSlugLine = content.split("\n").find((l) =>
+      l.includes("router.put") && l.includes('"/features/:slug"')
+    );
+    expect(putSlugLine).toBeDefined();
+    expect(putSlugLine).toContain("authenticate");
+    expect(putSlugLine).toContain("requireOrg");
+    expect(putSlugLine).toContain("requireUser");
   });
 
   it("should use buildInternalHeaders for all endpoints", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(9);
+    expect(headerMatches!.length).toBe(10);
   });
 
   it("should proxy to externalServices.features", () => {
@@ -170,6 +180,11 @@ describe("Features OpenAPI schemas", () => {
   it("should register PUT /v1/features for batch upsert", () => {
     const putMatch = schemaContent.match(/method: "put",\s*\n\s*path: "\/v1\/features"/);
     expect(putMatch).not.toBeNull();
+  });
+
+  it("should register PUT /v1/features/{slug} for single update", () => {
+    const putSlugMatch = schemaContent.match(/method: "put",\s*\n\s*path: "\/v1\/features\/\{slug\}"/);
+    expect(putSlugMatch).not.toBeNull();
   });
 
   it("should use Features tag", () => {


### PR DESCRIPTION
## Summary
- Add missing `PUT /v1/features/:slug` proxy endpoint for updating individual feature definitions
- This was the only features-service endpoint not exposed through api-service (9/10 were covered)
- Includes OpenAPI schema registration and updated tests

## Test plan
- [x] 35 features proxy tests pass (2 new: route + OpenAPI registration)
- [x] Updated `buildInternalHeaders` count assertion (9 → 10)
- [x] TypeScript build passes
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)