### PR TITLE
feat: proxy missing workflow-service endpoints for dashboard

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3334,6 +3334,58 @@
           }
         }
       },
+      "CreateWorkflowResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "CreateWorkflowRequest": {
+        "type": "object",
+        "properties": {}
+      },
+      "DeleteWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "WorkflowRunResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "ExecuteWorkflowRequest": {
+        "type": "object",
+        "properties": {
+          "inputs": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "Runtime inputs accessible via $ref:flow_input.fieldName"
+          }
+        }
+      },
+      "ListWorkflowRunsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "GetWorkflowRunResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "DebugWorkflowRunResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "CancelWorkflowRunResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "PromptResponse": {
         "type": "object",
         "properties": {
@@ -10175,6 +10227,125 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Create a workflow",
+        "description": "Create a new workflow with a DAG definition. The workflow is deployed to the execution engine and can then be executed via POST /v1/workflows/{id}/execute.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkflowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Workflow created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateWorkflowResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/workflows/{id}": {
@@ -10391,6 +10562,126 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Delete a workflow",
+        "description": "Delete a workflow by ID.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow ID"
+            },
+            "required": true,
+            "description": "Workflow ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workflow deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteWorkflowResponse"
                 }
               }
             }
@@ -10894,6 +11185,655 @@
           },
           "404": {
             "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflows/{id}/execute": {
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Execute a workflow",
+        "description": "Start executing a workflow. Returns a run ID that can be polled via GET /v1/workflow-runs/{id} for status and result.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow ID"
+            },
+            "required": true,
+            "description": "Workflow ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecuteWorkflowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Execution started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflow-runs": {
+      "get": {
+        "tags": [
+          "Workflow Runs"
+        ],
+        "summary": "List workflow runs",
+        "description": "List workflow runs with optional filters. Results are scoped to the authenticated org.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow ID"
+            },
+            "required": false,
+            "description": "Filter by workflow ID",
+            "name": "workflowId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign ID"
+            },
+            "required": false,
+            "description": "Filter by campaign ID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug"
+            },
+            "required": false,
+            "description": "Filter by feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by status (queued, running, completed, failed, cancelled)"
+            },
+            "required": false,
+            "description": "Filter by status (queued, running, completed, failed, cancelled)",
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of workflow runs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListWorkflowRunsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflow-runs/{id}": {
+      "get": {
+        "tags": [
+          "Workflow Runs"
+        ],
+        "summary": "Get a workflow run",
+        "description": "Get the current status and result of a workflow execution. If still running, polls the engine for the latest status before responding.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow run ID (UUID)"
+            },
+            "required": true,
+            "description": "Workflow run ID (UUID)",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workflow run details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetWorkflowRunResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflow-runs/{id}/debug": {
+      "get": {
+        "tags": [
+          "Workflow Runs"
+        ],
+        "summary": "Debug a workflow run",
+        "description": "Returns per-step execution details including resolved inputs and outputs for each module. Use this to diagnose runtime issues.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow run ID (UUID)"
+            },
+            "required": true,
+            "description": "Workflow run ID (UUID)",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Debug details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebugWorkflowRunResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflow-runs/{id}/cancel": {
+      "post": {
+        "tags": [
+          "Workflow Runs"
+        ],
+        "summary": "Cancel a workflow run",
+        "description": "Cancel a running or queued workflow execution.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow run ID (UUID)"
+            },
+            "required": true,
+            "description": "Workflow run ID (UUID)",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelWorkflowRunResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -219,6 +219,28 @@ router.get("/workflows/best", authenticate, requireOrg, requireUser, async (req:
 });
 
 /**
+ * POST /v1/workflows
+ * Create a new workflow
+ */
+router.post("/workflows", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.workflow,
+      "/workflows",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.status(201).json(result);
+  } catch (error: any) {
+    console.error("Create workflow error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create workflow" });
+  }
+});
+
+/**
  * GET /v1/workflows/:id/summary
  * Returns an AI-generated summary of a workflow's DAG in natural language.
  */
@@ -459,6 +481,138 @@ router.get("/workflows/:id", authenticate, requireOrg, requireUser, async (req: 
   } catch (error: any) {
     console.error("Get workflow error:", error.message);
     res.status(500).json({ error: error.message || "Failed to get workflow" });
+  }
+});
+
+/**
+ * DELETE /v1/workflows/:id
+ * Delete a workflow
+ */
+router.delete("/workflows/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const result = await callExternalService(
+      externalServices.workflow,
+      `/workflows/${id}`,
+      {
+        method: "DELETE",
+        headers: buildInternalHeaders(req),
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Delete workflow error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to delete workflow" });
+  }
+});
+
+/**
+ * POST /v1/workflows/:id/execute
+ * Execute a workflow by ID
+ */
+router.post("/workflows/:id/execute", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const result = await callExternalService(
+      externalServices.workflow,
+      `/workflows/${id}/execute`,
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.status(201).json(result);
+  } catch (error: any) {
+    console.error("Execute workflow error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to execute workflow" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Workflow runs
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /v1/workflow-runs
+ * List workflow runs with optional filters
+ */
+router.get("/workflow-runs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["workflowId", "campaignId", "featureSlug", "status"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.workflow,
+      `/workflow-runs${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("List workflow runs error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list workflow runs" });
+  }
+});
+
+/**
+ * GET /v1/workflow-runs/:id
+ * Get a single workflow run by ID
+ */
+router.get("/workflow-runs/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const result = await callExternalService(
+      externalServices.workflow,
+      `/workflow-runs/${id}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get workflow run error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get workflow run" });
+  }
+});
+
+/**
+ * GET /v1/workflow-runs/:id/debug
+ * Debug a workflow run — per-step execution details
+ */
+router.get("/workflow-runs/:id/debug", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const result = await callExternalService(
+      externalServices.workflow,
+      `/workflow-runs/${id}/debug`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Debug workflow run error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to debug workflow run" });
+  }
+});
+
+/**
+ * POST /v1/workflow-runs/:id/cancel
+ * Cancel a running workflow
+ */
+router.post("/workflow-runs/:id/cancel", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const result = await callExternalService(
+      externalServices.workflow,
+      `/workflow-runs/${id}/cancel`,
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Cancel workflow run error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to cancel workflow run" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2304,6 +2304,179 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "post",
+  path: "/v1/workflows",
+  tags: ["Workflows"],
+  summary: "Create a workflow",
+  description:
+    "Create a new workflow with a DAG definition. The workflow is deployed to the execution engine and can then be executed via POST /v1/workflows/{id}/execute.",
+  security: authed,
+  request: {
+    body: {
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("CreateWorkflowRequest") } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Workflow created",
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("CreateWorkflowResponse") } },
+    },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/v1/workflows/{id}",
+  tags: ["Workflows"],
+  summary: "Delete a workflow",
+  description: "Delete a workflow by ID.",
+  security: authed,
+  request: { params: WorkflowIdParam },
+  responses: {
+    200: {
+      description: "Workflow deleted",
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.string().describe("Confirmation message"),
+          }).openapi("DeleteWorkflowResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Workflow not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/workflows/{id}/execute",
+  tags: ["Workflows"],
+  summary: "Execute a workflow",
+  description:
+    "Start executing a workflow. Returns a run ID that can be polled via GET /v1/workflow-runs/{id} for status and result.",
+  security: authed,
+  request: {
+    params: WorkflowIdParam,
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            inputs: z.record(z.any()).optional().describe("Runtime inputs accessible via $ref:flow_input.fieldName"),
+          }).openapi("ExecuteWorkflowRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Execution started",
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("WorkflowRunResponse") } },
+    },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Workflow not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
+// WORKFLOW RUNS
+// ===================================================================
+
+const WorkflowRunIdParam = z.object({
+  id: z.string().describe("Workflow run ID (UUID)"),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/workflow-runs",
+  tags: ["Workflow Runs"],
+  summary: "List workflow runs",
+  description: "List workflow runs with optional filters. Results are scoped to the authenticated org.",
+  security: authed,
+  request: {
+    query: z.object({
+      workflowId: z.string().optional().describe("Filter by workflow ID"),
+      campaignId: z.string().optional().describe("Filter by campaign ID"),
+      featureSlug: z.string().optional().describe("Filter by feature slug"),
+      status: z.string().optional().describe("Filter by status (queued, running, completed, failed, cancelled)"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "List of workflow runs",
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("ListWorkflowRunsResponse") } },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/workflow-runs/{id}",
+  tags: ["Workflow Runs"],
+  summary: "Get a workflow run",
+  description:
+    "Get the current status and result of a workflow execution. If still running, polls the engine for the latest status before responding.",
+  security: authed,
+  request: { params: WorkflowRunIdParam },
+  responses: {
+    200: {
+      description: "Workflow run details",
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("GetWorkflowRunResponse") } },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Run not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/workflow-runs/{id}/debug",
+  tags: ["Workflow Runs"],
+  summary: "Debug a workflow run",
+  description:
+    "Returns per-step execution details including resolved inputs and outputs for each module. Use this to diagnose runtime issues.",
+  security: authed,
+  request: { params: WorkflowRunIdParam },
+  responses: {
+    200: {
+      description: "Debug details",
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("DebugWorkflowRunResponse") } },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Run not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/workflow-runs/{id}/cancel",
+  tags: ["Workflow Runs"],
+  summary: "Cancel a workflow run",
+  description: "Cancel a running or queued workflow execution.",
+  security: authed,
+  request: { params: WorkflowRunIdParam },
+  responses: {
+    200: {
+      description: "Run cancelled",
+      content: { "application/json": { schema: z.object({}).passthrough().openapi("CancelWorkflowRunResponse") } },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Run not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // PROMPTS (proxy to content-generation service)
 // ===================================================================

--- a/tests/unit/workflow-runs-proxy.test.ts
+++ b/tests/unit/workflow-runs-proxy.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+let mockAuth = {
+  userId: "user_test123",
+  orgId: "org_test456",
+  authType: "user_key" as "user_key" | "admin",
+};
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = mockAuth.userId;
+    req.orgId = mockAuth.orgId;
+    req.authType = mockAuth.authType;
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+import workflowsRoutes from "../../src/routes/workflows.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", workflowsRoutes);
+  return app;
+}
+
+function mockFetchWith(response: any, status = 200) {
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    fetchCalls.push({ url, method: init?.method, body });
+    return { ok: status < 400, status, json: () => Promise.resolve(response) };
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fetchCalls = [];
+  mockAuth = { userId: "user_test123", orgId: "org_test456", authType: "user_key" };
+  mockFetchWith({});
+});
+
+// -----------------------------------------------------------------------
+// POST /v1/workflows — create workflow
+// -----------------------------------------------------------------------
+
+describe("POST /v1/workflows", () => {
+  it("should proxy to workflow-service POST /workflows", async () => {
+    mockFetchWith({ id: "wf-123", name: "test-flow" });
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/workflows")
+      .send({ name: "test-flow", featureSlug: "pr-outreach", dag: { nodes: [], edges: [] } });
+
+    expect(res.status).toBe(201);
+    const call = fetchCalls.find((c) => c.method === "POST" && c.url.includes("/workflows"));
+    expect(call).toBeDefined();
+    expect(call!.body.name).toBe("test-flow");
+  });
+});
+
+// -----------------------------------------------------------------------
+// DELETE /v1/workflows/:id
+// -----------------------------------------------------------------------
+
+describe("DELETE /v1/workflows/:id", () => {
+  it("should proxy to workflow-service DELETE /workflows/:id", async () => {
+    mockFetchWith({ message: "deleted" });
+    const app = createApp();
+    const res = await request(app).delete("/v1/workflows/wf-123");
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.method === "DELETE");
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("/workflows/wf-123");
+  });
+});
+
+// -----------------------------------------------------------------------
+// POST /v1/workflows/:id/execute
+// -----------------------------------------------------------------------
+
+describe("POST /v1/workflows/:id/execute", () => {
+  it("should proxy to workflow-service POST /workflows/:id/execute", async () => {
+    mockFetchWith({ id: "run-456", status: "queued" });
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/workflows/wf-123/execute")
+      .send({ inputs: { email: "test@example.com" } });
+
+    expect(res.status).toBe(201);
+    const call = fetchCalls.find((c) => c.method === "POST" && c.url.includes("/execute"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("/workflows/wf-123/execute");
+    expect(call!.body.inputs.email).toBe("test@example.com");
+  });
+});
+
+// -----------------------------------------------------------------------
+// GET /v1/workflow-runs
+// -----------------------------------------------------------------------
+
+describe("GET /v1/workflow-runs", () => {
+  it("should proxy to workflow-service GET /workflow-runs", async () => {
+    mockFetchWith({ workflowRuns: [{ id: "run-1", status: "completed" }] });
+    const app = createApp();
+    const res = await request(app).get("/v1/workflow-runs");
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflowRuns).toHaveLength(1);
+    expect(fetchCalls[0].url).toContain("/workflow-runs");
+  });
+
+  it("should forward query params", async () => {
+    mockFetchWith({ workflowRuns: [] });
+    const app = createApp();
+    await request(app).get("/v1/workflow-runs?workflowId=wf-123&status=failed&featureSlug=pr-outreach");
+
+    const call = fetchCalls[0];
+    expect(call.url).toContain("workflowId=wf-123");
+    expect(call.url).toContain("status=failed");
+    expect(call.url).toContain("featureSlug=pr-outreach");
+  });
+});
+
+// -----------------------------------------------------------------------
+// GET /v1/workflow-runs/:id
+// -----------------------------------------------------------------------
+
+describe("GET /v1/workflow-runs/:id", () => {
+  it("should proxy to workflow-service GET /workflow-runs/:id", async () => {
+    mockFetchWith({ id: "run-456", status: "completed", result: { ok: true } });
+    const app = createApp();
+    const res = await request(app).get("/v1/workflow-runs/run-456");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("completed");
+    expect(fetchCalls[0].url).toContain("/workflow-runs/run-456");
+  });
+});
+
+// -----------------------------------------------------------------------
+// GET /v1/workflow-runs/:id/debug
+// -----------------------------------------------------------------------
+
+describe("GET /v1/workflow-runs/:id/debug", () => {
+  it("should proxy to workflow-service GET /workflow-runs/:id/debug", async () => {
+    mockFetchWith({ runId: "run-456", windmillJobId: "wm-789", status: "completed" });
+    const app = createApp();
+    const res = await request(app).get("/v1/workflow-runs/run-456/debug");
+
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBe("run-456");
+    expect(fetchCalls[0].url).toContain("/workflow-runs/run-456/debug");
+  });
+});
+
+// -----------------------------------------------------------------------
+// POST /v1/workflow-runs/:id/cancel
+// -----------------------------------------------------------------------
+
+describe("POST /v1/workflow-runs/:id/cancel", () => {
+  it("should proxy to workflow-service POST /workflow-runs/:id/cancel", async () => {
+    mockFetchWith({ id: "run-456", status: "cancelled" });
+    const app = createApp();
+    const res = await request(app).post("/v1/workflow-runs/run-456/cancel");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("cancelled");
+    const call = fetchCalls.find((c) => c.method === "POST" && c.url.includes("/cancel"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("/workflow-runs/run-456/cancel");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 7 missing workflow-service proxy endpoints that were never exposed through api-service
- **Workflow CRUD**: `POST /v1/workflows` (create), `DELETE /v1/workflows/:id` (delete)
- **Workflow execution**: `POST /v1/workflows/:id/execute` (start execution)
- **Run management**: `GET /v1/workflow-runs` (list), `GET /v1/workflow-runs/:id` (status/result), `GET /v1/workflow-runs/:id/debug` (per-step details), `POST /v1/workflow-runs/:id/cancel` (cancel)

## Test plan
- [x] 8 new unit tests covering all 7 endpoints (happy paths + query param forwarding)
- [x] Existing workflow proxy tests still pass (54/54 pass, 2 pre-existing failures in workflows-stats unrelated)
- [x] TypeScript build passes
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)