### PR TITLE
feat: forward fork-on-write status on PUT /features/:slug

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5130,6 +5130,10 @@
         "type": "object",
         "properties": {}
       },
+      "ForkedFeatureResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "UpdateFeatureRequest": {
         "type": "object",
         "properties": {}
@@ -18211,7 +18215,7 @@
           "Features"
         ],
         "summary": "Update feature by slug",
-        "description": "Update a single feature definition by its slug. All fields are optional — only provided fields are updated. Proxied from features-service.",
+        "description": "Update a single feature definition by its slug. Metadata-only updates (description, icon, charts, etc.) apply in-place and return 200. If inputs or outputs change, a new feature is forked and the original is deprecated (fork-on-write) — returns 201 with forkedFrom details. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -18294,11 +18298,21 @@
         },
         "responses": {
           "200": {
-            "description": "Updated feature",
+            "description": "In-place update (metadata only)",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UpdateFeatureResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Fork created (inputs/outputs changed). Response includes `forkedFrom` with the original feature's id, slug, and status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForkedFeatureResponse"
                 }
               }
             }

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -102,6 +102,16 @@ export async function callExternalService<T>(
   path: string,
   options: ServiceCallOptions = {}
 ): Promise<T> {
+  const { data } = await callExternalServiceWithStatus<T>(service, path, options);
+  return data;
+}
+
+// Like callExternalService but also returns the upstream HTTP status code
+export async function callExternalServiceWithStatus<T>(
+  service: { url: string; apiKey: string },
+  path: string,
+  options: ServiceCallOptions = {}
+): Promise<{ status: number; data: T }> {
   const { method = "GET", body, headers = {} } = options;
 
   const url = `${service.url}${path}`;
@@ -131,7 +141,8 @@ export async function callExternalService<T>(
       throw err;
     }
 
-    return await response.json();
+    const data: T = await response.json();
+    return { status: response.status, data };
   } catch (error: any) {
     const cause = error.cause ? ` (cause: ${error.cause?.code || error.cause?.message || error.cause})` : "";
     console.error(`[callExternalService] ${method} ${url} failed: ${error.message}${cause}`);

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
-import { callExternalService, externalServices } from "../lib/service-client.js";
+import { callExternalService, callExternalServiceWithStatus, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
@@ -176,11 +176,13 @@ router.post("/features", authenticate, requireOrg, requireUser, async (req: Auth
 
 /**
  * PUT /v1/features/:slug
- * Update a single feature by slug
+ * Update a single feature by slug.
+ * Returns 200 for in-place metadata updates, 201 when inputs/outputs changed
+ * and a fork was created (fork-on-write semantics from features-service).
  */
 router.put("/features/:slug", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const result = await callExternalService(
+    const { status, data } = await callExternalServiceWithStatus(
       externalServices.features,
       `/features/${encodeURIComponent(req.params.slug)}`,
       {
@@ -189,7 +191,7 @@ router.put("/features/:slug", authenticate, requireOrg, requireUser, async (req:
         body: req.body,
       },
     );
-    res.json(result);
+    res.status(status).json(data);
   } catch (error: any) {
     console.error("Update feature error:", error.message);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to update feature" });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4354,7 +4354,7 @@ registry.registerPath({
   path: "/v1/features/{slug}",
   tags: ["Features"],
   summary: "Update feature by slug",
-  description: "Update a single feature definition by its slug. All fields are optional — only provided fields are updated. Proxied from features-service.",
+  description: "Update a single feature definition by its slug. Metadata-only updates (description, icon, charts, etc.) apply in-place and return 200. If inputs or outputs change, a new feature is forked and the original is deprecated (fork-on-write) — returns 201 with forkedFrom details. Proxied from features-service.",
   security: authed,
   request: {
     params: z.object({ slug: z.string().describe("Feature slug") }),
@@ -4363,7 +4363,8 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Updated feature", content: { "application/json": { schema: z.object({}).passthrough().openapi("UpdateFeatureResponse") } } },
+    200: { description: "In-place update (metadata only)", content: { "application/json": { schema: z.object({}).passthrough().openapi("UpdateFeatureResponse") } } },
+    201: { description: "Fork created (inputs/outputs changed). Response includes `forkedFrom` with the original feature's id, slug, and status.", content: { "application/json": { schema: z.object({}).passthrough().openapi("ForkedFeatureResponse") } } },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Feature not found", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -82,6 +82,12 @@ describe("Features proxy routes", () => {
     expect(putSlugLine).toContain("requireUser");
   });
 
+  it("should forward upstream status code on PUT /features/:slug (fork-on-write)", () => {
+    expect(content).toContain("callExternalServiceWithStatus");
+    // The route should use res.status(status) to forward 200 or 201
+    expect(content).toContain("res.status(status).json(data)");
+  });
+
   it("should use buildInternalHeaders for all endpoints", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
@@ -144,6 +150,10 @@ describe("Features service client", () => {
     expect(serviceClientContent).toContain("FEATURES_SERVICE_URL");
     expect(serviceClientContent).toContain("FEATURES_SERVICE_API_KEY");
   });
+
+  it("should export callExternalServiceWithStatus", () => {
+    expect(serviceClientContent).toContain("export async function callExternalServiceWithStatus");
+  });
 });
 
 describe("Features OpenAPI schemas", () => {
@@ -185,6 +195,12 @@ describe("Features OpenAPI schemas", () => {
   it("should register PUT /v1/features/{slug} for single update", () => {
     const putSlugMatch = schemaContent.match(/method: "put",\s*\n\s*path: "\/v1\/features\/\{slug\}"/);
     expect(putSlugMatch).not.toBeNull();
+  });
+
+  it("should document 201 fork-on-write response on PUT /v1/features/{slug}", () => {
+    expect(schemaContent).toContain("ForkedFeatureResponse");
+    expect(schemaContent).toContain("Fork created");
+    expect(schemaContent).toContain("forkedFrom");
   });
 
   it("should use Features tag", () => {


### PR DESCRIPTION
## Summary
- Features-service PR #24 introduced fork-on-write: metadata-only PUT returns 200, input/output changes fork the feature and return 201 with `forkedFrom` details
- Added `callExternalServiceWithStatus()` to service-client so the proxy can forward the upstream HTTP status code
- PUT `/features/:slug` now returns 200 or 201 matching what features-service returns
- OpenAPI schema documents both response codes including the new `ForkedFeatureResponse`

## Test plan
- [x] All 38 features-proxy tests pass (including 3 new tests for fork-on-write behavior)
- [ ] Integration: PUT a feature with only metadata changes → verify 200
- [ ] Integration: PUT a feature with input/output changes → verify 201 with `forkedFrom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)