### PR TITLE
fix: remove GET /press-kits/organizations/:orgId/share-token proxy (removed upstream)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4772,18 +4772,6 @@
         "type": "object",
         "properties": {}
       },
-      "PressKitShareTokenResponse": {
-        "type": "object",
-        "properties": {
-          "shareToken": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "shareToken"
-        ]
-      },
       "PressKitOrgExistsResponse": {
         "type": "object",
         "properties": {}
@@ -15495,107 +15483,6 @@
             }
           }
         }
-      }
-    },
-    "/v1/press-kits/organizations/{orgId}/share-token": {
-      "get": {
-        "tags": [
-          "Press Kits"
-        ],
-        "summary": "Get organization share token",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Share token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PressKitShareTokenResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-name",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
       }
     },
     "/v1/press-kits/organizations/exists": {

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -22,20 +22,6 @@ router.get("/press-kits/public/:token", async (req: Request, res: Response) => {
 
 // ── Authenticated routes (mounted at /v1) ────────────────────────────────────
 
-// GET /v1/press-kits/organizations/:orgId/share-token — get share token
-router.get("/press-kits/organizations/:orgId/share-token", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
-  try {
-    const result = await callExternalService(
-      externalServices.pressKits,
-      `/organizations/${encodeURIComponent(req.params.orgId)}/share-token`,
-      { headers: buildInternalHeaders(req) }
-    );
-    res.json(result);
-  } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get share token" });
-  }
-});
-
 // GET /v1/press-kits/organizations/exists — batch check existence
 router.get("/press-kits/organizations/exists", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3928,19 +3928,6 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/organizations/{orgId}/share-token",
-  tags: ["Press Kits"],
-  summary: "Get organization share token",
-  security: authed,
-  responses: {
-    200: { description: "Share token", content: { "application/json": { schema: z.object({ shareToken: z.string().uuid() }).openapi("PressKitShareTokenResponse") } } },
-    404: { description: "Not found", content: errorContent },
-    401: { description: "Unauthorized", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "get",
   path: "/v1/press-kits/organizations/exists",
   tags: ["Press Kits"],
   summary: "Batch check organization existence",

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -44,8 +44,8 @@ describe("Press Kits proxy routes", () => {
     expect(postOrgLine).toBeUndefined();
   });
 
-  it("should have GET /press-kits/organizations/:orgId/share-token with auth", () => {
-    expect(content).toContain('"/press-kits/organizations/:orgId/share-token"');
+  it("should NOT have GET /press-kits/organizations/:orgId/share-token (removed upstream)", () => {
+    expect(content).not.toContain('"/press-kits/organizations/:orgId/share-token"');
   });
 
   it("should have GET /press-kits/organizations/exists with auth", () => {
@@ -134,15 +134,15 @@ describe("Press Kits proxy routes", () => {
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    // 18 authenticated routes + 1 import = 19
-    expect(authMatches!.length).toBe(19);
+    // 17 authenticated routes + 1 import = 18
+    expect(authMatches!.length).toBe(18);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(18);
+    expect(headerMatches!.length).toBe(17);
   });
 
   it("should proxy to externalServices.pressKits", () => {
@@ -197,7 +197,7 @@ describe("Press Kits OpenAPI schemas", () => {
 
   it("should register REST authenticated paths", () => {
     expect(schemaContent).not.toContain('path: "/v1/press-kits/organizations"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/organizations/{orgId}/share-token"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/organizations/{orgId}/share-token"');
     expect(schemaContent).toContain('path: "/v1/press-kits/organizations/exists"');
     expect(schemaContent).toContain('path: "/v1/press-kits/media-kits"');
     expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}"');


### PR DESCRIPTION
## Summary
- Remove dead proxy route for `GET /v1/press-kits/organizations/:orgId/share-token` — the endpoint was removed from the press-kits service upstream, causing 404s in workflows
- Remove corresponding OpenAPI schema registration
- Update tests to assert the route is no longer present

## Test plan
- [x] All 45 press-kits proxy tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)