### PR TITLE
fix: remove stale press-kits proxies, migrate admin to /media-kits

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4772,10 +4772,6 @@
         "type": "object",
         "properties": {}
       },
-      "PressKitOrgExistsResponse": {
-        "type": "object",
-        "properties": {}
-      },
       "PressKitMediaKitListResponse": {
         "type": "object",
         "properties": {}
@@ -15485,97 +15481,6 @@
         }
       }
     },
-    "/v1/press-kits/organizations/exists": {
-      "get": {
-        "tags": [
-          "Press Kits"
-        ],
-        "summary": "Batch check organization existence",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Existence check results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PressKitOrgExistsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-name",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
-      }
-    },
     "/v1/press-kits/media-kits": {
       "get": {
         "tags": [
@@ -16384,12 +16289,12 @@
         ]
       }
     },
-    "/v1/press-kits/admin/organizations": {
+    "/v1/press-kits/admin/media-kits": {
       "get": {
         "tags": [
           "Press Kits"
         ],
-        "summary": "List organizations with kit counts (admin)",
+        "summary": "List media kits (admin)",
         "security": [
           {
             "bearerAuth": []
@@ -16475,12 +16380,12 @@
         ]
       }
     },
-    "/v1/press-kits/admin/organizations/{id}": {
+    "/v1/press-kits/admin/media-kits/{id}": {
       "delete": {
         "tags": [
           "Press Kits"
         ],
-        "summary": "Delete organization (admin)",
+        "summary": "Delete media kit (admin)",
         "security": [
           {
             "bearerAuth": []

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -22,21 +22,6 @@ router.get("/press-kits/public/:token", async (req: Request, res: Response) => {
 
 // ── Authenticated routes (mounted at /v1) ────────────────────────────────────
 
-// GET /v1/press-kits/organizations/exists — batch check existence
-router.get("/press-kits/organizations/exists", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
-  try {
-    const qs = req.query.orgIds ? `?orgIds=${encodeURIComponent(req.query.orgIds as string)}` : "";
-    const result = await callExternalService(
-      externalServices.pressKits,
-      `/organizations/exists${qs}`,
-      { headers: buildInternalHeaders(req) }
-    );
-    res.json(result);
-  } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to check organizations" });
-  }
-});
-
 // GET /v1/press-kits/media-kits — list media kits
 router.get("/press-kits/media-kits", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
@@ -143,33 +128,33 @@ router.post("/press-kits/media-kits/:id/cancel", authenticate, requireOrg, async
 
 // ── Admin routes (authenticated) ─────────────────────────────────────────────
 
-// GET /v1/press-kits/admin/organizations — list orgs with kit counts
-router.get("/press-kits/admin/organizations", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// GET /v1/press-kits/admin/media-kits — list media kits (admin)
+router.get("/press-kits/admin/media-kits", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const qs = req.query.search ? `?search=${encodeURIComponent(req.query.search as string)}` : "";
     const result = await callExternalService(
       externalServices.pressKits,
-      `/admin/organizations${qs}`,
+      `/admin/media-kits${qs}`,
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list admin organizations" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list admin media kits" });
   }
 });
 
-// DELETE /v1/press-kits/admin/organizations/:id — delete organization
-router.delete("/press-kits/admin/organizations/:id", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+// DELETE /v1/press-kits/admin/media-kits/:id — delete media kit (admin)
+router.delete("/press-kits/admin/media-kits/:id", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const qs = req.query.confirmName ? `?confirmName=${encodeURIComponent(req.query.confirmName as string)}` : "";
     const result = await callExternalService(
       externalServices.pressKits,
-      `/admin/organizations/${encodeURIComponent(req.params.id)}${qs}`,
+      `/admin/media-kits/${encodeURIComponent(req.params.id)}${qs}`,
       { method: "DELETE", headers: buildInternalHeaders(req) }
     );
     res.json(result);
   } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to delete organization" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to delete media kit" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3928,18 +3928,6 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/organizations/exists",
-  tags: ["Press Kits"],
-  summary: "Batch check organization existence",
-  security: authed,
-  responses: {
-    200: { description: "Existence check results", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitOrgExistsResponse") } } },
-    401: { description: "Unauthorized", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "get",
   path: "/v1/press-kits/media-kits",
   tags: ["Press Kits"],
   summary: "List media kits",
@@ -4061,9 +4049,9 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/press-kits/admin/organizations",
+  path: "/v1/press-kits/admin/media-kits",
   tags: ["Press Kits"],
-  summary: "List organizations with kit counts (admin)",
+  summary: "List media kits (admin)",
   security: authed,
   responses: {
     200: { description: "Admin org list", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitAdminOrgListResponse") } } },
@@ -4073,9 +4061,9 @@ registry.registerPath({
 
 registry.registerPath({
   method: "delete",
-  path: "/v1/press-kits/admin/organizations/{id}",
+  path: "/v1/press-kits/admin/media-kits/{id}",
   tags: ["Press Kits"],
-  summary: "Delete organization (admin)",
+  summary: "Delete media kit (admin)",
   security: authed,
   responses: {
     200: { description: "Deleted", content: { "application/json": { schema: z.object({ success: z.boolean() }).openapi("PressKitAdminDeleteResponse") } } },

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -48,8 +48,8 @@ describe("Press Kits proxy routes", () => {
     expect(content).not.toContain('"/press-kits/organizations/:orgId/share-token"');
   });
 
-  it("should have GET /press-kits/organizations/exists with auth", () => {
-    expect(content).toContain('"/press-kits/organizations/exists"');
+  it("should NOT have GET /press-kits/organizations/exists (removed upstream)", () => {
+    expect(content).not.toContain('"/press-kits/organizations/exists"');
   });
 
   it("should have GET /press-kits/media-kits (plural) with auth", () => {
@@ -90,13 +90,18 @@ describe("Press Kits proxy routes", () => {
 
   // ── Admin endpoints ───────────────────────────────────────────────────
 
-  it("should have GET /press-kits/admin/organizations with auth", () => {
-    expect(content).toContain('"/press-kits/admin/organizations"');
+  it("should have GET /press-kits/admin/media-kits with auth", () => {
+    expect(content).toContain('"/press-kits/admin/media-kits"');
   });
 
-  it("should have DELETE /press-kits/admin/organizations/:id with auth", () => {
-    expect(content).toContain('"/press-kits/admin/organizations/:id"');
+  it("should have DELETE /press-kits/admin/media-kits/:id with auth", () => {
+    expect(content).toContain('"/press-kits/admin/media-kits/:id"');
     expect(content).toContain("router.delete");
+  });
+
+  it("should NOT have old /admin/organizations routes (moved to /admin/media-kits)", () => {
+    expect(content).not.toContain('"/press-kits/admin/organizations"');
+    expect(content).not.toContain('"/press-kits/admin/organizations/:id"');
   });
 
   // ── Internal endpoints (new REST paths) ───────────────────────────────
@@ -134,15 +139,15 @@ describe("Press Kits proxy routes", () => {
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    // 17 authenticated routes + 1 import = 18
-    expect(authMatches!.length).toBe(18);
+    // 16 authenticated routes + 1 import = 17
+    expect(authMatches!.length).toBe(17);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(17);
+    expect(headerMatches!.length).toBe(16);
   });
 
   it("should proxy to externalServices.pressKits", () => {
@@ -198,7 +203,7 @@ describe("Press Kits OpenAPI schemas", () => {
   it("should register REST authenticated paths", () => {
     expect(schemaContent).not.toContain('path: "/v1/press-kits/organizations"');
     expect(schemaContent).not.toContain('path: "/v1/press-kits/organizations/{orgId}/share-token"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/organizations/exists"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/organizations/exists"');
     expect(schemaContent).toContain('path: "/v1/press-kits/media-kits"');
     expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}"');
     expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/{id}/mdx"');
@@ -220,8 +225,10 @@ describe("Press Kits OpenAPI schemas", () => {
   });
 
   it("should register admin paths", () => {
-    expect(schemaContent).toContain('path: "/v1/press-kits/admin/organizations"');
-    expect(schemaContent).toContain('path: "/v1/press-kits/admin/organizations/{id}"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/admin/media-kits"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/admin/media-kits/{id}"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/admin/organizations"');
+    expect(schemaContent).not.toContain('path: "/v1/press-kits/admin/organizations/{id}"');
   });
 
   it("should register new internal paths", () => {


### PR DESCRIPTION
## Summary
- Remove `GET /v1/press-kits/organizations/exists` proxy (endpoint removed upstream)
- Rename admin routes from `/admin/organizations` → `/admin/media-kits` (upstream refactor)
- Update OpenAPI schemas and tests

## Test plan
- [x] All 46 press-kits proxy tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)