### PR TITLE
fix: enforce identity headers on all features proxy routes

### DIFF
--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -9,7 +9,7 @@ const router = Router();
  * GET /v1/features
  * List features with optional filters
  */
-router.get("/features", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/features", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
     for (const key of ["status", "category", "channel", "audienceType", "implemented"]) {
@@ -32,7 +32,7 @@ router.get("/features", authenticate, async (req: AuthenticatedRequest, res) => 
  * GET /v1/features/stats/registry
  * Public dictionary of stats keys (label + type per key)
  */
-router.get("/features/stats/registry", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/features/stats/registry", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.features,
@@ -50,7 +50,7 @@ router.get("/features/stats/registry", authenticate, async (req: AuthenticatedRe
  * GET /v1/features/stats
  * Global stats cross-features, groupable by featureSlug/workflowName/brandId/campaignId
  */
-router.get("/features/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/features/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
     for (const key of ["groupBy", "brandId"]) {
@@ -73,7 +73,7 @@ router.get("/features/stats", authenticate, requireOrg, async (req: Authenticate
  * GET /v1/features/:slug
  * Get a single feature by slug
  */
-router.get("/features/:slug", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/features/:slug", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.features,
@@ -91,7 +91,7 @@ router.get("/features/:slug", authenticate, async (req: AuthenticatedRequest, re
  * GET /v1/features/:slug/inputs
  * Get input schema for a feature
  */
-router.get("/features/:slug/inputs", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/features/:slug/inputs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.features,
@@ -109,7 +109,7 @@ router.get("/features/:slug/inputs", authenticate, async (req: AuthenticatedRequ
  * GET /v1/features/:slug/stats
  * Stats for a specific feature, groupable by workflowName/brandId/campaignId
  */
-router.get("/features/:slug/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
     for (const key of ["groupBy", "brandId", "campaignId", "workflowName"]) {
@@ -202,7 +202,7 @@ router.put("/features/:slug", authenticate, requireOrg, requireUser, async (req:
  * PUT /v1/features
  * Batch upsert features (cold-start registration)
  */
-router.put("/features", authenticate, async (req: AuthenticatedRequest, res) => {
+router.put("/features", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.features,

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -15,9 +15,14 @@ const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts"
 const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
 
 describe("Features proxy routes", () => {
-  it("should have GET /features with auth", () => {
-    expect(content).toContain('"/features"');
-    expect(content).toContain("router.get");
+  it("should have GET /features with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/features"') && !l.includes("/:slug") && !l.includes("/stats")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
   it("should forward query params on GET /features", () => {
@@ -26,12 +31,24 @@ describe("Features proxy routes", () => {
     }
   });
 
-  it("should have GET /features/:slug with auth", () => {
-    expect(content).toContain('"/features/:slug"');
+  it("should have GET /features/:slug with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/features/:slug"') && !l.includes("/inputs") && !l.includes("/stats")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
-  it("should have GET /features/:slug/inputs with auth", () => {
-    expect(content).toContain('"/features/:slug/inputs"');
+  it("should have GET /features/:slug/inputs with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/features/:slug/inputs"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
   it("should have POST /features/:slug/prefill with auth + requireOrg + requireUser", () => {
@@ -63,13 +80,15 @@ describe("Features proxy routes", () => {
     expect(content).toContain("res.status(201)");
   });
 
-  it("should have PUT /features for batch upsert with auth", () => {
+  it("should have PUT /features for batch upsert with auth + requireOrg + requireUser", () => {
     expect(content).toContain("router.put");
     const putLine = content.split("\n").find((l) =>
       l.includes("router.put") && l.includes('"/features"') && !l.includes(":slug")
     );
     expect(putLine).toBeDefined();
     expect(putLine).toContain("authenticate");
+    expect(putLine).toContain("requireOrg");
+    expect(putLine).toContain("requireUser");
   });
 
   it("should have PUT /features/:slug with auth + requireOrg + requireUser", () => {
@@ -99,21 +118,24 @@ describe("Features proxy routes", () => {
     expect(content).toContain("externalServices.features");
   });
 
-  it("should have GET /features/stats/registry with auth", () => {
+  it("should have GET /features/stats/registry with auth + requireOrg + requireUser", () => {
     expect(content).toContain('"/features/stats/registry"');
     const line = content.split("\n").find((l) =>
       l.includes('"/features/stats/registry"')
     );
     expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
-  it("should have GET /features/stats with auth + requireOrg", () => {
+  it("should have GET /features/stats with auth + requireOrg + requireUser", () => {
     expect(content).toContain('"/features/stats"');
     const line = content.split("\n").find((l) =>
       l.includes('router.get') && l.includes('"/features/stats"')
     );
     expect(line).toContain("authenticate");
     expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
   it("should forward groupBy and brandId on GET /features/stats", () => {
@@ -121,18 +143,32 @@ describe("Features proxy routes", () => {
     expect(content).toContain('"brandId"');
   });
 
-  it("should have GET /features/:slug/stats with auth + requireOrg", () => {
+  it("should have GET /features/:slug/stats with auth + requireOrg + requireUser", () => {
     expect(content).toContain('"/features/:slug/stats"');
     const line = content.split("\n").find((l) =>
       l.includes('"/features/:slug/stats"')
     );
     expect(line).toContain("authenticate");
     expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
   it("should forward groupBy, brandId, campaignId, workflowName on GET /features/:slug/stats", () => {
     expect(content).toContain('"campaignId"');
     expect(content).toContain('"workflowName"');
+  });
+
+  it("should enforce requireOrg + requireUser on ALL feature routes", () => {
+    // Every router.get / router.post / router.put line must include both guards
+    const routeLines = content.split("\n").filter((l) =>
+      /router\.(get|post|put)\(/.test(l) && l.includes('"/')
+    );
+    expect(routeLines.length).toBeGreaterThan(0);
+    for (const line of routeLines) {
+      expect(line).toContain("authenticate");
+      expect(line).toContain("requireOrg");
+      expect(line).toContain("requireUser");
+    }
   });
 
   it("should register static routes before parameterized :slug route", () => {


### PR DESCRIPTION
## Summary
- All features-service endpoints now require `x-org-id`, `x-user-id`, and `x-run-id` headers
- Added `requireOrg` + `requireUser` middleware to the 7 features proxy routes that were missing them: `GET /features`, `GET /features/stats/registry`, `GET /features/stats`, `GET /features/:slug`, `GET /features/:slug/inputs`, `GET /features/:slug/stats`, `PUT /features`
- Requests missing org/user context now fail fast at the api-service layer with a clear 400 instead of getting a confusing error from features-service

## Test plan
- [x] Updated all existing features-proxy tests to assert `requireOrg` + `requireUser` on every route
- [x] Added regression test that ensures ALL feature route definitions include both guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)