### PR TITLE
fix: use lead-service as source of truth for leadsServed

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -398,7 +398,7 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
     const internalHeaders = buildInternalHeaders(req);
 
     // Fetch stats from all services in parallel using campaignId filter
-    const [leadStats, emailgenStats, delivery, budgetUsage, costBreakdown, leadsFromRuns] = await Promise.all([
+    const [leadStats, emailgenStats, delivery, budgetUsage, costBreakdown] = await Promise.all([
       callExternalService(
         externalServices.lead,
         `/stats?campaignId=${id}`,
@@ -433,15 +433,6 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
         console.warn("[campaigns] Cost breakdown failed:", (err as Error).message);
         return null;
       }),
-      // Lead-serve run count from runs-service (source of truth for leadsServed)
-      callExternalService<{ groups: Array<{ dimensions: Record<string, string | null>; runCount: number }> }>(
-        externalServices.runs,
-        `/v1/stats/costs?orgId=${encodeURIComponent(orgId)}&campaignId=${encodeURIComponent(id)}&taskName=lead-serve&groupBy=serviceName`,
-        { headers: internalHeaders }
-      ).catch((err) => {
-        console.warn("[campaigns] Lead-serve runs stats failed:", (err as Error).message);
-        return null;
-      }),
     ]);
 
     const stats: Record<string, any> = { campaignId: id };
@@ -461,11 +452,9 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
       stats.leadsSkipped = 0;
     }
 
-    // Override leadsServed from runs-service (source of truth — lead-service
-    // tracking can lag behind the actual number of completed lead-serve runs)
-    if (leadsFromRuns?.groups?.length) {
-      stats.leadsServed = leadsFromRuns.groups[0].runCount;
-    }
+    // Lead-service served_leads table is the source of truth for leadsServed.
+    // Do NOT override with runs-service runCount — that counts all lead-serve
+    // runs including ones where no lead was found (e.g. empty buffer).
 
     // Emailgen stats
     if (emailgenStats) {

--- a/tests/unit/leads-served-runs-source.regression.test.ts
+++ b/tests/unit/leads-served-runs-source.regression.test.ts
@@ -1,42 +1,39 @@
 /**
- * Regression test: the lead-service /stats endpoint can return served: 0 even
- * when leads were successfully processed through the pipeline. The runs-service
- * tracks every lead-serve run accurately, so leadsServed must be derived from
- * the runs-service run count rather than trusting the lead-service stats alone.
+ * Regression test: leadsServed must come from lead-service's served_leads
+ * table, NOT from runs-service run counts. Runs-service counts all lead-serve
+ * runs including ones where no lead was found (e.g. empty buffer), which
+ * inflates the stat.
  *
- * Fix: campaigns.ts now fetches lead-serve run counts from runs-service
- * (GET /v1/stats/costs?taskName=lead-serve&groupBy=...) and uses that as the
- * source of truth for leadsServed, overriding the lead-service stats.
- *
- * Note: the batch-stats endpoint (POST /v1/campaigns/stats/batch) has been
- * removed. Only the single-campaign stats endpoint remains.
+ * Fix: campaigns.ts no longer fetches lead-serve run counts from runs-service
+ * and no longer overrides lead-service stats. Lead-service served_leads is
+ * the single source of truth for leadsServed.
  */
 import { describe, it, expect } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 
-describe("leadsServed uses runs-service as source of truth", () => {
+describe("leadsServed uses lead-service as source of truth (not runs-service)", () => {
   const routePath = path.join(__dirname, "../../src/routes/campaigns.ts");
   const content = fs.readFileSync(routePath, "utf-8");
 
-  it("should fetch lead-serve run counts from runs-service in single-campaign stats", () => {
-    // The single-campaign stats endpoint must call runs-service with taskName=lead-serve
-    const statsStart = content.indexOf("GET /v1/campaigns/:id/stats");
-    expect(statsStart).toBeGreaterThan(-1);
-    const statsSection = content.slice(statsStart, statsStart + 3000);
-    expect(statsSection).toContain("taskName=lead-serve");
-    expect(statsSection).toContain("groupBy=serviceName");
+  it("should NOT override leadsServed from runs-service run counts", () => {
+    // The old bug: leadsFromRuns.groups[0].runCount was used to override leadsServed
+    // This must no longer be present
+    expect(content).not.toContain("leadsFromRuns");
+    expect(content).not.toMatch(/stats\.leadsServed\s*=\s*.*runCount/);
   });
 
-  it("should override leadsServed from runs-service in single-campaign stats", () => {
+  it("should NOT fetch lead-serve run counts from runs-service for stats override", () => {
+    // We should not be making a separate runs-service call just for lead-serve counts
+    expect(content).not.toContain("taskName=lead-serve");
+  });
+
+  it("should use lead-service served count as leadsServed", () => {
+    // The single-campaign stats endpoint should set leadsServed from lead-service
     const statsStart = content.indexOf("GET /v1/campaigns/:id/stats");
     expect(statsStart).toBeGreaterThan(-1);
-    // Use a generous slice to capture the full endpoint handler
     const statsSection = content.slice(statsStart, statsStart + 5000);
-    // Must have a runs-service override that sets leadsServed from runCount
-    expect(statsSection).toContain("leadsFromRuns");
-    expect(statsSection).toContain("stats.leadsServed");
-    expect(statsSection).toContain("runCount");
+    expect(statsSection).toContain("stats.leadsServed = ls.served");
   });
 
   it("batch-stats endpoint should no longer exist", () => {


### PR DESCRIPTION
## Summary
- Removed the runs-service override that was inflating `leadsServed` by counting all lead-serve runs (including ones where no lead was found)
- `leadsServed` now comes directly from lead-service's `served_leads` table — the actual source of truth
- Removed the unnecessary runs-service `taskName=lead-serve` fetch from the single-campaign stats endpoint

## Context
Campaigns were showing inflated lead counts in the sidebar (e.g. 109) while the leads tab correctly showed 0. The stats endpoint was overriding lead-service's accurate count with runs-service run counts, which include runs where the buffer was empty and no lead was served.

## Test plan
- [x] Updated regression test to enforce new behavior (lead-service as source of truth)
- [x] Verified all existing tests pass (2 pre-existing failures in workflows-stats unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)