### PR TITLE
feat: allow admin auth with direct internal IDs

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -40,34 +40,44 @@ export async function authenticate(
       }
       req.authType = "admin";
 
-      const externalOrgId = req.headers["x-external-org-id"] as string | undefined;
-      const externalUserId = req.headers["x-external-user-id"] as string | undefined;
+      // Internal service-to-service calls pass internal UUIDs directly
+      const directOrgId = req.headers["x-org-id"] as string | undefined;
+      const directUserId = req.headers["x-user-id"] as string | undefined;
 
-      if (!externalOrgId || !externalUserId) {
-        return res.status(400).json({ error: "Admin auth requires both x-external-org-id and x-external-user-id" });
+      if (directOrgId && directUserId) {
+        req.orgId = directOrgId;
+        req.userId = directUserId;
+      } else {
+        // Dashboard calls pass external IDs that need resolution via client-service
+        const externalOrgId = req.headers["x-external-org-id"] as string | undefined;
+        const externalUserId = req.headers["x-external-user-id"] as string | undefined;
+
+        if (!externalOrgId || !externalUserId) {
+          return res.status(400).json({ error: "Admin auth requires identity headers: x-org-id/x-user-id or x-external-org-id/x-external-user-id" });
+        }
+
+        const resolved = await resolveExternalIds(externalOrgId, externalUserId, req);
+
+        if (!resolved) {
+          console.error("[auth] Admin identity resolution returned null", {
+            externalOrgId,
+            externalUserId,
+          });
+          return res.status(502).json({ error: "Identity resolution failed" });
+        }
+
+        if (!resolved.orgId || !resolved.userId) {
+          console.error("[auth] Admin identity resolution returned empty IDs", {
+            resolved,
+            externalOrgId,
+            externalUserId,
+          });
+          return res.status(502).json({ error: "Identity resolution returned incomplete data" });
+        }
+
+        req.orgId = resolved.orgId;
+        req.userId = resolved.userId;
       }
-
-      const resolved = await resolveExternalIds(externalOrgId, externalUserId, req);
-
-      if (!resolved) {
-        console.error("[auth] Admin identity resolution returned null", {
-          externalOrgId,
-          externalUserId,
-        });
-        return res.status(502).json({ error: "Identity resolution failed" });
-      }
-
-      if (!resolved.orgId || !resolved.userId) {
-        console.error("[auth] Admin identity resolution returned empty IDs", {
-          resolved,
-          externalOrgId,
-          externalUserId,
-        });
-        return res.status(502).json({ error: "Identity resolution returned incomplete data" });
-      }
-
-      req.orgId = resolved.orgId;
-      req.userId = resolved.userId;
 
     } else if (authHeader?.startsWith("Bearer ")) {
       // ── Path 2: User key auth via Bearer ──

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -152,35 +152,52 @@ describe("Auth middleware — admin key via X-API-Key", () => {
     );
   });
 
-  it("should return 400 when x-external-org-id is missing", async () => {
+  it("should accept direct x-org-id and x-user-id without calling client-service", async () => {
+    const res = await request(app)
+      .get("/v1/workflows")
+      .set("X-API-Key", ADMIN_KEY)
+      .set("x-org-id", "org-uuid-direct")
+      .set("x-user-id", "user-uuid-direct");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      orgId: "org-uuid-direct",
+      userId: "user-uuid-direct",
+      authType: "admin",
+    });
+    // No client-service call needed — IDs passed directly
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when x-external-org-id is missing and no direct IDs", async () => {
     const res = await request(app)
       .get("/v1/workflows")
       .set("X-API-Key", ADMIN_KEY)
       .set("x-external-user-id", "ext_user_456");
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Admin auth requires both x-external-org-id and x-external-user-id");
+    expect(res.body.error).toBe("Admin auth requires identity headers: x-org-id/x-user-id or x-external-org-id/x-external-user-id");
     expect(mockCall).not.toHaveBeenCalled();
   });
 
-  it("should return 400 when x-external-user-id is missing", async () => {
+  it("should return 400 when x-external-user-id is missing and no direct IDs", async () => {
     const res = await request(app)
       .get("/v1/workflows")
       .set("X-API-Key", ADMIN_KEY)
       .set("x-external-org-id", "ext_org_123");
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Admin auth requires both x-external-org-id and x-external-user-id");
+    expect(res.body.error).toBe("Admin auth requires identity headers: x-org-id/x-user-id or x-external-org-id/x-external-user-id");
     expect(mockCall).not.toHaveBeenCalled();
   });
 
-  it("should return 400 when both external ID headers are missing", async () => {
+  it("should return 400 when no identity headers are provided", async () => {
     const res = await request(app)
       .get("/v1/me")
       .set("X-API-Key", ADMIN_KEY);
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Admin auth requires both x-external-org-id and x-external-user-id");
+    expect(res.body.error).toBe("Admin auth requires identity headers: x-org-id/x-user-id or x-external-org-id/x-external-user-id");
   });
 
   it("should return 401 when X-API-Key does not match admin key", async () => {


### PR DESCRIPTION
## Summary
- Admin auth via `X-API-Key` now accepts direct `x-org-id`/`x-user-id` headers for internal service-to-service calls (e.g. chat-service)
- Skips client-service identity resolution when internal UUIDs are provided
- Falls back to `x-external-org-id`/`x-external-user-id` resolution for dashboard calls (existing behavior)

## Test plan
- [x] Existing admin auth tests updated and passing (19 tests)
- [x] New test: direct IDs accepted without client-service call
- [x] Existing external ID resolution still works
- [x] Missing identity headers still return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)