### PR TITLE
feat: add outlets + journalists proxy routes, fix stale endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1367,80 +1367,626 @@
       "CampaignJournalistsResponse": {
         "type": "object",
         "properties": {
-          "campaignOutletJournalists": {
+          "journalists": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "campaignId": {
-                  "type": "string"
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
                 },
                 "outletId": {
-                  "type": "string"
-                },
-                "journalistId": {
-                  "type": "string"
-                },
-                "whyRelevant": {
                   "type": "string",
-                  "nullable": true
-                },
-                "whyNotRelevant": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "relevanceScore": {
-                  "type": "number",
-                  "nullable": true
-                },
-                "createdAt": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "updatedAt": {
-                  "type": "string",
-                  "nullable": true
+                  "format": "uuid"
                 },
                 "journalistName": {
-                  "type": "string",
-                  "nullable": true,
-                  "description": "From press_journalists JOIN — available once journalist-service adds the JOIN"
+                  "type": "string"
                 },
                 "firstName": {
-                  "type": "string",
-                  "nullable": true,
-                  "description": "From press_journalists JOIN"
+                  "type": "string"
                 },
                 "lastName": {
-                  "type": "string",
-                  "nullable": true,
-                  "description": "From press_journalists JOIN"
+                  "type": "string"
                 },
                 "entityType": {
                   "type": "string",
-                  "nullable": true,
-                  "description": "From press_journalists JOIN"
+                  "enum": [
+                    "individual",
+                    "organization"
+                  ]
+                },
+                "relevanceScore": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "whyRelevant": {
+                  "type": "string"
+                },
+                "whyNotRelevant": {
+                  "type": "string"
+                },
+                "articleUrls": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [
-                "campaignId",
+                "id",
                 "outletId",
-                "journalistId",
-                "whyRelevant",
-                "whyNotRelevant",
-                "relevanceScore",
-                "createdAt",
-                "updatedAt",
                 "journalistName",
                 "firstName",
                 "lastName",
-                "entityType"
+                "entityType",
+                "relevanceScore",
+                "whyRelevant",
+                "whyNotRelevant",
+                "articleUrls"
               ]
             }
           }
         },
         "required": [
-          "campaignOutletJournalists"
+          "journalists"
+        ]
+      },
+      "CreateOutletRequest": {
+        "type": "object",
+        "properties": {
+          "outletName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "outletUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "outletDomain": {
+            "type": "string",
+            "minLength": 1
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "whyRelevant": {
+            "type": "string"
+          },
+          "whyNotRelevant": {
+            "type": "string"
+          },
+          "relevanceScore": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "overallRelevance": {
+            "type": "string"
+          },
+          "relevanceRationale": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "ended",
+              "denied"
+            ],
+            "default": "open"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "outletName",
+          "outletUrl",
+          "outletDomain",
+          "campaignId",
+          "brandId",
+          "whyRelevant",
+          "whyNotRelevant",
+          "relevanceScore"
+        ]
+      },
+      "BulkCreateOutletsRequest": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "outletName": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "outletUrl": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "outletDomain": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "campaignId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "brandId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "whyRelevant": {
+                  "type": "string"
+                },
+                "whyNotRelevant": {
+                  "type": "string"
+                },
+                "relevanceScore": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "overallRelevance": {
+                  "type": "string"
+                },
+                "relevanceRationale": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "open",
+                    "ended",
+                    "denied"
+                  ],
+                  "default": "open"
+                },
+                "workflowName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "outletName",
+                "outletUrl",
+                "outletDomain",
+                "campaignId",
+                "brandId",
+                "whyRelevant",
+                "whyNotRelevant",
+                "relevanceScore"
+              ]
+            }
+          }
+        },
+        "required": [
+          "outlets"
+        ]
+      },
+      "SearchOutletsRequest": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "default": 20
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "DiscoverOutletsRequest": {
+        "type": "object",
+        "properties": {
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "brandDescription": {
+            "type": "string",
+            "minLength": 1
+          },
+          "industry": {
+            "type": "string",
+            "minLength": 1
+          },
+          "targetGeo": {
+            "type": "string"
+          },
+          "targetAudience": {
+            "type": "string"
+          },
+          "angles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "campaignId",
+          "brandId",
+          "brandName",
+          "brandDescription",
+          "industry"
+        ]
+      },
+      "UpdateOutletRequest": {
+        "type": "object",
+        "properties": {
+          "outletName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "outletUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "outletDomain": {
+            "type": "string",
+            "minLength": 1
+          },
+          "whyRelevant": {
+            "type": "string"
+          },
+          "whyNotRelevant": {
+            "type": "string"
+          },
+          "relevanceScore": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "overallRelevance": {
+            "type": "string"
+          },
+          "relevanceRationale": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateOutletStatusRequest": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "ended",
+              "denied"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "DiscoverJournalistsResponse": {
+        "type": "object",
+        "properties": {
+          "journalists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "journalistName": {
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string"
+                },
+                "lastName": {
+                  "type": "string"
+                },
+                "entityType": {
+                  "type": "string",
+                  "enum": [
+                    "individual",
+                    "organization"
+                  ]
+                },
+                "relevanceScore": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "whyRelevant": {
+                  "type": "string"
+                },
+                "whyNotRelevant": {
+                  "type": "string"
+                },
+                "articleUrls": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "isNew": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "journalistName",
+                "firstName",
+                "lastName",
+                "entityType",
+                "relevanceScore",
+                "whyRelevant",
+                "whyNotRelevant",
+                "articleUrls",
+                "isNew"
+              ]
+            }
+          },
+          "totalArticlesSearched": {
+            "type": "number"
+          },
+          "totalNamesExtracted": {
+            "type": "number"
+          },
+          "totalJournalistsStored": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "journalists",
+          "totalArticlesSearched",
+          "totalNamesExtracted",
+          "totalJournalistsStored"
+        ]
+      },
+      "DiscoverJournalistsRequest": {
+        "type": "object",
+        "properties": {
+          "outletId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "featureInputs": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {}
+          },
+          "maxArticles": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 30,
+            "default": 15
+          }
+        },
+        "required": [
+          "outletId",
+          "brandId",
+          "campaignId"
+        ]
+      },
+      "DiscoverEmailsResponse": {
+        "type": "object",
+        "properties": {
+          "discovered": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          },
+          "skipped": {
+            "type": "number"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "journalistId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "email": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "emailStatus": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "cached": {
+                  "type": "boolean"
+                },
+                "enrichmentId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "journalistId",
+                "email",
+                "emailStatus",
+                "cached",
+                "enrichmentId"
+              ]
+            }
+          }
+        },
+        "required": [
+          "discovered",
+          "total",
+          "skipped",
+          "results"
+        ]
+      },
+      "DiscoverEmailsRequest": {
+        "type": "object",
+        "properties": {
+          "outletId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "organizationDomain": {
+            "type": "string",
+            "minLength": 1
+          },
+          "journalistIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "outletId",
+          "organizationDomain",
+          "brandId",
+          "campaignId"
+        ]
+      },
+      "ResolveJournalistsResponse": {
+        "type": "object",
+        "properties": {
+          "journalists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "journalistName": {
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string"
+                },
+                "lastName": {
+                  "type": "string"
+                },
+                "entityType": {
+                  "type": "string",
+                  "enum": [
+                    "individual",
+                    "organization"
+                  ]
+                },
+                "relevanceScore": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "whyRelevant": {
+                  "type": "string"
+                },
+                "whyNotRelevant": {
+                  "type": "string"
+                },
+                "articleUrls": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "journalistName",
+                "firstName",
+                "lastName",
+                "entityType",
+                "relevanceScore",
+                "whyRelevant",
+                "whyNotRelevant",
+                "articleUrls"
+              ]
+            }
+          },
+          "cached": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "journalists",
+          "cached"
+        ]
+      },
+      "ResolveJournalistsRequest": {
+        "type": "object",
+        "properties": {
+          "outletId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "featureInputs": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {}
+          },
+          "maxArticles": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 30,
+            "default": 15
+          }
+        },
+        "required": [
+          "outletId"
         ]
       },
       "OrgKeyItem": {
@@ -7031,7 +7577,7 @@
           "Campaigns"
         ],
         "summary": "Get campaign journalists",
-        "description": "Get discovered journalists for a campaign (proxied from journalist-service)",
+        "description": "Get discovered journalists for a campaign. Resolves journalists for each outlet via journalist-service.",
         "security": [
           {
             "bearerAuth": []
@@ -7135,6 +7681,1357 @@
             }
           }
         }
+      }
+    },
+    "/v1/outlets": {
+      "get": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "List outlets with filters",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "ended",
+                "denied"
+              ]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "default": 100
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "default": 0
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of outlets"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Create outlet (upsert by outlet_url)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOutletRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Outlet created"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/outlets/stats": {
+      "get": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Aggregated outlet discovery metrics",
+        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowName and optional groupBy.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "workflowName",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "workflowName",
+                "brandId",
+                "campaignId"
+              ]
+            },
+            "required": false,
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stats (flat or grouped)"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/outlets/bulk": {
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Bulk upsert outlets",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkCreateOutletsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Outlets created"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/outlets/search": {
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Search outlets by name/url",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchOutletsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/outlets/discover": {
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Discover relevant outlets via Google search + LLM scoring",
+        "description": "Takes a brand brief, generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverOutletsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Outlets discovered and saved"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/outlets/{id}": {
+      "get": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Get outlet by ID",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Outlet ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outlet found"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Outlet not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Update outlet",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Outlet ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOutletRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Outlet updated"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Outlet not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/outlets/{id}/status": {
+      "patch": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Update outlet status",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Outlet ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID (required)"
+            },
+            "required": true,
+            "description": "Campaign ID (required)",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOutletStatusRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status updated"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/journalists/discover": {
+      "post": {
+        "tags": [
+          "Journalists"
+        ],
+        "summary": "Discover relevant journalists for a brand on an outlet",
+        "description": "Searches outlet articles, extracts journalist names via LLM, scores them for relevance, and stores results.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverJournalistsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discovered journalists with relevance scores",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverJournalistsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/journalists/discover-emails": {
+      "post": {
+        "tags": [
+          "Journalists"
+        ],
+        "summary": "Discover journalist emails via Apollo person match",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverEmailsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discovery results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverEmailsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/journalists/resolve": {
+      "post": {
+        "tags": [
+          "Journalists"
+        ],
+        "summary": "Resolve journalists for a campaign+outlet",
+        "description": "Discovers journalists if needed, scores them, and returns results sorted by relevance.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveJournalistsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved journalists sorted by relevance score",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolveJournalistsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/keys": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import emailGatewayRoutes from "./routes/email-gateway.js";
 import runsRoutes from "./routes/runs.js";
 import contentRoutes from "./routes/content.js";
 import pressKitsRoutes from "./routes/press-kits.js";
+import outletsRoutes from "./routes/outlets.js";
+import journalistsRoutes from "./routes/journalists.js";
 import featuresRoutes from "./routes/features.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { readFileSync, existsSync } from "fs";
@@ -172,6 +174,8 @@ app.use("/v1", emailGatewayRoutes);
 app.use("/v1", runsRoutes);
 app.use("/v1", contentRoutes);
 app.use("/v1", pressKitsRoutes); // authenticated press-kit endpoints
+app.use("/v1", outletsRoutes);
+app.use("/v1", journalistsRoutes);
 app.use("/v1", featuresRoutes);
 
 // 404 handler

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -784,19 +784,46 @@ router.get("/campaigns/:id/outlets", authenticate, requireOrg, requireUser, asyn
 /**
  * GET /v1/campaigns/:id/journalists
  * Get discovered journalists for a campaign (proxy to journalist-service)
+ * Uses POST /journalists/resolve with the campaign's outlet data.
  */
 router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
 
-    const result = await callExternalService(
-      externalServices.journalist,
-      `/campaign-outlet-journalists?campaign_id=${encodeURIComponent(id)}`,
-      {
-        headers: buildInternalHeaders(req),
-      }
+    // First get the campaign's outlets, then resolve journalists for each
+    const outletsResult = await callExternalService<{ outlets: Array<{ id: string }> }>(
+      externalServices.outlet,
+      `/internal/outlets/by-campaign/${encodeURIComponent(id)}`,
+      { headers: buildInternalHeaders(req) }
     );
-    res.json(result);
+
+    const outlets = outletsResult.outlets || [];
+    if (outlets.length === 0) {
+      return res.json({ journalists: [] });
+    }
+
+    // Batch lookup journalists by outlet IDs via internal endpoint
+    const outletIds = outlets.map((o) => o.id);
+    const journalistResults = await Promise.all(
+      outletIds.map((outletId) =>
+        callExternalService<{ journalists: Array<Record<string, unknown>>; cached: boolean }>(
+          externalServices.journalist,
+          "/journalists/resolve",
+          {
+            method: "POST",
+            body: { outletId },
+            headers: buildInternalHeaders(req),
+          }
+        ).catch(() => ({ journalists: [], cached: false }))
+      )
+    );
+
+    // Flatten all journalists with their outlet context
+    const allJournalists = journalistResults.flatMap((r, idx) =>
+      r.journalists.map((j) => ({ ...j, outletId: outletIds[idx] }))
+    );
+
+    res.json({ journalists: allJournalists });
   } catch (error: any) {
     console.error("Get campaign journalists error:", error);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get campaign journalists" });

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -1,0 +1,50 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+// ── POST /v1/journalists/discover — discover journalists for brand+outlet ───
+router.post("/journalists/discover", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.journalist,
+      "/journalists/discover",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to discover journalists" });
+  }
+});
+
+// ── POST /v1/journalists/discover-emails — discover journalist emails ───────
+router.post("/journalists/discover-emails", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.journalist,
+      "/journalists/discover-emails",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to discover journalist emails" });
+  }
+});
+
+// ── POST /v1/journalists/resolve — resolve journalists for campaign+outlet ──
+router.post("/journalists/resolve", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.journalist,
+      "/journalists/resolve",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to resolve journalists" });
+  }
+});
+
+export default router;

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -1,0 +1,153 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+// ── GET /v1/outlets — list outlets with filters ─────────────────────────────
+router.get("/outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
+    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
+    if (req.query.status) params.set("status", req.query.status as string);
+    if (req.query.limit) params.set("limit", req.query.limit as string);
+    if (req.query.offset) params.set("offset", req.query.offset as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.outlet,
+      `/outlets${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list outlets" });
+  }
+});
+
+// ── GET /v1/outlets/stats — aggregated outlet discovery metrics ─────────────
+router.get("/outlets/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
+    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
+    if (req.query.workflowName) params.set("workflowName", req.query.workflowName as string);
+    if (req.query.groupBy) params.set("groupBy", req.query.groupBy as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.outlet,
+      `/outlets/stats${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get outlet stats" });
+  }
+});
+
+// ── POST /v1/outlets — create outlet (upsert by outlet_url) ────────────────
+router.post("/outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.outlet,
+      "/outlets",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.status(201).json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create outlet" });
+  }
+});
+
+// ── POST /v1/outlets/bulk — bulk upsert outlets ─────────────────────────────
+router.post("/outlets/bulk", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.outlet,
+      "/outlets/bulk",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.status(201).json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to bulk create outlets" });
+  }
+});
+
+// ── POST /v1/outlets/search — search outlets by name/url ────────────────────
+router.post("/outlets/search", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.outlet,
+      "/outlets/search",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to search outlets" });
+  }
+});
+
+// ── POST /v1/outlets/discover — discover relevant outlets via Google + LLM ──
+router.post("/outlets/discover", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.outlet,
+      "/outlets/discover",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.status(201).json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to discover outlets" });
+  }
+});
+
+// ── GET /v1/outlets/:id — get outlet by ID ──────────────────────────────────
+router.get("/outlets/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.outlet,
+      `/outlets/${encodeURIComponent(req.params.id)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get outlet" });
+  }
+});
+
+// ── PATCH /v1/outlets/:id — update outlet ───────────────────────────────────
+router.patch("/outlets/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.outlet,
+      `/outlets/${encodeURIComponent(req.params.id)}`,
+      { method: "PATCH", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to update outlet" });
+  }
+});
+
+// ── PATCH /v1/outlets/:id/status — update outlet status ─────────────────────
+router.patch("/outlets/:id/status", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.outlet,
+      `/outlets/${encodeURIComponent(req.params.id)}/status${qs}`,
+      { method: "PATCH", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to update outlet status" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -843,7 +843,7 @@ registry.registerPath({
   tags: ["Campaigns"],
   summary: "Get campaign journalists",
   description:
-    "Get discovered journalists for a campaign (proxied from journalist-service)",
+    "Get discovered journalists for a campaign. Resolves journalists for each outlet via journalist-service.",
   security: authed,
   request: { params: CampaignIdParam },
   responses: {
@@ -853,20 +853,18 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              campaignOutletJournalists: z.array(
+              journalists: z.array(
                 z.object({
-                  campaignId: z.string(),
-                  outletId: z.string(),
-                  journalistId: z.string(),
-                  whyRelevant: z.string().nullable(),
-                  whyNotRelevant: z.string().nullable(),
-                  relevanceScore: z.number().nullable(),
-                  createdAt: z.string().nullable(),
-                  updatedAt: z.string().nullable(),
-                  journalistName: z.string().nullable().describe("From press_journalists JOIN — available once journalist-service adds the JOIN"),
-                  firstName: z.string().nullable().describe("From press_journalists JOIN"),
-                  lastName: z.string().nullable().describe("From press_journalists JOIN"),
-                  entityType: z.string().nullable().describe("From press_journalists JOIN"),
+                  id: z.string().uuid(),
+                  outletId: z.string().uuid(),
+                  journalistName: z.string(),
+                  firstName: z.string(),
+                  lastName: z.string(),
+                  entityType: z.enum(["individual", "organization"]),
+                  relevanceScore: z.number().min(0).max(100),
+                  whyRelevant: z.string(),
+                  whyNotRelevant: z.string(),
+                  articleUrls: z.array(z.string()),
                 }),
               ),
             })
@@ -876,6 +874,444 @@ registry.registerPath({
     },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
+  },
+});
+
+// ===================================================================
+// OUTLETS
+// ===================================================================
+
+const OutletIdParam = z.object({
+  id: z.string().uuid().openapi({ description: "Outlet ID" }),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/outlets",
+  tags: ["Outlets"],
+  summary: "List outlets with filters",
+  security: authed,
+  request: {
+    query: z.object({
+      campaignId: z.string().uuid().optional(),
+      brandId: z.string().uuid().optional(),
+      status: z.enum(["open", "ended", "denied"]).optional(),
+      limit: z.coerce.number().int().optional().default(100),
+      offset: z.coerce.number().int().optional().default(0),
+    }),
+  },
+  responses: {
+    200: { description: "List of outlets" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/outlets",
+  tags: ["Outlets"],
+  summary: "Create outlet (upsert by outlet_url)",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outletName: z.string().min(1),
+              outletUrl: z.string().url(),
+              outletDomain: z.string().min(1),
+              campaignId: z.string().uuid(),
+              brandId: z.string().uuid(),
+              whyRelevant: z.string(),
+              whyNotRelevant: z.string(),
+              relevanceScore: z.number().min(0).max(100),
+              overallRelevance: z.string().optional(),
+              relevanceRationale: z.string().optional(),
+              status: z.enum(["open", "ended", "denied"]).optional().default("open"),
+              workflowName: z.string().optional(),
+            })
+            .openapi("CreateOutletRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    201: { description: "Outlet created" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/outlets/stats",
+  tags: ["Outlets"],
+  summary: "Aggregated outlet discovery metrics",
+  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowName and optional groupBy.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().optional(),
+      campaignId: z.string().uuid().optional(),
+      workflowName: z.string().optional(),
+      groupBy: z.enum(["workflowName", "brandId", "campaignId"]).optional(),
+    }),
+  },
+  responses: {
+    200: { description: "Stats (flat or grouped)" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/outlets/bulk",
+  tags: ["Outlets"],
+  summary: "Bulk upsert outlets",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outlets: z.array(
+                z.object({
+                  outletName: z.string().min(1),
+                  outletUrl: z.string().url(),
+                  outletDomain: z.string().min(1),
+                  campaignId: z.string().uuid(),
+                  brandId: z.string().uuid(),
+                  whyRelevant: z.string(),
+                  whyNotRelevant: z.string(),
+                  relevanceScore: z.number().min(0).max(100),
+                  overallRelevance: z.string().optional(),
+                  relevanceRationale: z.string().optional(),
+                  status: z.enum(["open", "ended", "denied"]).optional().default("open"),
+                  workflowName: z.string().optional(),
+                }),
+              ),
+            })
+            .openapi("BulkCreateOutletsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    201: { description: "Outlets created" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/outlets/search",
+  tags: ["Outlets"],
+  summary: "Search outlets by name/url",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              query: z.string().min(1),
+              campaignId: z.string().uuid().optional(),
+              limit: z.number().int().min(0).max(100).optional().default(20),
+            })
+            .openapi("SearchOutletsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Search results" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/outlets/discover",
+  tags: ["Outlets"],
+  summary: "Discover relevant outlets via Google search + LLM scoring",
+  description: "Takes a brand brief, generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets.",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              campaignId: z.string().uuid(),
+              brandId: z.string().uuid(),
+              brandName: z.string().min(1),
+              brandDescription: z.string().min(1),
+              industry: z.string().min(1),
+              targetGeo: z.string().optional(),
+              targetAudience: z.string().optional(),
+              angles: z.array(z.string()).optional(),
+              workflowName: z.string().optional(),
+            })
+            .openapi("DiscoverOutletsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    201: { description: "Outlets discovered and saved" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/outlets/{id}",
+  tags: ["Outlets"],
+  summary: "Get outlet by ID",
+  security: authed,
+  request: { params: OutletIdParam },
+  responses: {
+    200: { description: "Outlet found" },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Outlet not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/outlets/{id}",
+  tags: ["Outlets"],
+  summary: "Update outlet",
+  security: authed,
+  request: {
+    params: OutletIdParam,
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outletName: z.string().min(1).optional(),
+              outletUrl: z.string().url().optional(),
+              outletDomain: z.string().min(1).optional(),
+              whyRelevant: z.string().optional(),
+              whyNotRelevant: z.string().optional(),
+              relevanceScore: z.number().min(0).max(100).optional(),
+              overallRelevance: z.string().optional(),
+              relevanceRationale: z.string().optional(),
+            })
+            .openapi("UpdateOutletRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Outlet updated" },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Outlet not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/outlets/{id}/status",
+  tags: ["Outlets"],
+  summary: "Update outlet status",
+  security: authed,
+  request: {
+    params: OutletIdParam,
+    query: z.object({
+      campaignId: z.string().uuid().describe("Campaign ID (required)"),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              status: z.enum(["open", "ended", "denied"]),
+              reason: z.string().optional(),
+            })
+            .openapi("UpdateOutletStatusRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Status updated" },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Not found", content: errorContent },
+  },
+});
+
+// ===================================================================
+// JOURNALISTS
+// ===================================================================
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/journalists/discover",
+  tags: ["Journalists"],
+  summary: "Discover relevant journalists for a brand on an outlet",
+  description: "Searches outlet articles, extracts journalist names via LLM, scores them for relevance, and stores results.",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outletId: z.string().uuid(),
+              brandId: z.string().uuid(),
+              campaignId: z.string().uuid(),
+              featureInputs: z.record(z.string()).optional().default({}),
+              maxArticles: z.number().int().min(1).max(30).optional().default(15),
+            })
+            .openapi("DiscoverJournalistsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Discovered journalists with relevance scores",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              journalists: z.array(
+                z.object({
+                  id: z.string().uuid(),
+                  journalistName: z.string(),
+                  firstName: z.string(),
+                  lastName: z.string(),
+                  entityType: z.enum(["individual", "organization"]),
+                  relevanceScore: z.number().min(0).max(100),
+                  whyRelevant: z.string(),
+                  whyNotRelevant: z.string(),
+                  articleUrls: z.array(z.string()),
+                  isNew: z.boolean(),
+                }),
+              ),
+              totalArticlesSearched: z.number(),
+              totalNamesExtracted: z.number(),
+              totalJournalistsStored: z.number(),
+            })
+            .openapi("DiscoverJournalistsResponse"),
+        },
+      },
+    },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/journalists/discover-emails",
+  tags: ["Journalists"],
+  summary: "Discover journalist emails via Apollo person match",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outletId: z.string().uuid(),
+              organizationDomain: z.string().min(1),
+              journalistIds: z.array(z.string().uuid()).optional(),
+              brandId: z.string().uuid(),
+              campaignId: z.string().uuid(),
+            })
+            .openapi("DiscoverEmailsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Discovery results",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              discovered: z.number(),
+              total: z.number(),
+              skipped: z.number(),
+              results: z.array(
+                z.object({
+                  journalistId: z.string().uuid(),
+                  email: z.string().nullable(),
+                  emailStatus: z.string().nullable(),
+                  cached: z.boolean(),
+                  enrichmentId: z.string(),
+                }),
+              ),
+            })
+            .openapi("DiscoverEmailsResponse"),
+        },
+      },
+    },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/journalists/resolve",
+  tags: ["Journalists"],
+  summary: "Resolve journalists for a campaign+outlet",
+  description: "Discovers journalists if needed, scores them, and returns results sorted by relevance.",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outletId: z.string().uuid(),
+              featureInputs: z.record(z.string()).optional().default({}),
+              maxArticles: z.number().int().min(1).max(30).optional().default(15),
+            })
+            .openapi("ResolveJournalistsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Resolved journalists sorted by relevance score",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              journalists: z.array(
+                z.object({
+                  id: z.string().uuid(),
+                  journalistName: z.string(),
+                  firstName: z.string(),
+                  lastName: z.string(),
+                  entityType: z.enum(["individual", "organization"]),
+                  relevanceScore: z.number().min(0).max(100),
+                  whyRelevant: z.string(),
+                  whyNotRelevant: z.string(),
+                  articleUrls: z.array(z.string()),
+                }),
+              ),
+              cached: z.boolean(),
+            })
+            .openapi("ResolveJournalistsResponse"),
+        },
+      },
+    },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
   },
 });
 

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -68,12 +68,18 @@ describe("Campaign discovery proxy: journalists", () => {
     expect(journalistsSection).toContain("requireUser");
   });
 
-  it("should proxy to journalist-service with campaignId query param", () => {
+  it("should NOT proxy to stale /campaign-outlet-journalists endpoint (removed upstream)", () => {
+    expect(content).not.toContain("/campaign-outlet-journalists");
+  });
+
+  it("should fetch outlets from outlet-service then resolve journalists", () => {
     const journalistsSection = content.slice(
       content.indexOf('"/campaigns/:id/journalists"'),
     );
+    expect(journalistsSection).toContain("externalServices.outlet");
+    expect(journalistsSection).toContain("/internal/outlets/by-campaign/");
     expect(journalistsSection).toContain("externalServices.journalist");
-    expect(journalistsSection).toContain("/campaign-outlet-journalists?campaign_id=");
+    expect(journalistsSection).toContain("/journalists/resolve");
   });
 
   it("should forward internal headers", () => {
@@ -81,16 +87,6 @@ describe("Campaign discovery proxy: journalists", () => {
       content.indexOf('"/campaigns/:id/journalists"'),
     );
     expect(journalistsSection).toContain("buildInternalHeaders(req)");
-  });
-
-  it("should be a read-only GET (no method override)", () => {
-    const journalistsSection = content.slice(
-      content.indexOf('"/campaigns/:id/journalists"'),
-    );
-    expect(journalistsSection).not.toContain('method: "POST"');
-    expect(journalistsSection).not.toContain('method: "PUT"');
-    expect(journalistsSection).not.toContain('method: "PATCH"');
-    expect(journalistsSection).not.toContain('method: "DELETE"');
   });
 });
 
@@ -125,12 +121,11 @@ describe("OpenAPI schemas: campaign discovery endpoints", () => {
     expect(schemaContent).toContain("whyRelevant");
   });
 
-  it("should define CampaignJournalistsResponse schema with junction table fields", () => {
+  it("should define CampaignJournalistsResponse schema with resolved journalist fields", () => {
     expect(schemaContent).toContain("CampaignJournalistsResponse");
-    expect(schemaContent).toContain("campaignOutletJournalists");
-    expect(schemaContent).toContain("journalistId");
-    expect(schemaContent).toContain("outletId");
     expect(schemaContent).toContain("journalistName");
     expect(schemaContent).toContain("entityType");
+    expect(schemaContent).toContain("relevanceScore");
+    expect(schemaContent).toContain("articleUrls");
   });
 });

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/journalists.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+describe("Journalists proxy routes", () => {
+  it("should have POST /journalists/discover with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/journalists/discover"') && !l.includes("emails")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should have POST /journalists/discover-emails with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/journalists/discover-emails"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should have POST /journalists/resolve with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/journalists/resolve"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should NOT have stale /campaign-outlet-journalists endpoint", () => {
+    expect(content).not.toContain("/campaign-outlet-journalists");
+  });
+
+  it("should use buildInternalHeaders for all endpoints", () => {
+    const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(headerMatches).not.toBeNull();
+    expect(headerMatches!.length).toBe(3);
+  });
+
+  it("should proxy to externalServices.journalist", () => {
+    expect(content).toContain("externalServices.journalist");
+  });
+
+  it("should forward request body on all POST endpoints", () => {
+    const bodyMatches = content.match(/body: req\.body/g);
+    expect(bodyMatches).not.toBeNull();
+    expect(bodyMatches!.length).toBe(3);
+  });
+
+  it("should enforce requireOrg + requireUser on ALL journalist routes", () => {
+    const routeLines = content.split("\n").filter((l) =>
+      /router\.(get|post|patch)\(/.test(l) && l.includes('"/')
+    );
+    expect(routeLines.length).toBeGreaterThan(0);
+    for (const line of routeLines) {
+      expect(line).toContain("authenticate");
+      expect(line).toContain("requireOrg");
+      expect(line).toContain("requireUser");
+    }
+  });
+});
+
+describe("Journalists service client", () => {
+  it("should have journalist in externalServices", () => {
+    expect(serviceClientContent).toContain("journalist:");
+    expect(serviceClientContent).toContain("JOURNALISTS_SERVICE_URL");
+    expect(serviceClientContent).toContain("JOURNALISTS_SERVICE_API_KEY");
+  });
+});
+
+describe("Journalists OpenAPI schemas", () => {
+  it("should register POST /v1/journalists/discover", () => {
+    expect(schemaContent).toContain('path: "/v1/journalists/discover"');
+    expect(schemaContent).toContain("DiscoverJournalistsRequest");
+    expect(schemaContent).toContain("DiscoverJournalistsResponse");
+  });
+
+  it("should register POST /v1/journalists/discover-emails", () => {
+    expect(schemaContent).toContain('path: "/v1/journalists/discover-emails"');
+    expect(schemaContent).toContain("DiscoverEmailsRequest");
+    expect(schemaContent).toContain("DiscoverEmailsResponse");
+  });
+
+  it("should register POST /v1/journalists/resolve", () => {
+    expect(schemaContent).toContain('path: "/v1/journalists/resolve"');
+    expect(schemaContent).toContain("ResolveJournalistsRequest");
+    expect(schemaContent).toContain("ResolveJournalistsResponse");
+  });
+
+  it("should use Journalists tag", () => {
+    expect(schemaContent).toContain('tags: ["Journalists"]');
+  });
+
+  it("should define journalist entity type enum", () => {
+    expect(schemaContent).toContain('"individual"');
+    expect(schemaContent).toContain('"organization"');
+  });
+});
+
+describe("Journalists routes are mounted in index.ts", () => {
+  it("should import and mount journalists routes", () => {
+    expect(indexContent).toContain("journalistsRoutes");
+    expect(indexContent).toContain("./routes/journalists");
+  });
+
+  it("should mount at /v1", () => {
+    expect(indexContent).toContain('app.use("/v1", journalistsRoutes)');
+  });
+});

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/outlets.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+describe("Outlets proxy routes", () => {
+  it("should have GET /outlets with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/outlets"') && !l.includes("/:id") && !l.includes("/stats")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward query params on GET /outlets", () => {
+    for (const param of ["campaignId", "brandId", "status", "limit", "offset"]) {
+      expect(content).toContain(`"${param}"`);
+    }
+  });
+
+  it("should have GET /outlets/stats with auth", () => {
+    expect(content).toContain('"/outlets/stats"');
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/outlets/stats"')
+    );
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward groupBy on GET /outlets/stats", () => {
+    expect(content).toContain('"groupBy"');
+    expect(content).toContain('"workflowName"');
+  });
+
+  it("should have POST /outlets with auth", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/outlets"') && !l.includes("/bulk") && !l.includes("/search") && !l.includes("/discover")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should return 201 on POST /outlets", () => {
+    expect(content).toContain("res.status(201)");
+  });
+
+  it("should have POST /outlets/bulk with auth", () => {
+    expect(content).toContain('"/outlets/bulk"');
+  });
+
+  it("should have POST /outlets/search with auth", () => {
+    expect(content).toContain('"/outlets/search"');
+  });
+
+  it("should have POST /outlets/discover with auth", () => {
+    expect(content).toContain('"/outlets/discover"');
+  });
+
+  it("should have GET /outlets/:id with auth", () => {
+    expect(content).toContain('"/outlets/:id"');
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/outlets/:id"')
+    );
+    expect(line).toContain("authenticate");
+  });
+
+  it("should have PATCH /outlets/:id with auth", () => {
+    const patchLine = content.split("\n").find((l) =>
+      l.includes("router.patch") && l.includes('"/outlets/:id"') && !l.includes("/status")
+    );
+    expect(patchLine).toBeDefined();
+    expect(patchLine).toContain("authenticate");
+  });
+
+  it("should have PATCH /outlets/:id/status with auth", () => {
+    expect(content).toContain('"/outlets/:id/status"');
+  });
+
+  it("should forward campaignId query param on PATCH /outlets/:id/status", () => {
+    const statusSection = content.slice(content.indexOf('"/outlets/:id/status"'));
+    expect(statusSection).toContain("campaignId");
+  });
+
+  it("should use buildInternalHeaders for all endpoints", () => {
+    const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(headerMatches).not.toBeNull();
+    expect(headerMatches!.length).toBe(9);
+  });
+
+  it("should proxy to externalServices.outlet", () => {
+    expect(content).toContain("externalServices.outlet");
+  });
+
+  it("should register static routes before parameterized :id route", () => {
+    const statsIdx = content.indexOf('"/outlets/stats"');
+    const bulkIdx = content.indexOf('"/outlets/bulk"');
+    const searchIdx = content.indexOf('"/outlets/search"');
+    const discoverIdx = content.indexOf('"/outlets/discover"');
+    const idIdx = content.indexOf('"/outlets/:id"');
+    expect(statsIdx).toBeLessThan(idIdx);
+    expect(bulkIdx).toBeLessThan(idIdx);
+    expect(searchIdx).toBeLessThan(idIdx);
+    expect(discoverIdx).toBeLessThan(idIdx);
+  });
+
+  it("should enforce requireOrg + requireUser on ALL outlet routes", () => {
+    const routeLines = content.split("\n").filter((l) =>
+      /router\.(get|post|patch)\(/.test(l) && l.includes('"/')
+    );
+    expect(routeLines.length).toBeGreaterThan(0);
+    for (const line of routeLines) {
+      expect(line).toContain("authenticate");
+      expect(line).toContain("requireOrg");
+      expect(line).toContain("requireUser");
+    }
+  });
+});
+
+describe("Outlets service client", () => {
+  it("should have outlet in externalServices", () => {
+    expect(serviceClientContent).toContain("outlet:");
+    expect(serviceClientContent).toContain("OUTLETS_SERVICE_URL");
+    expect(serviceClientContent).toContain("OUTLETS_SERVICE_API_KEY");
+  });
+});
+
+describe("Outlets OpenAPI schemas", () => {
+  it("should register GET /v1/outlets", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets"');
+  });
+
+  it("should register POST /v1/outlets", () => {
+    expect(schemaContent).toContain("CreateOutletRequest");
+  });
+
+  it("should register POST /v1/outlets/bulk", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/bulk"');
+    expect(schemaContent).toContain("BulkCreateOutletsRequest");
+  });
+
+  it("should register POST /v1/outlets/search", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/search"');
+    expect(schemaContent).toContain("SearchOutletsRequest");
+  });
+
+  it("should register POST /v1/outlets/discover", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/discover"');
+    expect(schemaContent).toContain("DiscoverOutletsRequest");
+  });
+
+  it("should register GET /v1/outlets/{id}", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/{id}"');
+  });
+
+  it("should register PATCH /v1/outlets/{id}", () => {
+    const patchMatch = schemaContent.match(/method: "patch",\s*\n\s*path: "\/v1\/outlets\/\{id\}"/);
+    expect(patchMatch).not.toBeNull();
+  });
+
+  it("should register PATCH /v1/outlets/{id}/status", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/{id}/status"');
+    expect(schemaContent).toContain("UpdateOutletStatusRequest");
+  });
+
+  it("should register GET /v1/outlets/stats", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/stats"');
+  });
+
+  it("should use Outlets tag", () => {
+    expect(schemaContent).toContain('tags: ["Outlets"]');
+  });
+});
+
+describe("Outlets routes are mounted in index.ts", () => {
+  it("should import and mount outlets routes", () => {
+    expect(indexContent).toContain("outletsRoutes");
+    expect(indexContent).toContain("./routes/outlets");
+  });
+
+  it("should mount at /v1", () => {
+    expect(indexContent).toContain('app.use("/v1", outletsRoutes)');
+  });
+});


### PR DESCRIPTION
## Summary
- **Outlets**: Created `src/routes/outlets.ts` with all 9 proxy endpoints matching outlets-service OpenAPI v2.0.0 (list, create, bulk upsert, search, discover, get by ID, update, status update, stats)
- **Journalists**: Created `src/routes/journalists.ts` with all 3 proxy endpoints matching journalists-service v1.0.0 (discover, discover-emails, resolve)
- **Campaign journalists fix**: `GET /v1/campaigns/:id/journalists` was proxying to the removed `/campaign-outlet-journalists` endpoint — now fetches campaign outlets then resolves journalists per outlet via `POST /journalists/resolve`
- **Press-kits**: Already fully in sync with the spec, no changes needed
- **Airtik/Articles**: API registry kept timing out — needs separate follow-up
- Added full OpenAPI schemas for all new endpoints
- 108 new/updated tests passing

## Test plan
- [x] All proxy tests pass (outlets-proxy, journalists-proxy, campaign-discovery-proxy, press-kits-proxy)
- [x] Full test suite passes (742 pass, 6 pre-existing failures in workflows-stats unrelated to this PR)
- [ ] Verify outlets proxy routes work end-to-end with outlets-service
- [ ] Verify journalists proxy routes work end-to-end with journalists-service
- [ ] Verify campaign journalists endpoint returns resolved journalist data

🤖 Generated with [Claude Code](https://claude.com/claude-code)