### PR TITLE
feat: add articles service (airtik) proxy routes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1989,6 +1989,311 @@
           "outletId"
         ]
       },
+      "CreateArticleRequest": {
+        "type": "object",
+        "properties": {
+          "articleUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "ogDescription": {
+            "type": "string"
+          },
+          "twitterCreator": {
+            "type": "string"
+          },
+          "newsKeywords": {
+            "type": "string"
+          },
+          "articlePublished": {
+            "type": "string"
+          },
+          "articleChannel": {
+            "type": "string"
+          },
+          "twitterTitle": {
+            "type": "string"
+          },
+          "articleSection": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "ogTitle": {
+            "type": "string"
+          },
+          "articleAuthor": {
+            "type": "string"
+          },
+          "twitterDescription": {
+            "type": "string"
+          },
+          "articleModified": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "articleUrl"
+        ]
+      },
+      "BulkCreateArticlesRequest": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "articleUrl": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "snippet": {
+                  "type": "string"
+                },
+                "ogDescription": {
+                  "type": "string"
+                },
+                "twitterCreator": {
+                  "type": "string"
+                },
+                "newsKeywords": {
+                  "type": "string"
+                },
+                "articlePublished": {
+                  "type": "string"
+                },
+                "articleChannel": {
+                  "type": "string"
+                },
+                "twitterTitle": {
+                  "type": "string"
+                },
+                "articleSection": {
+                  "type": "string"
+                },
+                "author": {
+                  "type": "string"
+                },
+                "ogTitle": {
+                  "type": "string"
+                },
+                "articleAuthor": {
+                  "type": "string"
+                },
+                "twitterDescription": {
+                  "type": "string"
+                },
+                "articleModified": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "articleUrl"
+              ]
+            }
+          }
+        },
+        "required": [
+          "articles"
+        ]
+      },
+      "SearchArticlesRequest": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "CreateTopicRequest": {
+        "type": "object",
+        "properties": {
+          "topicName": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "topicName"
+        ]
+      },
+      "BulkCreateTopicsRequest": {
+        "type": "object",
+        "properties": {
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "topicName": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "topicName"
+              ]
+            }
+          }
+        },
+        "required": [
+          "topics"
+        ]
+      },
+      "CreateDiscoveryRequest": {
+        "type": "object",
+        "properties": {
+          "articleId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "outletId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "journalistId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "topicId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "articleId",
+          "brandId",
+          "campaignId"
+        ]
+      },
+      "BulkCreateDiscoveriesRequest": {
+        "type": "object",
+        "properties": {
+          "discoveries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "articleId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "brandId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "campaignId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "outletId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "journalistId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "topicId": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "required": [
+                "articleId",
+                "brandId",
+                "campaignId"
+              ]
+            }
+          }
+        },
+        "required": [
+          "discoveries"
+        ]
+      },
+      "DiscoverOutletArticlesRequest": {
+        "type": "object",
+        "properties": {
+          "outletDomain": {
+            "type": "string",
+            "minLength": 1
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "maxArticles": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "outletDomain",
+          "brandId",
+          "campaignId"
+        ]
+      },
+      "DiscoverJournalistPublicationsRequest": {
+        "type": "object",
+        "properties": {
+          "journalistFirstName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "journalistLastName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "journalistId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "maxResults": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "journalistFirstName",
+          "journalistLastName",
+          "journalistId",
+          "brandId",
+          "campaignId"
+        ]
+      },
       "OrgKeyItem": {
         "type": "object",
         "properties": {
@@ -8944,6 +9249,1486 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/articles": {
+      "get": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "List articles with pagination",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of articles"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Create or upsert an article by URL",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateArticleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Article created or updated"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/articles/authors": {
+      "get": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Articles with computed authors",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Articles with computed authors view"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/articles/{id}": {
+      "get": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Get a single article by ID",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Article ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Article found"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Article not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/articles/bulk": {
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Bulk upsert articles",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkCreateArticlesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Articles upserted"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/articles/search": {
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Full-text search across article fields",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchArticlesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/topics": {
+      "get": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "List all topics",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of topics"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Create or upsert a topic by name",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTopicRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Topic created or updated"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/topics/bulk": {
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Bulk upsert topics",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkCreateTopicsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Topics upserted"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/discoveries": {
+      "get": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "List article discoveries with filters",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "outletId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "journalistId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "topicId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of discoveries"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Link an article to a campaign context",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDiscoveryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discovery created"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/discoveries/bulk": {
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Bulk link articles to campaign contexts",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkCreateDiscoveriesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discoveries created"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/discover/outlet-articles": {
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Discover recent articles from an outlet via Google News + scraping",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverOutletArticlesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discovered articles"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-name",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/discover/journalist-publications": {
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Discover recent publications by a journalist",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverJournalistPublicationsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discovered publications"
           },
           "400": {
             "description": "Validation error",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import contentRoutes from "./routes/content.js";
 import pressKitsRoutes from "./routes/press-kits.js";
 import outletsRoutes from "./routes/outlets.js";
 import journalistsRoutes from "./routes/journalists.js";
+import articlesRoutes from "./routes/articles.js";
 import featuresRoutes from "./routes/features.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { readFileSync, existsSync } from "fs";
@@ -176,6 +177,7 @@ app.use("/v1", contentRoutes);
 app.use("/v1", pressKitsRoutes); // authenticated press-kit endpoints
 app.use("/v1", outletsRoutes);
 app.use("/v1", journalistsRoutes);
+app.use("/v1", articlesRoutes);
 app.use("/v1", featuresRoutes);
 
 // 404 handler

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -84,6 +84,10 @@ export const externalServices = {
     url: process.env.JOURNALISTS_SERVICE_URL || "http://localhost:3031",
     apiKey: process.env.JOURNALISTS_SERVICE_API_KEY || "",
   },
+  articles: {
+    url: process.env.ARTICLES_SERVICE_URL || "http://localhost:3012",
+    apiKey: process.env.ARTICLES_SERVICE_API_KEY || "",
+  },
   features: {
     url: process.env.FEATURES_SERVICE_URL || "http://localhost:3032",
     apiKey: process.env.FEATURES_SERVICE_API_KEY || "",

--- a/src/routes/articles.ts
+++ b/src/routes/articles.ts
@@ -1,0 +1,233 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+// ── Articles ────────────────────────────────────────────────────────────────
+
+// GET /v1/articles/authors — articles with computed authors view
+// (must be before /articles/:id to avoid matching "authors" as an :id)
+router.get("/articles/authors", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.limit) params.set("limit", req.query.limit as string);
+    if (req.query.offset) params.set("offset", req.query.offset as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.articles,
+      `/v1/articles/authors${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list article authors" });
+  }
+});
+
+// GET /v1/articles — list articles with pagination
+router.get("/articles", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.limit) params.set("limit", req.query.limit as string);
+    if (req.query.offset) params.set("offset", req.query.offset as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.articles,
+      `/v1/articles${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list articles" });
+  }
+});
+
+// POST /v1/articles — create or upsert an article by URL
+router.post("/articles", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/articles",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create article" });
+  }
+});
+
+// POST /v1/articles/bulk — bulk upsert articles
+router.post("/articles/bulk", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/articles/bulk",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to bulk create articles" });
+  }
+});
+
+// POST /v1/articles/search — full-text search across article fields
+router.post("/articles/search", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/articles/search",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to search articles" });
+  }
+});
+
+// GET /v1/articles/:id — get a single article by ID
+router.get("/articles/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      `/v1/articles/${encodeURIComponent(req.params.id)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get article" });
+  }
+});
+
+// ── Topics ──────────────────────────────────────────────────────────────────
+
+// GET /v1/topics — list all topics
+router.get("/topics", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/topics",
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list topics" });
+  }
+});
+
+// POST /v1/topics — create or upsert a topic by name
+router.post("/topics", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/topics",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create topic" });
+  }
+});
+
+// POST /v1/topics/bulk — bulk upsert topics
+router.post("/topics/bulk", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/topics/bulk",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to bulk create topics" });
+  }
+});
+
+// ── Discoveries ─────────────────────────────────────────────────────────────
+
+// GET /v1/discoveries — list article discoveries with filters
+router.get("/discoveries", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
+    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
+    if (req.query.outletId) params.set("outletId", req.query.outletId as string);
+    if (req.query.journalistId) params.set("journalistId", req.query.journalistId as string);
+    if (req.query.topicId) params.set("topicId", req.query.topicId as string);
+    if (req.query.limit) params.set("limit", req.query.limit as string);
+    if (req.query.offset) params.set("offset", req.query.offset as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.articles,
+      `/v1/discoveries${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list discoveries" });
+  }
+});
+
+// POST /v1/discoveries — link an article to a campaign context
+router.post("/discoveries", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/discoveries",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create discovery" });
+  }
+});
+
+// POST /v1/discoveries/bulk — bulk link articles to campaign contexts
+router.post("/discoveries/bulk", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/discoveries/bulk",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to bulk create discoveries" });
+  }
+});
+
+// ── Discovery workflows ─────────────────────────────────────────────────────
+
+// POST /v1/discover/outlet-articles — discover articles from an outlet via Google News + scraping
+router.post("/discover/outlet-articles", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/discover/outlet-articles",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to discover outlet articles" });
+  }
+});
+
+// POST /v1/discover/journalist-publications — discover publications by a journalist
+router.post("/discover/journalist-publications", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/discover/journalist-publications",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to discover journalist publications" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1316,6 +1316,399 @@ registry.registerPath({
 });
 
 // ===================================================================
+// ARTICLES (airtik)
+// ===================================================================
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/articles",
+  tags: ["Articles"],
+  summary: "List articles with pagination",
+  security: authed,
+  request: {
+    query: z.object({
+      limit: z.coerce.number().int().optional(),
+      offset: z.coerce.number().int().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "List of articles" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/articles",
+  tags: ["Articles"],
+  summary: "Create or upsert an article by URL",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              articleUrl: z.string().url(),
+              snippet: z.string().optional(),
+              ogDescription: z.string().optional(),
+              twitterCreator: z.string().optional(),
+              newsKeywords: z.string().optional(),
+              articlePublished: z.string().optional(),
+              articleChannel: z.string().optional(),
+              twitterTitle: z.string().optional(),
+              articleSection: z.string().optional(),
+              author: z.string().optional(),
+              ogTitle: z.string().optional(),
+              articleAuthor: z.string().optional(),
+              twitterDescription: z.string().optional(),
+              articleModified: z.string().optional(),
+            })
+            .openapi("CreateArticleRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Article created or updated" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/articles/authors",
+  tags: ["Articles"],
+  summary: "Articles with computed authors",
+  security: authed,
+  request: {
+    query: z.object({
+      limit: z.coerce.number().int().optional(),
+      offset: z.coerce.number().int().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "Articles with computed authors view" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/articles/{id}",
+  tags: ["Articles"],
+  summary: "Get a single article by ID",
+  security: authed,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: "Article ID" }),
+    }),
+  },
+  responses: {
+    200: { description: "Article found" },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Article not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/articles/bulk",
+  tags: ["Articles"],
+  summary: "Bulk upsert articles",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              articles: z.array(
+                z.object({
+                  articleUrl: z.string().url(),
+                  snippet: z.string().optional(),
+                  ogDescription: z.string().optional(),
+                  twitterCreator: z.string().optional(),
+                  newsKeywords: z.string().optional(),
+                  articlePublished: z.string().optional(),
+                  articleChannel: z.string().optional(),
+                  twitterTitle: z.string().optional(),
+                  articleSection: z.string().optional(),
+                  author: z.string().optional(),
+                  ogTitle: z.string().optional(),
+                  articleAuthor: z.string().optional(),
+                  twitterDescription: z.string().optional(),
+                  articleModified: z.string().optional(),
+                }),
+              ),
+            })
+            .openapi("BulkCreateArticlesRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Articles upserted" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/articles/search",
+  tags: ["Articles"],
+  summary: "Full-text search across article fields",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              query: z.string().min(1),
+              limit: z.number().int().optional(),
+              offset: z.number().int().optional(),
+            })
+            .openapi("SearchArticlesRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Search results" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+// ── Topics ──────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/topics",
+  tags: ["Articles"],
+  summary: "List all topics",
+  security: authed,
+  responses: {
+    200: { description: "List of topics" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/topics",
+  tags: ["Articles"],
+  summary: "Create or upsert a topic by name",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              topicName: z.string().min(1),
+            })
+            .openapi("CreateTopicRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Topic created or updated" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/topics/bulk",
+  tags: ["Articles"],
+  summary: "Bulk upsert topics",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              topics: z.array(
+                z.object({
+                  topicName: z.string().min(1),
+                }),
+              ),
+            })
+            .openapi("BulkCreateTopicsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Topics upserted" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+// ── Discoveries ─────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/discoveries",
+  tags: ["Articles"],
+  summary: "List article discoveries with filters",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().optional(),
+      campaignId: z.string().uuid().optional(),
+      outletId: z.string().uuid().optional(),
+      journalistId: z.string().uuid().optional(),
+      topicId: z.string().uuid().optional(),
+      limit: z.coerce.number().int().optional(),
+      offset: z.coerce.number().int().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "List of discoveries" },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/discoveries",
+  tags: ["Articles"],
+  summary: "Link an article to a campaign context",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              articleId: z.string().uuid(),
+              brandId: z.string().uuid(),
+              campaignId: z.string().uuid(),
+              outletId: z.string().uuid().optional(),
+              journalistId: z.string().uuid().optional(),
+              topicId: z.string().uuid().optional(),
+            })
+            .openapi("CreateDiscoveryRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Discovery created" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/discoveries/bulk",
+  tags: ["Articles"],
+  summary: "Bulk link articles to campaign contexts",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              discoveries: z.array(
+                z.object({
+                  articleId: z.string().uuid(),
+                  brandId: z.string().uuid(),
+                  campaignId: z.string().uuid(),
+                  outletId: z.string().uuid().optional(),
+                  journalistId: z.string().uuid().optional(),
+                  topicId: z.string().uuid().optional(),
+                }),
+              ),
+            })
+            .openapi("BulkCreateDiscoveriesRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Discoveries created" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+// ── Discovery workflows ─────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/discover/outlet-articles",
+  tags: ["Articles"],
+  summary: "Discover recent articles from an outlet via Google News + scraping",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outletDomain: z.string().min(1),
+              brandId: z.string().uuid(),
+              campaignId: z.string().uuid(),
+              maxArticles: z.number().int().optional(),
+            })
+            .openapi("DiscoverOutletArticlesRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Discovered articles" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/discover/journalist-publications",
+  tags: ["Articles"],
+  summary: "Discover recent publications by a journalist",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              journalistFirstName: z.string().min(1),
+              journalistLastName: z.string().min(1),
+              journalistId: z.string().uuid(),
+              brandId: z.string().uuid(),
+              campaignId: z.string().uuid(),
+              maxResults: z.number().int().optional(),
+            })
+            .openapi("DiscoverJournalistPublicationsRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Discovered publications" },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+// ===================================================================
 // PROVIDER KEYS
 // ===================================================================
 

--- a/tests/unit/articles-proxy.test.ts
+++ b/tests/unit/articles-proxy.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/articles.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+describe("Articles proxy routes", () => {
+  // ── Articles CRUD ─────────────────────────────────────────────────────
+
+  it("should have GET /articles with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/articles"') && !l.includes("/:id") && !l.includes("/authors")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward limit and offset on GET /articles", () => {
+    expect(content).toContain('"limit"');
+    expect(content).toContain('"offset"');
+  });
+
+  it("should have POST /articles with auth", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/articles"') && !l.includes("/bulk") && !l.includes("/search")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+  });
+
+  it("should have POST /articles/bulk with auth", () => {
+    expect(content).toContain('"/articles/bulk"');
+  });
+
+  it("should have POST /articles/search with auth", () => {
+    expect(content).toContain('"/articles/search"');
+  });
+
+  it("should have GET /articles/authors with auth", () => {
+    expect(content).toContain('"/articles/authors"');
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/articles/authors"')
+    );
+    expect(line).toContain("authenticate");
+  });
+
+  it("should have GET /articles/:id with auth", () => {
+    expect(content).toContain('"/articles/:id"');
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/articles/:id"')
+    );
+    expect(line).toContain("authenticate");
+  });
+
+  it("should register static routes before parameterized :id route", () => {
+    const authorsIdx = content.indexOf('"/articles/authors"');
+    const bulkIdx = content.indexOf('"/articles/bulk"');
+    const searchIdx = content.indexOf('"/articles/search"');
+    const idIdx = content.indexOf('"/articles/:id"');
+    expect(authorsIdx).toBeLessThan(idIdx);
+    expect(bulkIdx).toBeLessThan(idIdx);
+    expect(searchIdx).toBeLessThan(idIdx);
+  });
+
+  // ── Topics ────────────────────────────────────────────────────────────
+
+  it("should have GET /topics with auth", () => {
+    expect(content).toContain('"/topics"');
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/topics"')
+    );
+    expect(line).toContain("authenticate");
+  });
+
+  it("should have POST /topics with auth", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/topics"') && !l.includes("/bulk")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+  });
+
+  it("should have POST /topics/bulk with auth", () => {
+    expect(content).toContain('"/topics/bulk"');
+  });
+
+  // ── Discoveries ───────────────────────────────────────────────────────
+
+  it("should have GET /discoveries with auth and filter params", () => {
+    expect(content).toContain('"/discoveries"');
+    const section = content.slice(content.indexOf('router.get("/discoveries"'));
+    expect(section).toContain('"brandId"');
+    expect(section).toContain('"campaignId"');
+    expect(section).toContain('"outletId"');
+    expect(section).toContain('"journalistId"');
+    expect(section).toContain('"topicId"');
+  });
+
+  it("should have POST /discoveries with auth", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/discoveries"') && !l.includes("/bulk")
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+  });
+
+  it("should have POST /discoveries/bulk with auth", () => {
+    expect(content).toContain('"/discoveries/bulk"');
+  });
+
+  // ── Discovery workflows ───────────────────────────────────────────────
+
+  it("should have POST /discover/outlet-articles with auth", () => {
+    expect(content).toContain('"/discover/outlet-articles"');
+  });
+
+  it("should have POST /discover/journalist-publications with auth", () => {
+    expect(content).toContain('"/discover/journalist-publications"');
+  });
+
+  // ── General checks ────────────────────────────────────────────────────
+
+  it("should proxy to articles-service at /v1/ paths (articles-service uses /v1 prefix)", () => {
+    // All callExternalService calls should target /v1/... on the articles service
+    const calls = content.match(/`\/v1\//g);
+    expect(calls).not.toBeNull();
+    expect(calls!.length).toBeGreaterThanOrEqual(3);
+    // Verify we're calling externalServices.articles
+    expect(content).toContain("externalServices.articles");
+  });
+
+  it("should use buildInternalHeaders for all endpoints", () => {
+    const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(headerMatches).not.toBeNull();
+    expect(headerMatches!.length).toBe(14);
+  });
+
+  it("should enforce requireOrg + requireUser on ALL article routes", () => {
+    const routeLines = content.split("\n").filter((l) =>
+      /router\.(get|post)\(/.test(l) && l.includes('"/')
+    );
+    expect(routeLines.length).toBeGreaterThan(0);
+    for (const line of routeLines) {
+      expect(line).toContain("authenticate");
+      expect(line).toContain("requireOrg");
+      expect(line).toContain("requireUser");
+    }
+  });
+});
+
+describe("Articles service client", () => {
+  it("should have articles in externalServices", () => {
+    expect(serviceClientContent).toContain("articles:");
+    expect(serviceClientContent).toContain("ARTICLES_SERVICE_URL");
+    expect(serviceClientContent).toContain("ARTICLES_SERVICE_API_KEY");
+  });
+});
+
+describe("Articles OpenAPI schemas", () => {
+  it("should register GET /v1/articles", () => {
+    expect(schemaContent).toContain('path: "/v1/articles"');
+  });
+
+  it("should register POST /v1/articles", () => {
+    expect(schemaContent).toContain("CreateArticleRequest");
+  });
+
+  it("should register GET /v1/articles/authors", () => {
+    expect(schemaContent).toContain('path: "/v1/articles/authors"');
+  });
+
+  it("should register GET /v1/articles/{id}", () => {
+    expect(schemaContent).toContain('path: "/v1/articles/{id}"');
+  });
+
+  it("should register POST /v1/articles/bulk", () => {
+    expect(schemaContent).toContain('path: "/v1/articles/bulk"');
+    expect(schemaContent).toContain("BulkCreateArticlesRequest");
+  });
+
+  it("should register POST /v1/articles/search", () => {
+    expect(schemaContent).toContain('path: "/v1/articles/search"');
+    expect(schemaContent).toContain("SearchArticlesRequest");
+  });
+
+  it("should register GET /v1/topics", () => {
+    expect(schemaContent).toContain('path: "/v1/topics"');
+  });
+
+  it("should register POST /v1/topics", () => {
+    expect(schemaContent).toContain("CreateTopicRequest");
+  });
+
+  it("should register POST /v1/topics/bulk", () => {
+    expect(schemaContent).toContain('path: "/v1/topics/bulk"');
+    expect(schemaContent).toContain("BulkCreateTopicsRequest");
+  });
+
+  it("should register GET /v1/discoveries", () => {
+    expect(schemaContent).toContain('path: "/v1/discoveries"');
+  });
+
+  it("should register POST /v1/discoveries", () => {
+    expect(schemaContent).toContain("CreateDiscoveryRequest");
+  });
+
+  it("should register POST /v1/discoveries/bulk", () => {
+    expect(schemaContent).toContain('path: "/v1/discoveries/bulk"');
+    expect(schemaContent).toContain("BulkCreateDiscoveriesRequest");
+  });
+
+  it("should register POST /v1/discover/outlet-articles", () => {
+    expect(schemaContent).toContain('path: "/v1/discover/outlet-articles"');
+    expect(schemaContent).toContain("DiscoverOutletArticlesRequest");
+  });
+
+  it("should register POST /v1/discover/journalist-publications", () => {
+    expect(schemaContent).toContain('path: "/v1/discover/journalist-publications"');
+    expect(schemaContent).toContain("DiscoverJournalistPublicationsRequest");
+  });
+
+  it("should use Articles tag", () => {
+    expect(schemaContent).toContain('tags: ["Articles"]');
+  });
+});
+
+describe("Articles routes are mounted in index.ts", () => {
+  it("should import and mount articles routes", () => {
+    expect(indexContent).toContain("articlesRoutes");
+    expect(indexContent).toContain("./routes/articles");
+  });
+
+  it("should mount at /v1", () => {
+    expect(indexContent).toContain('app.use("/v1", articlesRoutes)');
+  });
+});


### PR DESCRIPTION
## Summary
- Created `src/routes/articles.ts` with all 14 proxy endpoints matching articles-service v1.0.0
  - **Articles**: list, create, bulk upsert, search, get by ID, authors view
  - **Topics**: list, create, bulk upsert
  - **Discoveries**: list with filters, create, bulk create
  - **Discovery workflows**: outlet-articles (Google News + scraping), journalist-publications
- Added `articles` service to `externalServices` (`ARTICLES_SERVICE_URL` / `ARTICLES_SERVICE_API_KEY`)
- Added full OpenAPI schemas for all endpoints under the "Articles" tag
- 37 new tests passing

## Test plan
- [x] All articles proxy tests pass (37/37)
- [ ] Verify proxy routes work end-to-end with articles-service
- [ ] Set `ARTICLES_SERVICE_URL` and `ARTICLES_SERVICE_API_KEY` env vars in Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)