### PR TITLE
feat: extract-fields response from array to keyed object

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3121,10 +3121,6 @@
       "ExtractFieldResult": {
         "type": "object",
         "properties": {
-          "key": {
-            "type": "string",
-            "description": "Field key"
-          },
           "value": {
             "anyOf": [
               {
@@ -3173,7 +3169,6 @@
           }
         },
         "required": [
-          "key",
           "value",
           "cached",
           "extractedAt",
@@ -3189,11 +3184,11 @@
             "description": "Brand ID"
           },
           "results": {
-            "type": "array",
-            "items": {
+            "type": "object",
+            "additionalProperties": {
               "$ref": "#/components/schemas/ExtractFieldResult"
             },
-            "description": "Extraction results"
+            "description": "Extraction results keyed by field name (e.g. results.biography.value)"
           }
         },
         "required": [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2320,7 +2320,6 @@ const ExtractFieldRequestSchema = z.object({
 }).openapi("ExtractFieldRequest");
 
 const ExtractFieldResultSchema = z.object({
-  key: z.string().describe("Field key"),
   value: z.union([
     z.string(),
     z.array(z.unknown()),
@@ -2473,7 +2472,7 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             brandId: z.string().describe("Brand ID"),
-            results: z.array(ExtractFieldResultSchema).describe("Extraction results"),
+            results: z.record(z.string(), ExtractFieldResultSchema).describe("Extraction results keyed by field name (e.g. results.biography.value)"),
           }).openapi("ExtractFieldsResponse"),
         },
       },

--- a/tests/unit/brand-sales-profile-404.regression.test.ts
+++ b/tests/unit/brand-sales-profile-404.regression.test.ts
@@ -44,10 +44,10 @@ describe("POST /v1/brands/:id/extract-fields", () => {
   it("should return 200 with extracted results", async () => {
     const response = {
       brandId: "b-1",
-      results: [
-        { key: "industry", value: "SaaS", cached: true, extractedAt: "2026-03-01T00:00:00Z", expiresAt: "2026-03-31T00:00:00Z" },
-        { key: "valueProposition", value: "All-in-one platform", cached: false, extractedAt: "2026-03-23T00:00:00Z", expiresAt: "2026-04-22T00:00:00Z" },
-      ],
+      results: {
+        industry: { value: "SaaS", cached: true, extractedAt: "2026-03-01T00:00:00Z", expiresAt: "2026-03-31T00:00:00Z" },
+        valueProposition: { value: "All-in-one platform", cached: false, extractedAt: "2026-03-23T00:00:00Z", expiresAt: "2026-04-22T00:00:00Z" },
+      },
     };
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: true,
@@ -65,15 +65,15 @@ describe("POST /v1/brands/:id/extract-fields", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.brandId).toBe("b-1");
-    expect(res.body.results).toHaveLength(2);
-    expect(res.body.results[0].key).toBe("industry");
-    expect(res.body.results[0].cached).toBe(true);
+    expect(Object.keys(res.body.results)).toHaveLength(2);
+    expect(res.body.results.industry.value).toBe("SaaS");
+    expect(res.body.results.industry.cached).toBe(true);
   });
 
   it("should forward the request body to brand-service", async () => {
     global.fetch = vi.fn().mockImplementation(async () => ({
       ok: true,
-      json: () => Promise.resolve({ brandId: "b-1", results: [] }),
+      json: () => Promise.resolve({ brandId: "b-1", results: {} }),
     }));
 
     const fields = [


### PR DESCRIPTION
## Summary
- Updates the `POST /v1/brands/{id}/extract-fields` response schema: `results` changes from `z.array(ExtractFieldResultSchema)` to `z.record(z.string(), ExtractFieldResultSchema)`
- Removes the `key` field from `ExtractFieldResultSchema` (the key is now the object property name)
- Updates tests and regenerated `openapi.json`

## Context
Breaking change coordinated with brand-service. Access pattern changes from `results[0].value` to `results.biography.value`.

## Test plan
- [x] Existing unit tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)