### PR TITLE
fix: preserve DAG edge conditions and node retries in workflow proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4103,6 +4103,11 @@
               "nullable": true
             },
             "description": "Maps input variables to this node"
+          },
+          "retries": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of retry attempts on failure. Defaults to 3 if omitted. Set to 0 for non-idempotent operations."
           }
         },
         "required": [
@@ -4120,6 +4125,10 @@
           "to": {
             "type": "string",
             "description": "Target node ID"
+          },
+          "condition": {
+            "type": "string",
+            "description": "JavaScript expression for conditional branching. Only used when source node is type 'condition'. Edges WITH condition: target node only executes when the condition is true. Edges WITHOUT condition from a condition node: target always executes after the branch."
           }
         },
         "required": [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3066,6 +3066,7 @@ const DAGNodeSchema = z
     type: z.string().describe("Node type (e.g. 'http.call', 'condition', 'wait', 'for-each', 'script')"),
     config: z.record(z.unknown()).optional().describe("Node-specific configuration"),
     inputMapping: z.record(z.unknown()).optional().describe("Maps input variables to this node"),
+    retries: z.number().int().min(0).optional().describe("Number of retry attempts on failure. Defaults to 3 if omitted. Set to 0 for non-idempotent operations."),
   })
   .openapi("DAGNode");
 
@@ -3073,6 +3074,7 @@ const DAGEdgeSchema = z
   .object({
     from: z.string().describe("Source node ID"),
     to: z.string().describe("Target node ID"),
+    condition: z.string().optional().describe("JavaScript expression for conditional branching. Only used when source node is type 'condition'. Edges WITH condition: target node only executes when the condition is true. Edges WITHOUT condition from a condition node: target always executes after the branch."),
   })
   .openapi("DAGEdge");
 

--- a/tests/unit/workflow-validate-update.test.ts
+++ b/tests/unit/workflow-validate-update.test.ts
@@ -118,4 +118,65 @@ describe("Workflow validate & update schemas", () => {
   it("should export UpdateWorkflowRequestSchema", () => {
     expect(content).toContain("export const UpdateWorkflowRequestSchema");
   });
+
+  it("should include condition field in DAGEdge schema", () => {
+    expect(content).toContain('"DAGEdge"');
+    // Find the DAGEdge schema block and verify it has condition
+    const edgeStart = content.indexOf("const DAGEdgeSchema");
+    const edgeEnd = content.indexOf(".openapi(", edgeStart);
+    const block = content.slice(edgeStart, edgeEnd);
+    expect(block).toContain("condition");
+  });
+
+  it("should include retries field in DAGNode schema", () => {
+    const nodeStart = content.indexOf("const DAGNodeSchema");
+    const nodeEnd = content.indexOf(".openapi(", nodeStart);
+    const block = content.slice(nodeStart, nodeEnd);
+    expect(block).toContain("retries");
+  });
+});
+
+describe("UpdateWorkflowRequestSchema preserves edge conditions and node retries", () => {
+  it("should not strip condition from edges during parse", async () => {
+    const { UpdateWorkflowRequestSchema } = await import("../../src/schemas.js");
+    const input = {
+      name: "test-workflow",
+      dag: {
+        nodes: [
+          { id: "step-1", type: "condition" },
+          { id: "step-2", type: "http.call" },
+          { id: "step-3", type: "http.call" },
+        ],
+        edges: [
+          { from: "step-1", to: "step-2", condition: 'results.step_1.found == true' },
+          { from: "step-1", to: "step-3" },
+        ],
+      },
+    };
+    const result = UpdateWorkflowRequestSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    const edges = result.data!.dag!.edges;
+    expect(edges[0].condition).toBe('results.step_1.found == true');
+    expect(edges[1].condition).toBeUndefined();
+  });
+
+  it("should not strip retries from nodes during parse", async () => {
+    const { UpdateWorkflowRequestSchema } = await import("../../src/schemas.js");
+    const input = {
+      dag: {
+        nodes: [
+          { id: "send-email", type: "http.call", retries: 0 },
+          { id: "fetch-data", type: "http.call", retries: 5 },
+          { id: "default-retries", type: "http.call" },
+        ],
+        edges: [{ from: "send-email", to: "fetch-data" }],
+      },
+    };
+    const result = UpdateWorkflowRequestSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    const nodes = result.data!.dag!.nodes;
+    expect(nodes[0].retries).toBe(0);
+    expect(nodes[1].retries).toBe(5);
+    expect(nodes[2].retries).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- `DAGEdgeSchema` in api-service only defined `{from, to}` — Zod's default stripping silently dropped `condition` when proxying `PUT /workflows/:id` to workflow-service
- `DAGNodeSchema` was also missing `retries`
- This was the root cause of the IVORY→MAST issue: conditional branching and retry config were lost during fork because api-service's Zod schema stripped them before forwarding

## Changes
- Added `condition?: string` to `DAGEdgeSchema`
- Added `retries?: number` to `DAGNodeSchema`
- Regenerated `openapi.json`
- Added regression tests verifying `condition` and `retries` survive schema parse

## Test plan
- [x] `UpdateWorkflowRequestSchema.safeParse()` preserves `condition` on edges
- [x] `UpdateWorkflowRequestSchema.safeParse()` preserves `retries` on nodes
- [x] All existing workflow tests pass (56/56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)