### PR TITLE
feat: apply brand-service + campaign-context conventions

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1605,40 +1605,13 @@
             "type": "string",
             "format": "uuid"
           },
-          "brandName": {
-            "type": "string",
-            "minLength": 1
-          },
-          "brandDescription": {
-            "type": "string",
-            "minLength": 1
-          },
-          "industry": {
-            "type": "string",
-            "minLength": 1
-          },
-          "targetGeo": {
-            "type": "string"
-          },
-          "targetAudience": {
-            "type": "string"
-          },
-          "angles": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "workflowName": {
             "type": "string"
           }
         },
         "required": [
           "campaignId",
-          "brandId",
-          "brandName",
-          "brandDescription",
-          "industry"
+          "brandId"
         ]
       },
       "UpdateOutletRequest": {
@@ -1788,13 +1761,6 @@
           "campaignId": {
             "type": "string",
             "format": "uuid"
-          },
-          "featureInputs": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "default": {}
           },
           "maxArticles": {
             "type": "integer",
@@ -8544,7 +8510,7 @@
           "Outlets"
         ],
         "summary": "Discover relevant outlets via Google search + LLM scoring",
-        "description": "Takes a brand brief, generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets.",
+        "description": "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. Brand context (industry, audience, etc.) is resolved from brand-service by the downstream service.",
         "security": [
           {
             "bearerAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1036,7 +1036,7 @@ registry.registerPath({
   path: "/v1/outlets/discover",
   tags: ["Outlets"],
   summary: "Discover relevant outlets via Google search + LLM scoring",
-  description: "Takes a brand brief, generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets.",
+  description: "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. Brand context (industry, audience, etc.) is resolved from brand-service by the downstream service.",
   security: authed,
   request: {
     body: {
@@ -1046,12 +1046,6 @@ registry.registerPath({
             .object({
               campaignId: z.string().uuid(),
               brandId: z.string().uuid(),
-              brandName: z.string().min(1),
-              brandDescription: z.string().min(1),
-              industry: z.string().min(1),
-              targetGeo: z.string().optional(),
-              targetAudience: z.string().optional(),
-              angles: z.array(z.string()).optional(),
               workflowName: z.string().optional(),
             })
             .openapi("DiscoverOutletsRequest"),
@@ -1166,7 +1160,6 @@ registry.registerPath({
               outletId: z.string().uuid(),
               brandId: z.string().uuid(),
               campaignId: z.string().uuid(),
-              featureInputs: z.record(z.string()).optional().default({}),
               maxArticles: z.number().int().min(1).max(30).optional().default(15),
             })
             .openapi("DiscoverJournalistsRequest"),

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -109,6 +109,20 @@ describe("Journalists OpenAPI schemas", () => {
     expect(schemaContent).toContain('tags: ["Journalists"]');
   });
 
+  it("should NOT include featureInputs in DiscoverJournalistsRequest (convention: resolve from campaign-service)", () => {
+    const start = schemaContent.indexOf("DiscoverJournalistsRequest");
+    const blockBefore = schemaContent.slice(Math.max(0, start - 400), start);
+    expect(blockBefore).not.toContain("featureInputs:");
+  });
+
+  it("should keep brandId, campaignId, outletId in DiscoverJournalistsRequest", () => {
+    const start = schemaContent.indexOf("DiscoverJournalistsRequest");
+    const blockBefore = schemaContent.slice(Math.max(0, start - 400), start);
+    expect(blockBefore).toContain("brandId:");
+    expect(blockBefore).toContain("campaignId:");
+    expect(blockBefore).toContain("outletId:");
+  });
+
   it("should define journalist entity type enum", () => {
     expect(schemaContent).toContain('"individual"');
     expect(schemaContent).toContain('"organization"');

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -185,6 +185,27 @@ describe("Outlets OpenAPI schemas", () => {
   it("should use Outlets tag", () => {
     expect(schemaContent).toContain('tags: ["Outlets"]');
   });
+
+  it("should NOT include brand fields in DiscoverOutletsRequest (convention: resolve from brand-service)", () => {
+    // Extract the DiscoverOutletsRequest schema block
+    const start = schemaContent.indexOf("DiscoverOutletsRequest");
+    const blockBefore = schemaContent.slice(Math.max(0, start - 500), start);
+    // brandName, brandDescription, industry, targetGeo, targetAudience, angles
+    // should NOT appear in the discover request schema
+    expect(blockBefore).not.toContain("brandName:");
+    expect(blockBefore).not.toContain("brandDescription:");
+    expect(blockBefore).not.toContain("industry:");
+    expect(blockBefore).not.toContain("targetGeo:");
+    expect(blockBefore).not.toContain("targetAudience:");
+    expect(blockBefore).not.toContain("angles:");
+  });
+
+  it("should keep brandId and campaignId in DiscoverOutletsRequest", () => {
+    const start = schemaContent.indexOf("DiscoverOutletsRequest");
+    const blockBefore = schemaContent.slice(Math.max(0, start - 300), start);
+    expect(blockBefore).toContain("brandId:");
+    expect(blockBefore).toContain("campaignId:");
+  });
 });
 
 describe("Outlets routes are mounted in index.ts", () => {


### PR DESCRIPTION
## Summary
- Removed ad-hoc brand fields (`brandName`, `brandDescription`, `industry`, `targetGeo`, `targetAudience`, `angles`) from `DiscoverOutletsRequest` — outlets-service now resolves these from brand-service via `POST /brands/{brandId}/extract-fields`
- Removed `featureInputs` from `DiscoverJournalistsRequest` — journalists-service now fetches campaign context from campaign-service via `GET /campaigns/{campaignId}`
- Added convention-enforcement tests to prevent regression

## Test plan
- [x] New tests verify brand fields are absent from `DiscoverOutletsRequest`
- [x] New tests verify `featureInputs` is absent from `DiscoverJournalistsRequest`
- [x] New tests verify required identifiers (`brandId`, `campaignId`, `outletId`) are preserved
- [x] All existing tests pass (50/50 in affected suites)
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)