### PR TITLE
fix: use headers for brandId/campaignId in discover endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1597,22 +1597,10 @@
       "DiscoverOutletsRequest": {
         "type": "object",
         "properties": {
-          "campaignId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "brandId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "workflowName": {
             "type": "string"
           }
-        },
-        "required": [
-          "campaignId",
-          "brandId"
-        ]
+        }
       },
       "UpdateOutletRequest": {
         "type": "object",
@@ -1754,14 +1742,6 @@
             "type": "string",
             "format": "uuid"
           },
-          "brandId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "campaignId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "maxArticles": {
             "type": "integer",
             "minimum": 1,
@@ -1770,9 +1750,7 @@
           }
         },
         "required": [
-          "outletId",
-          "brandId",
-          "campaignId"
+          "outletId"
         ]
       },
       "DiscoverEmailsResponse": {
@@ -8510,7 +8488,7 @@
           "Outlets"
         ],
         "summary": "Discover relevant outlets via Google search + LLM scoring",
-        "description": "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. Brand context (industry, audience, etc.) is resolved from brand-service by the downstream service.",
+        "description": "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. Brand and campaign context are resolved via x-brand-id and x-campaign-id headers.",
         "security": [
           {
             "bearerAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1036,7 +1036,8 @@ registry.registerPath({
   path: "/v1/outlets/discover",
   tags: ["Outlets"],
   summary: "Discover relevant outlets via Google search + LLM scoring",
-  description: "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. Brand context (industry, audience, etc.) is resolved from brand-service by the downstream service.",
+  description: "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. " +
+    "Brand and campaign context are resolved via x-brand-id and x-campaign-id headers.",
   security: authed,
   request: {
     body: {
@@ -1044,8 +1045,6 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              campaignId: z.string().uuid(),
-              brandId: z.string().uuid(),
               workflowName: z.string().optional(),
             })
             .openapi("DiscoverOutletsRequest"),
@@ -1158,8 +1157,6 @@ registry.registerPath({
           schema: z
             .object({
               outletId: z.string().uuid(),
-              brandId: z.string().uuid(),
-              campaignId: z.string().uuid(),
               maxArticles: z.number().int().min(1).max(30).optional().default(15),
             })
             .openapi("DiscoverJournalistsRequest"),

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -109,17 +109,17 @@ describe("Journalists OpenAPI schemas", () => {
     expect(schemaContent).toContain('tags: ["Journalists"]');
   });
 
-  it("should NOT include featureInputs in DiscoverJournalistsRequest (convention: resolve from campaign-service)", () => {
+  it("should NOT include featureInputs, brandId, or campaignId in DiscoverJournalistsRequest body (convention: use headers)", () => {
     const start = schemaContent.indexOf("DiscoverJournalistsRequest");
     const blockBefore = schemaContent.slice(Math.max(0, start - 400), start);
     expect(blockBefore).not.toContain("featureInputs:");
+    expect(blockBefore).not.toContain("brandId:");
+    expect(blockBefore).not.toContain("campaignId:");
   });
 
-  it("should keep brandId, campaignId, outletId in DiscoverJournalistsRequest", () => {
+  it("should keep outletId in DiscoverJournalistsRequest (endpoint-specific required field)", () => {
     const start = schemaContent.indexOf("DiscoverJournalistsRequest");
     const blockBefore = schemaContent.slice(Math.max(0, start - 400), start);
-    expect(blockBefore).toContain("brandId:");
-    expect(blockBefore).toContain("campaignId:");
     expect(blockBefore).toContain("outletId:");
   });
 

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -186,25 +186,18 @@ describe("Outlets OpenAPI schemas", () => {
     expect(schemaContent).toContain('tags: ["Outlets"]');
   });
 
-  it("should NOT include brand fields in DiscoverOutletsRequest (convention: resolve from brand-service)", () => {
-    // Extract the DiscoverOutletsRequest schema block
+  it("should NOT include brand/campaign fields in DiscoverOutletsRequest body (convention: use headers)", () => {
     const start = schemaContent.indexOf("DiscoverOutletsRequest");
     const blockBefore = schemaContent.slice(Math.max(0, start - 500), start);
-    // brandName, brandDescription, industry, targetGeo, targetAudience, angles
-    // should NOT appear in the discover request schema
+    // These must come from x-brand-id / x-campaign-id headers, not the body
+    expect(blockBefore).not.toContain("brandId:");
+    expect(blockBefore).not.toContain("campaignId:");
     expect(blockBefore).not.toContain("brandName:");
     expect(blockBefore).not.toContain("brandDescription:");
     expect(blockBefore).not.toContain("industry:");
     expect(blockBefore).not.toContain("targetGeo:");
     expect(blockBefore).not.toContain("targetAudience:");
     expect(blockBefore).not.toContain("angles:");
-  });
-
-  it("should keep brandId and campaignId in DiscoverOutletsRequest", () => {
-    const start = schemaContent.indexOf("DiscoverOutletsRequest");
-    const blockBefore = schemaContent.slice(Math.max(0, start - 300), start);
-    expect(blockBefore).toContain("brandId:");
-    expect(blockBefore).toContain("campaignId:");
   });
 });
 


### PR DESCRIPTION
## Summary
- Removed `brandId` and `campaignId` from `DiscoverOutletsRequest` and `DiscoverJournalistsRequest` body schemas
- These are already propagated via `x-brand-id` and `x-campaign-id` headers (auth middleware → `buildInternalHeaders`)
- No need to duplicate them in the request body — downstream services read from headers

## Test plan
- [x] Tests verify `brandId` and `campaignId` are absent from discover request bodies
- [x] Tests verify `outletId` (endpoint-specific) still present in journalist discover
- [x] 49/49 tests pass in affected suites
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)