### PR TITLE
fix: align stale tests and add missing openapi response schemas

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "distribute API",
-    "description": "API Gateway for distribute.\n\n## Quick Start\n\n1. Create an API key in the distribute dashboard, or via `POST /v1/api-keys`\n2. Use it as a Bearer token — that's it, no extra headers needed\n\n```\nAuthorization: Bearer distrib.usr_abc123...\n```\n\nYour key carries your org and user identity. All endpoints work out of the box.\n\n## Storing provider keys (BYOK)\n\nTo store your own provider API keys (e.g. OpenAI, Anthropic) for use in workflows:\n\n```\nPOST /v1/keys\nAuthorization: Bearer distrib.usr_abc123...\n\n{ \"provider\": \"openai\", \"apiKey\": \"sk-...\" }\n```\n\n## Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Organization context required (missing `x-org-id` — app key only) |\n| 502 | Identity resolution failed (internal service unreachable) |\n\n",
+    "description": "API Gateway for distribute.\n\n## Quick Start\n\n1. Create an API key in the distribute dashboard, or via `POST /v1/api-keys`\n2. Use it as a Bearer token \u2014 that's it, no extra headers needed\n\n```\nAuthorization: Bearer distrib.usr_abc123...\n```\n\nYour key carries your org and user identity. All endpoints work out of the box.\n\n## Storing provider keys (BYOK)\n\nTo store your own provider API keys (e.g. OpenAI, Anthropic) for use in workflows:\n\n```\nPOST /v1/keys\nAuthorization: Bearer distrib.usr_abc123...\n\n{ \"provider\": \"openai\", \"apiKey\": \"sk-...\" }\n```\n\n## Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Organization context required (missing `x-org-id` \u2014 app key only) |\n| 502 | Identity resolution failed (internal service unreachable) |\n\n",
     "version": "1.0.0"
   },
   "servers": [
@@ -636,7 +636,7 @@
           "featureSlug": {
             "type": "string",
             "minLength": 1,
-            "description": "Feature slug — used to validate inputs against features-service"
+            "description": "Feature slug \u2014 used to validate inputs against features-service"
           },
           "featureInputs": {
             "type": "object",
@@ -5417,7 +5417,7 @@
           "externalUserId": {
             "type": "string",
             "minLength": 1,
-            "description": "External user ID — use a generated UUID for anonymous users"
+            "description": "External user ID \u2014 use a generated UUID for anonymous users"
           },
           "email": {
             "type": "string",
@@ -6000,6 +6000,301 @@
       "FeaturesBatchUpsertRequest": {
         "type": "object",
         "properties": {}
+      },
+      "OutletSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "outletUrl": {
+            "type": "string"
+          },
+          "outletName": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "OutletListResponse": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutletSummary"
+            }
+          }
+        }
+      },
+      "OutletResponse": {
+        "type": "object",
+        "properties": {
+          "outlet": {
+            "$ref": "#/components/schemas/OutletSummary"
+          }
+        }
+      },
+      "OutletStatsResponse": {
+        "type": "object",
+        "description": "Flat or grouped outlet stats"
+      },
+      "BulkOutletsResponse": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutletSummary"
+            }
+          },
+          "created": {
+            "type": "integer"
+          },
+          "updated": {
+            "type": "integer"
+          }
+        }
+      },
+      "SearchOutletsResponse": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutletSummary"
+            }
+          }
+        }
+      },
+      "DiscoverOutletsResponse": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutletSummary"
+            }
+          },
+          "discovered": {
+            "type": "integer"
+          }
+        }
+      },
+      "ArticleSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ArticleListResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleSummary"
+            }
+          }
+        }
+      },
+      "ArticleResponse": {
+        "type": "object",
+        "properties": {
+          "article": {
+            "$ref": "#/components/schemas/ArticleSummary"
+          }
+        }
+      },
+      "ArticleAuthorsResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleSummary"
+            }
+          }
+        }
+      },
+      "BulkArticlesResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleSummary"
+            }
+          },
+          "created": {
+            "type": "integer"
+          },
+          "updated": {
+            "type": "integer"
+          }
+        }
+      },
+      "SearchArticlesResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleSummary"
+            }
+          }
+        }
+      },
+      "TopicSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TopicListResponse": {
+        "type": "object",
+        "properties": {
+          "topics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TopicSummary"
+            }
+          }
+        }
+      },
+      "TopicResponse": {
+        "type": "object",
+        "properties": {
+          "topic": {
+            "$ref": "#/components/schemas/TopicSummary"
+          }
+        }
+      },
+      "BulkTopicsResponse": {
+        "type": "object",
+        "properties": {
+          "topics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TopicSummary"
+            }
+          },
+          "created": {
+            "type": "integer"
+          },
+          "updated": {
+            "type": "integer"
+          }
+        }
+      },
+      "DiscoverySummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "articleId": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "DiscoveryListResponse": {
+        "type": "object",
+        "properties": {
+          "discoveries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscoverySummary"
+            }
+          }
+        }
+      },
+      "DiscoveryResponse": {
+        "type": "object",
+        "properties": {
+          "discovery": {
+            "$ref": "#/components/schemas/DiscoverySummary"
+          }
+        }
+      },
+      "BulkDiscoveriesResponse": {
+        "type": "object",
+        "properties": {
+          "discoveries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscoverySummary"
+            }
+          },
+          "created": {
+            "type": "integer"
+          }
+        }
+      },
+      "DiscoverOutletArticlesResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleSummary"
+            }
+          },
+          "discovered": {
+            "type": "integer"
+          }
+        }
+      },
+      "DiscoverJournalistPublicationsResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleSummary"
+            }
+          },
+          "discovered": {
+            "type": "integer"
+          }
+        }
       }
     },
     "parameters": {}
@@ -6174,22 +6469,22 @@
           "Workflows"
         ],
         "summary": "Hero records (public)",
-        "description": "Public hero records — best cost-per-open/reply. Use ?by=brand for brand-level heroes. No authentication required.",
+        "description": "Public hero records \u2014 best cost-per-open/reply. Use ?by=brand for brand-level heroes. No authentication required.",
         "parameters": [
           {
             "schema": {
               "type": "string",
-              "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand"
+              "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand"
             },
             "required": false,
-            "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
+            "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand",
             "name": "by",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Hero records — best cost-per-open and cost-per-reply",
+            "description": "Hero records \u2014 best cost-per-open and cost-per-reply",
             "content": {
               "application/json": {
                 "schema": {
@@ -6299,7 +6594,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6308,7 +6603,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6317,7 +6612,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6326,7 +6621,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -6379,10 +6674,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand"
+              "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand"
             },
             "required": false,
-            "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
+            "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand",
             "name": "by",
             "in": "query"
           },
@@ -6411,7 +6706,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6420,7 +6715,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6429,7 +6724,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6438,12 +6733,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Hero records — best cost-per-open and cost-per-reply",
+            "description": "Hero records \u2014 best cost-per-open and cost-per-reply",
             "content": {
               "application/json": {
                 "schema": {
@@ -6545,7 +6840,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6554,7 +6849,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6563,7 +6858,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6572,7 +6867,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -6635,7 +6930,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6644,7 +6939,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6653,7 +6948,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6662,7 +6957,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -6786,7 +7081,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6795,7 +7090,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6804,7 +7099,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6813,7 +7108,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -6866,7 +7161,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6875,7 +7170,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6884,7 +7179,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6893,7 +7188,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -6976,7 +7271,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6985,7 +7280,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6994,7 +7289,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7003,7 +7298,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7088,7 +7383,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7097,7 +7392,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7106,7 +7401,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7115,7 +7410,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7200,7 +7495,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7209,7 +7504,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7218,7 +7513,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7227,7 +7522,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7312,7 +7607,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7321,7 +7616,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7330,7 +7625,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7339,7 +7634,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7424,7 +7719,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7433,7 +7728,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7442,7 +7737,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7451,7 +7746,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7536,7 +7831,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7545,7 +7840,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7554,7 +7849,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7563,7 +7858,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7648,7 +7943,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7657,7 +7952,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7666,7 +7961,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7675,7 +7970,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7760,7 +8055,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7769,7 +8064,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7778,7 +8073,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7787,7 +8082,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7872,7 +8167,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7881,7 +8176,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7890,7 +8185,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7899,7 +8194,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -8024,7 +8319,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8033,7 +8328,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8042,7 +8337,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8051,12 +8346,19 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "List of outlets"
+            "description": "List of outlets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletListResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -8091,7 +8393,14 @@
         },
         "responses": {
           "201": {
-            "description": "Outlet created"
+            "description": "Outlet created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -8140,7 +8449,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8149,7 +8458,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8158,7 +8467,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8167,7 +8476,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8249,7 +8558,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8258,7 +8567,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8267,7 +8576,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8276,12 +8585,19 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Stats (flat or grouped)"
+            "description": "Stats (flat or grouped)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletStatsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -8318,7 +8634,14 @@
         },
         "responses": {
           "201": {
-            "description": "Outlets created"
+            "description": "Outlets created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkOutletsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -8357,7 +8680,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8366,7 +8689,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8375,7 +8698,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8384,7 +8707,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8411,7 +8734,14 @@
         },
         "responses": {
           "200": {
-            "description": "Search results"
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchOutletsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -8450,7 +8780,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8459,7 +8789,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8468,7 +8798,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8477,7 +8807,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8505,7 +8835,14 @@
         },
         "responses": {
           "201": {
-            "description": "Outlets discovered and saved"
+            "description": "Outlets discovered and saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverOutletsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -8564,7 +8901,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8573,7 +8910,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8582,7 +8919,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8591,7 +8928,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8643,7 +8980,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8652,7 +8989,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8661,7 +8998,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8670,12 +9007,19 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Outlet found"
+            "description": "Outlet found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -8745,7 +9089,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8754,7 +9098,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8763,7 +9107,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8772,7 +9116,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -8786,7 +9130,14 @@
         },
         "responses": {
           "200": {
-            "description": "Outlet updated"
+            "description": "Outlet updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -8869,7 +9220,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8878,7 +9229,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8887,7 +9238,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8896,7 +9247,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -8910,7 +9261,14 @@
         },
         "responses": {
           "200": {
-            "description": "Status updated"
+            "description": "Status updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -9024,7 +9382,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9033,7 +9391,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9042,7 +9400,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9051,7 +9409,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9134,7 +9492,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9143,7 +9501,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9152,7 +9510,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9161,7 +9519,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9255,7 +9613,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9264,7 +9622,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9273,7 +9631,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9282,7 +9640,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9342,7 +9700,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9351,7 +9709,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9360,7 +9718,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9369,12 +9727,19 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "List of articles"
+            "description": "List of articles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleListResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -9409,7 +9774,14 @@
         },
         "responses": {
           "200": {
-            "description": "Article created or updated"
+            "description": "Article created or updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -9458,7 +9830,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9467,7 +9839,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9476,7 +9848,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9485,7 +9857,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9545,7 +9917,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9554,7 +9926,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9563,7 +9935,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9572,12 +9944,19 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Articles with computed authors view"
+            "description": "Articles with computed authors view",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleAuthorsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -9639,7 +10018,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9648,7 +10027,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9657,7 +10036,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9666,12 +10045,19 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Article found"
+            "description": "Article found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -9718,7 +10104,14 @@
         },
         "responses": {
           "200": {
-            "description": "Articles upserted"
+            "description": "Articles upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkArticlesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -9767,7 +10160,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9776,7 +10169,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9785,7 +10178,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9794,7 +10187,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9821,7 +10214,14 @@
         },
         "responses": {
           "200": {
-            "description": "Search results"
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchArticlesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -9870,7 +10270,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9879,7 +10279,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9888,7 +10288,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9897,7 +10297,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9915,7 +10315,14 @@
         ],
         "responses": {
           "200": {
-            "description": "List of topics"
+            "description": "List of topics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopicListResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -9954,7 +10361,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9963,7 +10370,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9972,7 +10379,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9981,7 +10388,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -10006,7 +10413,14 @@
         },
         "responses": {
           "200": {
-            "description": "Topic created or updated"
+            "description": "Topic created or updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopicResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -10055,7 +10469,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10064,7 +10478,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10073,7 +10487,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10082,7 +10496,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10109,7 +10523,14 @@
         },
         "responses": {
           "200": {
-            "description": "Topics upserted"
+            "description": "Topics upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkTopicsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -10158,7 +10579,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10167,7 +10588,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10176,7 +10597,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10185,7 +10606,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10290,7 +10711,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10299,7 +10720,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10308,7 +10729,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10317,12 +10738,19 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "List of discoveries"
+            "description": "List of discoveries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoveryListResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -10357,7 +10785,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discovery created"
+            "description": "Discovery created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoveryResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -10406,7 +10841,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10415,7 +10850,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10424,7 +10859,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10433,7 +10868,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10460,7 +10895,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discoveries created"
+            "description": "Discoveries created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkDiscoveriesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -10509,7 +10951,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10518,7 +10960,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10527,7 +10969,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10536,7 +10978,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10563,7 +11005,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discovered articles"
+            "description": "Discovered articles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverOutletArticlesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -10622,7 +11071,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10631,7 +11080,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10640,7 +11089,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10649,7 +11098,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10676,7 +11125,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discovered publications"
+            "description": "Discovered publications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverJournalistPublicationsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -10735,7 +11191,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10744,7 +11200,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10753,7 +11209,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10762,7 +11218,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10837,7 +11293,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10846,7 +11302,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10855,7 +11311,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10864,7 +11320,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -10956,7 +11412,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10965,7 +11421,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10974,7 +11430,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10983,7 +11439,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11036,7 +11492,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11045,7 +11501,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11054,7 +11510,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11063,7 +11519,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -11170,7 +11626,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11179,7 +11635,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11188,7 +11644,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11197,7 +11653,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11250,7 +11706,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11259,7 +11715,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11268,7 +11724,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11277,7 +11733,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -11360,7 +11816,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11369,7 +11825,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11378,7 +11834,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11387,7 +11843,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -11532,7 +11988,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11541,7 +11997,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11550,7 +12006,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11559,7 +12015,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11634,7 +12090,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11643,7 +12099,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11652,7 +12108,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11661,7 +12117,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -11687,7 +12143,7 @@
         },
         "responses": {
           "200": {
-            "description": "Created API key (includes the full key — only shown once)",
+            "description": "Created API key (includes the full key \u2014 only shown once)",
             "content": {
               "application/json": {
                 "schema": {
@@ -11743,7 +12199,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11752,7 +12208,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11761,7 +12217,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11770,7 +12226,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11823,7 +12279,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11832,7 +12288,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11841,7 +12297,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11850,7 +12306,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -11957,7 +12413,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11966,7 +12422,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11975,7 +12431,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11984,7 +12440,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12078,7 +12534,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12087,7 +12543,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12096,7 +12552,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12105,7 +12561,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12199,7 +12655,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12208,7 +12664,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12217,7 +12673,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12226,7 +12682,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12320,7 +12776,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12329,7 +12785,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12338,7 +12794,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12347,7 +12803,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12400,7 +12856,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12409,7 +12865,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12418,7 +12874,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12427,7 +12883,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -12544,7 +13000,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12553,7 +13009,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12562,7 +13018,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12571,7 +13027,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -12663,7 +13119,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12672,7 +13128,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12681,7 +13137,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12690,7 +13146,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12743,7 +13199,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12752,7 +13208,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12761,7 +13217,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12770,7 +13226,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -12855,7 +13311,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12864,7 +13320,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12873,7 +13329,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12882,7 +13338,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -12986,7 +13442,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12995,7 +13451,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13004,7 +13460,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13013,7 +13469,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13149,7 +13605,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13158,7 +13614,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13167,7 +13623,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13176,7 +13632,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -13229,7 +13685,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13238,7 +13694,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13247,7 +13703,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13256,7 +13712,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13351,7 +13807,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13360,7 +13816,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13369,7 +13825,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13378,7 +13834,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13493,7 +13949,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13502,7 +13958,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13511,7 +13967,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13520,7 +13976,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13615,7 +14071,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13624,7 +14080,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13633,7 +14089,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13642,7 +14098,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13737,7 +14193,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13746,7 +14202,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13755,7 +14211,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13764,7 +14220,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13888,7 +14344,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13897,7 +14353,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13906,7 +14362,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13915,7 +14371,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -13968,7 +14424,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13977,7 +14433,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13986,7 +14442,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13995,7 +14451,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14078,7 +14534,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14087,7 +14543,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14096,7 +14552,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14105,7 +14561,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -14270,7 +14726,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14279,7 +14735,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14288,7 +14744,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14297,7 +14753,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -14350,7 +14806,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14359,7 +14815,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14368,7 +14824,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14377,7 +14833,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14472,7 +14928,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14481,7 +14937,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14490,7 +14946,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14499,7 +14955,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14542,7 +14998,7 @@
           "Workflows"
         ],
         "summary": "Validate a workflow DAG",
-        "description": "Validates the workflow's DAG structure and checks template contracts — whether the variables provided by the workflow match those expected by prompt templates. Use after every modification to verify consistency.",
+        "description": "Validates the workflow's DAG structure and checks template contracts \u2014 whether the variables provided by the workflow match those expected by prompt templates. Use after every modification to verify consistency.",
         "security": [
           {
             "bearerAuth": []
@@ -14584,7 +15040,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14593,7 +15049,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14602,7 +15058,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14611,7 +15067,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14706,7 +15162,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14715,7 +15171,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14724,7 +15180,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14733,7 +15189,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -14877,7 +15333,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14886,7 +15342,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14895,7 +15351,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14904,7 +15360,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14989,7 +15445,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14998,7 +15454,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15007,7 +15463,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15016,7 +15472,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15111,7 +15567,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15120,7 +15576,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15129,7 +15585,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15138,7 +15594,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15233,7 +15689,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15242,7 +15698,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15251,7 +15707,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15260,7 +15716,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15414,7 +15870,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15423,7 +15879,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15432,7 +15888,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15441,7 +15897,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -15494,7 +15950,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15503,7 +15959,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15512,7 +15968,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15521,7 +15977,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15629,7 +16085,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15638,7 +16094,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15647,7 +16103,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15656,7 +16112,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -15750,7 +16206,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15759,7 +16215,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15768,7 +16224,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15777,7 +16233,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -15788,7 +16244,7 @@
           "Chat"
         ],
         "summary": "Stream chat response (SSE)",
-        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, **omit `sessionId`**. The first SSE event will be `data: {\"sessionId\":\"<uuid>\"}` — store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** — `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** *(optional)* — `thinking_start` → one or more `thinking_delta` → `thinking_stop`\n3. **Tokens** — `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally\n4. **Tool calls** *(optional, repeatable)* — `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues\n5. **Input request** *(optional)* — `input_request` when the AI needs structured user input\n6. **Buttons** *(optional)* — `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options\n7. **Error** *(optional)* — `{\"type\":\"error\",\"message\":\"...\"}` when the model returns an empty response (e.g. context overflow, safety filter). Always followed by `[DONE]`.\n8. **Done** — `\"[DONE]\"` (always last)\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEToolCallEvent, etc.) for exact payload shapes.",
+        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, **omit `sessionId`**. The first SSE event will be `data: {\"sessionId\":\"<uuid>\"}` \u2014 store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** \u2014 `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** *(optional)* \u2014 `thinking_start` \u2192 one or more `thinking_delta` \u2192 `thinking_stop`\n3. **Tokens** \u2014 `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally\n4. **Tool calls** *(optional, repeatable)* \u2014 `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues\n5. **Input request** *(optional)* \u2014 `input_request` when the AI needs structured user input\n6. **Buttons** *(optional)* \u2014 `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options\n7. **Error** *(optional)* \u2014 `{\"type\":\"error\",\"message\":\"...\"}` when the model returns an empty response (e.g. context overflow, safety filter). Always followed by `[DONE]`.\n8. **Done** \u2014 `\"[DONE]\"` (always last)\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEToolCallEvent, etc.) for exact payload shapes.",
         "security": [
           {
             "bearerAuth": []
@@ -15882,7 +16338,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15891,7 +16347,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15900,7 +16356,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15909,7 +16365,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -15920,7 +16376,7 @@
           "Platform"
         ],
         "summary": "Register a platform key",
-        "description": "Register or update a platform-level API key for a provider. Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "description": "Register or update a platform-level API key for a provider. Platform-level \u2014 no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
         "security": [
           {
             "apiKeyAuth": []
@@ -16003,7 +16459,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16012,7 +16468,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16021,7 +16477,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16030,7 +16486,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16041,7 +16497,7 @@
           "Platform"
         ],
         "summary": "Deploy a platform prompt",
-        "description": "Register or update a platform-level prompt template. Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "description": "Register or update a platform-level prompt template. Platform-level \u2014 no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
         "security": [
           {
             "apiKeyAuth": []
@@ -16124,7 +16580,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16133,7 +16589,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16142,7 +16598,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16151,7 +16607,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16162,7 +16618,7 @@
           "Chat"
         ],
         "summary": "Deploy platform-level chat config",
-        "description": "Register or update the global chat configuration (system prompt). Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "description": "Register or update the global chat configuration (system prompt). Platform-level \u2014 no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
         "security": [
           {
             "apiKeyAuth": []
@@ -16245,7 +16701,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16254,7 +16710,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16263,7 +16719,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16272,7 +16728,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16347,7 +16803,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16356,7 +16812,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16365,7 +16821,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16374,7 +16830,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16449,7 +16905,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16458,7 +16914,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16467,7 +16923,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16476,7 +16932,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16551,7 +17007,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16560,7 +17016,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16569,7 +17025,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16578,7 +17034,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16672,7 +17128,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16681,7 +17137,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16690,7 +17146,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16699,7 +17155,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -16772,7 +17228,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16781,7 +17237,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16790,7 +17246,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16799,7 +17255,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16810,7 +17266,7 @@
           "Billing"
         ],
         "summary": "Deduct credits",
-        "description": "Deduct credits from the organization's billing account. Accepts negative balances — if insufficient and auto-reload fails, the deduction still goes through. Auto-creates billing account if none exists.",
+        "description": "Deduct credits from the organization's billing account. Accepts negative balances \u2014 if insufficient and auto-reload fails, the deduction still goes through. Auto-creates billing account if none exists.",
         "security": [
           {
             "bearerAuth": []
@@ -16883,7 +17339,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16892,7 +17348,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16901,7 +17357,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16910,7 +17366,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16994,7 +17450,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17003,7 +17459,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17012,7 +17468,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17021,7 +17477,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17115,7 +17571,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17124,7 +17580,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17133,7 +17589,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17142,7 +17598,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17236,7 +17692,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17245,7 +17701,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17254,7 +17710,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17263,7 +17719,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17316,7 +17772,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17325,7 +17781,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17334,7 +17790,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17343,7 +17799,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -17469,7 +17925,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17478,7 +17934,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17487,7 +17943,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17496,7 +17952,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17507,7 +17963,7 @@
           "Internal"
         ],
         "summary": "Deploy email templates (platform)",
-        "description": "Platform-level template deployment — no identity headers required. Authenticated by X-API-Key only. Used at cold start when no Clerk session exists. Same body format as PUT /v1/emails/templates.",
+        "description": "Platform-level template deployment \u2014 no identity headers required. Authenticated by X-API-Key only. Used at cold start when no Clerk session exists. Same body format as PUT /v1/emails/templates.",
         "security": [
           {
             "apiKeyAuth": []
@@ -17590,7 +18046,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17599,7 +18055,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17608,7 +18064,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17617,7 +18073,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17670,7 +18126,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17679,7 +18135,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17688,7 +18144,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17697,7 +18153,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -17740,7 +18196,7 @@
           "Stripe"
         ],
         "summary": "Create a Stripe product",
-        "description": "Create a new Stripe product. Idempotent — returns existing product if the ID already exists. No org context required (app-level operation).",
+        "description": "Create a new Stripe product. Idempotent \u2014 returns existing product if the ID already exists. No org context required (app-level operation).",
         "security": [
           {
             "bearerAuth": []
@@ -17823,7 +18279,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17832,7 +18288,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17841,7 +18297,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17850,7 +18306,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17903,7 +18359,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17912,7 +18368,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17921,7 +18377,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17930,7 +18386,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -18056,7 +18512,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18065,7 +18521,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18074,7 +18530,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18083,7 +18539,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18136,7 +18592,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18145,7 +18601,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18154,7 +18610,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18163,7 +18619,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -18289,7 +18745,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18298,7 +18754,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18307,7 +18763,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18316,7 +18772,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18410,7 +18866,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18419,7 +18875,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18428,7 +18884,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18437,7 +18893,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18510,7 +18966,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18519,7 +18975,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18528,7 +18984,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18537,7 +18993,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -18590,7 +19046,7 @@
           "Users"
         ],
         "summary": "Resolve external user identity",
-        "description": "Map external org/user IDs to internal UUIDs via client-service (idempotent upsert). For anonymous users, generate a UUID as externalUserId — each call with a new ID creates a new user. Calling again with the same IDs updates optional contact fields (email, firstName, etc.).",
+        "description": "Map external org/user IDs to internal UUIDs via client-service (idempotent upsert). For anonymous users, generate a UUID as externalUserId \u2014 each call with a new ID creates a new user. Calling again with the same IDs updates optional contact fields (email, firstName, etc.).",
         "security": [
           {
             "bearerAuth": []
@@ -18673,7 +19129,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18682,7 +19138,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18691,7 +19147,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18700,7 +19156,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18735,10 +19191,10 @@
               "minimum": 1,
               "maximum": 200,
               "default": 50,
-              "description": "Max results (1–200, default 50)"
+              "description": "Max results (1\u2013200, default 50)"
             },
             "required": false,
-            "description": "Max results (1–200, default 50)",
+            "description": "Max results (1\u2013200, default 50)",
             "name": "limit",
             "in": "query"
           },
@@ -18780,7 +19236,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18789,7 +19245,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18798,7 +19254,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18807,7 +19263,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -18914,7 +19370,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18923,7 +19379,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18932,7 +19388,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18941,7 +19397,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18994,7 +19450,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19003,7 +19459,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19012,7 +19468,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19021,7 +19477,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -19135,10 +19591,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by campaign ID — returns media kit(s) linked to this campaign"
+              "description": "Filter by campaign ID \u2014 returns media kit(s) linked to this campaign"
             },
             "required": false,
-            "description": "Filter by campaign ID — returns media kit(s) linked to this campaign",
+            "description": "Filter by campaign ID \u2014 returns media kit(s) linked to this campaign",
             "name": "campaign_id",
             "in": "query"
           },
@@ -19177,7 +19633,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19186,7 +19642,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19195,7 +19651,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19204,7 +19660,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -19308,7 +19764,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19317,7 +19773,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19326,7 +19782,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19335,7 +19791,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19409,7 +19865,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19418,7 +19874,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19427,7 +19883,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19436,7 +19892,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19530,7 +19986,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19539,7 +19995,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19548,7 +20004,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19557,7 +20013,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19651,7 +20107,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19660,7 +20116,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19669,7 +20125,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19678,7 +20134,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19763,7 +20219,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19772,7 +20228,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19781,7 +20237,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19790,7 +20246,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19875,7 +20331,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19884,7 +20340,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19893,7 +20349,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19902,7 +20358,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19966,7 +20422,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19975,7 +20431,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19984,7 +20440,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19993,7 +20449,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20077,7 +20533,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20086,7 +20542,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20095,7 +20551,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20104,7 +20560,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20169,7 +20625,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20178,7 +20634,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20187,7 +20643,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20196,7 +20652,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20261,7 +20717,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20270,7 +20726,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20279,7 +20735,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20288,7 +20744,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20361,7 +20817,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20370,7 +20826,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20379,7 +20835,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20388,7 +20844,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20452,7 +20908,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20461,7 +20917,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20470,7 +20926,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20479,7 +20935,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20573,7 +21029,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20582,7 +21038,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20591,7 +21047,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20600,7 +21056,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20675,7 +21131,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20684,7 +21140,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20693,7 +21149,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20702,7 +21158,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20795,7 +21251,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20804,7 +21260,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20813,7 +21269,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20822,7 +21278,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -20910,7 +21366,7 @@
             }
           },
           "409": {
-            "description": "Conflict — feature with this name already exists",
+            "description": "Conflict \u2014 feature with this name already exists",
             "content": {
               "application/json": {
                 "schema": {
@@ -20956,7 +21412,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20965,7 +21421,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20974,7 +21430,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20983,7 +21439,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -21065,7 +21521,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21074,7 +21530,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21083,7 +21539,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21092,7 +21548,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -21145,7 +21601,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21154,7 +21610,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21163,7 +21619,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21172,7 +21628,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -21223,7 +21679,7 @@
           "Features"
         ],
         "summary": "Update feature by slug",
-        "description": "Update a single feature definition by its slug. Metadata-only updates (description, icon, charts, etc.) apply in-place and return 200. If inputs or outputs change, a new feature is forked and the original is deprecated (fork-on-write) — returns 201 with forkedFrom details. Proxied from features-service.",
+        "description": "Update a single feature definition by its slug. Metadata-only updates (description, icon, charts, etc.) apply in-place and return 200. If inputs or outputs change, a new feature is forked and the original is deprecated (fork-on-write) \u2014 returns 201 with forkedFrom details. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -21265,7 +21721,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21274,7 +21730,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21283,7 +21739,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21292,7 +21748,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -21426,7 +21882,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21435,7 +21891,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21444,7 +21900,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21453,7 +21909,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -21562,7 +22018,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21571,7 +22027,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21580,7 +22036,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21589,7 +22045,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -21715,7 +22171,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21724,7 +22180,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21733,7 +22189,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21742,7 +22198,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -21753,7 +22209,7 @@
           "Features"
         ],
         "summary": "Global stats cross-features",
-        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId \u2014 comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -21805,7 +22261,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21814,7 +22270,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21823,7 +22279,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21832,7 +22288,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -21957,7 +22413,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21966,7 +22422,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21975,7 +22431,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21984,7 +22440,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -34,15 +34,15 @@ describe("Auth middleware — admin auth requires both external ID headers", () 
     expect(content).toContain('"x-external-user-id"');
   });
 
-  it("should NOT read from legacy x-org-id / x-user-id for admin identity", () => {
-    // x-org-id and x-user-id should only appear in requireOrg logging, not in admin identity resolution
+  it("should read direct x-org-id / x-user-id for service-to-service admin calls", () => {
+    // Admin path supports direct internal UUIDs via x-org-id / x-user-id for service-to-service calls
     const adminSection = content.split("Path 2")[0]; // everything before user key path
-    expect(adminSection).not.toContain('"x-org-id"');
-    expect(adminSection).not.toContain('"x-user-id"');
+    expect(adminSection).toContain('"x-org-id"');
+    expect(adminSection).toContain('"x-user-id"');
   });
 
-  it("should return 400 when either external ID header is missing", () => {
-    expect(content).toContain("Admin auth requires both x-external-org-id and x-external-user-id");
+  it("should return 400 when identity headers are missing", () => {
+    expect(content).toContain("Admin auth requires identity headers: x-org-id/x-user-id or x-external-org-id/x-external-user-id");
   });
 
   it("should NOT have single-ID resolution functions", () => {

--- a/tests/unit/json-parse-error.regression.test.ts
+++ b/tests/unit/json-parse-error.regression.test.ts
@@ -60,6 +60,8 @@ describe("callExternalService – malformed JSON response handling", () => {
     // The fix ensures callExternalService logs the error before re-throwing
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("[callExternalService]"),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Unexpected end of JSON input"),
     );
   });
@@ -75,6 +77,8 @@ describe("callExternalService – malformed JSON response handling", () => {
     expect(res.status).toBe(500);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("[callExternalService]"),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Unexpected token"),
     );
   });
@@ -90,6 +94,8 @@ describe("callExternalService – malformed JSON response handling", () => {
     expect(res.status).toBe(500);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("[callExternalService]"),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Unexpected end of JSON input"),
     );
   });
@@ -107,6 +113,8 @@ describe("callExternalService – malformed JSON response handling", () => {
     expect(res.status).toBe(500);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("[callExternalService]"),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Unexpected end of JSON input"),
     );
   });

--- a/tests/unit/workflows-stats.test.ts
+++ b/tests/unit/workflows-stats.test.ts
@@ -72,7 +72,7 @@ describe("GET /v1/workflows/ranked", () => {
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/workflows/ranked?category=sales&groupBy=section&limit=20&brandId=b-1");
+    const res = await request(app).get("/v1/workflows/ranked?objective=sales&groupBy=section&limit=20&brandId=b-1");
 
     expect(res.status).toBe(200);
     expect(res.body.results).toEqual(MOCK_RANKED.results);
@@ -82,7 +82,7 @@ describe("GET /v1/workflows/ranked", () => {
     );
     expect(call).toBeDefined();
     const url = call![1] as string;
-    expect(url).toContain("category=sales");
+    expect(url).toContain("objective=sales");
     expect(url).toContain("groupBy=section");
     expect(url).toContain("limit=20");
     expect(url).toContain("brandId=b-1");
@@ -126,7 +126,7 @@ describe("GET /v1/public/workflows/ranked", () => {
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/public/workflows/ranked?category=sales&groupBy=brand");
+    const res = await request(app).get("/v1/public/workflows/ranked?objective=sales&groupBy=brand");
 
     expect(res.status).toBe(200);
     expect(res.body.results).toEqual(MOCK_RANKED.results);
@@ -136,7 +136,7 @@ describe("GET /v1/public/workflows/ranked", () => {
     );
     expect(call).toBeDefined();
     const url = call![1] as string;
-    expect(url).toContain("category=sales");
+    expect(url).toContain("objective=sales");
     expect(url).toContain("groupBy=brand");
   });
 });


### PR DESCRIPTION
## Summary
- **auth.test.ts**: Updated assertions to match current admin auth which supports direct `x-org-id`/`x-user-id` headers for service-to-service calls (added alongside external ID flow)
- **json-parse-error.regression.test.ts**: Fixed `console.error` assertions — `callExternalService` logs a single template literal string, not two separate args
- **workflows-stats.test.ts**: Tests used `category` param which isn't in `RANKED_PARAMS`; changed to `objective` which is
- **openapi.json**: Added response schemas for 23 outlet/article/topic/discovery endpoints that had `description` but no `content` in their success responses

## Test plan
- [x] All 793 tests pass (0 failures, up from 9 failures before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)