### PR TITLE
fix: forward identity headers in template deployment

### DIFF
--- a/src/routes/internal-emails.ts
+++ b/src/routes/internal-emails.ts
@@ -18,14 +18,22 @@ router.put("/emails/templates", authenticatePlatform, async (req: AuthenticatedR
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
 
+    // Forward identity headers from the caller — transactional-email-service requires them
+    const headers: Record<string, string> = {};
+    const orgId = req.headers["x-org-id"] as string | undefined;
+    const userId = req.headers["x-user-id"] as string | undefined;
+    const runId = req.headers["x-run-id"] as string | undefined;
+    if (orgId) headers["x-org-id"] = orgId;
+    if (userId) headers["x-user-id"] = userId;
+    if (runId) headers["x-run-id"] = runId;
+
     const result = await callExternalService(
       externalServices.transactionalEmail,
       "/templates",
       {
         method: "PUT",
-        body: {
-          ...parsed.data,
-        },
+        body: parsed.data,
+        headers,
       }
     );
     res.json(result);

--- a/tests/unit/internal-emails.test.ts
+++ b/tests/unit/internal-emails.test.ts
@@ -88,10 +88,32 @@ describe("PUT /internal/emails/templates", () => {
         },
       ],
     });
-    // No identity headers forwarded
+    // No identity headers forwarded when caller doesn't send them
     expect(deployCall!.headers!["x-org-id"]).toBeUndefined();
     expect(deployCall!.headers!["x-user-id"]).toBeUndefined();
     expect(deployCall!.headers!["x-run-id"]).toBeUndefined();
+  });
+
+  it("should forward identity headers to transactional-email-service when present", async () => {
+    const res = await request(app)
+      .put("/internal/emails/templates")
+      .set("X-API-Key", VALID_API_KEY)
+      .set("x-org-id", "org-uuid-123")
+      .set("x-user-id", "user-uuid-456")
+      .set("x-run-id", "run-uuid-789")
+      .send({
+        templates: [
+          { name: "campaign_created", subject: "Campaign Created", htmlBody: "<h1>Created</h1>" },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+
+    const deployCall = fetchCalls.find((c) => c.url.includes("/templates"));
+    expect(deployCall).toBeDefined();
+    expect(deployCall!.headers!["x-org-id"]).toBe("org-uuid-123");
+    expect(deployCall!.headers!["x-user-id"]).toBe("user-uuid-456");
+    expect(deployCall!.headers!["x-run-id"]).toBe("run-uuid-789");
   });
 
   it("should return 401 without API key", async () => {


### PR DESCRIPTION
## Summary
- `PUT /internal/emails/templates` was calling transactional-email-service without forwarding `x-org-id`, `x-user-id`, `x-run-id` headers from the caller
- transactional-email-service requires these headers, causing 400 errors on every template deployment at cold start
- Now forwards whatever identity headers the caller provides

## Test plan
- [x] New regression test: verifies identity headers are forwarded when present
- [x] Existing test: verifies no headers forwarded when caller doesn't send them
- [x] Full test suite passes (pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)