### PR TITLE
fix: forward x-campaign-id in campaigns/:id/journalists

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -804,6 +804,7 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
 
     // Batch lookup journalists by outlet IDs via internal endpoint
     const outletIds = outlets.map((o) => o.id);
+    const headers = { ...buildInternalHeaders(req), "x-campaign-id": id };
     const journalistResults = await Promise.all(
       outletIds.map((outletId) =>
         callExternalService<{ journalists: Array<Record<string, unknown>>; cached: boolean }>(
@@ -812,7 +813,7 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
           {
             method: "POST",
             body: { outletId },
-            headers: buildInternalHeaders(req),
+            headers,
           }
         ).catch(() => ({ journalists: [], cached: false }))
       )

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -90,6 +90,17 @@ describe("Campaign discovery proxy: journalists", () => {
   });
 });
 
+describe("Campaign journalists: x-campaign-id header forwarding", () => {
+  it("should explicitly set x-campaign-id from path param when calling journalist-service resolve", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    // The campaign ID from the URL path must be forwarded as x-campaign-id header
+    // even when the caller does not send x-campaign-id in the request headers
+    expect(journalistsSection).toContain('"x-campaign-id"');
+  });
+});
+
 describe("Service client: outlet and journalist services", () => {
   it("should define outlet service config", () => {
     expect(serviceClientContent).toContain("OUTLETS_SERVICE_URL");


### PR DESCRIPTION
## Summary
- `GET /v1/campaigns/:id/journalists` calls journalist-service `POST /journalists/resolve` for each outlet
- The campaign ID is in the URL path (`req.params.id`), but was only forwarded as `x-campaign-id` if the **caller** sent it as a header
- Journalist-service requires `x-campaign-id` → all 18 resolve calls failed with 400
- Fix: explicitly set `x-campaign-id: id` from the path param in the outgoing headers

## Test plan
- [x] Regression test added: verifies `x-campaign-id` appears in the journalists section of campaigns route
- [x] All 794 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)