### PR TITLE
fix: enrich campaign-create headers with resolved IDs

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -132,12 +132,21 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       type: body.type,
       featureSlug: body.featureSlug,
     });
+    // Enrich headers with IDs resolved during this request — the dashboard
+    // sends brandUrl/workflowName/featureSlug in the body, not as headers,
+    // so buildInternalHeaders(req) alone won't include them.
+    const campaignHeaders: Record<string, string> = {
+      ...buildInternalHeaders(req),
+      "x-brand-id": brandResult.brandId,
+      "x-feature-slug": featureSlug,
+      "x-workflow-name": workflowName,
+    };
     const result = await callExternalService(
       externalServices.campaign,
       "/campaigns",
       {
         method: "POST",
-        headers: buildInternalHeaders(req),
+        headers: campaignHeaders,
         body,
       }
     );

--- a/tests/unit/campaign-discovery.test.ts
+++ b/tests/unit/campaign-discovery.test.ts
@@ -41,7 +41,7 @@ function createApp() {
 }
 
 describe("Discovery campaign creation", () => {
-  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown> }>;
+  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown>; headers?: Record<string, string> }>;
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -49,7 +49,8 @@ describe("Discovery campaign creation", () => {
 
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : undefined;
-      fetchCalls.push({ url, method: init?.method, body });
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers as Record<string, string>)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
 
       // Features-service: discovery features only require targetAudience
       if (url.includes("/features/") && url.includes("/inputs")) {
@@ -154,6 +155,27 @@ describe("Discovery campaign creation", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Missing required feature inputs");
     expect(res.body.missingKeys).toContain("targetAudience");
+  });
+
+  it("should forward x-brand-id, x-feature-slug, x-workflow-name headers to campaign-service", async () => {
+    const app = createApp();
+    await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Header Test",
+        workflowName: "outlets-database-discovery-cedar",
+        brandUrl: "https://acme.com",
+        featureSlug: "outlet-discovery",
+        featureInputs: { targetAudience: "Tech publications" },
+      });
+
+    const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
+    expect(campaignCall).toBeDefined();
+    // Resolved brandId from brand-service must be forwarded as header
+    expect(campaignCall!.headers!["x-brand-id"]).toBe("brand-uuid-123");
+    // featureSlug and workflowName from body must also be forwarded as headers
+    expect(campaignCall!.headers!["x-feature-slug"]).toBe("outlet-discovery");
+    expect(campaignCall!.headers!["x-workflow-name"]).toBe("outlets-database-discovery-cedar");
   });
 
   it("should convert budget numbers to strings for discovery campaigns", async () => {


### PR DESCRIPTION
## Summary
- When the dashboard calls `POST /v1/campaigns`, it sends `brandUrl`, `workflowName`, `featureSlug` in the **body** — not as headers
- Api-service resolves `brandUrl` → `brandId` via brand-service, but then called campaign-service with only `buildInternalHeaders(req)` which didn't include the resolved `brandId`, `featureSlug`, or `workflowName`
- Campaign-service (and subsequently workflow-service) never received `x-brand-id`, `x-feature-slug`, `x-workflow-name` as headers → downstream http.call nodes couldn't propagate them
- Fix: explicitly set `x-brand-id`, `x-feature-slug`, `x-workflow-name` headers on the campaign-service call using values resolved/extracted during the request

## Test plan
- [x] New test: verifies `x-brand-id`, `x-feature-slug`, `x-workflow-name` headers are present on the campaign-service call
- [x] All 795 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)