### PR TITLE
fix: enrich journalist-resolve headers with campaign brandId

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -798,12 +798,20 @@ router.get("/campaigns/:id/outlets", authenticate, requireOrg, requireUser, asyn
 router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    const baseHeaders = buildInternalHeaders(req);
+
+    // Fetch campaign to get brandId/featureSlug/workflowName for downstream headers
+    const campaignResult = await callExternalService<{
+      campaign: { brandId?: string; featureSlug?: string; workflowName?: string };
+    }>(externalServices.campaign, `/campaigns/${encodeURIComponent(id)}`, { headers: baseHeaders });
+
+    const campaign = campaignResult.campaign;
 
     // First get the campaign's outlets, then resolve journalists for each
     const outletsResult = await callExternalService<{ outlets: Array<{ id: string }> }>(
       externalServices.outlet,
       `/internal/outlets/by-campaign/${encodeURIComponent(id)}`,
-      { headers: buildInternalHeaders(req) }
+      { headers: baseHeaders }
     );
 
     const outlets = outletsResult.outlets || [];
@@ -811,9 +819,15 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
       return res.json({ journalists: [] });
     }
 
-    // Batch lookup journalists by outlet IDs via internal endpoint
+    // Enrich headers with campaign metadata so journalist-service gets x-brand-id
     const outletIds = outlets.map((o) => o.id);
-    const headers = { ...buildInternalHeaders(req), "x-campaign-id": id };
+    const headers: Record<string, string> = {
+      ...baseHeaders,
+      "x-campaign-id": id,
+    };
+    if (campaign.brandId) headers["x-brand-id"] = campaign.brandId;
+    if (campaign.featureSlug) headers["x-feature-slug"] = campaign.featureSlug;
+    if (campaign.workflowName) headers["x-workflow-name"] = campaign.workflowName;
     const journalistResults = await Promise.all(
       outletIds.map((outletId) =>
         callExternalService<{ journalists: Array<Record<string, unknown>>; cached: boolean }>(

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -90,14 +90,38 @@ describe("Campaign discovery proxy: journalists", () => {
   });
 });
 
-describe("Campaign journalists: x-campaign-id header forwarding", () => {
+describe("Campaign journalists: header enrichment from campaign data", () => {
   it("should explicitly set x-campaign-id from path param when calling journalist-service resolve", () => {
     const journalistsSection = content.slice(
       content.indexOf('"/campaigns/:id/journalists"'),
     );
-    // The campaign ID from the URL path must be forwarded as x-campaign-id header
-    // even when the caller does not send x-campaign-id in the request headers
     expect(journalistsSection).toContain('"x-campaign-id"');
+  });
+
+  it("should fetch campaign from campaign-service to resolve brandId", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("externalServices.campaign");
+    expect(journalistsSection).toContain("/campaigns/");
+  });
+
+  it("should forward x-brand-id resolved from campaign data to journalist-service", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain('"x-brand-id"');
+    expect(journalistsSection).toContain("campaign.brandId");
+  });
+
+  it("should forward x-feature-slug and x-workflow-name from campaign data", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain('"x-feature-slug"');
+    expect(journalistsSection).toContain("campaign.featureSlug");
+    expect(journalistsSection).toContain('"x-workflow-name"');
+    expect(journalistsSection).toContain("campaign.workflowName");
   });
 });
 


### PR DESCRIPTION
## Summary
- The scheduler in campaign-service calls `GET /campaigns/:id/journalists` without `x-brand-id` in request headers
- This route proxies to journalist-service at `POST /journalists/resolve`, which requires `x-brand-id`
- Now fetches the campaign from campaign-service first to resolve `brandId`, `featureSlug`, and `workflowName`, then forwards them as headers to journalist-service

## Test plan
- [x] Added regression tests verifying campaign data is fetched and brand/feature/workflow headers are forwarded
- [x] All 798 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)