### PR TITLE
fix: prefix all console output with [api-service]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,16 @@
 // Sentry is loaded via --import flag in package.json start script
+
+// ── Prefix all console output with [api-service] ────────────────────────────
+// Shared Railway log streams mix output from multiple containers;
+// this makes api-service lines instantly identifiable.
+const PREFIX = "[api-service]";
+const _log = console.log.bind(console);
+const _error = console.error.bind(console);
+const _warn = console.warn.bind(console);
+console.log = (...args: unknown[]) => _log(PREFIX, ...args);
+console.error = (...args: unknown[]) => _error(PREFIX, ...args);
+console.warn = (...args: unknown[]) => _warn(PREFIX, ...args);
+
 import * as Sentry from "@sentry/node";
 import express from "express";
 import cors from "cors";

--- a/tests/unit/log-prefix.test.ts
+++ b/tests/unit/log-prefix.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const content = fs.readFileSync(indexPath, "utf-8");
+
+describe("Console log prefix", () => {
+  it("should override console.log with [api-service] prefix", () => {
+    expect(content).toContain('console.log = ');
+    expect(content).toContain('[api-service]');
+  });
+
+  it("should override console.error with [api-service] prefix", () => {
+    expect(content).toContain('console.error = ');
+  });
+
+  it("should override console.warn with [api-service] prefix", () => {
+    expect(content).toContain('console.warn = ');
+  });
+
+  it("should set up prefix before any imports that might log", () => {
+    const prefixLine = content.indexOf('const PREFIX = "[api-service]"');
+    const sentryImport = content.indexOf('import * as Sentry');
+    expect(prefixLine).toBeGreaterThan(-1);
+    expect(sentryImport).toBeGreaterThan(prefixLine);
+  });
+});


### PR DESCRIPTION
## Summary
- Railway log streams mix output from multiple containers (api-service, campaign-service, etc.)
- Overrides `console.log`, `console.error`, `console.warn` at startup with a `[api-service]` prefix
- Every log line is now instantly identifiable without touching individual log statements

## Test plan
- [x] Added tests verifying the prefix override is set up before other imports
- [x] All 802 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)