### PR TITLE
fix: rewire journalist-resolve to actual upstream endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "distribute API",
-    "description": "API Gateway for distribute.\n\n## Quick Start\n\n1. Create an API key in the distribute dashboard, or via `POST /v1/api-keys`\n2. Use it as a Bearer token \u2014 that's it, no extra headers needed\n\n```\nAuthorization: Bearer distrib.usr_abc123...\n```\n\nYour key carries your org and user identity. All endpoints work out of the box.\n\n## Storing provider keys (BYOK)\n\nTo store your own provider API keys (e.g. OpenAI, Anthropic) for use in workflows:\n\n```\nPOST /v1/keys\nAuthorization: Bearer distrib.usr_abc123...\n\n{ \"provider\": \"openai\", \"apiKey\": \"sk-...\" }\n```\n\n## Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Organization context required (missing `x-org-id` \u2014 app key only) |\n| 502 | Identity resolution failed (internal service unreachable) |\n\n",
+    "description": "API Gateway for distribute.\n\n## Quick Start\n\n1. Create an API key in the distribute dashboard, or via `POST /v1/api-keys`\n2. Use it as a Bearer token — that's it, no extra headers needed\n\n```\nAuthorization: Bearer distrib.usr_abc123...\n```\n\nYour key carries your org and user identity. All endpoints work out of the box.\n\n## Storing provider keys (BYOK)\n\nTo store your own provider API keys (e.g. OpenAI, Anthropic) for use in workflows:\n\n```\nPOST /v1/keys\nAuthorization: Bearer distrib.usr_abc123...\n\n{ \"provider\": \"openai\", \"apiKey\": \"sk-...\" }\n```\n\n## Error codes\n\n| Code | Meaning |\n|------|---------|\n| 401 | Missing or invalid Bearer token |\n| 400 | Organization context required (missing `x-org-id` — app key only) |\n| 502 | Identity resolution failed (internal service unreachable) |\n\n",
     "version": "1.0.0"
   },
   "servers": [
@@ -636,7 +636,7 @@
           "featureSlug": {
             "type": "string",
             "minLength": 1,
-            "description": "Feature slug \u2014 used to validate inputs against features-service"
+            "description": "Feature slug — used to validate inputs against features-service"
           },
           "featureInputs": {
             "type": "object",
@@ -5417,7 +5417,7 @@
           "externalUserId": {
             "type": "string",
             "minLength": 1,
-            "description": "External user ID \u2014 use a generated UUID for anonymous users"
+            "description": "External user ID — use a generated UUID for anonymous users"
           },
           "email": {
             "type": "string",
@@ -6000,301 +6000,6 @@
       "FeaturesBatchUpsertRequest": {
         "type": "object",
         "properties": {}
-      },
-      "OutletSummary": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "outletUrl": {
-            "type": "string"
-          },
-          "outletName": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "OutletListResponse": {
-        "type": "object",
-        "properties": {
-          "outlets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OutletSummary"
-            }
-          }
-        }
-      },
-      "OutletResponse": {
-        "type": "object",
-        "properties": {
-          "outlet": {
-            "$ref": "#/components/schemas/OutletSummary"
-          }
-        }
-      },
-      "OutletStatsResponse": {
-        "type": "object",
-        "description": "Flat or grouped outlet stats"
-      },
-      "BulkOutletsResponse": {
-        "type": "object",
-        "properties": {
-          "outlets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OutletSummary"
-            }
-          },
-          "created": {
-            "type": "integer"
-          },
-          "updated": {
-            "type": "integer"
-          }
-        }
-      },
-      "SearchOutletsResponse": {
-        "type": "object",
-        "properties": {
-          "outlets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OutletSummary"
-            }
-          }
-        }
-      },
-      "DiscoverOutletsResponse": {
-        "type": "object",
-        "properties": {
-          "outlets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OutletSummary"
-            }
-          },
-          "discovered": {
-            "type": "integer"
-          }
-        }
-      },
-      "ArticleSummary": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string",
-            "nullable": true
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "ArticleListResponse": {
-        "type": "object",
-        "properties": {
-          "articles": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArticleSummary"
-            }
-          }
-        }
-      },
-      "ArticleResponse": {
-        "type": "object",
-        "properties": {
-          "article": {
-            "$ref": "#/components/schemas/ArticleSummary"
-          }
-        }
-      },
-      "ArticleAuthorsResponse": {
-        "type": "object",
-        "properties": {
-          "articles": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArticleSummary"
-            }
-          }
-        }
-      },
-      "BulkArticlesResponse": {
-        "type": "object",
-        "properties": {
-          "articles": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArticleSummary"
-            }
-          },
-          "created": {
-            "type": "integer"
-          },
-          "updated": {
-            "type": "integer"
-          }
-        }
-      },
-      "SearchArticlesResponse": {
-        "type": "object",
-        "properties": {
-          "articles": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArticleSummary"
-            }
-          }
-        }
-      },
-      "TopicSummary": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "TopicListResponse": {
-        "type": "object",
-        "properties": {
-          "topics": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TopicSummary"
-            }
-          }
-        }
-      },
-      "TopicResponse": {
-        "type": "object",
-        "properties": {
-          "topic": {
-            "$ref": "#/components/schemas/TopicSummary"
-          }
-        }
-      },
-      "BulkTopicsResponse": {
-        "type": "object",
-        "properties": {
-          "topics": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TopicSummary"
-            }
-          },
-          "created": {
-            "type": "integer"
-          },
-          "updated": {
-            "type": "integer"
-          }
-        }
-      },
-      "DiscoverySummary": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "articleId": {
-            "type": "string"
-          },
-          "campaignId": {
-            "type": "string",
-            "nullable": true
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "DiscoveryListResponse": {
-        "type": "object",
-        "properties": {
-          "discoveries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DiscoverySummary"
-            }
-          }
-        }
-      },
-      "DiscoveryResponse": {
-        "type": "object",
-        "properties": {
-          "discovery": {
-            "$ref": "#/components/schemas/DiscoverySummary"
-          }
-        }
-      },
-      "BulkDiscoveriesResponse": {
-        "type": "object",
-        "properties": {
-          "discoveries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DiscoverySummary"
-            }
-          },
-          "created": {
-            "type": "integer"
-          }
-        }
-      },
-      "DiscoverOutletArticlesResponse": {
-        "type": "object",
-        "properties": {
-          "articles": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArticleSummary"
-            }
-          },
-          "discovered": {
-            "type": "integer"
-          }
-        }
-      },
-      "DiscoverJournalistPublicationsResponse": {
-        "type": "object",
-        "properties": {
-          "articles": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArticleSummary"
-            }
-          },
-          "discovered": {
-            "type": "integer"
-          }
-        }
       }
     },
     "parameters": {}
@@ -6469,22 +6174,22 @@
           "Workflows"
         ],
         "summary": "Hero records (public)",
-        "description": "Public hero records \u2014 best cost-per-open/reply. Use ?by=brand for brand-level heroes. No authentication required.",
+        "description": "Public hero records — best cost-per-open/reply. Use ?by=brand for brand-level heroes. No authentication required.",
         "parameters": [
           {
             "schema": {
               "type": "string",
-              "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand"
+              "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand"
             },
             "required": false,
-            "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand",
+            "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
             "name": "by",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Hero records \u2014 best cost-per-open and cost-per-reply",
+            "description": "Hero records — best cost-per-open and cost-per-reply",
             "content": {
               "application/json": {
                 "schema": {
@@ -6594,7 +6299,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6603,7 +6308,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6612,7 +6317,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6621,7 +6326,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -6674,10 +6379,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand"
+              "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand"
             },
             "required": false,
-            "description": "'workflow' (default) or 'brand' \u2014 hero records by workflow or by brand",
+            "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
             "name": "by",
             "in": "query"
           },
@@ -6706,7 +6411,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6715,7 +6420,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6724,7 +6429,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6733,12 +6438,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Hero records \u2014 best cost-per-open and cost-per-reply",
+            "description": "Hero records — best cost-per-open and cost-per-reply",
             "content": {
               "application/json": {
                 "schema": {
@@ -6840,7 +6545,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6849,7 +6554,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6858,7 +6563,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6867,7 +6572,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -6930,7 +6635,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -6939,7 +6644,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -6948,7 +6653,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6957,7 +6662,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7081,7 +6786,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7090,7 +6795,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7099,7 +6804,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7108,7 +6813,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -7161,7 +6866,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7170,7 +6875,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7179,7 +6884,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7188,7 +6893,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7271,7 +6976,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7280,7 +6985,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7289,7 +6994,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7298,7 +7003,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7383,7 +7088,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7392,7 +7097,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7401,7 +7106,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7410,7 +7115,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7495,7 +7200,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7504,7 +7209,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7513,7 +7218,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7522,7 +7227,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7607,7 +7312,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7616,7 +7321,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7625,7 +7330,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7634,7 +7339,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7719,7 +7424,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7728,7 +7433,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7737,7 +7442,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7746,7 +7451,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7831,7 +7536,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7840,7 +7545,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7849,7 +7554,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7858,7 +7563,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -7943,7 +7648,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -7952,7 +7657,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -7961,7 +7666,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7970,7 +7675,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -8055,7 +7760,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8064,7 +7769,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8073,7 +7778,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8082,7 +7787,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -8167,7 +7872,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8176,7 +7881,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8185,7 +7890,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8194,7 +7899,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -8319,7 +8024,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8328,7 +8033,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8337,7 +8042,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8346,19 +8051,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "List of outlets",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OutletListResponse"
-                }
-              }
-            }
+            "description": "List of outlets"
           },
           "401": {
             "description": "Unauthorized",
@@ -8393,14 +8091,7 @@
         },
         "responses": {
           "201": {
-            "description": "Outlet created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OutletResponse"
-                }
-              }
-            }
+            "description": "Outlet created"
           },
           "400": {
             "description": "Validation error",
@@ -8449,7 +8140,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8458,7 +8149,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8467,7 +8158,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8476,7 +8167,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8558,7 +8249,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8567,7 +8258,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8576,7 +8267,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8585,19 +8276,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Stats (flat or grouped)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OutletStatsResponse"
-                }
-              }
-            }
+            "description": "Stats (flat or grouped)"
           },
           "401": {
             "description": "Unauthorized",
@@ -8634,14 +8318,7 @@
         },
         "responses": {
           "201": {
-            "description": "Outlets created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkOutletsResponse"
-                }
-              }
-            }
+            "description": "Outlets created"
           },
           "401": {
             "description": "Unauthorized",
@@ -8680,7 +8357,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8689,7 +8366,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8698,7 +8375,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8707,7 +8384,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8734,14 +8411,7 @@
         },
         "responses": {
           "200": {
-            "description": "Search results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SearchOutletsResponse"
-                }
-              }
-            }
+            "description": "Search results"
           },
           "401": {
             "description": "Unauthorized",
@@ -8780,7 +8450,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8789,7 +8459,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8798,7 +8468,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8807,7 +8477,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8835,14 +8505,7 @@
         },
         "responses": {
           "201": {
-            "description": "Outlets discovered and saved",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DiscoverOutletsResponse"
-                }
-              }
-            }
+            "description": "Outlets discovered and saved"
           },
           "400": {
             "description": "Validation error",
@@ -8901,7 +8564,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8910,7 +8573,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8919,7 +8582,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8928,7 +8591,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -8980,7 +8643,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -8989,7 +8652,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -8998,7 +8661,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9007,19 +8670,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Outlet found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OutletResponse"
-                }
-              }
-            }
+            "description": "Outlet found"
           },
           "401": {
             "description": "Unauthorized",
@@ -9089,7 +8745,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9098,7 +8754,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9107,7 +8763,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9116,7 +8772,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -9130,14 +8786,7 @@
         },
         "responses": {
           "200": {
-            "description": "Outlet updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OutletResponse"
-                }
-              }
-            }
+            "description": "Outlet updated"
           },
           "401": {
             "description": "Unauthorized",
@@ -9220,7 +8869,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9229,7 +8878,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9238,7 +8887,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9247,7 +8896,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -9261,14 +8910,7 @@
         },
         "responses": {
           "200": {
-            "description": "Status updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OutletResponse"
-                }
-              }
-            }
+            "description": "Status updated"
           },
           "401": {
             "description": "Unauthorized",
@@ -9382,7 +9024,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9391,7 +9033,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9400,7 +9042,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9409,7 +9051,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9492,7 +9134,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9501,7 +9143,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9510,7 +9152,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9519,7 +9161,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9613,7 +9255,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9622,7 +9264,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9631,7 +9273,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9640,7 +9282,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9700,7 +9342,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9709,7 +9351,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9718,7 +9360,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9727,19 +9369,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "List of articles",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArticleListResponse"
-                }
-              }
-            }
+            "description": "List of articles"
           },
           "401": {
             "description": "Unauthorized",
@@ -9774,14 +9409,7 @@
         },
         "responses": {
           "200": {
-            "description": "Article created or updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArticleResponse"
-                }
-              }
-            }
+            "description": "Article created or updated"
           },
           "400": {
             "description": "Validation error",
@@ -9830,7 +9458,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9839,7 +9467,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9848,7 +9476,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9857,7 +9485,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -9917,7 +9545,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -9926,7 +9554,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -9935,7 +9563,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9944,19 +9572,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Articles with computed authors view",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArticleAuthorsResponse"
-                }
-              }
-            }
+            "description": "Articles with computed authors view"
           },
           "401": {
             "description": "Unauthorized",
@@ -10018,7 +9639,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10027,7 +9648,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10036,7 +9657,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10045,19 +9666,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "Article found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArticleResponse"
-                }
-              }
-            }
+            "description": "Article found"
           },
           "401": {
             "description": "Unauthorized",
@@ -10104,14 +9718,7 @@
         },
         "responses": {
           "200": {
-            "description": "Articles upserted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkArticlesResponse"
-                }
-              }
-            }
+            "description": "Articles upserted"
           },
           "400": {
             "description": "Validation error",
@@ -10160,7 +9767,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10169,7 +9776,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10178,7 +9785,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10187,7 +9794,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10214,14 +9821,7 @@
         },
         "responses": {
           "200": {
-            "description": "Search results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SearchArticlesResponse"
-                }
-              }
-            }
+            "description": "Search results"
           },
           "400": {
             "description": "Validation error",
@@ -10270,7 +9870,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10279,7 +9879,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10288,7 +9888,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10297,7 +9897,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10315,14 +9915,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List of topics",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TopicListResponse"
-                }
-              }
-            }
+            "description": "List of topics"
           },
           "401": {
             "description": "Unauthorized",
@@ -10361,7 +9954,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10370,7 +9963,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10379,7 +9972,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10388,7 +9981,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -10413,14 +10006,7 @@
         },
         "responses": {
           "200": {
-            "description": "Topic created or updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TopicResponse"
-                }
-              }
-            }
+            "description": "Topic created or updated"
           },
           "400": {
             "description": "Validation error",
@@ -10469,7 +10055,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10478,7 +10064,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10487,7 +10073,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10496,7 +10082,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10523,14 +10109,7 @@
         },
         "responses": {
           "200": {
-            "description": "Topics upserted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkTopicsResponse"
-                }
-              }
-            }
+            "description": "Topics upserted"
           },
           "400": {
             "description": "Validation error",
@@ -10579,7 +10158,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10588,7 +10167,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10597,7 +10176,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10606,7 +10185,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10711,7 +10290,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10720,7 +10299,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10729,7 +10308,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10738,19 +10317,12 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
           "200": {
-            "description": "List of discoveries",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DiscoveryListResponse"
-                }
-              }
-            }
+            "description": "List of discoveries"
           },
           "401": {
             "description": "Unauthorized",
@@ -10785,14 +10357,7 @@
         },
         "responses": {
           "200": {
-            "description": "Discovery created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DiscoveryResponse"
-                }
-              }
-            }
+            "description": "Discovery created"
           },
           "400": {
             "description": "Validation error",
@@ -10841,7 +10406,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10850,7 +10415,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10859,7 +10424,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10868,7 +10433,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -10895,14 +10460,7 @@
         },
         "responses": {
           "200": {
-            "description": "Discoveries created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkDiscoveriesResponse"
-                }
-              }
-            }
+            "description": "Discoveries created"
           },
           "400": {
             "description": "Validation error",
@@ -10951,7 +10509,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -10960,7 +10518,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -10969,7 +10527,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10978,7 +10536,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11005,14 +10563,7 @@
         },
         "responses": {
           "200": {
-            "description": "Discovered articles",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DiscoverOutletArticlesResponse"
-                }
-              }
-            }
+            "description": "Discovered articles"
           },
           "400": {
             "description": "Validation error",
@@ -11071,7 +10622,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11080,7 +10631,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11089,7 +10640,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11098,7 +10649,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11125,14 +10676,7 @@
         },
         "responses": {
           "200": {
-            "description": "Discovered publications",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DiscoverJournalistPublicationsResponse"
-                }
-              }
-            }
+            "description": "Discovered publications"
           },
           "400": {
             "description": "Validation error",
@@ -11191,7 +10735,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11200,7 +10744,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11209,7 +10753,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11218,7 +10762,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11293,7 +10837,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11302,7 +10846,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11311,7 +10855,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11320,7 +10864,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -11412,7 +10956,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11421,7 +10965,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11430,7 +10974,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11439,7 +10983,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11492,7 +11036,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11501,7 +11045,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11510,7 +11054,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11519,7 +11063,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -11626,7 +11170,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11635,7 +11179,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11644,7 +11188,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11653,7 +11197,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -11706,7 +11250,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11715,7 +11259,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11724,7 +11268,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11733,7 +11277,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -11816,7 +11360,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11825,7 +11369,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -11834,7 +11378,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11843,7 +11387,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -11988,7 +11532,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -11997,7 +11541,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12006,7 +11550,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12015,7 +11559,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12090,7 +11634,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12099,7 +11643,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12108,7 +11652,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12117,7 +11661,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -12143,7 +11687,7 @@
         },
         "responses": {
           "200": {
-            "description": "Created API key (includes the full key \u2014 only shown once)",
+            "description": "Created API key (includes the full key — only shown once)",
             "content": {
               "application/json": {
                 "schema": {
@@ -12199,7 +11743,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12208,7 +11752,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12217,7 +11761,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12226,7 +11770,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12279,7 +11823,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12288,7 +11832,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12297,7 +11841,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12306,7 +11850,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -12413,7 +11957,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12422,7 +11966,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12431,7 +11975,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12440,7 +11984,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12534,7 +12078,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12543,7 +12087,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12552,7 +12096,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12561,7 +12105,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12655,7 +12199,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12664,7 +12208,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12673,7 +12217,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12682,7 +12226,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12776,7 +12320,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12785,7 +12329,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12794,7 +12338,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12803,7 +12347,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -12856,7 +12400,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -12865,7 +12409,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -12874,7 +12418,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12883,7 +12427,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13000,7 +12544,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13009,7 +12553,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13018,7 +12562,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13027,7 +12571,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -13119,7 +12663,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13128,7 +12672,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13137,7 +12681,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13146,7 +12690,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -13199,7 +12743,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13208,7 +12752,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13217,7 +12761,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13226,7 +12770,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13311,7 +12855,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13320,7 +12864,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13329,7 +12873,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13338,7 +12882,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -13442,7 +12986,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13451,7 +12995,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13460,7 +13004,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13469,7 +13013,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13605,7 +13149,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13614,7 +13158,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13623,7 +13167,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13632,7 +13176,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -13685,7 +13229,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13694,7 +13238,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13703,7 +13247,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13712,7 +13256,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13807,7 +13351,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13816,7 +13360,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13825,7 +13369,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13834,7 +13378,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -13949,7 +13493,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -13958,7 +13502,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -13967,7 +13511,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13976,7 +13520,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14071,7 +13615,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14080,7 +13624,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14089,7 +13633,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14098,7 +13642,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14193,7 +13737,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14202,7 +13746,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14211,7 +13755,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14220,7 +13764,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14344,7 +13888,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14353,7 +13897,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14362,7 +13906,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14371,7 +13915,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -14424,7 +13968,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14433,7 +13977,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14442,7 +13986,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14451,7 +13995,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14534,7 +14078,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14543,7 +14087,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14552,7 +14096,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14561,7 +14105,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -14726,7 +14270,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14735,7 +14279,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14744,7 +14288,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14753,7 +14297,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -14806,7 +14350,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14815,7 +14359,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14824,7 +14368,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14833,7 +14377,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14928,7 +14472,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -14937,7 +14481,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -14946,7 +14490,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14955,7 +14499,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -14998,7 +14542,7 @@
           "Workflows"
         ],
         "summary": "Validate a workflow DAG",
-        "description": "Validates the workflow's DAG structure and checks template contracts \u2014 whether the variables provided by the workflow match those expected by prompt templates. Use after every modification to verify consistency.",
+        "description": "Validates the workflow's DAG structure and checks template contracts — whether the variables provided by the workflow match those expected by prompt templates. Use after every modification to verify consistency.",
         "security": [
           {
             "bearerAuth": []
@@ -15040,7 +14584,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15049,7 +14593,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15058,7 +14602,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15067,7 +14611,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15162,7 +14706,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15171,7 +14715,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15180,7 +14724,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15189,7 +14733,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -15333,7 +14877,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15342,7 +14886,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15351,7 +14895,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15360,7 +14904,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15445,7 +14989,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15454,7 +14998,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15463,7 +15007,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15472,7 +15016,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15567,7 +15111,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15576,7 +15120,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15585,7 +15129,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15594,7 +15138,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15689,7 +15233,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15698,7 +15242,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15707,7 +15251,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15716,7 +15260,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -15870,7 +15414,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15879,7 +15423,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15888,7 +15432,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15897,7 +15441,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -15950,7 +15494,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -15959,7 +15503,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -15968,7 +15512,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15977,7 +15521,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -16085,7 +15629,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16094,7 +15638,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16103,7 +15647,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16112,7 +15656,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16206,7 +15750,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16215,7 +15759,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16224,7 +15768,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16233,7 +15777,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16244,7 +15788,7 @@
           "Chat"
         ],
         "summary": "Stream chat response (SSE)",
-        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, **omit `sessionId`**. The first SSE event will be `data: {\"sessionId\":\"<uuid>\"}` \u2014 store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** \u2014 `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** *(optional)* \u2014 `thinking_start` \u2192 one or more `thinking_delta` \u2192 `thinking_stop`\n3. **Tokens** \u2014 `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally\n4. **Tool calls** *(optional, repeatable)* \u2014 `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues\n5. **Input request** *(optional)* \u2014 `input_request` when the AI needs structured user input\n6. **Buttons** *(optional)* \u2014 `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options\n7. **Error** *(optional)* \u2014 `{\"type\":\"error\",\"message\":\"...\"}` when the model returns an empty response (e.g. context overflow, safety filter). Always followed by `[DONE]`.\n8. **Done** \u2014 `\"[DONE]\"` (always last)\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEToolCallEvent, etc.) for exact payload shapes.",
+        "description": "Send a message and receive a streamed AI response via Server-Sent Events (SSE).\n\n**Session lifecycle:**\n- To start a new conversation, **omit `sessionId`**. The first SSE event will be `data: {\"sessionId\":\"<uuid>\"}` — store this ID.\n- To continue a conversation, pass that `sessionId` in subsequent requests.\n- If a provided `sessionId` does not exist or belongs to a different org, the stream returns an error and closes.\n\n**SSE event order:**\nEach `data:` line contains a JSON object. Events arrive in this order:\n\n1. **Session** — `{\"sessionId\":\"<uuid>\"}` (always first)\n2. **Thinking** *(optional)* — `thinking_start` → one or more `thinking_delta` → `thinking_stop`\n3. **Tokens** — `{\"type\":\"token\",\"content\":\"...\"}` streamed incrementally\n4. **Tool calls** *(optional, repeatable)* — `tool_call` followed by `tool_result`, then more thinking/tokens as the AI continues\n5. **Input request** *(optional)* — `input_request` when the AI needs structured user input\n6. **Buttons** *(optional)* — `{\"type\":\"buttons\",\"buttons\":[...]}` with quick-reply options\n7. **Error** *(optional)* — `{\"type\":\"error\",\"message\":\"...\"}` when the model returns an empty response (e.g. context overflow, safety filter). Always followed by `[DONE]`.\n8. **Done** — `\"[DONE]\"` (always last)\n\nSee the SSE event schemas (SSESessionEvent, SSETokenEvent, SSEToolCallEvent, etc.) for exact payload shapes.",
         "security": [
           {
             "bearerAuth": []
@@ -16338,7 +15882,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16347,7 +15891,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16356,7 +15900,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16365,7 +15909,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16376,7 +15920,7 @@
           "Platform"
         ],
         "summary": "Register a platform key",
-        "description": "Register or update a platform-level API key for a provider. Platform-level \u2014 no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "description": "Register or update a platform-level API key for a provider. Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
         "security": [
           {
             "apiKeyAuth": []
@@ -16459,7 +16003,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16468,7 +16012,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16477,7 +16021,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16486,7 +16030,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16497,7 +16041,7 @@
           "Platform"
         ],
         "summary": "Deploy a platform prompt",
-        "description": "Register or update a platform-level prompt template. Platform-level \u2014 no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "description": "Register or update a platform-level prompt template. Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
         "security": [
           {
             "apiKeyAuth": []
@@ -16580,7 +16124,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16589,7 +16133,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16598,7 +16142,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16607,7 +16151,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16618,7 +16162,7 @@
           "Chat"
         ],
         "summary": "Deploy platform-level chat config",
-        "description": "Register or update the global chat configuration (system prompt). Platform-level \u2014 no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
+        "description": "Register or update the global chat configuration (system prompt). Platform-level — no org/user identity required. Used by the dashboard at cold start. Idempotent (safe to call on every boot).",
         "security": [
           {
             "apiKeyAuth": []
@@ -16701,7 +16245,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16710,7 +16254,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16719,7 +16263,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16728,7 +16272,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16803,7 +16347,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16812,7 +16356,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16821,7 +16365,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16830,7 +16374,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -16905,7 +16449,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -16914,7 +16458,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -16923,7 +16467,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16932,7 +16476,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17007,7 +16551,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17016,7 +16560,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17025,7 +16569,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17034,7 +16578,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17128,7 +16672,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17137,7 +16681,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17146,7 +16690,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17155,7 +16699,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -17228,7 +16772,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17237,7 +16781,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17246,7 +16790,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17255,7 +16799,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17266,7 +16810,7 @@
           "Billing"
         ],
         "summary": "Deduct credits",
-        "description": "Deduct credits from the organization's billing account. Accepts negative balances \u2014 if insufficient and auto-reload fails, the deduction still goes through. Auto-creates billing account if none exists.",
+        "description": "Deduct credits from the organization's billing account. Accepts negative balances — if insufficient and auto-reload fails, the deduction still goes through. Auto-creates billing account if none exists.",
         "security": [
           {
             "bearerAuth": []
@@ -17339,7 +16883,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17348,7 +16892,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17357,7 +16901,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17366,7 +16910,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17450,7 +16994,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17459,7 +17003,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17468,7 +17012,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17477,7 +17021,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17571,7 +17115,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17580,7 +17124,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17589,7 +17133,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17598,7 +17142,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17692,7 +17236,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17701,7 +17245,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17710,7 +17254,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17719,7 +17263,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17772,7 +17316,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17781,7 +17325,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17790,7 +17334,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17799,7 +17343,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -17925,7 +17469,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -17934,7 +17478,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -17943,7 +17487,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17952,7 +17496,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -17963,7 +17507,7 @@
           "Internal"
         ],
         "summary": "Deploy email templates (platform)",
-        "description": "Platform-level template deployment \u2014 no identity headers required. Authenticated by X-API-Key only. Used at cold start when no Clerk session exists. Same body format as PUT /v1/emails/templates.",
+        "description": "Platform-level template deployment — no identity headers required. Authenticated by X-API-Key only. Used at cold start when no Clerk session exists. Same body format as PUT /v1/emails/templates.",
         "security": [
           {
             "apiKeyAuth": []
@@ -18046,7 +17590,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18055,7 +17599,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18064,7 +17608,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18073,7 +17617,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18126,7 +17670,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18135,7 +17679,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18144,7 +17688,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18153,7 +17697,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -18196,7 +17740,7 @@
           "Stripe"
         ],
         "summary": "Create a Stripe product",
-        "description": "Create a new Stripe product. Idempotent \u2014 returns existing product if the ID already exists. No org context required (app-level operation).",
+        "description": "Create a new Stripe product. Idempotent — returns existing product if the ID already exists. No org context required (app-level operation).",
         "security": [
           {
             "bearerAuth": []
@@ -18279,7 +17823,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18288,7 +17832,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18297,7 +17841,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18306,7 +17850,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18359,7 +17903,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18368,7 +17912,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18377,7 +17921,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18386,7 +17930,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -18512,7 +18056,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18521,7 +18065,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18530,7 +18074,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18539,7 +18083,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18592,7 +18136,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18601,7 +18145,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18610,7 +18154,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18619,7 +18163,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -18745,7 +18289,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18754,7 +18298,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18763,7 +18307,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18772,7 +18316,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18866,7 +18410,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18875,7 +18419,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18884,7 +18428,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18893,7 +18437,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -18966,7 +18510,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -18975,7 +18519,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -18984,7 +18528,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18993,7 +18537,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -19046,7 +18590,7 @@
           "Users"
         ],
         "summary": "Resolve external user identity",
-        "description": "Map external org/user IDs to internal UUIDs via client-service (idempotent upsert). For anonymous users, generate a UUID as externalUserId \u2014 each call with a new ID creates a new user. Calling again with the same IDs updates optional contact fields (email, firstName, etc.).",
+        "description": "Map external org/user IDs to internal UUIDs via client-service (idempotent upsert). For anonymous users, generate a UUID as externalUserId — each call with a new ID creates a new user. Calling again with the same IDs updates optional contact fields (email, firstName, etc.).",
         "security": [
           {
             "bearerAuth": []
@@ -19129,7 +18673,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19138,7 +18682,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19147,7 +18691,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19156,7 +18700,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19191,10 +18735,10 @@
               "minimum": 1,
               "maximum": 200,
               "default": 50,
-              "description": "Max results (1\u2013200, default 50)"
+              "description": "Max results (1–200, default 50)"
             },
             "required": false,
-            "description": "Max results (1\u2013200, default 50)",
+            "description": "Max results (1–200, default 50)",
             "name": "limit",
             "in": "query"
           },
@@ -19236,7 +18780,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19245,7 +18789,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19254,7 +18798,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19263,7 +18807,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -19370,7 +18914,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19379,7 +18923,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19388,7 +18932,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19397,7 +18941,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19450,7 +18994,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19459,7 +19003,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19468,7 +19012,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19477,7 +19021,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -19591,10 +19135,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by campaign ID \u2014 returns media kit(s) linked to this campaign"
+              "description": "Filter by campaign ID — returns media kit(s) linked to this campaign"
             },
             "required": false,
-            "description": "Filter by campaign ID \u2014 returns media kit(s) linked to this campaign",
+            "description": "Filter by campaign ID — returns media kit(s) linked to this campaign",
             "name": "campaign_id",
             "in": "query"
           },
@@ -19633,7 +19177,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19642,7 +19186,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19651,7 +19195,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19660,7 +19204,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -19764,7 +19308,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19773,7 +19317,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19782,7 +19326,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19791,7 +19335,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19865,7 +19409,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19874,7 +19418,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -19883,7 +19427,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19892,7 +19436,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -19986,7 +19530,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -19995,7 +19539,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20004,7 +19548,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20013,7 +19557,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20107,7 +19651,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20116,7 +19660,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20125,7 +19669,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20134,7 +19678,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20219,7 +19763,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20228,7 +19772,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20237,7 +19781,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20246,7 +19790,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20331,7 +19875,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20340,7 +19884,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20349,7 +19893,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20358,7 +19902,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20422,7 +19966,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20431,7 +19975,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20440,7 +19984,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20449,7 +19993,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20533,7 +20077,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20542,7 +20086,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20551,7 +20095,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20560,7 +20104,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20625,7 +20169,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20634,7 +20178,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20643,7 +20187,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20652,7 +20196,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20717,7 +20261,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20726,7 +20270,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20735,7 +20279,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20744,7 +20288,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20817,7 +20361,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20826,7 +20370,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20835,7 +20379,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20844,7 +20388,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -20908,7 +20452,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -20917,7 +20461,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -20926,7 +20470,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20935,7 +20479,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -21029,7 +20573,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21038,7 +20582,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21047,7 +20591,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21056,7 +20600,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -21131,7 +20675,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21140,7 +20684,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21149,7 +20693,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21158,7 +20702,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -21251,7 +20795,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21260,7 +20804,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21269,7 +20813,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21278,7 +20822,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -21366,7 +20910,7 @@
             }
           },
           "409": {
-            "description": "Conflict \u2014 feature with this name already exists",
+            "description": "Conflict — feature with this name already exists",
             "content": {
               "application/json": {
                 "schema": {
@@ -21412,7 +20956,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21421,7 +20965,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21430,7 +20974,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21439,7 +20983,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       },
@@ -21521,7 +21065,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21530,7 +21074,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21539,7 +21083,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21548,7 +21092,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -21601,7 +21145,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21610,7 +21154,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21619,7 +21163,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21628,7 +21172,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -21679,7 +21223,7 @@
           "Features"
         ],
         "summary": "Update feature by slug",
-        "description": "Update a single feature definition by its slug. Metadata-only updates (description, icon, charts, etc.) apply in-place and return 200. If inputs or outputs change, a new feature is forked and the original is deprecated (fork-on-write) \u2014 returns 201 with forkedFrom details. Proxied from features-service.",
+        "description": "Update a single feature definition by its slug. Metadata-only updates (description, icon, charts, etc.) apply in-place and return 200. If inputs or outputs change, a new feature is forked and the original is deprecated (fork-on-write) — returns 201 with forkedFrom details. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -21721,7 +21265,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21730,7 +21274,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21739,7 +21283,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21748,7 +21292,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -21882,7 +21426,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -21891,7 +21435,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -21900,7 +21444,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21909,7 +21453,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -22018,7 +21562,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -22027,7 +21571,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -22036,7 +21580,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -22045,7 +21589,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -22171,7 +21715,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -22180,7 +21724,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -22189,7 +21733,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -22198,7 +21742,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
       }
@@ -22209,7 +21753,7 @@
           "Features"
         ],
         "summary": "Global stats cross-features",
-        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId \u2014 comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -22261,7 +21805,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -22270,7 +21814,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -22279,7 +21823,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -22288,7 +21832,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -22413,7 +21957,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-brand-id",
@@ -22422,7 +21966,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-workflow-name",
@@ -22431,7 +21975,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional \u2014 forwarded to downstream services for tracking."
+            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -22440,7 +21984,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Feature slug. Optional \u2014 forwarded to downstream services and runs for tracking."
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -820,7 +820,6 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
     }
 
     // Enrich headers with campaign metadata so journalist-service gets x-brand-id
-    const outletIds = outlets.map((o) => o.id);
     const headers: Record<string, string> = {
       ...baseHeaders,
       "x-campaign-id": id,
@@ -828,24 +827,20 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
     if (campaign.brandId) headers["x-brand-id"] = campaign.brandId;
     if (campaign.featureSlug) headers["x-feature-slug"] = campaign.featureSlug;
     if (campaign.workflowName) headers["x-workflow-name"] = campaign.workflowName;
-    const journalistResults = await Promise.all(
-      outletIds.map((outletId) =>
-        callExternalService<{ journalists: Array<Record<string, unknown>>; cached: boolean }>(
-          externalServices.journalist,
-          "/journalists/resolve",
-          {
-            method: "POST",
-            body: { outletId },
-            headers,
-          }
-        ).catch(() => ({ journalists: [], cached: false }))
-      )
+
+    // Fetch all journalists for this campaign in one call
+    const journalistsResult = await callExternalService<{
+      campaignJournalists: Array<Record<string, unknown>>;
+    }>(
+      externalServices.journalist,
+      `/campaign-outlet-journalists?campaign_id=${encodeURIComponent(id)}`,
+      { headers }
     );
 
-    // Flatten all journalists with their outlet context
-    const allJournalists = journalistResults.flatMap((r, idx) =>
-      r.journalists.map((j) => ({ ...j, outletId: outletIds[idx] }))
-    );
+    const allJournalists = (journalistsResult.campaignJournalists || []).map((j) => ({
+      ...j,
+      // Normalize outletId from the response (already present on each record)
+    }));
 
     res.json({ journalists: allJournalists });
   } catch (error: any) {

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -34,14 +34,46 @@ router.post("/journalists/discover-emails", authenticate, requireOrg, requireUse
 });
 
 // ── POST /v1/journalists/resolve — resolve journalists for campaign+outlet ──
+// Translates the POST body into a GET /campaign-outlet-journalists query on journalist-service
 router.post("/journalists/resolve", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const result = await callExternalService(
+    const { outletId } = req.body as { outletId?: string };
+    const campaignId = req.campaignId;
+
+    if (!campaignId) {
+      return res.status(400).json({ error: "Missing x-campaign-id header (required for journalist resolution)" });
+    }
+    if (!outletId) {
+      return res.status(400).json({ error: "Missing outletId in request body" });
+    }
+
+    const params = new URLSearchParams({
+      campaign_id: campaignId,
+      outlet_id: outletId,
+    });
+
+    const result = await callExternalService<{
+      campaignJournalists: Array<Record<string, unknown>>;
+    }>(
       externalServices.journalist,
-      "/journalists/resolve",
-      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+      `/campaign-outlet-journalists?${params}`,
+      { headers: buildInternalHeaders(req) }
     );
-    res.json(result);
+
+    // Transform response to match the ResolveJournalistsResponse schema
+    const journalists = (result.campaignJournalists || []).map((j) => ({
+      id: j.journalistId ?? j.id,
+      journalistName: j.journalistName,
+      firstName: j.firstName,
+      lastName: j.lastName,
+      entityType: j.entityType,
+      relevanceScore: typeof j.relevanceScore === "string" ? parseFloat(j.relevanceScore as string) : j.relevanceScore,
+      whyRelevant: j.whyRelevant,
+      whyNotRelevant: j.whyNotRelevant,
+      articleUrls: j.articleUrls,
+    }));
+
+    res.json({ journalists, cached: true });
   } catch (error: any) {
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to resolve journalists" });
   }

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -68,18 +68,13 @@ describe("Campaign discovery proxy: journalists", () => {
     expect(journalistsSection).toContain("requireUser");
   });
 
-  it("should NOT proxy to stale /campaign-outlet-journalists endpoint (removed upstream)", () => {
-    expect(content).not.toContain("/campaign-outlet-journalists");
-  });
-
-  it("should fetch outlets from outlet-service then resolve journalists", () => {
+  it("should call GET /campaign-outlet-journalists on journalist-service", () => {
     const journalistsSection = content.slice(
       content.indexOf('"/campaigns/:id/journalists"'),
     );
-    expect(journalistsSection).toContain("externalServices.outlet");
-    expect(journalistsSection).toContain("/internal/outlets/by-campaign/");
     expect(journalistsSection).toContain("externalServices.journalist");
-    expect(journalistsSection).toContain("/journalists/resolve");
+    expect(journalistsSection).toContain("/campaign-outlet-journalists");
+    expect(journalistsSection).toContain("campaign_id");
   });
 
   it("should forward internal headers", () => {

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -45,10 +45,6 @@ describe("Journalists proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
-  it("should NOT have stale /campaign-outlet-journalists endpoint", () => {
-    expect(content).not.toContain("/campaign-outlet-journalists");
-  });
-
   it("should use buildInternalHeaders for all endpoints", () => {
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
@@ -59,10 +55,21 @@ describe("Journalists proxy routes", () => {
     expect(content).toContain("externalServices.journalist");
   });
 
-  it("should forward request body on all POST endpoints", () => {
+  it("should forward request body on discover and discover-emails endpoints", () => {
     const bodyMatches = content.match(/body: req\.body/g);
     expect(bodyMatches).not.toBeNull();
-    expect(bodyMatches!.length).toBe(3);
+    expect(bodyMatches!.length).toBe(2);
+  });
+
+  it("should translate resolve to GET /campaign-outlet-journalists on journalist-service", () => {
+    expect(content).toContain("/campaign-outlet-journalists");
+    expect(content).toContain("campaign_id");
+    expect(content).toContain("outlet_id");
+  });
+
+  it("should require x-campaign-id header for resolve endpoint", () => {
+    expect(content).toContain("req.campaignId");
+    expect(content).toContain("Missing x-campaign-id header");
   });
 
   it("should enforce requireOrg + requireUser on ALL journalist routes", () => {


### PR DESCRIPTION
## Summary
- `POST /journalists/resolve` does not exist on journalist-service — every call was returning 404 "Not found"
- Rewired `POST /v1/journalists/resolve` proxy to call `GET /campaign-outlet-journalists?campaign_id=X&outlet_id=Y` (the actual endpoint) and transform the response shape
- Rewired `GET /v1/campaigns/:id/journalists` to make a single `GET /campaign-outlet-journalists?campaign_id=X` call instead of N parallel POST calls to a non-existent endpoint
- Updated tests and regenerated `openapi.json`

## Test plan
- [x] All 802 unit tests pass
- [ ] Verify `GET /v1/campaigns/:id/journalists` returns journalist data for an active campaign
- [ ] Verify `POST /v1/journalists/resolve` returns journalists when called with `x-campaign-id` header and `{ outletId }` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)