### PR TITLE
feat: resolve outletName/outletDomain in campaign journalists

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1380,6 +1380,15 @@
                   "type": "string",
                   "format": "uuid"
                 },
+                "outletName": {
+                  "type": "string",
+                  "description": "Resolved outlet name"
+                },
+                "outletDomain": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Resolved outlet domain (e.g. techcrunch.com)"
+                },
                 "journalistName": {
                   "type": "string"
                 },
@@ -1417,6 +1426,8 @@
               "required": [
                 "id",
                 "outletId",
+                "outletName",
+                "outletDomain",
                 "journalistName",
                 "firstName",
                 "lastName",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -808,7 +808,7 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
     const campaign = campaignResult.campaign;
 
     // First get the campaign's outlets, then resolve journalists for each
-    const outletsResult = await callExternalService<{ outlets: Array<{ id: string }> }>(
+    const outletsResult = await callExternalService<{ outlets: Array<{ id: string; outletName?: string; outletDomain?: string | null }> }>(
       externalServices.outlet,
       `/internal/outlets/by-campaign/${encodeURIComponent(id)}`,
       { headers: baseHeaders }
@@ -837,10 +837,23 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
       { headers }
     );
 
-    const allJournalists = (journalistsResult.campaignJournalists || []).map((j) => ({
-      ...j,
-      // Normalize outletId from the response (already present on each record)
-    }));
+    // Build outlet lookup map for enriching journalists with outlet name/domain
+    const outletMap = new Map<string, { outletName: string; outletDomain: string | null }>();
+    for (const o of outlets) {
+      if (o.id && o.outletName) {
+        outletMap.set(o.id, { outletName: o.outletName, outletDomain: o.outletDomain ?? null });
+      }
+    }
+
+    const allJournalists = (journalistsResult.campaignJournalists || []).map((j) => {
+      const outletId = j.outletId as string | undefined;
+      const outlet = outletId ? outletMap.get(outletId) : undefined;
+      return {
+        ...j,
+        outletName: outlet?.outletName ?? (j.outletName as string | undefined) ?? "",
+        outletDomain: outlet?.outletDomain ?? (j.outletDomain as string | null | undefined) ?? null,
+      };
+    });
 
     res.json({ journalists: allJournalists });
   } catch (error: any) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -857,6 +857,8 @@ registry.registerPath({
                 z.object({
                   id: z.string().uuid(),
                   outletId: z.string().uuid(),
+                  outletName: z.string().describe("Resolved outlet name"),
+                  outletDomain: z.string().nullable().describe("Resolved outlet domain (e.g. techcrunch.com)"),
                   journalistName: z.string(),
                   firstName: z.string(),
                   lastName: z.string(),

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -158,4 +158,39 @@ describe("OpenAPI schemas: campaign discovery endpoints", () => {
     expect(schemaContent).toContain("relevanceScore");
     expect(schemaContent).toContain("articleUrls");
   });
+
+  it("should include outletName and outletDomain in CampaignJournalistsResponse schema", () => {
+    // Find the CampaignJournalistsResponse block and check it contains outlet fields
+    const start = schemaContent.indexOf("CampaignJournalistsResponse");
+    const block = schemaContent.slice(Math.max(0, start - 800), start);
+    expect(block).toContain("outletName:");
+    expect(block).toContain("outletDomain:");
+  });
+});
+
+describe("Campaign journalists: outlet name/domain enrichment", () => {
+  it("should build an outlet lookup map from the fetched outlets", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("outletMap");
+    expect(journalistsSection).toContain("new Map");
+  });
+
+  it("should enrich each journalist with outletName and outletDomain from the outlet map", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("outletName:");
+    expect(journalistsSection).toContain("outletDomain:");
+    expect(journalistsSection).toContain("outletMap.get");
+  });
+
+  it("should type the outlets response to include outletName and outletDomain", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("outletName?:");
+    expect(journalistsSection).toContain("outletDomain?:");
+  });
 });


### PR DESCRIPTION
## Summary
- The `GET /v1/campaigns/{id}/journalists` endpoint returned `outletId` for each journalist but never resolved `outletName` or `outletDomain`, leaving the dashboard unable to display outlet logos and names.
- Builds a lookup map from the already-fetched outlets and enriches each journalist with `outletName` (string) and `outletDomain` (string | null).
- Updated the OpenAPI schema (`CampaignJournalistsResponse`) and regenerated `openapi.json`.
- Added regression tests for the outlet enrichment logic.

## Test plan
- [x] Existing tests pass (pre-existing failure in `openapi-response-schemas.test.ts` is unrelated)
- [x] New tests verify outlet map construction and journalist enrichment
- [ ] Verify in dashboard that journalist rows now show outlet logo and name

🤖 Generated with [Claude Code](https://claude.com/claude-code)