### PR TITLE
fix: strip null sessionId in chat proxy so reset preserves context

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -22,12 +22,17 @@ router.put("/chat/config", authenticate, requireOrg, requireUser, async (req: Au
 // POST /v1/chat — stream AI response via SSE
 router.post("/chat", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
+    // Chat-service requires sessionId to be omitted (not null) to create a new session.
+    // The dashboard sends sessionId: null after "Reset Chat", so strip it here.
+    const { sessionId, ...rest } = req.body;
+    const body = sessionId ? { ...rest, sessionId } : rest;
+
     await streamExternalService(
       externalServices.chat,
       "/chat",
       {
         method: "POST",
-        body: req.body,
+        body,
         headers: buildInternalHeaders(req),
         expressRes: res,
       }

--- a/tests/unit/chat-proxy.test.ts
+++ b/tests/unit/chat-proxy.test.ts
@@ -79,6 +79,14 @@ describe("Chat proxy routes", () => {
   it("should handle errors after headers sent for SSE", () => {
     expect(content).toContain("res.headersSent");
   });
+
+  it("should strip null/falsy sessionId before forwarding to chat-service", () => {
+    // When the dashboard sends sessionId: null after "Reset Chat",
+    // the proxy must omit sessionId so chat-service creates a new session
+    // with the provided context (not a generic session).
+    expect(content).toContain("const { sessionId, ...rest } = req.body");
+    expect(content).toContain("sessionId ? { ...rest, sessionId } : rest");
+  });
 });
 
 describe("Chat OpenAPI schemas", () => {


### PR DESCRIPTION
## Summary
- When the dashboard sends `sessionId: null` after "Reset Chat", chat-service needs `sessionId` to be **omitted** (not `null`) to create a new session that respects the `context` payload
- The proxy now destructures `sessionId` from `req.body` and only includes it when truthy, so chat-service correctly creates a fresh context-aware session

## Test plan
- [x] Existing chat proxy tests pass (24/24)
- [x] New test verifies null sessionId stripping logic
- [x] Full test suite passes (1 pre-existing unrelated failure in openapi-response-schemas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)