### PR TITLE
refactor: rename workflowName → workflowSlug

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -327,9 +327,9 @@
             "type": "string",
             "description": "ID of the workflow holding the record"
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string",
-            "description": "Name of the workflow"
+            "description": "Slug of the workflow"
           },
           "displayName": {
             "type": "string",
@@ -348,7 +348,7 @@
         },
         "required": [
           "workflowId",
-          "workflowName",
+          "workflowSlug",
           "displayName",
           "createdForBrandId",
           "value"
@@ -470,9 +470,9 @@
             "type": "string",
             "description": "Campaign name"
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string",
-            "description": "Workflow name used for execution"
+            "description": "Workflow slug used for execution"
           },
           "brandUrl": {
             "type": "string",
@@ -570,7 +570,7 @@
           "orgId",
           "createdByUserId",
           "name",
-          "workflowName",
+          "workflowSlug",
           "brandUrl",
           "brandId",
           "featureSlug",
@@ -623,10 +623,10 @@
             "type": "string",
             "description": "Campaign name"
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string",
             "minLength": 1,
-            "description": "Workflow name (e.g. 'sales-email-cold-outreach-sienna'). Determines which execution pipeline to use."
+            "description": "Workflow slug (e.g. 'sales-email-cold-outreach-sienna'). Determines which execution pipeline to use."
           },
           "brandUrl": {
             "type": "string",
@@ -700,7 +700,7 @@
         },
         "required": [
           "name",
-          "workflowName",
+          "workflowSlug",
           "brandUrl",
           "featureSlug",
           "featureInputs"
@@ -1493,7 +1493,7 @@
             ],
             "default": "open"
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string"
           }
         },
@@ -1562,7 +1562,7 @@
                   ],
                   "default": "open"
                 },
-                "workflowName": {
+                "workflowSlug": {
                   "type": "string"
                 }
               },
@@ -1608,7 +1608,7 @@
       "DiscoverOutletsRequest": {
         "type": "object",
         "properties": {
-          "workflowName": {
+          "workflowSlug": {
             "type": "string"
           }
         }
@@ -3604,7 +3604,7 @@
               },
               "name": {
                 "type": "string",
-                "description": "Auto-generated workflow name"
+                "description": "Auto-generated workflow slug"
               },
               "featureSlug": {
                 "type": "string",
@@ -3783,9 +3783,9 @@
       "WorkflowSummaryResponse": {
         "type": "object",
         "properties": {
-          "workflowName": {
+          "workflowSlug": {
             "type": "string",
-            "description": "Workflow name"
+            "description": "Workflow slug"
           },
           "summary": {
             "type": "string",
@@ -3807,7 +3807,7 @@
           }
         },
         "required": [
-          "workflowName",
+          "workflowSlug",
           "summary",
           "requiredProviders",
           "steps"
@@ -3848,9 +3848,9 @@
       "WorkflowKeyStatusResponse": {
         "type": "object",
         "properties": {
-          "workflowName": {
+          "workflowSlug": {
             "type": "string",
-            "description": "Workflow name"
+            "description": "Workflow slug"
           },
           "ready": {
             "type": "boolean",
@@ -3872,7 +3872,7 @@
           }
         },
         "required": [
-          "workflowName",
+          "workflowSlug",
           "ready",
           "keys",
           "missing"
@@ -6322,13 +6322,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6434,13 +6434,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6568,13 +6568,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6658,13 +6658,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6714,7 +6714,7 @@
           "Campaigns"
         ],
         "summary": "Create a campaign",
-        "description": "Create a new campaign. Requires `featureSlug` and `featureInputs`.\n\nFeature inputs are validated by key-presence against features-service (api-service never inspects values). The `workflowName` determines which execution pipeline campaign-service uses.",
+        "description": "Create a new campaign. Requires `featureSlug` and `featureInputs`.\n\nFeature inputs are validated by key-presence against features-service (api-service never inspects values). The `workflowSlug` determines which execution pipeline campaign-service uses.",
         "security": [
           {
             "bearerAuth": []
@@ -6809,13 +6809,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6889,13 +6889,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -6999,13 +6999,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7111,13 +7111,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7223,13 +7223,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7335,13 +7335,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7447,13 +7447,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7559,13 +7559,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7671,13 +7671,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7783,13 +7783,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -7895,13 +7895,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8047,13 +8047,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8163,13 +8163,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8189,7 +8189,7 @@
           "Outlets"
         ],
         "summary": "Aggregated outlet discovery metrics",
-        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowName and optional groupBy.",
+        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug and optional groupBy.",
         "security": [
           {
             "bearerAuth": []
@@ -8219,14 +8219,14 @@
               "type": "string"
             },
             "required": false,
-            "name": "workflowName",
+            "name": "workflowSlug",
             "in": "query"
           },
           {
             "schema": {
               "type": "string",
               "enum": [
-                "workflowName",
+                "workflowSlug",
                 "brandId",
                 "campaignId"
               ]
@@ -8272,13 +8272,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8380,13 +8380,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8473,13 +8473,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8587,13 +8587,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8666,13 +8666,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8768,13 +8768,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -8892,13 +8892,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9047,13 +9047,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9157,13 +9157,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9278,13 +9278,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9365,13 +9365,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9481,13 +9481,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9568,13 +9568,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9662,13 +9662,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9790,13 +9790,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9893,13 +9893,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -9977,13 +9977,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10078,13 +10078,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10181,13 +10181,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10313,13 +10313,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10429,13 +10429,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10532,13 +10532,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10645,13 +10645,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10758,13 +10758,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10860,13 +10860,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -10979,13 +10979,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11059,13 +11059,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11193,13 +11193,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11273,13 +11273,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11383,13 +11383,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11555,13 +11555,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11657,13 +11657,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11766,13 +11766,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11846,13 +11846,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -11980,13 +11980,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12101,13 +12101,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12222,13 +12222,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12343,13 +12343,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12423,13 +12423,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12567,13 +12567,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12686,13 +12686,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12766,13 +12766,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -12878,13 +12878,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13009,13 +13009,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13172,13 +13172,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13252,13 +13252,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13374,13 +13374,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13516,13 +13516,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13638,13 +13638,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13760,13 +13760,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13911,13 +13911,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -13991,13 +13991,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14101,13 +14101,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14293,13 +14293,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14373,13 +14373,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14495,13 +14495,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14607,13 +14607,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14729,13 +14729,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -14900,13 +14900,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15012,13 +15012,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15134,13 +15134,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15256,13 +15256,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15437,13 +15437,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15517,13 +15517,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15652,13 +15652,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15773,13 +15773,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -15905,13 +15905,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16026,13 +16026,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16147,13 +16147,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16268,13 +16268,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16370,13 +16370,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16472,13 +16472,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16574,13 +16574,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16695,13 +16695,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16795,13 +16795,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -16906,13 +16906,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17017,13 +17017,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17138,13 +17138,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17259,13 +17259,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17339,13 +17339,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17492,13 +17492,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17613,13 +17613,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17693,13 +17693,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17846,13 +17846,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -17926,13 +17926,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18079,13 +18079,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18159,13 +18159,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18312,13 +18312,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18433,13 +18433,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18533,13 +18533,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18696,13 +18696,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18803,13 +18803,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -18937,13 +18937,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19017,13 +19017,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19200,13 +19200,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19331,13 +19331,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19432,13 +19432,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19553,13 +19553,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19674,13 +19674,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19786,13 +19786,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19898,13 +19898,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -19989,13 +19989,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20100,13 +20100,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20192,13 +20192,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20284,13 +20284,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20384,13 +20384,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20475,13 +20475,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20596,13 +20596,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20698,13 +20698,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20818,13 +20818,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -20979,13 +20979,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21088,13 +21088,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21168,13 +21168,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21288,13 +21288,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21449,13 +21449,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21585,13 +21585,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21738,13 +21738,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21764,7 +21764,7 @@
           "Features"
         ],
         "summary": "Global stats cross-features",
-        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -21774,10 +21774,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Group dimension(s), comma-separated: featureSlug, workflowName, brandId, campaignId"
+              "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, brandId, campaignId"
             },
             "required": false,
-            "description": "Group dimension(s), comma-separated: featureSlug, workflowName, brandId, campaignId",
+            "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, brandId, campaignId",
             "name": "groupBy",
             "in": "query"
           },
@@ -21828,13 +21828,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",
@@ -21886,7 +21886,7 @@
           "Features"
         ],
         "summary": "Feature stats",
-        "description": "Stats for a specific feature, groupable by workflowName, brandId, or campaignId. Supports optional brandId, campaignId, and workflowName filters. Requires x-org-id. Proxied from features-service.",
+        "description": "Stats for a specific feature, groupable by workflowSlug, brandId, or campaignId. Supports optional brandId, campaignId, and workflowSlug filters. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -21906,10 +21906,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Group dimension: workflowName | brandId | campaignId"
+              "description": "Group dimension: workflowSlug | brandId | campaignId"
             },
             "required": false,
-            "description": "Group dimension: workflowName | brandId | campaignId",
+            "description": "Group dimension: workflowSlug | brandId | campaignId",
             "name": "groupBy",
             "in": "query"
           },
@@ -21936,11 +21936,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by workflow name"
+              "description": "Filter by workflow slug"
             },
             "required": false,
-            "description": "Filter by workflow name",
-            "name": "workflowName",
+            "description": "Filter by workflow slug",
+            "name": "workflowSlug",
             "in": "query"
           },
           {
@@ -21980,13 +21980,13 @@
             "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
           },
           {
             "name": "x-feature-slug",

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -116,12 +116,12 @@ const identityParams = [
       "Optional — forwarded to downstream services for tracking.",
   },
   {
-    name: "x-workflow-name",
+    name: "x-workflow-slug",
     in: "header" as const,
     required: false,
     schema: { type: "string" as const },
     description:
-      "Workflow name. Automatically injected by workflow-service on workflow HTTP calls. " +
+      "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. " +
       "Optional — forwarded to downstream services for tracking.",
   },
   {

--- a/shared/content/src/index.ts
+++ b/shared/content/src/index.ts
@@ -29,7 +29,7 @@ export {
   getWorkflowDefinitionsByTag,
   WORKFLOW_CATEGORY_LABELS,
   SECTION_LABELS,
-  parseWorkflowName,
+  parseWorkflowSlug,
   getSectionKey,
   getSignatureName,
   getWorkflowCategory,

--- a/shared/content/src/workflows.ts
+++ b/shared/content/src/workflows.ts
@@ -83,12 +83,12 @@ const KNOWN_CHANNELS = new Set<string>(["email"]);
 const TWO_WORD_AUDIENCE_TYPES = new Set<string>(["cold-outreach"]);
 
 /**
- * Parse a workflow name: {category}-{channel}-{audienceType}-{signatureName}.
+ * Parse a workflow slug: {category}-{channel}-{audienceType}-{signatureName}.
  * Example: "sales-email-cold-outreach-sienna"
- * Returns null if the name doesn't match the expected format.
+ * Returns null if the slug doesn't match the expected format.
  */
-export function parseWorkflowName(name: string): ParsedWorkflowName | null {
-  const parts = name.split("-");
+export function parseWorkflowSlug(slug: string): ParsedWorkflowName | null {
+  const parts = slug.split("-");
   if (parts.length < 4) return null;
 
   if (!KNOWN_CATEGORIES.has(parts[0])) return null;
@@ -119,28 +119,28 @@ export function parseWorkflowName(name: string): ParsedWorkflowName | null {
   return null;
 }
 
-/** Get the section key for grouping. Returns null if name doesn't match expected format. */
-export function getSectionKey(workflowName: string): string | null {
-  return parseWorkflowName(workflowName)?.sectionKey ?? null;
+/** Get the section key for grouping. Returns null if slug doesn't match expected format. */
+export function getSectionKey(workflowSlug: string): string | null {
+  return parseWorkflowSlug(workflowSlug)?.sectionKey ?? null;
 }
 
-/** Extract signatureName from a workflow name. Returns null if name doesn't match expected format. */
-export function getSignatureName(workflowName: string): string | null {
-  return parseWorkflowName(workflowName)?.signatureName ?? null;
+/** Extract signatureName from a workflow slug. Returns null if slug doesn't match expected format. */
+export function getSignatureName(workflowSlug: string): string | null {
+  return parseWorkflowSlug(workflowSlug)?.signatureName ?? null;
 }
 
-/** Resolve category for a workflow name. Returns null if name doesn't match expected format. */
-export function getWorkflowCategory(workflowName: string): WorkflowCategory | null {
-  return parseWorkflowName(workflowName)?.category ?? null;
+/** Resolve category for a workflow slug. Returns null if slug doesn't match expected format. */
+export function getWorkflowCategory(workflowSlug: string): WorkflowCategory | null {
+  return parseWorkflowSlug(workflowSlug)?.category ?? null;
 }
 
-/** Resolve display name for a workflow name. Returns the capitalized signatureName if parseable, otherwise title-cases the raw name. */
-export function getWorkflowDisplayName(workflowName: string): string {
-  const parsed = parseWorkflowName(workflowName);
+/** Resolve display name for a workflow slug. Returns the capitalized signatureName if parseable, otherwise title-cases the raw slug. */
+export function getWorkflowDisplayName(workflowSlug: string): string {
+  const parsed = parseWorkflowSlug(workflowSlug);
   if (parsed) {
     return parsed.signatureName.charAt(0).toUpperCase() + parsed.signatureName.slice(1);
   }
-  return workflowName
+  return workflowSlug
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");

--- a/shared/content/tests/workflows.test.ts
+++ b/shared/content/tests/workflows.test.ts
@@ -4,7 +4,7 @@ import {
   getWorkflowDefinition,
   getWorkflowDefinitionsByCategory,
   getWorkflowDefinitionsByTag,
-  parseWorkflowName,
+  parseWorkflowSlug,
   getSectionKey,
   getSignatureName,
   getWorkflowCategory,
@@ -65,9 +65,9 @@ describe("getWorkflowDefinitionsByCategory", () => {
   });
 });
 
-describe("parseWorkflowName", () => {
-  it("parses a valid workflow name", () => {
-    const result = parseWorkflowName("sales-email-cold-outreach-sienna");
+describe("parseWorkflowSlug", () => {
+  it("parses a valid workflow slug", () => {
+    const result = parseWorkflowSlug("sales-email-cold-outreach-sienna");
     expect(result).toEqual({
       category: "sales",
       channel: "email",
@@ -77,8 +77,8 @@ describe("parseWorkflowName", () => {
     });
   });
 
-  it("parses pr workflow name", () => {
-    const result = parseWorkflowName("pr-email-cold-outreach-sequoia");
+  it("parses pr workflow slug", () => {
+    const result = parseWorkflowSlug("pr-email-cold-outreach-sequoia");
     expect(result).toEqual({
       category: "pr",
       channel: "email",
@@ -88,51 +88,51 @@ describe("parseWorkflowName", () => {
     });
   });
 
-  it("returns null for invalid names", () => {
-    expect(parseWorkflowName("invalid")).toBeNull();
-    expect(parseWorkflowName("")).toBeNull();
-    expect(parseWorkflowName("foo-bar")).toBeNull();
-    expect(parseWorkflowName("unknown-email-cold-outreach-sienna")).toBeNull();
+  it("returns null for invalid slugs", () => {
+    expect(parseWorkflowSlug("invalid")).toBeNull();
+    expect(parseWorkflowSlug("")).toBeNull();
+    expect(parseWorkflowSlug("foo-bar")).toBeNull();
+    expect(parseWorkflowSlug("unknown-email-cold-outreach-sienna")).toBeNull();
   });
 });
 
 describe("getSectionKey", () => {
-  it("extracts section key from workflow name", () => {
+  it("extracts section key from workflow slug", () => {
     expect(getSectionKey("sales-email-cold-outreach-sienna")).toBe("sales-email-cold-outreach");
   });
 
-  it("returns null for invalid names", () => {
+  it("returns null for invalid slugs", () => {
     expect(getSectionKey("invalid")).toBeNull();
   });
 });
 
 describe("getSignatureName", () => {
-  it("extracts signature name from workflow name", () => {
+  it("extracts signature name from workflow slug", () => {
     expect(getSignatureName("sales-email-cold-outreach-sienna")).toBe("sienna");
   });
 
-  it("returns null for invalid names", () => {
+  it("returns null for invalid slugs", () => {
     expect(getSignatureName("invalid")).toBeNull();
   });
 });
 
 describe("getWorkflowCategory", () => {
-  it("returns category for valid workflow name", () => {
+  it("returns category for valid workflow slug", () => {
     expect(getWorkflowCategory("sales-email-cold-outreach-sienna")).toBe("sales");
     expect(getWorkflowCategory("pr-email-cold-outreach-sequoia")).toBe("pr");
   });
 
-  it("returns null for invalid names", () => {
+  it("returns null for invalid slugs", () => {
     expect(getWorkflowCategory("invalid")).toBeNull();
   });
 });
 
 describe("getWorkflowDisplayName", () => {
-  it("capitalizes the signature name for valid workflow names", () => {
+  it("capitalizes the signature name for valid workflow slugs", () => {
     expect(getWorkflowDisplayName("sales-email-cold-outreach-sienna")).toBe("Sienna");
   });
 
-  it("title-cases the raw name for invalid format", () => {
+  it("title-cases the raw slug for invalid format", () => {
     expect(getWorkflowDisplayName("my-custom-thing")).toBe("My Custom Thing");
   });
 });

--- a/src/lib/internal-headers.ts
+++ b/src/lib/internal-headers.ts
@@ -8,7 +8,7 @@ import { AuthenticatedRequest } from "../middleware/auth.js";
  * - x-run-id: Request run ID for cost tracking (when available)
  * - x-campaign-id: Campaign ID from workflow-service (when available)
  * - x-brand-id: Brand ID from workflow-service (when available)
- * - x-workflow-name: Workflow name from workflow-service (when available)
+ * - x-workflow-slug: Workflow slug from workflow-service (when available)
  * - x-feature-slug: Feature slug for tracking (when available)
  */
 export function buildInternalHeaders(req: AuthenticatedRequest): Record<string, string> {
@@ -18,7 +18,7 @@ export function buildInternalHeaders(req: AuthenticatedRequest): Record<string, 
   if (req.runId) headers["x-run-id"] = req.runId;
   if (req.campaignId) headers["x-campaign-id"] = req.campaignId;
   if (req.brandId) headers["x-brand-id"] = req.brandId;
-  if (req.workflowName) headers["x-workflow-name"] = req.workflowName;
+  if (req.workflowSlug) headers["x-workflow-slug"] = req.workflowSlug;
   if (req.featureSlug) headers["x-feature-slug"] = req.featureSlug;
   return headers;
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -10,7 +10,7 @@ export interface AuthenticatedRequest extends Request {
   /** Workflow tracking headers — injected by workflow-service, optional */
   campaignId?: string;
   brandId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
   featureSlug?: string;
 }
 
@@ -98,11 +98,11 @@ export async function authenticate(
     // Extract optional workflow tracking headers (injected by workflow-service)
     const campaignId = req.headers["x-campaign-id"] as string | undefined;
     const brandId = req.headers["x-brand-id"] as string | undefined;
-    const workflowName = req.headers["x-workflow-name"] as string | undefined;
+    const workflowSlug = req.headers["x-workflow-slug"] as string | undefined;
     const featureSlug = req.headers["x-feature-slug"] as string | undefined;
     if (campaignId) req.campaignId = campaignId;
     if (brandId) req.brandId = brandId;
-    if (workflowName) req.workflowName = workflowName;
+    if (workflowSlug) req.workflowSlug = workflowSlug;
     if (featureSlug) req.featureSlug = featureSlug;
 
     // Create a request run for tracking — mandatory, fail the request if runs-service is down
@@ -111,7 +111,7 @@ export async function authenticate(
         const runHeaders: Record<string, string> = {};
         if (req.brandId) runHeaders["x-brand-id"] = req.brandId;
         if (req.campaignId) runHeaders["x-campaign-id"] = req.campaignId;
-        if (req.workflowName) runHeaders["x-workflow-name"] = req.workflowName;
+        if (req.workflowSlug) runHeaders["x-workflow-slug"] = req.workflowSlug;
         if (req.featureSlug) runHeaders["x-feature-slug"] = req.featureSlug;
 
         const run = await createRun({

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -63,7 +63,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       return res.status(400).json({
         error: `Missing or invalid required fields: ${missingFields.join(", ")}.`,
         missingFields,
-        hint: "Campaign creation requires: name, workflowName, brandUrl, featureSlug, and featureInputs.",
+        hint: "Campaign creation requires: name, workflowSlug, brandUrl, featureSlug, and featureInputs.",
       });
     }
 
@@ -111,11 +111,11 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
     console.log("[api-service] POST /v1/campaigns — brand upserted", { brandId: brandResult.brandId });
 
     // 4. Forward to campaign-service (featureInputs forwarded as-is, never inspected)
-    const { workflowName, ...restData } = parsed.data;
-    const campaignType = deriveCampaignType(workflowName);
+    const { workflowSlug, ...restData } = parsed.data;
+    const campaignType = deriveCampaignType(workflowSlug);
     const body: Record<string, unknown> = {
       ...restData,
-      workflowName,
+      workflowSlug,
       type: campaignType,
       orgId: req.orgId,
       brandId: brandResult.brandId,
@@ -128,18 +128,18 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
 
     console.log("[api-service] POST /v1/campaigns — forwarding to campaign-service", {
       brandId: body.brandId,
-      workflowName: body.workflowName,
+      workflowSlug: body.workflowSlug,
       type: body.type,
       featureSlug: body.featureSlug,
     });
     // Enrich headers with IDs resolved during this request — the dashboard
-    // sends brandUrl/workflowName/featureSlug in the body, not as headers,
+    // sends brandUrl/workflowSlug/featureSlug in the body, not as headers,
     // so buildInternalHeaders(req) alone won't include them.
     const campaignHeaders: Record<string, string> = {
       ...buildInternalHeaders(req),
       "x-brand-id": brandResult.brandId,
       "x-feature-slug": featureSlug,
-      "x-workflow-name": workflowName,
+      "x-workflow-slug": workflowSlug,
     };
     const result = await callExternalService(
       externalServices.campaign,
@@ -800,9 +800,9 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
     const { id } = req.params;
     const baseHeaders = buildInternalHeaders(req);
 
-    // Fetch campaign to get brandId/featureSlug/workflowName for downstream headers
+    // Fetch campaign to get brandId/featureSlug/workflowSlug for downstream headers
     const campaignResult = await callExternalService<{
-      campaign: { brandId?: string; featureSlug?: string; workflowName?: string };
+      campaign: { brandId?: string; featureSlug?: string; workflowSlug?: string };
     }>(externalServices.campaign, `/campaigns/${encodeURIComponent(id)}`, { headers: baseHeaders });
 
     const campaign = campaignResult.campaign;
@@ -826,7 +826,7 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
     };
     if (campaign.brandId) headers["x-brand-id"] = campaign.brandId;
     if (campaign.featureSlug) headers["x-feature-slug"] = campaign.featureSlug;
-    if (campaign.workflowName) headers["x-workflow-name"] = campaign.workflowName;
+    if (campaign.workflowSlug) headers["x-workflow-slug"] = campaign.workflowSlug;
 
     // Fetch all journalists for this campaign in one call
     const journalistsResult = await callExternalService<{

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -48,7 +48,7 @@ router.get("/features/stats/registry", authenticate, requireOrg, requireUser, as
 
 /**
  * GET /v1/features/stats
- * Global stats cross-features, groupable by featureSlug/workflowName/brandId/campaignId
+ * Global stats cross-features, groupable by featureSlug/workflowSlug/brandId/campaignId
  */
 router.get("/features/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
@@ -107,12 +107,12 @@ router.get("/features/:slug/inputs", authenticate, requireOrg, requireUser, asyn
 
 /**
  * GET /v1/features/:slug/stats
- * Stats for a specific feature, groupable by workflowName/brandId/campaignId
+ * Stats for a specific feature, groupable by workflowSlug/brandId/campaignId
  */
 router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["groupBy", "brandId", "campaignId", "workflowName"]) {
+    for (const key of ["groupBy", "brandId", "campaignId", "workflowSlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -33,7 +33,7 @@ router.get("/outlets/stats", authenticate, requireOrg, requireUser, async (req: 
     const params = new URLSearchParams();
     if (req.query.brandId) params.set("brandId", req.query.brandId as string);
     if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
-    if (req.query.workflowName) params.set("workflowName", req.query.workflowName as string);
+    if (req.query.workflowSlug) params.set("workflowSlug", req.query.workflowSlug as string);
     if (req.query.groupBy) params.set("groupBy", req.query.groupBy as string);
     const qs = params.toString() ? `?${params.toString()}` : "";
 

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -265,7 +265,7 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
     const dag = workflow.dag;
     if (!dag || !dag.nodes?.length) {
       return res.json({
-        workflowName: workflow.name,
+        workflowSlug: workflow.name,
         summary: "This workflow has no steps defined yet.",
         requiredProviders,
         steps: [],
@@ -327,7 +327,7 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
     const summary = `This workflow has ${ordered.length} step${ordered.length === 1 ? "" : "s"}.${providerList}`;
 
     res.json({
-      workflowName: workflow.name,
+      workflowSlug: workflow.name,
       summary,
       requiredProviders,
       steps,
@@ -372,20 +372,20 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
 
     const missing = keys.filter((k) => !k.configured).map((k) => k.provider);
 
-    let workflowName = id;
+    let workflowSlug = id;
     try {
       const wf = await callExternalService<{ workflow: { name: string } }>(
         externalServices.workflow,
         `/workflows/${id}`,
         { headers: buildInternalHeaders(req) },
       );
-      workflowName = wf.workflow?.name ?? id;
+      workflowSlug = wf.workflow?.name ?? id;
     } catch {
       // Fall back to id
     }
 
     res.json({
-      workflowName,
+      workflowSlug,
       ready: missing.length === 0,
       keys,
       missing,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -208,7 +208,7 @@ const PublicRankedWorkflowItemSchema = z
 const BestWorkflowRecordSchema = z
   .object({
     workflowId: z.string().describe("ID of the workflow holding the record"),
-    workflowName: z.string().describe("Name of the workflow"),
+    workflowSlug: z.string().describe("Slug of the workflow"),
     displayName: z.string().nullable().describe("Stable display name of the workflow family"),
     createdForBrandId: z.string().nullable().describe("Brand ID that created this workflow"),
     value: z.number().describe("The record value in USD cents"),
@@ -342,7 +342,7 @@ registry.registerPath({
 export const CreateCampaignRequestSchema = z
   .object({
     name: z.string().describe("Campaign name"),
-    workflowName: z.string().min(1).describe("Workflow name (e.g. 'sales-email-cold-outreach-sienna'). Determines which execution pipeline to use."),
+    workflowSlug: z.string().min(1).describe("Workflow slug (e.g. 'sales-email-cold-outreach-sienna'). Determines which execution pipeline to use."),
     brandUrl: z.string().min(1).describe("Brand website URL"),
     featureSlug: z.string().min(1).describe("Feature slug — used to validate inputs against features-service"),
     featureInputs: z.record(z.unknown()).describe("Opaque feature inputs. Validated by key-presence against features-service, never inspected by api-service."),
@@ -361,12 +361,12 @@ export const DISCOVERY_PREFIXES: Array<{ prefix: string; type: string }> = [
   { prefix: "journalists-database-discovery-", type: "journalists-database-discovery" },
 ];
 
-export function isDiscoveryWorkflow(workflowName: string): boolean {
-  return DISCOVERY_PREFIXES.some((d) => workflowName.startsWith(d.prefix));
+export function isDiscoveryWorkflow(workflowSlug: string): boolean {
+  return DISCOVERY_PREFIXES.some((d) => workflowSlug.startsWith(d.prefix));
 }
 
-export function deriveCampaignType(workflowName: string): string {
-  const match = DISCOVERY_PREFIXES.find((d) => workflowName.startsWith(d.prefix));
+export function deriveCampaignType(workflowSlug: string): string {
+  const match = DISCOVERY_PREFIXES.find((d) => workflowSlug.startsWith(d.prefix));
   return match ? match.type : "cold-email-outreach";
 }
 
@@ -415,7 +415,7 @@ const CampaignSchema = z
     orgId: z.string().describe("Organization ID"),
     createdByUserId: z.string().nullable().describe("User who created the campaign"),
     name: z.string().describe("Campaign name"),
-    workflowName: z.string().describe("Workflow name used for execution"),
+    workflowSlug: z.string().describe("Workflow slug used for execution"),
     brandUrl: z.string().nullable().describe("Brand website URL"),
     brandId: z.string().nullable().describe("Brand ID"),
     featureSlug: z.string().nullable().describe("Feature slug for tracking"),
@@ -477,7 +477,7 @@ registry.registerPath({
   description:
     "Create a new campaign. Requires `featureSlug` and `featureInputs`.\n\n" +
     "Feature inputs are validated by key-presence against features-service (api-service never inspects values). " +
-    "The `workflowName` determines which execution pipeline campaign-service uses.",
+    "The `workflowSlug` determines which execution pipeline campaign-service uses.",
   security: authed,
   request: {
     body: {
@@ -931,7 +931,7 @@ registry.registerPath({
               overallRelevance: z.string().optional(),
               relevanceRationale: z.string().optional(),
               status: z.enum(["open", "ended", "denied"]).optional().default("open"),
-              workflowName: z.string().optional(),
+              workflowSlug: z.string().optional(),
             })
             .openapi("CreateOutletRequest"),
         },
@@ -950,14 +950,14 @@ registry.registerPath({
   path: "/v1/outlets/stats",
   tags: ["Outlets"],
   summary: "Aggregated outlet discovery metrics",
-  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowName and optional groupBy.",
+  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug and optional groupBy.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().uuid().optional(),
       campaignId: z.string().uuid().optional(),
-      workflowName: z.string().optional(),
-      groupBy: z.enum(["workflowName", "brandId", "campaignId"]).optional(),
+      workflowSlug: z.string().optional(),
+      groupBy: z.enum(["workflowSlug", "brandId", "campaignId"]).optional(),
     }),
   },
   responses: {
@@ -991,7 +991,7 @@ registry.registerPath({
                   overallRelevance: z.string().optional(),
                   relevanceRationale: z.string().optional(),
                   status: z.enum(["open", "ended", "denied"]).optional().default("open"),
-                  workflowName: z.string().optional(),
+                  workflowSlug: z.string().optional(),
                 }),
               ),
             })
@@ -1047,7 +1047,7 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              workflowName: z.string().optional(),
+              workflowSlug: z.string().optional(),
             })
             .openapi("DiscoverOutletsRequest"),
         },
@@ -2857,7 +2857,7 @@ registry.registerPath({
             .object({
               workflow: z.object({
                 id: z.string().describe("Workflow ID"),
-                name: z.string().describe("Auto-generated workflow name"),
+                name: z.string().describe("Auto-generated workflow slug"),
                 featureSlug: z.string().describe("Feature slug this workflow belongs to"),
                 signature: z.string().describe("SHA-256 hash of the canonical DAG"),
                 signatureName: z.string().describe("Human-readable name for this DAG variant"),
@@ -2902,7 +2902,7 @@ const ProviderInfoSchema = z
 
 export const WorkflowSummaryResponseSchema = z
   .object({
-    workflowName: z.string().describe("Workflow name"),
+    workflowSlug: z.string().describe("Workflow slug"),
     summary: z.string().describe("Natural-language summary of the workflow"),
     requiredProviders: z.array(ProviderInfoSchema).describe("External providers required by this workflow, with domains for logo display"),
     steps: z.array(z.string()).describe("Ordered list of workflow steps in human-readable format"),
@@ -2943,7 +2943,7 @@ export const WorkflowKeyStatusItemSchema = z
 
 export const WorkflowKeyStatusResponseSchema = z
   .object({
-    workflowName: z.string().describe("Workflow name"),
+    workflowSlug: z.string().describe("Workflow slug"),
     ready: z.boolean().describe("True if all required provider keys are configured"),
     keys: z.array(WorkflowKeyStatusItemSchema).describe("Status of each required provider key"),
     missing: z.array(z.string()).describe("List of provider names with missing keys"),
@@ -5190,11 +5190,11 @@ registry.registerPath({
   tags: ["Features"],
   summary: "Global stats cross-features",
   description:
-    "Aggregated stats across all features. Supports groupBy (featureSlug, workflowName, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+    "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
   security: authed,
   request: {
     query: z.object({
-      groupBy: z.string().optional().describe("Group dimension(s), comma-separated: featureSlug, workflowName, brandId, campaignId"),
+      groupBy: z.string().optional().describe("Group dimension(s), comma-separated: featureSlug, workflowSlug, brandId, campaignId"),
       brandId: z.string().optional().describe("Filter by brand UUID"),
     }),
   },
@@ -5211,15 +5211,15 @@ registry.registerPath({
   tags: ["Features"],
   summary: "Feature stats",
   description:
-    "Stats for a specific feature, groupable by workflowName, brandId, or campaignId. Supports optional brandId, campaignId, and workflowName filters. Requires x-org-id. Proxied from features-service.",
+    "Stats for a specific feature, groupable by workflowSlug, brandId, or campaignId. Supports optional brandId, campaignId, and workflowSlug filters. Requires x-org-id. Proxied from features-service.",
   security: authed,
   request: {
     params: z.object({ featureSlug: z.string().describe("Feature slug") }),
     query: z.object({
-      groupBy: z.string().optional().describe("Group dimension: workflowName | brandId | campaignId"),
+      groupBy: z.string().optional().describe("Group dimension: workflowSlug | brandId | campaignId"),
       brandId: z.string().optional().describe("Filter by brand UUID"),
       campaignId: z.string().optional().describe("Filter by campaign UUID"),
-      workflowName: z.string().optional().describe("Filter by workflow name"),
+      workflowSlug: z.string().optional().describe("Filter by workflow slug"),
     }),
   },
   responses: {

--- a/tests/__mocks__/content.ts
+++ b/tests/__mocks__/content.ts
@@ -10,27 +10,27 @@ export const SECTION_LABELS: Record<string, string> = {
   "pr-email-cold-outreach": "PR & Media Email Outreach",
 };
 
-export function getSectionKey(workflowName: string): string | null {
-  const parsed = parseWorkflowName(workflowName);
+export function getSectionKey(workflowSlug: string): string | null {
+  const parsed = parseWorkflowSlug(workflowSlug);
   return parsed?.sectionKey ?? null;
 }
 
-export function getSignatureName(workflowName: string): string | null {
-  const parsed = parseWorkflowName(workflowName);
+export function getSignatureName(workflowSlug: string): string | null {
+  const parsed = parseWorkflowSlug(workflowSlug);
   return parsed?.signatureName ?? null;
 }
 
-export function getWorkflowCategory(workflowName: string): WorkflowCategory | null {
-  const parsed = parseWorkflowName(workflowName);
+export function getWorkflowCategory(workflowSlug: string): WorkflowCategory | null {
+  const parsed = parseWorkflowSlug(workflowSlug);
   return parsed?.category ?? null;
 }
 
-export function getWorkflowDisplayName(workflowName: string): string {
-  const parsed = parseWorkflowName(workflowName);
+export function getWorkflowDisplayName(workflowSlug: string): string {
+  const parsed = parseWorkflowSlug(workflowSlug);
   if (parsed) {
     return parsed.signatureName.charAt(0).toUpperCase() + parsed.signatureName.slice(1);
   }
-  return workflowName
+  return workflowSlug
     .split("-")
     .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
@@ -40,8 +40,8 @@ const KNOWN_CATEGORIES = new Set<string>(["sales", "pr"]);
 const KNOWN_CHANNELS = new Set<string>(["email"]);
 const TWO_WORD_AUDIENCE_TYPES = new Set<string>(["cold-outreach"]);
 
-function parseWorkflowName(name: string) {
-  const parts = name.split("-");
+function parseWorkflowSlug(slug: string) {
+  const parts = slug.split("-");
   if (parts.length < 4) return null;
   if (!KNOWN_CATEGORIES.has(parts[0])) return null;
   const category = parts[0] as WorkflowCategory;

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -352,7 +352,7 @@ describe("Auth middleware — run creation is mandatory", () => {
     expect(res.body.error).toBe("Run tracking unavailable");
   });
 
-  it("should forward x-brand-id, x-campaign-id, x-workflow-name, x-feature-slug headers to createRun", async () => {
+  it("should forward x-brand-id, x-campaign-id, x-workflow-slug, x-feature-slug headers to createRun", async () => {
     const { createRun } = await import("@distribute/runs-client");
     const mockCreateRun = vi.mocked(createRun);
     mockCreateRun.mockResolvedValueOnce({ id: "run-with-context" } as never);
@@ -369,7 +369,7 @@ describe("Auth middleware — run creation is mandatory", () => {
       .set("x-external-user-id", "ext_user_456")
       .set("x-brand-id", "brand-abc")
       .set("x-campaign-id", "campaign-xyz")
-      .set("x-workflow-name", "my-workflow")
+      .set("x-workflow-slug", "my-workflow")
       .set("x-feature-slug", "press-outreach");
 
     expect(res.status).toBe(200);
@@ -383,7 +383,7 @@ describe("Auth middleware — run creation is mandatory", () => {
       {
         "x-brand-id": "brand-abc",
         "x-campaign-id": "campaign-xyz",
-        "x-workflow-name": "my-workflow",
+        "x-workflow-slug": "my-workflow",
         "x-feature-slug": "press-outreach",
       },
     );

--- a/tests/unit/brand-service-run-id.regression.test.ts
+++ b/tests/unit/brand-service-run-id.regression.test.ts
@@ -165,7 +165,7 @@ describe("campaign brand upsert sends internal headers", () => {
       .post("/v1/campaigns")
       .send({
         name: "Test Campaign",
-        workflowName: "sales-email-cold-outreach-sienna",
+        workflowSlug: "sales-email-cold-outreach-sienna",
         brandUrl: "https://example.com",
         featureSlug: "cold-outreach-v2",
         featureInputs: {

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -109,14 +109,14 @@ describe("Campaign journalists: header enrichment from campaign data", () => {
     expect(journalistsSection).toContain("campaign.brandId");
   });
 
-  it("should forward x-feature-slug and x-workflow-name from campaign data", () => {
+  it("should forward x-feature-slug and x-workflow-slug from campaign data", () => {
     const journalistsSection = content.slice(
       content.indexOf('"/campaigns/:id/journalists"'),
     );
     expect(journalistsSection).toContain('"x-feature-slug"');
     expect(journalistsSection).toContain("campaign.featureSlug");
-    expect(journalistsSection).toContain('"x-workflow-name"');
-    expect(journalistsSection).toContain("campaign.workflowName");
+    expect(journalistsSection).toContain('"x-workflow-slug"');
+    expect(journalistsSection).toContain("campaign.workflowSlug");
   });
 });
 

--- a/tests/unit/campaign-discovery.test.ts
+++ b/tests/unit/campaign-discovery.test.ts
@@ -5,7 +5,7 @@ import express from "express";
 /**
  * Tests for discovery campaign creation.
  * Discovery campaigns use the same schema as outreach — featureSlug + featureInputs.
- * The campaign type is derived from workflowName prefix.
+ * The campaign type is derived from workflowSlug prefix.
  */
 
 // Mock auth middleware
@@ -87,7 +87,7 @@ describe("Discovery campaign creation", () => {
       .post("/v1/campaigns")
       .send({
         name: "Tech Media Discovery",
-        workflowName: "outlets-database-discovery-cedar",
+        workflowSlug: "outlets-database-discovery-cedar",
         brandUrl: "https://acme.com",
         featureSlug: "outlet-discovery",
         featureInputs: { targetAudience: "Tech publications covering SaaS and AI" },
@@ -96,11 +96,11 @@ describe("Discovery campaign creation", () => {
     expect(res.status).toBe(200);
     expect(res.body.campaign.id).toBe("campaign-disc-1");
 
-    // Verify campaign-service received the correct type derived from workflowName
+    // Verify campaign-service received the correct type derived from workflowSlug
     const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
     expect(campaignCall).toBeDefined();
     expect(campaignCall!.body!.type).toBe("outlets-database-discovery");
-    expect(campaignCall!.body!.workflowName).toBe("outlets-database-discovery-cedar");
+    expect(campaignCall!.body!.workflowSlug).toBe("outlets-database-discovery-cedar");
     expect(campaignCall!.body!.featureInputs).toEqual({ targetAudience: "Tech publications covering SaaS and AI" });
 
     // No legacy top-level targetAudience
@@ -113,7 +113,7 @@ describe("Discovery campaign creation", () => {
       .post("/v1/campaigns")
       .send({
         name: "Journalist Discovery",
-        workflowName: "journalists-database-discovery-birch",
+        workflowSlug: "journalists-database-discovery-birch",
         brandUrl: "https://acme.com",
         featureSlug: "journalist-discovery",
         featureInputs: { targetAudience: "Journalists covering fintech in the US" },
@@ -131,7 +131,7 @@ describe("Discovery campaign creation", () => {
       .post("/v1/campaigns")
       .send({
         name: "Missing Slug",
-        workflowName: "outlets-database-discovery-cedar",
+        workflowSlug: "outlets-database-discovery-cedar",
         brandUrl: "https://acme.com",
         featureInputs: { targetAudience: "Tech publications" },
       });
@@ -146,7 +146,7 @@ describe("Discovery campaign creation", () => {
       .post("/v1/campaigns")
       .send({
         name: "Missing Input",
-        workflowName: "outlets-database-discovery-cedar",
+        workflowSlug: "outlets-database-discovery-cedar",
         brandUrl: "https://acme.com",
         featureSlug: "outlet-discovery",
         featureInputs: {}, // Missing targetAudience
@@ -157,13 +157,13 @@ describe("Discovery campaign creation", () => {
     expect(res.body.missingKeys).toContain("targetAudience");
   });
 
-  it("should forward x-brand-id, x-feature-slug, x-workflow-name headers to campaign-service", async () => {
+  it("should forward x-brand-id, x-feature-slug, x-workflow-slug headers to campaign-service", async () => {
     const app = createApp();
     await request(app)
       .post("/v1/campaigns")
       .send({
         name: "Header Test",
-        workflowName: "outlets-database-discovery-cedar",
+        workflowSlug: "outlets-database-discovery-cedar",
         brandUrl: "https://acme.com",
         featureSlug: "outlet-discovery",
         featureInputs: { targetAudience: "Tech publications" },
@@ -173,9 +173,9 @@ describe("Discovery campaign creation", () => {
     expect(campaignCall).toBeDefined();
     // Resolved brandId from brand-service must be forwarded as header
     expect(campaignCall!.headers!["x-brand-id"]).toBe("brand-uuid-123");
-    // featureSlug and workflowName from body must also be forwarded as headers
+    // featureSlug and workflowSlug from body must also be forwarded as headers
     expect(campaignCall!.headers!["x-feature-slug"]).toBe("outlet-discovery");
-    expect(campaignCall!.headers!["x-workflow-name"]).toBe("outlets-database-discovery-cedar");
+    expect(campaignCall!.headers!["x-workflow-slug"]).toBe("outlets-database-discovery-cedar");
   });
 
   it("should convert budget numbers to strings for discovery campaigns", async () => {
@@ -184,7 +184,7 @@ describe("Discovery campaign creation", () => {
       .post("/v1/campaigns")
       .send({
         name: "Budget Discovery",
-        workflowName: "outlets-database-discovery-cedar",
+        workflowSlug: "outlets-database-discovery-cedar",
         brandUrl: "https://acme.com",
         featureSlug: "outlet-discovery",
         featureInputs: { targetAudience: "Tech publications" },

--- a/tests/unit/campaign-duplicate-name.test.ts
+++ b/tests/unit/campaign-duplicate-name.test.ts
@@ -38,7 +38,7 @@ function createApp() {
 
 const validCampaignBody = {
   name: "Test Campaign",
-  workflowName: "sales-email-cold-outreach-v1",
+  workflowSlug: "sales-email-cold-outreach-v1",
   brandUrl: "https://example.com",
   featureSlug: "cold-outreach-v2",
   featureInputs: {

--- a/tests/unit/campaign-key-validation.test.ts
+++ b/tests/unit/campaign-key-validation.test.ts
@@ -38,7 +38,7 @@ function createApp() {
 
 const validCampaignBody = {
   name: "Test Campaign",
-  workflowName: "sales-email-cold-outreach-v1",
+  workflowSlug: "sales-email-cold-outreach-v1",
   brandUrl: "https://example.com",
   featureSlug: "cold-outreach-v2",
   featureInputs: {

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -46,7 +46,7 @@ function createApp() {
 
 const validBody = {
   name: "Test Campaign",
-  workflowName: "sales-email-cold-outreach-sienna",
+  workflowSlug: "sales-email-cold-outreach-sienna",
   brandUrl: "https://example.com",
   featureSlug: "cold-outreach-v2",
   featureInputs: {
@@ -127,7 +127,7 @@ describe("POST /v1/campaigns with featureInputs", () => {
     // Verify campaign-service received featureInputs as-is
     const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
     expect(campaignCall).toBeDefined();
-    expect(campaignCall!.body!.workflowName).toBe("sales-email-cold-outreach-sienna");
+    expect(campaignCall!.body!.workflowSlug).toBe("sales-email-cold-outreach-sienna");
     expect(campaignCall!.body!.type).toBe("cold-email-outreach");
     expect(campaignCall!.body!.featureSlug).toBe("cold-outreach-v2");
     expect(campaignCall!.body!.featureInputs).toEqual(validBody.featureInputs);
@@ -201,7 +201,7 @@ describe("POST /v1/campaigns with featureInputs", () => {
       .post("/v1/campaigns")
       .send({
         name: "Custom Feature",
-        workflowName: "custom-workflow-v1",
+        workflowSlug: "custom-workflow-v1",
         brandUrl: "https://example.com",
         featureSlug: "custom-search",
         featureInputs: { query: "AI startups", customField: 42, nested: { a: 1 } },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -153,9 +153,9 @@ describe("Features proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
-  it("should forward groupBy, brandId, campaignId, workflowName on GET /features/:slug/stats", () => {
+  it("should forward groupBy, brandId, campaignId, workflowSlug on GET /features/:slug/stats", () => {
     expect(content).toContain('"campaignId"');
-    expect(content).toContain('"workflowName"');
+    expect(content).toContain('"workflowSlug"');
   });
 
   it("should enforce requireOrg + requireUser on ALL feature routes", () => {

--- a/tests/unit/header-forwarding-audit.test.ts
+++ b/tests/unit/header-forwarding-audit.test.ts
@@ -72,8 +72,8 @@ describe("header forwarding audit", () => {
       expect(src).toContain('req.headers["x-brand-id"]');
     });
 
-    it("should extract x-workflow-name from incoming request", () => {
-      expect(src).toContain('req.headers["x-workflow-name"]');
+    it("should extract x-workflow-slug from incoming request", () => {
+      expect(src).toContain('req.headers["x-workflow-slug"]');
     });
 
     it("should extract x-feature-slug from incoming request", () => {
@@ -84,7 +84,7 @@ describe("header forwarding audit", () => {
   describe("internal-headers.ts — workflow tracking headers forwarding", () => {
     const src = readSrc("src/lib/internal-headers.ts");
 
-    for (const header of ["x-campaign-id", "x-brand-id", "x-workflow-name", "x-feature-slug"]) {
+    for (const header of ["x-campaign-id", "x-brand-id", "x-workflow-slug", "x-feature-slug"]) {
       it(`should forward ${header} to downstream services`, () => {
         expect(src).toContain(`headers["${header}"]`);
       });

--- a/tests/unit/openapi-response-schemas.test.ts
+++ b/tests/unit/openapi-response-schemas.test.ts
@@ -75,7 +75,7 @@ describe("OpenAPI spec — response schemas", () => {
     const campaign = spec.components.schemas.Campaign;
     expect(campaign.properties).toHaveProperty("id");
     expect(campaign.properties).toHaveProperty("name");
-    expect(campaign.properties).toHaveProperty("workflowName");
+    expect(campaign.properties).toHaveProperty("workflowSlug");
     expect(campaign.properties).toHaveProperty("status");
     expect(campaign.properties).toHaveProperty("brandId");
   });

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -43,7 +43,7 @@ describe("Outlets proxy routes", () => {
 
   it("should forward groupBy on GET /outlets/stats", () => {
     expect(content).toContain('"groupBy"');
-    expect(content).toContain('"workflowName"');
+    expect(content).toContain('"workflowSlug"');
   });
 
   it("should have POST /outlets with auth", () => {

--- a/tests/unit/workflow-enrichment.test.ts
+++ b/tests/unit/workflow-enrichment.test.ts
@@ -215,7 +215,7 @@ describe("GET /v1/workflows/:id/summary", () => {
     const res = await request(app).get("/v1/workflows/wf-1/summary");
 
     expect(res.status).toBe(200);
-    expect(res.body.workflowName).toBe("sales-email-cold-outreach-v1");
+    expect(res.body.workflowSlug).toBe("sales-email-cold-outreach-v1");
     expect(res.body.requiredProviders).toEqual([{ name: "apollo", domain: "apollo.io" }, { name: "anthropic", domain: "anthropic.com" }, { name: "instantly", domain: "instantly.ai" }]);
     expect(res.body.steps).toHaveLength(4);
     expect(res.body.steps[0]).toContain("1.");
@@ -250,7 +250,7 @@ describe("GET /v1/workflows/:id/summary", () => {
     const res = await request(app).get("/v1/workflows/wf-regression/summary");
 
     expect(res.status).toBe(200);
-    expect(res.body.workflowName).toBe("regression-flow");
+    expect(res.body.workflowSlug).toBe("regression-flow");
     expect(res.body.steps).toHaveLength(1);
   });
 
@@ -285,7 +285,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
     requiredProviders?: string[];
     orgKeys?: Array<{ provider: string; maskedKey: string }>;
     keySources?: Array<{ provider: string; keySource: "org" | "platform" }>;
-    workflowName?: string;
+    workflowSlug?: string;
   } = {}) {
     const {
       requiredProviders = ["apollo", "anthropic", "instantly"],
@@ -294,7 +294,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
         { provider: "anthropic", maskedKey: "sk-...abc" },
       ],
       keySources = [],
-      workflowName = "sales-email-cold-outreach-v1",
+      workflowSlug = "sales-email-cold-outreach-v1",
     } = opts;
 
     return vi.fn().mockImplementation(async (url: string) => {
@@ -310,7 +310,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
         return { ok: true, json: () => Promise.resolve({ keys: orgKeys }) };
       }
       if (url.match(/\/workflows\/wf-1$/)) {
-        return { ok: true, json: () => Promise.resolve({ workflow: { name: workflowName } }) };
+        return { ok: true, json: () => Promise.resolve({ workflow: { name: workflowSlug } }) };
       }
       return { ok: true, json: () => Promise.resolve({}) };
     });
@@ -337,7 +337,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
     const res = await request(app).get("/v1/workflows/wf-1/key-status");
 
     expect(res.status).toBe(200);
-    expect(res.body.workflowName).toBe("sales-email-cold-outreach-v1");
+    expect(res.body.workflowSlug).toBe("sales-email-cold-outreach-v1");
     expect(res.body.ready).toBe(false);
     expect(res.body.keys).toHaveLength(3);
     expect(res.body.keys).toContainEqual({ provider: "apollo", configured: true, maskedKey: "apol...123", keySource: "org" });
@@ -369,7 +369,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
       requiredProviders: ["apollo"],
       orgKeys: [{ provider: "apollo", maskedKey: "apol...123" }],
       keySources: [{ provider: "apollo", keySource: "org" }],
-      workflowName: "simple-flow",
+      workflowSlug: "simple-flow",
     });
     app = createApp();
 

--- a/tests/unit/workflows-stats.test.ts
+++ b/tests/unit/workflows-stats.test.ts
@@ -56,7 +56,7 @@ const MOCK_RANKED = {
 };
 
 const MOCK_HERO = {
-  bestCostPerOpen: { workflowId: "wf-1", workflowName: "sales-email-cold-outreach-mintaka", displayName: "Mintaka", brandId: "b-1", value: 12 },
+  bestCostPerOpen: { workflowId: "wf-1", workflowSlug: "sales-email-cold-outreach-mintaka", displayName: "Mintaka", brandId: "b-1", value: 12 },
   bestCostPerReply: null,
 };
 


### PR DESCRIPTION
## Summary
- Renames `workflowName` → `workflowSlug` in all Zod schemas, request/response bodies, and route logic
- Renames inbound/outbound header `x-workflow-name` → `x-workflow-slug`
- Regenerates `openapi.json` with updated field and header names
- Updates shared content lib (`parseWorkflowName` → `parseWorkflowSlug`) and all tests

Aligns with workflow-service naming refactor (PRs #180, #181).

## Test plan
- [x] All 806 tests pass (1 pre-existing failure in openapi-response-schemas unrelated to this change)
- [x] OpenAPI spec regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)