### PR TITLE
feat: add GET /features/dynasty proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5886,6 +5886,23 @@
         "type": "object",
         "properties": {}
       },
+      "FeatureDynastyResponse": {
+        "type": "object",
+        "properties": {
+          "feature_dynasty_name": {
+            "type": "string",
+            "description": "Stable dynasty display name"
+          },
+          "feature_dynasty_slug": {
+            "type": "string",
+            "description": "Stable dynasty slug (unversioned)"
+          }
+        },
+        "required": [
+          "feature_dynasty_name",
+          "feature_dynasty_slug"
+        ]
+      },
       "FeatureResponse": {
         "type": "object",
         "properties": {}
@@ -21106,6 +21123,138 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/features/dynasty": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Resolve feature dynasty",
+        "description": "Returns stable, unversioned dynasty identifiers (dynasty name and slug) for a given versioned feature slug. Useful for composing workflow names. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Versioned feature slug (e.g. 'pr-cold-email-outreach-v2')"
+            },
+            "required": true,
+            "description": "Versioned feature slug (e.g. 'pr-cold-email-outreach-v2')",
+            "name": "slug",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dynasty identifiers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureDynastyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing slug parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/features/{slug}": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -70,6 +70,28 @@ router.get("/features/stats", authenticate, requireOrg, requireUser, async (req:
 });
 
 /**
+ * GET /v1/features/dynasty
+ * Resolve stable dynasty identifiers for a versioned feature slug.
+ */
+router.get("/features/dynasty", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const slug = req.query.slug as string | undefined;
+    if (!slug) {
+      return res.status(400).json({ error: "Missing required query parameter: slug" });
+    }
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/dynasty?slug=${encodeURIComponent(slug)}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Dynasty lookup error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to resolve dynasty" });
+  }
+});
+
+/**
  * GET /v1/features/:slug
  * Get a single feature by slug
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5077,6 +5077,39 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/features/dynasty",
+  tags: ["Features"],
+  summary: "Resolve feature dynasty",
+  description:
+    "Returns stable, unversioned dynasty identifiers (dynasty name and slug) for a given versioned feature slug. " +
+    "Useful for composing workflow names. Proxied from features-service.",
+  security: authed,
+  request: {
+    query: z.object({
+      slug: z.string().describe("Versioned feature slug (e.g. 'pr-cold-email-outreach-v2')"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Dynasty identifiers",
+      content: {
+        "application/json": {
+          schema: z.object({
+            feature_dynasty_name: z.string().describe("Stable dynasty display name"),
+            feature_dynasty_slug: z.string().describe("Stable dynasty slug (unversioned)"),
+          }).openapi("FeatureDynastyResponse"),
+        },
+      },
+    },
+    400: { description: "Missing slug parameter", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/features/{slug}",
   tags: ["Features"],
   summary: "Get feature by slug",

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -41,6 +41,22 @@ describe("Features proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
+  it("should have GET /features/dynasty with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/features/dynasty"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should validate slug query param on GET /features/dynasty", () => {
+    const dynastySection = content.slice(content.indexOf('"/features/dynasty"'));
+    expect(dynastySection).toContain("req.query.slug");
+    expect(dynastySection).toContain("/features/dynasty?slug=");
+  });
+
   it("should have GET /features/:slug/inputs with auth + requireOrg + requireUser", () => {
     const line = content.split("\n").find((l) =>
       l.includes("router.get") && l.includes('"/features/:slug/inputs"')
@@ -111,7 +127,7 @@ describe("Features proxy routes", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(10);
+    expect(headerMatches!.length).toBe(11);
   });
 
   it("should proxy to externalServices.features", () => {
@@ -174,9 +190,11 @@ describe("Features proxy routes", () => {
   it("should register static routes before parameterized :slug route", () => {
     const registryIdx = content.indexOf('"/features/stats/registry"');
     const globalStatsIdx = content.indexOf('"/features/stats"');
+    const dynastyIdx = content.indexOf('"/features/dynasty"');
     const slugIdx = content.indexOf('"/features/:slug"');
     expect(registryIdx).toBeLessThan(slugIdx);
     expect(globalStatsIdx).toBeLessThan(slugIdx);
+    expect(dynastyIdx).toBeLessThan(slugIdx);
   });
 });
 
@@ -199,6 +217,16 @@ describe("Features OpenAPI schemas", () => {
 
   it("should register GET /v1/features/{slug}", () => {
     expect(schemaContent).toContain('path: "/v1/features/{slug}"');
+  });
+
+  it("should register GET /v1/features/dynasty", () => {
+    expect(schemaContent).toContain('path: "/v1/features/dynasty"');
+  });
+
+  it("should define FeatureDynastyResponse schema", () => {
+    expect(schemaContent).toContain("FeatureDynastyResponse");
+    expect(schemaContent).toContain("feature_dynasty_name");
+    expect(schemaContent).toContain("feature_dynasty_slug");
   });
 
   it("should register GET /v1/features/{slug}/inputs", () => {


### PR DESCRIPTION
## Summary
- Adds proxy route `GET /v1/features/dynasty?slug=<versioned-slug>` → features-service
- Returns `{ feature_dynasty_name, feature_dynasty_slug }` (stable, unversioned dynasty identifiers)
- Route registered before `:slug` param to avoid Express matching `dynasty` as a slug
- OpenAPI spec updated with `FeatureDynastyResponse` schema
- Aligns with features-service v3 (PRs #43, #44, #45)

No changes needed for:
- `displayName → dynastyName`: api-service proxies Feature responses opaquely (`.passthrough()`)
- Stats `workflowName → workflowSlug`: already done in PR #229

## Test plan
- [x] 810 tests pass (1 pre-existing failure unrelated)
- [x] Dynasty route has auth + requireOrg + requireUser guards
- [x] Static route ordering verified (dynasty before :slug)
- [x] OpenAPI spec regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)