### PR TITLE
feat: forward dynasty slug params on stats endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8206,7 +8206,7 @@
           "Outlets"
         ],
         "summary": "Aggregated outlet discovery metrics",
-        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug and optional groupBy.",
+        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy.",
         "security": [
           {
             "bearerAuth": []
@@ -8242,10 +8242,43 @@
           {
             "schema": {
               "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "enum": [
                 "workflowSlug",
+                "featureSlug",
                 "brandId",
-                "campaignId"
+                "campaignId",
+                "workflowDynastySlug",
+                "featureDynastySlug"
               ]
             },
             "required": false,
@@ -13449,7 +13482,7 @@
           "Runs"
         ],
         "summary": "Get cost stats from runs-service",
-        "description": "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName. Filter by brandId, campaignId, taskName.",
+        "description": "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug. Filter by brandId, campaignId, taskName, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug.",
         "security": [
           {
             "bearerAuth": []
@@ -13459,10 +13492,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Grouping dimension: brandId, costName, campaignId, serviceName"
+              "description": "Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug"
             },
             "required": true,
-            "description": "Grouping dimension: brandId, costName, campaignId, serviceName",
+            "description": "Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug",
             "name": "groupBy",
             "in": "query"
           },
@@ -13494,6 +13527,46 @@
             "required": false,
             "description": "Filter by task name (e.g. lead-serve)",
             "name": "taskName",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact workflow slug"
+            },
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -21913,7 +21986,7 @@
           "Features"
         ],
         "summary": "Global stats cross-features",
-        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId — comma-separated combos allowed) and optional filters. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -21923,10 +21996,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, brandId, campaignId"
+              "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId"
             },
             "required": false,
-            "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, brandId, campaignId",
+            "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId",
             "name": "groupBy",
             "in": "query"
           },
@@ -21938,6 +22011,46 @@
             "required": false,
             "description": "Filter by brand UUID",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact workflow slug"
+            },
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
             "in": "query"
           },
           {
@@ -22035,7 +22148,7 @@
           "Features"
         ],
         "summary": "Feature stats",
-        "description": "Stats for a specific feature, groupable by workflowSlug, brandId, or campaignId. Supports optional brandId, campaignId, and workflowSlug filters. Requires x-org-id. Proxied from features-service.",
+        "description": "Stats for a specific feature, groupable by workflowSlug, workflowDynastySlug, brandId, or campaignId. Supports optional filters including dynasty slugs. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -22055,10 +22168,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Group dimension: workflowSlug | brandId | campaignId"
+              "description": "Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId"
             },
             "required": false,
-            "description": "Group dimension: workflowSlug | brandId | campaignId",
+            "description": "Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId",
             "name": "groupBy",
             "in": "query"
           },
@@ -22085,11 +22198,31 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by workflow slug"
+              "description": "Filter by exact workflow slug"
             },
             "required": false,
-            "description": "Filter by workflow slug",
+            "description": "Filter by exact workflow slug",
             "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
             "in": "query"
           },
           {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -53,7 +53,7 @@ router.get("/features/stats/registry", authenticate, requireOrg, requireUser, as
 router.get("/features/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["groupBy", "brandId"]) {
+    for (const key of ["groupBy", "brandId", "featureSlug", "workflowSlug", "featureDynastySlug", "workflowDynastySlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";
@@ -134,7 +134,7 @@ router.get("/features/:slug/inputs", authenticate, requireOrg, requireUser, asyn
 router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["groupBy", "brandId", "campaignId", "workflowSlug"]) {
+    for (const key of ["groupBy", "brandId", "campaignId", "workflowSlug", "featureDynastySlug", "workflowDynastySlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -31,10 +31,9 @@ router.get("/outlets", authenticate, requireOrg, requireUser, async (req: Authen
 router.get("/outlets/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
-    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
-    if (req.query.workflowSlug) params.set("workflowSlug", req.query.workflowSlug as string);
-    if (req.query.groupBy) params.set("groupBy", req.query.groupBy as string);
+    for (const key of ["brandId", "campaignId", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug", "groupBy"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
     const qs = params.toString() ? `?${params.toString()}` : "";
 
     const result = await callExternalService(

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -28,9 +28,9 @@ router.get("/runs/stats/costs", authenticate, requireOrg, requireUser, async (re
       orgId,
       groupBy,
     });
-    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
-    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
-    if (req.query.taskName) params.set("taskName", req.query.taskName as string);
+    for (const key of ["brandId", "campaignId", "taskName", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
 
     const data = await callExternalService<{
       groups: Array<Record<string, unknown>>;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -950,14 +950,17 @@ registry.registerPath({
   path: "/v1/outlets/stats",
   tags: ["Outlets"],
   summary: "Aggregated outlet discovery metrics",
-  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug and optional groupBy.",
+  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().uuid().optional(),
       campaignId: z.string().uuid().optional(),
       workflowSlug: z.string().optional(),
-      groupBy: z.enum(["workflowSlug", "brandId", "campaignId"]).optional(),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
+      groupBy: z.enum(["workflowSlug", "featureSlug", "brandId", "campaignId", "workflowDynastySlug", "featureDynastySlug"]).optional(),
     }),
   },
   responses: {
@@ -2656,14 +2659,18 @@ registry.registerPath({
   tags: ["Runs"],
   summary: "Get cost stats from runs-service",
   description:
-    "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName. Filter by brandId, campaignId, taskName.",
+    "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug. Filter by brandId, campaignId, taskName, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug.",
   security: authed,
   request: {
     query: z.object({
-      groupBy: z.string().describe("Grouping dimension: brandId, costName, campaignId, serviceName"),
+      groupBy: z.string().describe("Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug"),
       brandId: z.string().optional().describe("Filter by brand ID"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),
       taskName: z.string().optional().describe("Filter by task name (e.g. lead-serve)"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {
@@ -5223,12 +5230,16 @@ registry.registerPath({
   tags: ["Features"],
   summary: "Global stats cross-features",
   description:
-    "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, brandId, campaignId — comma-separated combos allowed) and optional brandId filter. Requires x-org-id. Proxied from features-service.",
+    "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId — comma-separated combos allowed) and optional filters. Requires x-org-id. Proxied from features-service.",
   security: authed,
   request: {
     query: z.object({
-      groupBy: z.string().optional().describe("Group dimension(s), comma-separated: featureSlug, workflowSlug, brandId, campaignId"),
+      groupBy: z.string().optional().describe("Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId"),
       brandId: z.string().optional().describe("Filter by brand UUID"),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {
@@ -5244,15 +5255,17 @@ registry.registerPath({
   tags: ["Features"],
   summary: "Feature stats",
   description:
-    "Stats for a specific feature, groupable by workflowSlug, brandId, or campaignId. Supports optional brandId, campaignId, and workflowSlug filters. Requires x-org-id. Proxied from features-service.",
+    "Stats for a specific feature, groupable by workflowSlug, workflowDynastySlug, brandId, or campaignId. Supports optional filters including dynasty slugs. Requires x-org-id. Proxied from features-service.",
   security: authed,
   request: {
     params: z.object({ featureSlug: z.string().describe("Feature slug") }),
     query: z.object({
-      groupBy: z.string().optional().describe("Group dimension: workflowSlug | brandId | campaignId"),
+      groupBy: z.string().optional().describe("Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId"),
       brandId: z.string().optional().describe("Filter by brand UUID"),
       campaignId: z.string().optional().describe("Filter by campaign UUID"),
-      workflowSlug: z.string().optional().describe("Filter by workflow slug"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {

--- a/tests/unit/dynasty-slug-forwarding.test.ts
+++ b/tests/unit/dynasty-slug-forwarding.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const featuresRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/features.ts"), "utf-8");
+const outletsRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/outlets.ts"), "utf-8");
+const runsRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/runs.ts"), "utf-8");
+const schemaContent = fs.readFileSync(path.join(__dirname, "../../src/schemas.ts"), "utf-8");
+const openapiSpec = JSON.parse(fs.readFileSync(path.join(__dirname, "../../openapi.json"), "utf-8"));
+
+const dynastyParams = ["workflowDynastySlug", "featureDynastySlug"];
+
+describe("Dynasty slug forwarding — features/stats", () => {
+  it("should forward dynasty slug filters on GET /features/stats", () => {
+    const statsSection = featuresRoute.slice(
+      featuresRoute.indexOf('"/features/stats"'),
+      featuresRoute.indexOf('"/features/dynasty"'),
+    );
+    for (const param of dynastyParams) {
+      expect(statsSection).toContain(`"${param}"`);
+    }
+    // Also forwards featureSlug + workflowSlug filters
+    expect(statsSection).toContain('"featureSlug"');
+    expect(statsSection).toContain('"workflowSlug"');
+  });
+
+  it("should forward dynasty slug filters on GET /features/:slug/stats", () => {
+    const slugStatsSection = featuresRoute.slice(
+      featuresRoute.indexOf('"/features/:slug/stats"'),
+    );
+    for (const param of dynastyParams) {
+      expect(slugStatsSection).toContain(`"${param}"`);
+    }
+  });
+});
+
+describe("Dynasty slug forwarding — outlets/stats", () => {
+  it("should forward dynasty slug filters on GET /outlets/stats", () => {
+    const statsSection = outletsRoute.slice(
+      outletsRoute.indexOf('"/outlets/stats"'),
+      outletsRoute.indexOf('"/outlets"', outletsRoute.indexOf('"/outlets/stats"') + 20),
+    );
+    for (const param of [...dynastyParams, "featureSlug"]) {
+      expect(statsSection).toContain(`"${param}"`);
+    }
+  });
+});
+
+describe("Dynasty slug forwarding — runs/stats/costs", () => {
+  it("should forward dynasty slug filters on GET /runs/stats/costs", () => {
+    for (const param of [...dynastyParams, "workflowSlug", "featureSlug"]) {
+      expect(runsRoute).toContain(`"${param}"`);
+    }
+  });
+});
+
+describe("Dynasty slug OpenAPI schemas", () => {
+  it("should include dynasty slug filters in /v1/outlets/stats query schema", () => {
+    expect(schemaContent).toContain('featureDynastySlug: z.string().optional()');
+    expect(schemaContent).toContain('workflowDynastySlug: z.string().optional()');
+  });
+
+  it("should include dynasty groupBy values in /v1/outlets/stats schema", () => {
+    // The enum should include dynasty slugs
+    const outletsStatsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/outlets/stats"'),
+      schemaContent.indexOf('path: "/v1/outlets/stats"') + 1200,
+    );
+    expect(outletsStatsSection).toContain('"workflowDynastySlug"');
+    expect(outletsStatsSection).toContain('"featureDynastySlug"');
+  });
+
+  it("should include dynasty slug filters in /v1/features/stats query schema", () => {
+    const featuresStatsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/features/stats"'),
+      schemaContent.indexOf('path: "/v1/features/stats"') + 1200,
+    );
+    expect(featuresStatsSection).toContain("featureDynastySlug");
+    expect(featuresStatsSection).toContain("workflowDynastySlug");
+    expect(featuresStatsSection).toContain("featureSlug");
+    expect(featuresStatsSection).toContain("workflowSlug");
+  });
+
+  it("should include dynasty slug filters in /v1/features/{featureSlug}/stats query schema", () => {
+    const start = schemaContent.indexOf('path: "/v1/features/{featureSlug}/stats"');
+    const featureSlugStatsSection = schemaContent.slice(start, start + 1200);
+    expect(featureSlugStatsSection).toContain("featureDynastySlug");
+    expect(featureSlugStatsSection).toContain("workflowDynastySlug");
+  });
+
+  it("should include dynasty slug filters in /v1/runs/stats/costs query schema", () => {
+    const runsStatsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/runs/stats/costs"'),
+      schemaContent.indexOf('path: "/v1/runs/stats/costs"') + 1200,
+    );
+    expect(runsStatsSection).toContain("featureDynastySlug");
+    expect(runsStatsSection).toContain("workflowDynastySlug");
+    expect(runsStatsSection).toContain("featureSlug");
+    expect(runsStatsSection).toContain("workflowSlug");
+  });
+});
+
+describe("Dynasty slug params in generated openapi.json", () => {
+  it("should have dynasty query params on /v1/outlets/stats", () => {
+    const params = openapiSpec.paths["/v1/outlets/stats"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    expect(paramNames).toContain("workflowDynastySlug");
+    expect(paramNames).toContain("featureDynastySlug");
+    expect(paramNames).toContain("featureSlug");
+  });
+
+  it("should have dynasty groupBy values on /v1/outlets/stats", () => {
+    const params = openapiSpec.paths["/v1/outlets/stats"]?.get?.parameters ?? [];
+    const groupByParam = params.find((p: { name: string }) => p.name === "groupBy");
+    expect(groupByParam).toBeDefined();
+    expect(groupByParam.schema.enum).toContain("workflowDynastySlug");
+    expect(groupByParam.schema.enum).toContain("featureDynastySlug");
+    expect(groupByParam.schema.enum).toContain("featureSlug");
+  });
+
+  it("should have dynasty query params on /v1/features/stats", () => {
+    const params = openapiSpec.paths["/v1/features/stats"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    expect(paramNames).toContain("workflowDynastySlug");
+    expect(paramNames).toContain("featureDynastySlug");
+    expect(paramNames).toContain("featureSlug");
+    expect(paramNames).toContain("workflowSlug");
+  });
+
+  it("should have dynasty query params on /v1/features/{featureSlug}/stats", () => {
+    const params = openapiSpec.paths["/v1/features/{featureSlug}/stats"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    expect(paramNames).toContain("workflowDynastySlug");
+    expect(paramNames).toContain("featureDynastySlug");
+  });
+
+  it("should have dynasty query params on /v1/runs/stats/costs", () => {
+    const params = openapiSpec.paths["/v1/runs/stats/costs"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    expect(paramNames).toContain("workflowDynastySlug");
+    expect(paramNames).toContain("featureDynastySlug");
+    expect(paramNames).toContain("workflowSlug");
+    expect(paramNames).toContain("featureSlug");
+  });
+});


### PR DESCRIPTION
## Summary
- Forward `workflowDynastySlug`, `featureDynastySlug`, `featureSlug`, `workflowSlug` query params on all stats proxy endpoints (`/features/stats`, `/features/:slug/stats`, `/outlets/stats`, `/runs/stats/costs`)
- Update OpenAPI schemas to document the new filter and groupBy values (including dynasty slugs in groupBy enums)
- Regenerate `openapi.json`

## Test plan
- [x] 14 new unit tests covering dynasty slug forwarding in routes and OpenAPI spec
- [x] All 810 existing tests still pass (1 pre-existing failure in `openapi-response-schemas` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)