### PR TITLE
feat: forward dynasty slug params on all remaining stats endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7410,7 +7410,7 @@
           "Campaigns"
         ],
         "summary": "Get stats for all campaigns (grouped)",
-        "description": "Aggregates stats from email-gateway, lead-service, content-generation, and runs-service using groupBy=campaignId. Returns one entry per campaign. Replaces the old POST /v1/campaigns/stats/batch endpoint.",
+        "description": "Aggregates stats from email-gateway, lead-service, content-generation, and runs-service using groupBy=campaignId. Returns one entry per campaign. Supports filtering by brandId, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug. Replaces the old POST /v1/campaigns/stats/batch endpoint.",
         "security": [
           {
             "bearerAuth": []
@@ -7425,6 +7425,46 @@
             "required": false,
             "description": "Filter by brand ID",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact workflow slug"
+            },
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -13360,7 +13400,7 @@
           "Email Gateway"
         ],
         "summary": "Get email delivery stats",
-        "description": "Get broadcast delivery statistics from email-gateway. Filter by brandId and/or campaignId.",
+        "description": "Get broadcast delivery statistics from email-gateway. Filter by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
         "security": [
           {
             "bearerAuth": []
@@ -13385,6 +13425,46 @@
             "required": false,
             "description": "Filter by campaign ID",
             "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact workflow slug"
+            },
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -17375,7 +17455,7 @@
           "Emails"
         ],
         "summary": "Get email stats",
-        "description": "Get aggregated email sending stats for the org, optionally filtered by eventType.",
+        "description": "Get aggregated email sending stats for the org. Filterable by eventType, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
         "security": [
           {
             "bearerAuth": []
@@ -17390,6 +17470,46 @@
             "required": false,
             "description": "Filter by event type",
             "name": "eventType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact workflow slug"
+            },
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -18549,7 +18669,7 @@
           "Stripe"
         ],
         "summary": "Get Stripe sales stats",
-        "description": "Get aggregated sales stats. Filterable by brandId, campaignId, or runIds via query params.",
+        "description": "Get aggregated sales stats. Filterable by brandId, campaignId, runIds, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
         "security": [
           {
             "bearerAuth": []
@@ -18584,6 +18704,46 @@
             "required": false,
             "description": "Comma-separated run IDs",
             "name": "runIds",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact workflow slug"
+            },
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {

--- a/src/lib/delivery-stats.ts
+++ b/src/lib/delivery-stats.ts
@@ -11,13 +11,14 @@ interface EmailGatewayStats {
 
 /** Fetch delivery stats from email-gateway (aggregates transactional + broadcast). */
 export async function fetchDeliveryStats(
-  filters: { campaignId?: string; brandId?: string },
+  filters: { campaignId?: string; brandId?: string; workflowSlug?: string; featureSlug?: string; workflowDynastySlug?: string; featureDynastySlug?: string },
   req: AuthenticatedRequest,
 ): Promise<Record<string, number> | null> {
   const orgId = req.orgId!;
   const params = new URLSearchParams({ orgId });
-  if (filters.campaignId) params.set("campaignId", filters.campaignId);
-  if (filters.brandId) params.set("brandId", filters.brandId);
+  for (const key of ["campaignId", "brandId", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"] as const) {
+    if (filters[key]) params.set(key, filters[key]!);
+  }
   const deliveryResult = await callExternalService<{ transactional: EmailGatewayStats; broadcast: EmailGatewayStats }>(
     externalServices.emailGateway,
     `/stats?${params}`,

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -177,23 +177,33 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
     const brandId = req.query.brandId as string | undefined;
     const internalHeaders = buildInternalHeaders(req);
 
+    // Dynasty / slug filters forwarded to all downstream stats calls
+    const slugFilters: Record<string, string> = {};
+    for (const key of ["workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"]) {
+      if (req.query[key]) slugFilters[key] = req.query[key] as string;
+    }
+
     // Build shared query params
     const baseParams = new URLSearchParams({ orgId });
     if (brandId) baseParams.set("brandId", brandId);
+    for (const [k, v] of Object.entries(slugFilters)) baseParams.set(k, v);
 
     const deliveryParams = new URLSearchParams(baseParams);
     deliveryParams.set("groupBy", "campaignId");
 
     const leadParams = new URLSearchParams({ orgId });
     if (brandId) leadParams.set("brandId", brandId);
+    for (const [k, v] of Object.entries(slugFilters)) leadParams.set(k, v);
     leadParams.set("groupBy", "campaignId");
 
     const emailgenParams = new URLSearchParams({ orgId });
     if (brandId) emailgenParams.set("brandId", brandId);
+    for (const [k, v] of Object.entries(slugFilters)) emailgenParams.set(k, v);
     emailgenParams.set("groupBy", "campaignId");
 
     const runsParams = new URLSearchParams({ orgId, groupBy: "campaignId" });
     if (brandId) runsParams.set("brandId", brandId);
+    for (const [k, v] of Object.entries(slugFilters)) runsParams.set(k, v);
 
     // 4 parallel calls
     const [deliveryGroups, leadGroups, emailgenGroups, costGroups] = await Promise.all([

--- a/src/routes/email-gateway.ts
+++ b/src/routes/email-gateway.ts
@@ -11,10 +11,12 @@ const router = Router();
  */
 router.get("/email-gateway/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const brandId = req.query.brandId as string | undefined;
-    const campaignId = req.query.campaignId as string | undefined;
+    const filters: Record<string, string | undefined> = {};
+    for (const key of ["brandId", "campaignId", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"]) {
+      if (req.query[key]) filters[key] = req.query[key] as string;
+    }
 
-    const delivery = await fetchDeliveryStats({ brandId, campaignId }, req);
+    const delivery = await fetchDeliveryStats(filters, req);
 
     res.json(delivery ?? {
       emailsContacted: 0,

--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -44,7 +44,9 @@ router.post("/emails/send", authenticate, requireOrg, async (req: AuthenticatedR
 router.get("/emails/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams({ orgId: req.orgId! });
-    if (req.query.eventType) params.set("eventType", req.query.eventType as string);
+    for (const key of ["eventType", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
 
     const result = await callExternalService(
       externalServices.transactionalEmail,

--- a/src/routes/stripe.ts
+++ b/src/routes/stripe.ts
@@ -203,9 +203,9 @@ router.post("/stripe/checkout", authenticate, requireOrg, async (req: Authentica
 router.get("/stripe/stats", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
-    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
-    if (req.query.runIds) params.set("runIds", req.query.runIds as string);
+    for (const key of ["brandId", "campaignId", "runIds", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
 
     const result = await callExternalService(
       externalServices.stripe,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -659,11 +659,16 @@ registry.registerPath({
   description:
     "Aggregates stats from email-gateway, lead-service, content-generation, and runs-service " +
     "using groupBy=campaignId. Returns one entry per campaign. " +
+    "Supports filtering by brandId, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug. " +
     "Replaces the old POST /v1/campaigns/stats/batch endpoint.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().optional().describe("Filter by brand ID"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {
@@ -2612,12 +2617,16 @@ registry.registerPath({
   tags: ["Email Gateway"],
   summary: "Get email delivery stats",
   description:
-    "Get broadcast delivery statistics from email-gateway. Filter by brandId and/or campaignId.",
+    "Get broadcast delivery statistics from email-gateway. Filter by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().optional().describe("Filter by brand ID"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {
@@ -4107,11 +4116,15 @@ registry.registerPath({
   path: "/v1/emails/stats",
   tags: ["Emails"],
   summary: "Get email stats",
-  description: "Get aggregated email sending stats for the org, optionally filtered by eventType.",
+  description: "Get aggregated email sending stats for the org. Filterable by eventType, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
   security: authed,
   request: {
     query: z.object({
       eventType: z.string().optional().describe("Filter by event type"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {
@@ -4497,13 +4510,17 @@ registry.registerPath({
   path: "/v1/stripe/stats",
   tags: ["Stripe"],
   summary: "Get Stripe sales stats",
-  description: "Get aggregated sales stats. Filterable by brandId, campaignId, or runIds via query params.",
+  description: "Get aggregated sales stats. Filterable by brandId, campaignId, runIds, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().optional().describe("Filter by brand ID"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),
       runIds: z.string().optional().describe("Comma-separated run IDs"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {

--- a/tests/unit/dynasty-slug-forwarding.test.ts
+++ b/tests/unit/dynasty-slug-forwarding.test.ts
@@ -5,10 +5,16 @@ import * as path from "path";
 const featuresRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/features.ts"), "utf-8");
 const outletsRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/outlets.ts"), "utf-8");
 const runsRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/runs.ts"), "utf-8");
+const emailGatewayRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/email-gateway.ts"), "utf-8");
+const emailsRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/emails.ts"), "utf-8");
+const stripeRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/stripe.ts"), "utf-8");
+const campaignsRoute = fs.readFileSync(path.join(__dirname, "../../src/routes/campaigns.ts"), "utf-8");
+const deliveryStatsLib = fs.readFileSync(path.join(__dirname, "../../src/lib/delivery-stats.ts"), "utf-8");
 const schemaContent = fs.readFileSync(path.join(__dirname, "../../src/schemas.ts"), "utf-8");
 const openapiSpec = JSON.parse(fs.readFileSync(path.join(__dirname, "../../openapi.json"), "utf-8"));
 
 const dynastyParams = ["workflowDynastySlug", "featureDynastySlug"];
+const allSlugParams = ["workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"];
 
 describe("Dynasty slug forwarding — features/stats", () => {
   it("should forward dynasty slug filters on GET /features/stats", () => {
@@ -50,6 +56,50 @@ describe("Dynasty slug forwarding — runs/stats/costs", () => {
   it("should forward dynasty slug filters on GET /runs/stats/costs", () => {
     for (const param of [...dynastyParams, "workflowSlug", "featureSlug"]) {
       expect(runsRoute).toContain(`"${param}"`);
+    }
+  });
+});
+
+describe("Dynasty slug forwarding — email-gateway/stats", () => {
+  it("should forward dynasty slug filters on GET /email-gateway/stats", () => {
+    for (const param of allSlugParams) {
+      expect(emailGatewayRoute).toContain(`"${param}"`);
+    }
+  });
+
+  it("should accept dynasty slug filters in fetchDeliveryStats", () => {
+    for (const param of allSlugParams) {
+      expect(deliveryStatsLib).toContain(param);
+    }
+  });
+});
+
+describe("Dynasty slug forwarding — emails/stats", () => {
+  it("should forward dynasty slug filters on GET /emails/stats", () => {
+    const statsSection = emailsRoute.slice(emailsRoute.indexOf('"/emails/stats"'));
+    for (const param of allSlugParams) {
+      expect(statsSection).toContain(`"${param}"`);
+    }
+  });
+});
+
+describe("Dynasty slug forwarding — stripe/stats", () => {
+  it("should forward dynasty slug filters on GET /stripe/stats", () => {
+    const statsSection = stripeRoute.slice(stripeRoute.indexOf('"/stripe/stats"'));
+    for (const param of allSlugParams) {
+      expect(statsSection).toContain(`"${param}"`);
+    }
+  });
+});
+
+describe("Dynasty slug forwarding — campaigns/stats", () => {
+  it("should forward dynasty slug filters on GET /campaigns/stats downstream calls", () => {
+    const statsSection = campaignsRoute.slice(
+      campaignsRoute.indexOf('"/campaigns/stats"'),
+      campaignsRoute.indexOf('"/campaigns/:id"'),
+    );
+    for (const param of allSlugParams) {
+      expect(statsSection).toContain(`"${param}"`);
     }
   });
 });
@@ -98,6 +148,46 @@ describe("Dynasty slug OpenAPI schemas", () => {
     expect(runsStatsSection).toContain("featureSlug");
     expect(runsStatsSection).toContain("workflowSlug");
   });
+
+  it("should include dynasty slug filters in /v1/email-gateway/stats query schema", () => {
+    const section = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/email-gateway/stats"'),
+      schemaContent.indexOf('path: "/v1/email-gateway/stats"') + 1200,
+    );
+    for (const param of allSlugParams) {
+      expect(section).toContain(param);
+    }
+  });
+
+  it("should include dynasty slug filters in /v1/emails/stats query schema", () => {
+    const section = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/emails/stats"'),
+      schemaContent.indexOf('path: "/v1/emails/stats"') + 1200,
+    );
+    for (const param of allSlugParams) {
+      expect(section).toContain(param);
+    }
+  });
+
+  it("should include dynasty slug filters in /v1/stripe/stats query schema", () => {
+    const section = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/stripe/stats"'),
+      schemaContent.indexOf('path: "/v1/stripe/stats"') + 1200,
+    );
+    for (const param of allSlugParams) {
+      expect(section).toContain(param);
+    }
+  });
+
+  it("should include dynasty slug filters in /v1/campaigns/stats query schema", () => {
+    const section = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/campaigns/stats"'),
+      schemaContent.indexOf('path: "/v1/campaigns/stats"') + 1500,
+    );
+    for (const param of allSlugParams) {
+      expect(section).toContain(param);
+    }
+  });
 });
 
 describe("Dynasty slug params in generated openapi.json", () => {
@@ -141,5 +231,37 @@ describe("Dynasty slug params in generated openapi.json", () => {
     expect(paramNames).toContain("featureDynastySlug");
     expect(paramNames).toContain("workflowSlug");
     expect(paramNames).toContain("featureSlug");
+  });
+
+  it("should have dynasty query params on /v1/email-gateway/stats", () => {
+    const params = openapiSpec.paths["/v1/email-gateway/stats"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    for (const param of allSlugParams) {
+      expect(paramNames).toContain(param);
+    }
+  });
+
+  it("should have dynasty query params on /v1/emails/stats", () => {
+    const params = openapiSpec.paths["/v1/emails/stats"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    for (const param of allSlugParams) {
+      expect(paramNames).toContain(param);
+    }
+  });
+
+  it("should have dynasty query params on /v1/stripe/stats", () => {
+    const params = openapiSpec.paths["/v1/stripe/stats"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    for (const param of allSlugParams) {
+      expect(paramNames).toContain(param);
+    }
+  });
+
+  it("should have dynasty query params on /v1/campaigns/stats", () => {
+    const params = openapiSpec.paths["/v1/campaigns/stats"]?.get?.parameters ?? [];
+    const paramNames = params.map((p: { name: string }) => p.name);
+    for (const param of allSlugParams) {
+      expect(paramNames).toContain(param);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Forwards `workflowSlug`, `featureSlug`, `workflowDynastySlug`, `featureDynastySlug` query params on 4 stats proxy endpoints that were missing them: `email-gateway/stats`, `emails/stats`, `stripe/stats`, and `campaigns/stats` (downstream calls)
- Updates `fetchDeliveryStats` helper to accept and forward the new filter params
- Adds corresponding Zod query schemas for OpenAPI and regenerates `openapi.json`
- Extends `dynasty-slug-forwarding.test.ts` from 16 → 27 tests covering all stats endpoints

## Endpoints updated
| Endpoint | New params forwarded |
|----------|---------------------|
| `GET /v1/email-gateway/stats` | workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug |
| `GET /v1/emails/stats` | workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug |
| `GET /v1/stripe/stats` | workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug |
| `GET /v1/campaigns/stats` | workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug (on all 4 downstream service calls) |

## Test plan
- [x] All 27 dynasty-slug-forwarding tests pass
- [x] Full test suite: 837/838 pass (1 pre-existing failure in openapi-response-schemas unrelated)
- [x] TypeScript compiles clean
- [x] openapi.json regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)