### PR TITLE
feat: add dynasty fields to GET /v1/workflows schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -140,6 +140,10 @@
             "type": "string",
             "description": "Workflow ID"
           },
+          "slug": {
+            "type": "string",
+            "description": "Unique technical identifier. Use this to execute via /workflows/by-slug/{slug}/execute"
+          },
           "name": {
             "type": "string",
             "description": "Workflow name"
@@ -148,6 +152,18 @@
             "type": "string",
             "nullable": true,
             "description": "Stable display name for the workflow family"
+          },
+          "dynastyName": {
+            "type": "string",
+            "description": "Stable name for the lineage. Constant across all versions of a dynasty"
+          },
+          "dynastySlug": {
+            "type": "string",
+            "description": "Stable slug for the lineage. Use as key for dynasty-level lookups and stats grouping"
+          },
+          "version": {
+            "type": "integer",
+            "description": "Version number within the dynasty. Starts at 1"
           },
           "createdForBrandId": {
             "type": "string",
@@ -181,8 +197,12 @@
         },
         "required": [
           "id",
+          "slug",
           "name",
           "displayName",
+          "dynastyName",
+          "dynastySlug",
+          "version",
           "createdForBrandId",
           "featureSlug",
           "signature",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -162,8 +162,12 @@ const WorkflowEmailStatsSchema = z
 const WorkflowMetadataSchema = z
   .object({
     id: z.string().describe("Workflow ID"),
+    slug: z.string().describe("Unique technical identifier. Use this to execute via /workflows/by-slug/{slug}/execute"),
     name: z.string().describe("Workflow name"),
     displayName: z.string().nullable().describe("Stable display name for the workflow family"),
+    dynastyName: z.string().describe("Stable name for the lineage. Constant across all versions of a dynasty"),
+    dynastySlug: z.string().describe("Stable slug for the lineage. Use as key for dynasty-level lookups and stats grouping"),
+    version: z.number().int().describe("Version number within the dynasty. Starts at 1"),
     createdForBrandId: z.string().nullable().describe("Brand ID that created this workflow"),
     category: z.string().optional().describe("Workflow category (e.g. 'sales', 'pr')"),
     channel: z.string().optional().describe("Communication channel (e.g. 'email')"),

--- a/tests/unit/workflow-enrichment.test.ts
+++ b/tests/unit/workflow-enrichment.test.ts
@@ -86,6 +86,44 @@ describe("GET /v1/workflows — enrichment with requiredProviders", () => {
     expect(res.body.workflows[1].requiredProviders).toEqual([{ name: "apollo", domain: "apollo.io" }, { name: "anthropic", domain: "anthropic.com" }]);
   });
 
+  it("should pass through dynastySlug, dynastyName, version, and slug from workflow-service", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/required-providers")) {
+        return { ok: true, json: () => Promise.resolve({ providers: [] }) };
+      }
+      if (url.includes("/workflows")) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              workflows: [
+                {
+                  id: "wf-1",
+                  name: "cold-outreach-v3",
+                  slug: "cold-outreach-hormozi-v3",
+                  dynastyName: "Cold Outreach Hormozi",
+                  dynastySlug: "cold-outreach-hormozi",
+                  version: 3,
+                  category: "sales",
+                },
+              ],
+            }),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    app = createApp();
+    const res = await request(app).get("/v1/workflows");
+
+    expect(res.status).toBe(200);
+    const wf = res.body.workflows[0];
+    expect(wf.dynastySlug).toBe("cold-outreach-hormozi");
+    expect(wf.dynastyName).toBe("Cold Outreach Hormozi");
+    expect(wf.version).toBe(3);
+    expect(wf.slug).toBe("cold-outreach-hormozi-v3");
+  });
+
   it("should call required-providers for each workflow", async () => {
     await request(app).get("/v1/workflows");
 


### PR DESCRIPTION
## Summary
- Adds `dynastySlug`, `dynastyName`, `version`, and `slug` to the `WorkflowMetadata` Zod schema
- These fields were already returned by the proxy at runtime (pass-through from workflow-service) but missing from the OpenAPI spec, making them invisible to clients relying on the spec
- Regenerated `openapi.json` to include the new fields
- Unblocks the dashboard team's migration to dynasty-level stats grouping

## Test plan
- [x] Added test: verifies `dynastySlug`, `dynastyName`, `version`, `slug` are passed through in GET /v1/workflows response
- [x] All 15 existing workflow enrichment tests pass
- [x] TypeScript type-check passes
- [x] OpenAPI spec regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)