### PR TITLE
fix: drop workflowDynastySlug from features stats proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -22166,7 +22166,7 @@
           "Features"
         ],
         "summary": "Global stats cross-features",
-        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId — comma-separated combos allowed) and optional filters. Requires x-org-id. Proxied from features-service.",
+        "description": "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, featureDynastySlug, brandId, campaignId — comma-separated combos allowed) and optional filters. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -22176,10 +22176,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId"
+              "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, brandId, campaignId"
             },
             "required": false,
-            "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId",
+            "description": "Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, brandId, campaignId",
             "name": "groupBy",
             "in": "query"
           },
@@ -22221,16 +22221,6 @@
             "required": false,
             "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
             "name": "featureDynastySlug",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
-            },
-            "required": false,
-            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
-            "name": "workflowDynastySlug",
             "in": "query"
           },
           {
@@ -22328,7 +22318,7 @@
           "Features"
         ],
         "summary": "Feature stats",
-        "description": "Stats for a specific feature, groupable by workflowSlug, workflowDynastySlug, brandId, or campaignId. Supports optional filters including dynasty slugs. Requires x-org-id. Proxied from features-service.",
+        "description": "Stats for a specific feature, groupable by workflowSlug, brandId, or campaignId. Supports optional filters including featureDynastySlug. Requires x-org-id. Proxied from features-service.",
         "security": [
           {
             "bearerAuth": []
@@ -22348,10 +22338,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId"
+              "description": "Group dimension: workflowSlug | brandId | campaignId"
             },
             "required": false,
-            "description": "Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId",
+            "description": "Group dimension: workflowSlug | brandId | campaignId",
             "name": "groupBy",
             "in": "query"
           },
@@ -22393,16 +22383,6 @@
             "required": false,
             "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
             "name": "featureDynastySlug",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)"
-            },
-            "required": false,
-            "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
-            "name": "workflowDynastySlug",
             "in": "query"
           },
           {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -53,7 +53,7 @@ router.get("/features/stats/registry", authenticate, requireOrg, requireUser, as
 router.get("/features/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["groupBy", "brandId", "featureSlug", "workflowSlug", "featureDynastySlug", "workflowDynastySlug"]) {
+    for (const key of ["groupBy", "brandId", "featureSlug", "workflowSlug", "featureDynastySlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";
@@ -134,7 +134,7 @@ router.get("/features/:slug/inputs", authenticate, requireOrg, requireUser, asyn
 router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["groupBy", "brandId", "campaignId", "workflowSlug", "featureDynastySlug", "workflowDynastySlug"]) {
+    for (const key of ["groupBy", "brandId", "campaignId", "workflowSlug", "featureDynastySlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5251,16 +5251,15 @@ registry.registerPath({
   tags: ["Features"],
   summary: "Global stats cross-features",
   description:
-    "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId — comma-separated combos allowed) and optional filters. Requires x-org-id. Proxied from features-service.",
+    "Aggregated stats across all features. Supports groupBy (featureSlug, workflowSlug, featureDynastySlug, brandId, campaignId — comma-separated combos allowed) and optional filters. Requires x-org-id. Proxied from features-service.",
   security: authed,
   request: {
     query: z.object({
-      groupBy: z.string().optional().describe("Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, brandId, campaignId"),
+      groupBy: z.string().optional().describe("Group dimension(s), comma-separated: featureSlug, workflowSlug, featureDynastySlug, brandId, campaignId"),
       brandId: z.string().optional().describe("Filter by brand UUID"),
       featureSlug: z.string().optional().describe("Filter by exact feature slug"),
       workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
       featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
-      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {
@@ -5276,17 +5275,16 @@ registry.registerPath({
   tags: ["Features"],
   summary: "Feature stats",
   description:
-    "Stats for a specific feature, groupable by workflowSlug, workflowDynastySlug, brandId, or campaignId. Supports optional filters including dynasty slugs. Requires x-org-id. Proxied from features-service.",
+    "Stats for a specific feature, groupable by workflowSlug, brandId, or campaignId. Supports optional filters including featureDynastySlug. Requires x-org-id. Proxied from features-service.",
   security: authed,
   request: {
     params: z.object({ featureSlug: z.string().describe("Feature slug") }),
     query: z.object({
-      groupBy: z.string().optional().describe("Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId"),
+      groupBy: z.string().optional().describe("Group dimension: workflowSlug | brandId | campaignId"),
       brandId: z.string().optional().describe("Filter by brand UUID"),
       campaignId: z.string().optional().describe("Filter by campaign UUID"),
       workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
       featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
-      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {

--- a/tests/unit/dynasty-slug-forwarding.test.ts
+++ b/tests/unit/dynasty-slug-forwarding.test.ts
@@ -17,26 +17,24 @@ const dynastyParams = ["workflowDynastySlug", "featureDynastySlug"];
 const allSlugParams = ["workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"];
 
 describe("Dynasty slug forwarding — features/stats", () => {
-  it("should forward dynasty slug filters on GET /features/stats", () => {
+  it("should forward featureDynastySlug but NOT workflowDynastySlug on GET /features/stats", () => {
     const statsSection = featuresRoute.slice(
       featuresRoute.indexOf('"/features/stats"'),
       featuresRoute.indexOf('"/features/dynasty"'),
     );
-    for (const param of dynastyParams) {
-      expect(statsSection).toContain(`"${param}"`);
-    }
+    expect(statsSection).toContain('"featureDynastySlug"');
+    expect(statsSection).not.toContain('"workflowDynastySlug"');
     // Also forwards featureSlug + workflowSlug filters
     expect(statsSection).toContain('"featureSlug"');
     expect(statsSection).toContain('"workflowSlug"');
   });
 
-  it("should forward dynasty slug filters on GET /features/:slug/stats", () => {
+  it("should forward featureDynastySlug but NOT workflowDynastySlug on GET /features/:slug/stats", () => {
     const slugStatsSection = featuresRoute.slice(
       featuresRoute.indexOf('"/features/:slug/stats"'),
     );
-    for (const param of dynastyParams) {
-      expect(slugStatsSection).toContain(`"${param}"`);
-    }
+    expect(slugStatsSection).toContain('"featureDynastySlug"');
+    expect(slugStatsSection).not.toContain('"workflowDynastySlug"');
   });
 });
 
@@ -120,22 +118,22 @@ describe("Dynasty slug OpenAPI schemas", () => {
     expect(outletsStatsSection).toContain('"featureDynastySlug"');
   });
 
-  it("should include dynasty slug filters in /v1/features/stats query schema", () => {
+  it("should include featureDynastySlug but NOT workflowDynastySlug in /v1/features/stats query schema", () => {
     const featuresStatsSection = schemaContent.slice(
       schemaContent.indexOf('path: "/v1/features/stats"'),
       schemaContent.indexOf('path: "/v1/features/stats"') + 1200,
     );
     expect(featuresStatsSection).toContain("featureDynastySlug");
-    expect(featuresStatsSection).toContain("workflowDynastySlug");
+    expect(featuresStatsSection).not.toContain("workflowDynastySlug");
     expect(featuresStatsSection).toContain("featureSlug");
     expect(featuresStatsSection).toContain("workflowSlug");
   });
 
-  it("should include dynasty slug filters in /v1/features/{featureSlug}/stats query schema", () => {
+  it("should include featureDynastySlug but NOT workflowDynastySlug in /v1/features/{featureSlug}/stats query schema", () => {
     const start = schemaContent.indexOf('path: "/v1/features/{featureSlug}/stats"');
     const featureSlugStatsSection = schemaContent.slice(start, start + 1200);
     expect(featureSlugStatsSection).toContain("featureDynastySlug");
-    expect(featureSlugStatsSection).toContain("workflowDynastySlug");
+    expect(featureSlugStatsSection).not.toContain("workflowDynastySlug");
   });
 
   it("should include dynasty slug filters in /v1/runs/stats/costs query schema", () => {
@@ -208,20 +206,20 @@ describe("Dynasty slug params in generated openapi.json", () => {
     expect(groupByParam.schema.enum).toContain("featureSlug");
   });
 
-  it("should have dynasty query params on /v1/features/stats", () => {
+  it("should have featureDynastySlug but NOT workflowDynastySlug on /v1/features/stats", () => {
     const params = openapiSpec.paths["/v1/features/stats"]?.get?.parameters ?? [];
     const paramNames = params.map((p: { name: string }) => p.name);
-    expect(paramNames).toContain("workflowDynastySlug");
     expect(paramNames).toContain("featureDynastySlug");
+    expect(paramNames).not.toContain("workflowDynastySlug");
     expect(paramNames).toContain("featureSlug");
     expect(paramNames).toContain("workflowSlug");
   });
 
-  it("should have dynasty query params on /v1/features/{featureSlug}/stats", () => {
+  it("should have featureDynastySlug but NOT workflowDynastySlug on /v1/features/{featureSlug}/stats", () => {
     const params = openapiSpec.paths["/v1/features/{featureSlug}/stats"]?.get?.parameters ?? [];
     const paramNames = params.map((p: { name: string }) => p.name);
-    expect(paramNames).toContain("workflowDynastySlug");
     expect(paramNames).toContain("featureDynastySlug");
+    expect(paramNames).not.toContain("workflowDynastySlug");
   });
 
   it("should have dynasty query params on /v1/runs/stats/costs", () => {


### PR DESCRIPTION
## Summary
- Removes `workflowDynastySlug` from the two features-service stats proxy endpoints (`GET /v1/features/stats` and `GET /v1/features/:slug/stats`)
- Aligns with features-service PR #49 which removed this param since features-service doesn't own workflow data
- Updates Zod schemas, regenerates `openapi.json`, updates tests to assert the param is NOT forwarded

## What changed
| Endpoint | `workflowDynastySlug` | `featureDynastySlug` |
|----------|:---:|:---:|
| `GET /v1/features/stats` | removed | kept |
| `GET /v1/features/:slug/stats` | removed | kept |

## Test plan
- [x] 27 dynasty-slug-forwarding tests pass (including negative assertions)
- [x] Full suite: 838/839 pass (1 pre-existing)
- [x] TypeScript clean
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)