### PR TITLE
feat: add brand_id to media-kits and journalists proxies

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1946,6 +1946,11 @@
             "type": "string",
             "format": "uuid"
           },
+          "brandId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Brand ID — alternative to x-campaign-id header. Returns journalists across all campaigns for this brand."
+          },
           "featureInputs": {
             "type": "object",
             "additionalProperties": {
@@ -9292,8 +9297,8 @@
         "tags": [
           "Journalists"
         ],
-        "summary": "Resolve journalists for a campaign+outlet",
-        "description": "Discovers journalists if needed, scores them, and returns results sorted by relevance.",
+        "summary": "Resolve journalists for a campaign+outlet or brand+outlet",
+        "description": "Discovers journalists if needed, scores them, and returns results sorted by relevance. At least one of x-campaign-id header or brandId in body is required.",
         "security": [
           {
             "bearerAuth": []
@@ -19386,7 +19391,7 @@
           "Press Kits"
         ],
         "summary": "List media kits",
-        "description": "List media kits, optionally filtered by org_id, organization_id, campaign_id, or title.",
+        "description": "List media kits, optionally filtered by org_id, organization_id, campaign_id, brand_id, or title.",
         "security": [
           {
             "bearerAuth": []
@@ -19421,6 +19426,16 @@
             "required": false,
             "description": "Filter by campaign ID — returns media kit(s) linked to this campaign",
             "name": "campaign_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand ID — returns media kit(s) linked to this brand"
+            },
+            "required": false,
+            "description": "Filter by brand ID — returns media kit(s) linked to this brand",
+            "name": "brand_id",
             "in": "query"
           },
           {

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -33,24 +33,24 @@ router.post("/journalists/discover-emails", authenticate, requireOrg, requireUse
   }
 });
 
-// ── POST /v1/journalists/resolve — resolve journalists for campaign+outlet ──
+// ── POST /v1/journalists/resolve — resolve journalists for campaign+outlet or brand+outlet ──
 // Translates the POST body into a GET /campaign-outlet-journalists query on journalist-service
 router.post("/journalists/resolve", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const { outletId } = req.body as { outletId?: string };
+    const { outletId, brandId } = req.body as { outletId?: string; brandId?: string };
     const campaignId = req.campaignId;
 
-    if (!campaignId) {
-      return res.status(400).json({ error: "Missing x-campaign-id header (required for journalist resolution)" });
+    if (!campaignId && !brandId) {
+      return res.status(400).json({ error: "Either x-campaign-id header or brandId in request body is required" });
     }
     if (!outletId) {
       return res.status(400).json({ error: "Missing outletId in request body" });
     }
 
-    const params = new URLSearchParams({
-      campaign_id: campaignId,
-      outlet_id: outletId,
-    });
+    const params = new URLSearchParams();
+    if (campaignId) params.set("campaign_id", campaignId);
+    if (brandId) params.set("brand_id", brandId);
+    params.set("outlet_id", outletId);
 
     const result = await callExternalService<{
       campaignJournalists: Array<Record<string, unknown>>;

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -29,6 +29,7 @@ router.get("/press-kits/media-kits", authenticate, requireOrg, async (req: Authe
     if (req.query.org_id) params.set("org_id", req.query.org_id as string);
     if (req.query.organization_id) params.set("organization_id", req.query.organization_id as string);
     if (req.query.campaign_id) params.set("campaign_id", req.query.campaign_id as string);
+    if (req.query.brand_id) params.set("brand_id", req.query.brand_id as string);
     if (req.query.title) params.set("title", req.query.title as string);
     const qs = params.toString() ? `?${params.toString()}` : "";
     const result = await callExternalService(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1269,8 +1269,8 @@ registry.registerPath({
   method: "post",
   path: "/v1/journalists/resolve",
   tags: ["Journalists"],
-  summary: "Resolve journalists for a campaign+outlet",
-  description: "Discovers journalists if needed, scores them, and returns results sorted by relevance.",
+  summary: "Resolve journalists for a campaign+outlet or brand+outlet",
+  description: "Discovers journalists if needed, scores them, and returns results sorted by relevance. At least one of x-campaign-id header or brandId in body is required.",
   security: authed,
   request: {
     body: {
@@ -1279,6 +1279,7 @@ registry.registerPath({
           schema: z
             .object({
               outletId: z.string().uuid(),
+              brandId: z.string().uuid().optional().describe("Brand ID — alternative to x-campaign-id header. Returns journalists across all campaigns for this brand."),
               featureInputs: z.record(z.string()).optional().default({}),
               maxArticles: z.number().int().min(1).max(30).optional().default(15),
             })
@@ -4781,13 +4782,14 @@ registry.registerPath({
   path: "/v1/press-kits/media-kits",
   tags: ["Press Kits"],
   summary: "List media kits",
-  description: "List media kits, optionally filtered by org_id, organization_id, campaign_id, or title.",
+  description: "List media kits, optionally filtered by org_id, organization_id, campaign_id, brand_id, or title.",
   security: authed,
   request: {
     query: z.object({
       org_id: z.string().optional().describe("Filter by org ID"),
       organization_id: z.string().optional().describe("Filter by organization ID (alias for org_id)"),
       campaign_id: z.string().optional().describe("Filter by campaign ID — returns media kit(s) linked to this campaign"),
+      brand_id: z.string().optional().describe("Filter by brand ID — returns media kit(s) linked to this brand"),
       title: z.string().optional().describe("Filter by title"),
     }),
   },

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -67,9 +67,10 @@ describe("Journalists proxy routes", () => {
     expect(content).toContain("outlet_id");
   });
 
-  it("should require x-campaign-id header for resolve endpoint", () => {
+  it("should require x-campaign-id header or brandId for resolve endpoint", () => {
     expect(content).toContain("req.campaignId");
-    expect(content).toContain("Missing x-campaign-id header");
+    expect(content).toContain("brandId");
+    expect(content).toContain("Either x-campaign-id header or brandId in request body is required");
   });
 
   it("should enforce requireOrg + requireUser on ALL journalist routes", () => {


### PR DESCRIPTION
## Summary
- `GET /v1/press-kits/media-kits`: forward new `brand_id` query param (press-kits-service PR #23)
- `POST /v1/journalists/resolve`: accept `brandId` in body as alternative to `x-campaign-id` header (journalists-service PR #25) — at least one is required
- Zod schemas + openapi.json updated

## Test plan
- [x] journalists-proxy tests updated and passing (19/19)
- [x] Full suite: 838/839 pass (1 pre-existing failure on outlets openapi schemas)
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)