### PR TITLE
feat: add GET /v1/journalists?brandId proxy route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1686,6 +1686,77 @@
           "status"
         ]
       },
+      "ListJournalistsResponse": {
+        "type": "object",
+        "properties": {
+          "campaignJournalists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "journalistId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "journalistName": {
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string"
+                },
+                "lastName": {
+                  "type": "string"
+                },
+                "entityType": {
+                  "type": "string",
+                  "enum": [
+                    "individual",
+                    "organization"
+                  ]
+                },
+                "relevanceScore": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "whyRelevant": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "whyNotRelevant": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "articleUrls": {
+                  "type": "array",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "journalistId",
+                "journalistName",
+                "firstName",
+                "lastName",
+                "entityType",
+                "relevanceScore",
+                "whyRelevant",
+                "whyNotRelevant",
+                "articleUrls"
+              ]
+            }
+          }
+        },
+        "required": [
+          "campaignJournalists"
+        ]
+      },
       "DiscoverJournalistsResponse": {
         "type": "object",
         "properties": {
@@ -9050,6 +9121,119 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/journalists": {
+      "get": {
+        "tags": [
+          "Journalists"
+        ],
+        "summary": "List journalists by brand",
+        "description": "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID to filter journalists by"
+            },
+            "required": true,
+            "description": "Brand ID to filter journalists by",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of journalists for the brand",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListJournalistsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing brandId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -5,6 +5,28 @@ import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
 
+// ── GET /v1/journalists — list journalists by brand ─────────────────────────
+router.get("/journalists", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId } = req.query as { brandId?: string };
+    if (!brandId) {
+      return res.status(400).json({ error: "Missing required query parameter: brandId" });
+    }
+
+    const params = new URLSearchParams();
+    params.set("brand_id", brandId);
+
+    const result = await callExternalService(
+      externalServices.journalist,
+      `/campaign-outlet-journalists?${params}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list journalists" });
+  }
+});
+
 // ── POST /v1/journalists/discover — discover journalists for brand+outlet ───
 router.post("/journalists/discover", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1158,6 +1158,50 @@ registry.registerPath({
 // ===================================================================
 
 registry.registerPath({
+  method: "get",
+  path: "/v1/journalists",
+  tags: ["Journalists"],
+  summary: "List journalists by brand",
+  description: "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().describe("Brand ID to filter journalists by"),
+    }).openapi("ListJournalistsQuery"),
+  },
+  responses: {
+    200: {
+      description: "List of journalists for the brand",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              campaignJournalists: z.array(
+                z.object({
+                  id: z.string().uuid(),
+                  journalistId: z.string().uuid(),
+                  journalistName: z.string(),
+                  firstName: z.string(),
+                  lastName: z.string(),
+                  entityType: z.enum(["individual", "organization"]),
+                  relevanceScore: z.number().nullable(),
+                  whyRelevant: z.string().nullable(),
+                  whyNotRelevant: z.string().nullable(),
+                  articleUrls: z.array(z.string()).nullable(),
+                }).passthrough(),
+              ),
+            })
+            .passthrough()
+            .openapi("ListJournalistsResponse"),
+        },
+      },
+    },
+    400: { description: "Missing brandId", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "post",
   path: "/v1/journalists/discover",
   tags: ["Journalists"],

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -15,6 +15,25 @@ const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts"
 const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
 
 describe("Journalists proxy routes", () => {
+  it("should have GET /journalists with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/journalists"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should proxy GET /journalists to /campaign-outlet-journalists with brand_id", () => {
+    // The route should forward brandId as brand_id query param to journalist-service
+    expect(content).toContain('params.set("brand_id", brandId)');
+  });
+
+  it("should require brandId query parameter on GET /journalists", () => {
+    expect(content).toContain("Missing required query parameter: brandId");
+  });
+
   it("should have POST /journalists/discover with auth + requireOrg + requireUser", () => {
     const line = content.split("\n").find((l) =>
       l.includes("router.post") && l.includes('"/journalists/discover"') && !l.includes("emails")
@@ -48,7 +67,7 @@ describe("Journalists proxy routes", () => {
   it("should use buildInternalHeaders for all endpoints", () => {
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(3);
+    expect(headerMatches!.length).toBe(4);
   });
 
   it("should proxy to externalServices.journalist", () => {
@@ -95,6 +114,12 @@ describe("Journalists service client", () => {
 });
 
 describe("Journalists OpenAPI schemas", () => {
+  it("should register GET /v1/journalists", () => {
+    expect(schemaContent).toContain('path: "/v1/journalists"');
+    expect(schemaContent).toContain("ListJournalistsQuery");
+    expect(schemaContent).toContain("ListJournalistsResponse");
+  });
+
   it("should register POST /v1/journalists/discover", () => {
     expect(schemaContent).toContain('path: "/v1/journalists/discover"');
     expect(schemaContent).toContain("DiscoverJournalistsRequest");


### PR DESCRIPTION
## Summary
- Adds `GET /v1/journalists?brandId={brandId}` route that proxies to `GET /campaign-outlet-journalists?brand_id={brandId}` on journalists-service
- Includes OpenAPI schema registration (`ListJournalistsQuery`, `ListJournalistsResponse`)
- Regenerated `openapi.json`
- Added unit tests (23 passing)

## Context
The dashboard needs to list journalists at the brand level. journalists-service already supports `brand_id` filtering on `GET /campaign-outlet-journalists` (PR #235), but api-service had no route exposing it. This unblocks the Journalists tool in the brand dashboard.

## Test plan
- [x] Unit tests pass (`tests/unit/journalists-proxy.test.ts` — 23 tests)
- [ ] Verify `GET /v1/journalists?brandId=xxx` returns journalist data from journalists-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)