### PR TITLE
feat: add media kit stats/views proxy route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5808,6 +5808,10 @@
         "type": "object",
         "properties": {}
       },
+      "PressKitMediaKitStatsViewsResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "ContentComposeResponse": {
         "type": "object",
         "properties": {
@@ -20962,6 +20966,163 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/press-kits/media-kits/stats/views": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Get media kit view stats",
+        "description": "Returns view statistics for media kits. Supports filtering by brandId, campaignId, mediaKitId, date range (from/to), and grouping by country, mediaKitId, or day.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand ID"
+            },
+            "required": false,
+            "description": "Filter by brand ID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign ID"
+            },
+            "required": false,
+            "description": "Filter by campaign ID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by media kit ID"
+            },
+            "required": false,
+            "description": "Filter by media kit ID",
+            "name": "mediaKitId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Start date (ISO 8601)"
+            },
+            "required": false,
+            "description": "Start date (ISO 8601)",
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "End date (ISO 8601)"
+            },
+            "required": false,
+            "description": "End date (ISO 8601)",
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "country",
+                "mediaKitId",
+                "day"
+              ],
+              "description": "Group results by country, mediaKitId, or day"
+            },
+            "required": false,
+            "description": "Group results by country, mediaKitId, or day",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "View statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitMediaKitStatsViewsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/content/compose": {

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -127,6 +127,27 @@ router.post("/press-kits/media-kits/:id/cancel", authenticate, requireOrg, async
   }
 });
 
+// ── Stats routes (authenticated) ─────────────────────────────────────────────
+
+// GET /v1/press-kits/media-kits/stats/views — media kit view stats
+router.get("/press-kits/media-kits/stats/views", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "campaignId", "mediaKitId", "from", "to", "groupBy"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/media-kits/stats/views${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get media kit stats" });
+  }
+});
+
 // ── Admin routes (authenticated) ─────────────────────────────────────────────
 
 // GET /v1/press-kits/admin/media-kits — list media kits (admin)

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5024,6 +5024,31 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/media-kits/stats/views",
+  tags: ["Press Kits"],
+  summary: "Get media kit view stats",
+  description:
+    "Returns view statistics for media kits. Supports filtering by brandId, campaignId, mediaKitId, " +
+    "date range (from/to), and grouping by country, mediaKitId, or day.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().optional().describe("Filter by brand ID"),
+      campaignId: z.string().optional().describe("Filter by campaign ID"),
+      mediaKitId: z.string().optional().describe("Filter by media kit ID"),
+      from: z.string().optional().describe("Start date (ISO 8601)"),
+      to: z.string().optional().describe("End date (ISO 8601)"),
+      groupBy: z.enum(["country", "mediaKitId", "day"]).optional().describe("Group results by country, mediaKitId, or day"),
+    }),
+  },
+  responses: {
+    200: { description: "View statistics", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitMediaKitStatsViewsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
 // Content – Compose (proxy to content-generation-service)
 // ---------------------------------------------------------------------------
 export const ContentComposeRequestSchema = z

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -88,6 +88,18 @@ describe("Press Kits proxy routes", () => {
     expect(content).toContain('"/press-kits/media-kits/:id/cancel"');
   });
 
+  // ── Stats endpoints ────────────────────────────────────────────────────
+
+  it("should have GET /press-kits/media-kits/stats/views with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits/stats/views"');
+  });
+
+  it("should forward stats query params (brandId, campaignId, mediaKitId, from, to, groupBy)", () => {
+    for (const key of ["brandId", "campaignId", "mediaKitId", "from", "to", "groupBy"]) {
+      expect(content).toContain(`"${key}"`);
+    }
+  });
+
   // ── Admin endpoints ───────────────────────────────────────────────────
 
   it("should have GET /press-kits/admin/media-kits with auth", () => {
@@ -139,15 +151,15 @@ describe("Press Kits proxy routes", () => {
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    // 13 authenticated routes + 1 import = 14
-    expect(authMatches!.length).toBe(14);
+    // 14 authenticated routes + 1 import = 15
+    expect(authMatches!.length).toBe(15);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(13);
+    expect(headerMatches!.length).toBe(14);
   });
 
   it("should proxy to externalServices.pressKits", () => {
@@ -222,6 +234,10 @@ describe("Press Kits OpenAPI schemas", () => {
     expect(mdxMatch).not.toBeNull();
     const statusMatch = schemaContent.match(/method: "patch",\s*\n\s*path: "\/v1\/press-kits\/media-kits\/{id}\/status"/);
     expect(statusMatch).not.toBeNull();
+  });
+
+  it("should register stats paths", () => {
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/stats/views"');
   });
 
   it("should register admin paths", () => {


### PR DESCRIPTION
## Summary
- Adds `GET /v1/press-kits/media-kits/stats/views` proxy route to press-kits-service (PR #25 merged)
- Forwards query params: `brandId`, `campaignId`, `mediaKitId`, `from`, `to`, `groupBy`
- OpenAPI spec and tests updated

## Test plan
- [x] Unit tests pass (49 tests)
- [x] `openapi.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)