### PR TITLE
feat: add key, allowedTools, configKey to chat schemas

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4362,9 +4362,20 @@
             "type": "string",
             "description": "Organization ID"
           },
+          "key": {
+            "type": "string",
+            "description": "Config key"
+          },
           "systemPrompt": {
             "type": "string",
             "description": "The registered system prompt"
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Allowed MCP tool names"
           },
           "createdAt": {
             "type": "string",
@@ -4377,7 +4388,9 @@
         },
         "required": [
           "orgId",
+          "key",
           "systemPrompt",
+          "allowedTools",
           "createdAt",
           "updatedAt"
         ]
@@ -4385,14 +4398,29 @@
       "ChatConfigRequest": {
         "type": "object",
         "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Config key identifying this configuration (e.g. \"workflow\", \"feature\")"
+          },
           "systemPrompt": {
             "type": "string",
             "minLength": 1,
             "description": "System prompt for the AI assistant"
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "List of MCP tool names this config is allowed to invoke"
           }
         },
         "required": [
-          "systemPrompt"
+          "key",
+          "systemPrompt",
+          "allowedTools"
         ]
       },
       "ChatMessageRequest": {
@@ -4402,6 +4430,11 @@
             "type": "string",
             "minLength": 1,
             "description": "The user's chat message"
+          },
+          "configKey": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The config key to use for this chat session (e.g. \"workflow\", \"feature\"). Must match a key previously registered via PUT /config or PUT /platform-config."
           },
           "sessionId": {
             "type": "string",
@@ -4417,7 +4450,8 @@
           }
         },
         "required": [
-          "message"
+          "message",
+          "configKey"
         ]
       },
       "PlatformKeyResponse": {
@@ -4491,9 +4525,20 @@
       "PlatformChatConfigResponse": {
         "type": "object",
         "properties": {
+          "key": {
+            "type": "string",
+            "description": "Config key"
+          },
           "systemPrompt": {
             "type": "string",
             "description": "The registered system prompt"
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Allowed MCP tool names"
           },
           "createdAt": {
             "type": "string",
@@ -4505,7 +4550,9 @@
           }
         },
         "required": [
+          "key",
           "systemPrompt",
+          "allowedTools",
           "createdAt",
           "updatedAt"
         ]
@@ -4513,14 +4560,29 @@
       "PlatformChatConfigRequest": {
         "type": "object",
         "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Config key identifying this configuration (e.g. \"workflow\", \"feature\")"
+          },
           "systemPrompt": {
             "type": "string",
             "minLength": 1,
             "description": "System prompt for the AI assistant"
+          },
+          "allowedTools": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "List of MCP tool names this config is allowed to invoke"
           }
         },
         "required": [
-          "systemPrompt"
+          "key",
+          "systemPrompt",
+          "allowedTools"
         ]
       },
       "BillingAccountResponse": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3458,13 +3458,22 @@ registry.registerPath({
 
 export const ChatConfigRequestSchema = z
   .object({
+    key: z.string().min(1).describe('Config key identifying this configuration (e.g. "workflow", "feature")'),
     systemPrompt: z.string().min(1).describe("System prompt for the AI assistant"),
+    allowedTools: z.array(z.string()).min(1).describe("List of MCP tool names this config is allowed to invoke"),
   })
   .openapi("ChatConfigRequest");
 
 export const ChatMessageRequestSchema = z
   .object({
     message: z.string().min(1).describe("The user's chat message"),
+    configKey: z
+      .string()
+      .min(1)
+      .describe(
+        'The config key to use for this chat session (e.g. "workflow", "feature"). ' +
+        "Must match a key previously registered via PUT /config or PUT /platform-config.",
+      ),
     sessionId: z
       .string()
       .uuid()
@@ -3597,7 +3606,9 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             orgId: z.string().describe("Organization ID"),
+            key: z.string().describe("Config key"),
             systemPrompt: z.string().describe("The registered system prompt"),
+            allowedTools: z.array(z.string()).describe("Allowed MCP tool names"),
             createdAt: z.string().describe("ISO timestamp of creation"),
             updatedAt: z.string().describe("ISO timestamp of last update"),
           }).openapi("ChatConfigResponse"),
@@ -3760,7 +3771,9 @@ registry.registerPath({
 
 export const PlatformChatConfigRequestSchema = z
   .object({
+    key: z.string().min(1).describe('Config key identifying this configuration (e.g. "workflow", "feature")'),
     systemPrompt: z.string().min(1).describe("System prompt for the AI assistant"),
+    allowedTools: z.array(z.string()).min(1).describe("List of MCP tool names this config is allowed to invoke"),
   })
   .openapi("PlatformChatConfigRequest");
 
@@ -3785,7 +3798,9 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
+            key: z.string().describe("Config key"),
             systemPrompt: z.string().describe("The registered system prompt"),
+            allowedTools: z.array(z.string()).describe("Allowed MCP tool names"),
             createdAt: z.string().describe("ISO timestamp of creation"),
             updatedAt: z.string().describe("ISO timestamp of last update"),
           }).openapi("PlatformChatConfigResponse"),

--- a/tests/unit/chat-proxy.test.ts
+++ b/tests/unit/chat-proxy.test.ts
@@ -99,15 +99,17 @@ describe("Chat OpenAPI schemas", () => {
     expect(schemaContent).toContain('path: "/v1/chat"');
   });
 
-  it("should define ChatConfigRequestSchema", () => {
+  it("should define ChatConfigRequestSchema with key and allowedTools", () => {
     expect(schemaContent).toContain("ChatConfigRequestSchema");
     expect(schemaContent).toContain("systemPrompt");
+    expect(schemaContent).toContain("allowedTools");
     expect(schemaContent).not.toContain("mcpServerUrl");
     expect(schemaContent).not.toContain("mcpKeyName");
   });
 
-  it("should define ChatMessageRequestSchema with session lifecycle docs", () => {
+  it("should define ChatMessageRequestSchema with configKey and session lifecycle docs", () => {
     expect(schemaContent).toContain("ChatMessageRequestSchema");
+    expect(schemaContent).toContain("configKey");
     expect(schemaContent).toContain("sessionId");
     // sessionId field must document the server-created session contract
     expect(schemaContent).toContain("Omit to create a new session");
@@ -146,24 +148,28 @@ describe("Chat OpenAPI schemas", () => {
   });
 
   it("should return full config object from PUT /v1/chat/config (not just message)", () => {
-    // chat-service returns { orgId, systemPrompt, createdAt, updatedAt }
+    // chat-service returns { orgId, key, systemPrompt, allowedTools, createdAt, updatedAt }
     const configResponseBlock = schemaContent.slice(
-      schemaContent.indexOf('.openapi("ChatConfigResponse")') - 300,
+      schemaContent.indexOf('.openapi("ChatConfigResponse")') - 500,
       schemaContent.indexOf('.openapi("ChatConfigResponse")'),
     );
     expect(configResponseBlock).toContain("orgId");
+    expect(configResponseBlock).toContain("key");
     expect(configResponseBlock).toContain("systemPrompt");
+    expect(configResponseBlock).toContain("allowedTools");
     expect(configResponseBlock).toContain("createdAt");
     expect(configResponseBlock).toContain("updatedAt");
   });
 
   it("should return full config object from PUT /platform-chat/config (not just message)", () => {
-    // chat-service returns { systemPrompt, createdAt, updatedAt }
+    // chat-service returns { key, systemPrompt, allowedTools, createdAt, updatedAt }
     const configResponseBlock = schemaContent.slice(
-      schemaContent.indexOf('.openapi("PlatformChatConfigResponse")') - 300,
+      schemaContent.indexOf('.openapi("PlatformChatConfigResponse")') - 400,
       schemaContent.indexOf('.openapi("PlatformChatConfigResponse")'),
     );
+    expect(configResponseBlock).toContain("key");
     expect(configResponseBlock).toContain("systemPrompt");
+    expect(configResponseBlock).toContain("allowedTools");
     expect(configResponseBlock).toContain("createdAt");
     expect(configResponseBlock).toContain("updatedAt");
   });

--- a/tests/unit/platform-chat.test.ts
+++ b/tests/unit/platform-chat.test.ts
@@ -63,7 +63,9 @@ describe("PUT /platform-chat/config", () => {
       .put("/platform-chat/config")
       .set("X-API-Key", VALID_API_KEY)
       .send({
+        key: "workflow",
         systemPrompt: "You are a helpful workflow assistant.",
+        allowedTools: ["request_user_input", "update_workflow"],
       });
 
     expect(res.status).toBe(200);
@@ -73,7 +75,9 @@ describe("PUT /platform-chat/config", () => {
     expect(call).toBeDefined();
     expect(call!.method).toBe("PUT");
     expect(call!.body).toMatchObject({
+      key: "workflow",
       systemPrompt: "You are a helpful workflow assistant.",
+      allowedTools: ["request_user_input", "update_workflow"],
     });
     // No identity headers forwarded
     expect(call!.headers!["x-org-id"]).toBeUndefined();
@@ -86,7 +90,9 @@ describe("PUT /platform-chat/config", () => {
       .put("/platform-chat/config")
       .set("X-API-Key", VALID_API_KEY)
       .send({
+        key: "workflow",
         systemPrompt: "You are a helpful assistant.",
+        allowedTools: ["request_user_input"],
         mcpServerUrl: "https://mcp.example.com",
         mcpKeyName: "dashboard-mcp",
       });
@@ -95,7 +101,9 @@ describe("PUT /platform-chat/config", () => {
 
     const call = fetchCalls.find((c) => c.url.includes("/platform-config"));
     expect(call!.body).toMatchObject({
+      key: "workflow",
       systemPrompt: "You are a helpful assistant.",
+      allowedTools: ["request_user_input"],
     });
     expect(call!.body).not.toHaveProperty("mcpServerUrl");
     expect(call!.body).not.toHaveProperty("mcpKeyName");
@@ -104,7 +112,7 @@ describe("PUT /platform-chat/config", () => {
   it("should return 401 without API key", async () => {
     const res = await request(app)
       .put("/platform-chat/config")
-      .send({ systemPrompt: "test" });
+      .send({ key: "workflow", systemPrompt: "test", allowedTools: ["request_user_input"] });
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("Invalid or missing platform API key");
@@ -114,7 +122,7 @@ describe("PUT /platform-chat/config", () => {
     const res = await request(app)
       .put("/platform-chat/config")
       .set("X-API-Key", "wrong-key")
-      .send({ systemPrompt: "test" });
+      .send({ key: "workflow", systemPrompt: "test", allowedTools: ["request_user_input"] });
 
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("Invalid or missing platform API key");
@@ -134,7 +142,7 @@ describe("PUT /platform-chat/config", () => {
     const res = await request(app)
       .put("/platform-chat/config")
       .set("X-API-Key", VALID_API_KEY)
-      .send({ systemPrompt: "" });
+      .send({ key: "workflow", systemPrompt: "", allowedTools: ["request_user_input"] });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("Invalid request");


### PR DESCRIPTION
## Summary
- Adapts api-service to chat-service breaking change (PR #108)
- `PUT /platform-config` and `PUT /config` now require `key` (e.g. "workflow", "feature") and `allowedTools` fields
- `POST /chat` now requires `configKey` to select which config to use
- `call_api` tool removed from documented allowed tools (security fix)
- Updated Zod schemas, response schemas, OpenAPI spec, and tests

## Test plan
- [x] `platform-chat.test.ts` — all 6 tests pass with new required fields
- [x] `chat-proxy.test.ts` — all 24 tests pass with schema assertions for `key`, `allowedTools`, `configKey`
- [x] Full test suite — 845/846 pass (1 pre-existing failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)