### PR TITLE
feat: add "failed" status to PressKitMediaKitStatus enum

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5790,6 +5790,7 @@
           "generating",
           "validated",
           "denied",
+          "failed",
           "archived"
         ]
       },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4817,7 +4817,7 @@ const LlmContextResponseSchema = z
 // ===================================================================
 
 const PressKitMediaKitStatusEnum = z
-  .enum(["drafted", "generating", "validated", "denied", "archived"])
+  .enum(["drafted", "generating", "validated", "denied", "failed", "archived"])
   .openapi("PressKitMediaKitStatus");
 
 // ── Public endpoints (no auth) ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `"failed"` to the `PressKitMediaKitStatus` enum in `schemas.ts` — used when media kit generation fails technically (distinct from `"denied"`)
- Regenerated `openapi.json` to include the new enum value so clients see the updated spec

## Context
Follows press-kits-service PR #29 which introduced the `"failed"` status for kits stuck in "generating". The API gateway spec needs to match.

## Test plan
- [x] Pre-existing test failure (`openapi-response-schemas`) confirmed unrelated (fails on `main` too)
- [x] All other 845 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)