### PR TITLE
feat: add GET /v1/press-kits/media-kits/stats/costs proxy route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5875,6 +5875,10 @@
         "type": "object",
         "properties": {}
       },
+      "PressKitMediaKitStatsCostsResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "ContentComposeResponse": {
         "type": "object",
         "properties": {
@@ -21171,6 +21175,141 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PressKitMediaKitStatsViewsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/press-kits/media-kits/stats/costs": {
+      "get": {
+        "tags": [
+          "Press Kits"
+        ],
+        "summary": "Get media kit cost stats",
+        "description": "Returns cost statistics for media kits. Supports filtering by mediaKitId, brandId, campaignId, and grouping by mediaKitId. Costs include downstream service costs (chat-service, etc.) via run hierarchy. Requires POST /v1/runs/costs/batch on runs-service to be deployed for costs to be visible.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by media kit ID"
+            },
+            "required": false,
+            "description": "Filter by media kit ID",
+            "name": "mediaKitId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand ID"
+            },
+            "required": false,
+            "description": "Filter by brand ID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign ID"
+            },
+            "required": false,
+            "description": "Filter by campaign ID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "mediaKitId"
+              ],
+              "description": "Group results by mediaKitId"
+            },
+            "required": false,
+            "description": "Group results by mediaKitId",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cost statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitMediaKitStatsCostsResponse"
                 }
               }
             }

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -148,6 +148,25 @@ router.get("/press-kits/media-kits/stats/views", authenticate, requireOrg, async
   }
 });
 
+// GET /v1/press-kits/media-kits/stats/costs — media kit cost stats
+router.get("/press-kits/media-kits/stats/costs", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["mediaKitId", "brandId", "campaignId", "groupBy"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.pressKits,
+      `/media-kits/stats/costs${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get media kit cost stats" });
+  }
+});
+
 // ── Admin routes (authenticated) ─────────────────────────────────────────────
 
 // GET /v1/press-kits/admin/media-kits — list media kits (admin)

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5064,6 +5064,30 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/press-kits/media-kits/stats/costs",
+  tags: ["Press Kits"],
+  summary: "Get media kit cost stats",
+  description:
+    "Returns cost statistics for media kits. Supports filtering by mediaKitId, brandId, campaignId, " +
+    "and grouping by mediaKitId. Costs include downstream service costs (chat-service, etc.) via run hierarchy. " +
+    "Requires POST /v1/runs/costs/batch on runs-service to be deployed for costs to be visible.",
+  security: authed,
+  request: {
+    query: z.object({
+      mediaKitId: z.string().optional().describe("Filter by media kit ID"),
+      brandId: z.string().optional().describe("Filter by brand ID"),
+      campaignId: z.string().optional().describe("Filter by campaign ID"),
+      groupBy: z.enum(["mediaKitId"]).optional().describe("Group results by mediaKitId"),
+    }),
+  },
+  responses: {
+    200: { description: "Cost statistics", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitMediaKitStatsCostsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
 // Content – Compose (proxy to content-generation-service)
 // ---------------------------------------------------------------------------
 export const ContentComposeRequestSchema = z

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -100,6 +100,16 @@ describe("Press Kits proxy routes", () => {
     }
   });
 
+  it("should have GET /press-kits/media-kits/stats/costs with auth", () => {
+    expect(content).toContain('"/press-kits/media-kits/stats/costs"');
+  });
+
+  it("should forward cost stats query params (mediaKitId, brandId, campaignId, groupBy)", () => {
+    for (const key of ["mediaKitId", "brandId", "campaignId", "groupBy"]) {
+      expect(content).toContain(`"${key}"`);
+    }
+  });
+
   // ── Admin endpoints ───────────────────────────────────────────────────
 
   it("should have GET /press-kits/admin/media-kits with auth", () => {
@@ -151,15 +161,15 @@ describe("Press Kits proxy routes", () => {
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    // 14 authenticated routes + 1 import = 15
-    expect(authMatches!.length).toBe(15);
+    // 15 authenticated routes + 1 import = 16
+    expect(authMatches!.length).toBe(16);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(14);
+    expect(headerMatches!.length).toBe(15);
   });
 
   it("should proxy to externalServices.pressKits", () => {
@@ -238,6 +248,7 @@ describe("Press Kits OpenAPI schemas", () => {
 
   it("should register stats paths", () => {
     expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/stats/views"');
+    expect(schemaContent).toContain('path: "/v1/press-kits/media-kits/stats/costs"');
   });
 
   it("should register admin paths", () => {


### PR DESCRIPTION
## Summary
- Add proxy route `GET /v1/press-kits/media-kits/stats/costs` to forward cost stats requests to press-kits-service
- Supports query params: `mediaKitId`, `brandId`, `campaignId`, `groupBy=mediaKitId`
- Register OpenAPI path with full schema documentation
- Update tests (route existence, query param forwarding, schema registration, auth/header counts)

## Note
Costs will only be visible once `POST /v1/runs/costs/batch` is deployed on runs-service.

## Test plan
- [x] Unit tests pass (51/51)
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)