### PR TITLE
feat: update journalists OpenAPI for discover/buffer endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1736,6 +1736,12 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "runId": {
+                  "type": "string",
+                  "nullable": true,
+                  "format": "uuid",
+                  "description": "The discovery run that created this journalist entry"
                 }
               },
               "required": [
@@ -1748,7 +1754,8 @@
                 "relevanceScore",
                 "whyRelevant",
                 "whyNotRelevant",
-                "articleUrls"
+                "articleUrls",
+                "runId"
               ]
             }
           }
@@ -1760,81 +1767,19 @@
       "DiscoverJournalistsResponse": {
         "type": "object",
         "properties": {
-          "journalists": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                "journalistName": {
-                  "type": "string"
-                },
-                "firstName": {
-                  "type": "string"
-                },
-                "lastName": {
-                  "type": "string"
-                },
-                "entityType": {
-                  "type": "string",
-                  "enum": [
-                    "individual",
-                    "organization"
-                  ]
-                },
-                "relevanceScore": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 100
-                },
-                "whyRelevant": {
-                  "type": "string"
-                },
-                "whyNotRelevant": {
-                  "type": "string"
-                },
-                "articleUrls": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "isNew": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "id",
-                "journalistName",
-                "firstName",
-                "lastName",
-                "entityType",
-                "relevanceScore",
-                "whyRelevant",
-                "whyNotRelevant",
-                "articleUrls",
-                "isNew"
-              ]
-            }
+          "runId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child run ID for this discovery. Use to query journalists from this run or check costs via runs-service."
           },
-          "totalArticlesSearched": {
-            "type": "number"
-          },
-          "totalNamesExtracted": {
-            "type": "number"
-          },
-          "totalJournalistsStored": {
-            "type": "number"
+          "discovered": {
+            "type": "integer",
+            "description": "Number of journalists discovered and stored as buffered"
           }
         },
         "required": [
-          "journalists",
-          "totalArticlesSearched",
-          "totalNamesExtracted",
-          "totalJournalistsStored"
+          "runId",
+          "discovered"
         ]
       },
       "DiscoverJournalistsRequest": {
@@ -1848,7 +1793,8 @@
             "type": "integer",
             "minimum": 1,
             "maximum": 30,
-            "default": 15
+            "default": 15,
+            "description": "Maximum number of articles to search (1-30, default 15)"
           }
         },
         "required": [
@@ -1940,6 +1886,19 @@
           "organizationDomain",
           "brandId",
           "campaignId"
+        ]
+      },
+      "BufferNextJournalistResponse": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child run ID for this buffer/next call"
+          }
+        },
+        "required": [
+          "runId"
         ]
       },
       "ResolveJournalistsResponse": {
@@ -9205,7 +9164,7 @@
           "Journalists"
         ],
         "summary": "List journalists by brand",
-        "description": "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}.",
+        "description": "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}. Optionally filter by runId to get journalists from a specific discovery run.",
         "security": [
           {
             "bearerAuth": []
@@ -9221,6 +9180,17 @@
             "required": true,
             "description": "Brand ID to filter journalists by",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter journalists by discovery run ID"
+            },
+            "required": false,
+            "description": "Filter journalists by discovery run ID",
+            "name": "runId",
             "in": "query"
           },
           {
@@ -9318,7 +9288,7 @@
           "Journalists"
         ],
         "summary": "Discover relevant journalists for a brand on an outlet",
-        "description": "Searches outlet articles, extracts journalist names via LLM, scores them for relevance, and stores results.",
+        "description": "Triggers journalist discovery for a given outlet. Requires x-campaign-id and x-brand-id headers. Creates a child run, discovers journalists, and stores them as buffered. Use the returned runId to query journalists from this specific discovery run via GET /v1/journalists?runId={runId}.",
         "security": [
           {
             "bearerAuth": []
@@ -9335,7 +9305,7 @@
         },
         "responses": {
           "200": {
-            "description": "Discovered journalists with relevance scores",
+            "description": "Discovery initiated — returns run ID and count of discovered journalists",
             "content": {
               "application/json": {
                 "schema": {
@@ -9473,6 +9443,101 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/journalists/buffer/next": {
+      "post": {
+        "tags": [
+          "Journalists"
+        ],
+        "summary": "Get next buffered journalist",
+        "description": "Returns the next buffered journalist from the queue. Response includes the runId (child run ID) for the buffer/next call.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Next buffered journalist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BufferNextJournalistResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No buffered journalists available"
           },
           "401": {
             "description": "Unauthorized",

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -8,13 +8,14 @@ const router = Router();
 // ── GET /v1/journalists — list journalists by brand ─────────────────────────
 router.get("/journalists", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId } = req.query as { brandId?: string };
+    const { brandId, runId } = req.query as { brandId?: string; runId?: string };
     if (!brandId) {
       return res.status(400).json({ error: "Missing required query parameter: brandId" });
     }
 
     const params = new URLSearchParams();
     params.set("brand_id", brandId);
+    if (runId) params.set("run_id", runId);
 
     const result = await callExternalService(
       externalServices.journalist,
@@ -32,7 +33,7 @@ router.post("/journalists/discover", authenticate, requireOrg, requireUser, asyn
   try {
     const result = await callExternalService(
       externalServices.journalist,
-      "/journalists/discover",
+      "/discover",
       { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -52,6 +53,20 @@ router.post("/journalists/discover-emails", authenticate, requireOrg, requireUse
     res.json(result);
   } catch (error: any) {
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to discover journalist emails" });
+  }
+});
+
+// ── POST /v1/journalists/buffer/next — get next buffered journalist ──────────
+router.post("/journalists/buffer/next", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.journalist,
+      "/buffer/next",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get next buffered journalist" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1162,11 +1162,12 @@ registry.registerPath({
   path: "/v1/journalists",
   tags: ["Journalists"],
   summary: "List journalists by brand",
-  description: "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}.",
+  description: "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}. Optionally filter by runId to get journalists from a specific discovery run.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().uuid().describe("Brand ID to filter journalists by"),
+      runId: z.string().uuid().optional().describe("Filter journalists by discovery run ID"),
     }).openapi("ListJournalistsQuery"),
   },
   responses: {
@@ -1188,6 +1189,7 @@ registry.registerPath({
                   whyRelevant: z.string().nullable(),
                   whyNotRelevant: z.string().nullable(),
                   articleUrls: z.array(z.string()).nullable(),
+                  runId: z.string().uuid().nullable().describe("The discovery run that created this journalist entry"),
                 }).passthrough(),
               ),
             })
@@ -1206,7 +1208,7 @@ registry.registerPath({
   path: "/v1/journalists/discover",
   tags: ["Journalists"],
   summary: "Discover relevant journalists for a brand on an outlet",
-  description: "Searches outlet articles, extracts journalist names via LLM, scores them for relevance, and stores results.",
+  description: "Triggers journalist discovery for a given outlet. Requires x-campaign-id and x-brand-id headers. Creates a child run, discovers journalists, and stores them as buffered. Use the returned runId to query journalists from this specific discovery run via GET /v1/journalists?runId={runId}.",
   security: authed,
   request: {
     body: {
@@ -1215,7 +1217,7 @@ registry.registerPath({
           schema: z
             .object({
               outletId: z.string().uuid(),
-              maxArticles: z.number().int().min(1).max(30).optional().default(15),
+              maxArticles: z.number().int().min(1).max(30).optional().default(15).describe("Maximum number of articles to search (1-30, default 15)"),
             })
             .openapi("DiscoverJournalistsRequest"),
         },
@@ -1224,28 +1226,13 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "Discovered journalists with relevance scores",
+      description: "Discovery initiated — returns run ID and count of discovered journalists",
       content: {
         "application/json": {
           schema: z
             .object({
-              journalists: z.array(
-                z.object({
-                  id: z.string().uuid(),
-                  journalistName: z.string(),
-                  firstName: z.string(),
-                  lastName: z.string(),
-                  entityType: z.enum(["individual", "organization"]),
-                  relevanceScore: z.number().min(0).max(100),
-                  whyRelevant: z.string(),
-                  whyNotRelevant: z.string(),
-                  articleUrls: z.array(z.string()),
-                  isNew: z.boolean(),
-                }),
-              ),
-              totalArticlesSearched: z.number(),
-              totalNamesExtracted: z.number(),
-              totalJournalistsStored: z.number(),
+              runId: z.string().uuid().describe("Child run ID for this discovery. Use to query journalists from this run or check costs via runs-service."),
+              discovered: z.number().int().describe("Number of journalists discovered and stored as buffered"),
             })
             .openapi("DiscoverJournalistsResponse"),
         },
@@ -1305,6 +1292,33 @@ registry.registerPath({
       },
     },
     400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/journalists/buffer/next",
+  tags: ["Journalists"],
+  summary: "Get next buffered journalist",
+  description: "Returns the next buffered journalist from the queue. Response includes the runId (child run ID) for the buffer/next call.",
+  security: authed,
+  request: {},
+  responses: {
+    200: {
+      description: "Next buffered journalist",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              runId: z.string().uuid().describe("Child run ID for this buffer/next call"),
+            })
+            .passthrough()
+            .openapi("BufferNextJournalistResponse"),
+        },
+      },
+    },
+    204: { description: "No buffered journalists available" },
     401: { description: "Unauthorized", content: errorContent },
   },
 });

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -64,20 +64,53 @@ describe("Journalists proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
+  it("should have POST /journalists/buffer/next with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/journalists/buffer/next"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should proxy POST /journalists/discover to /discover on journalist-service", () => {
+    // The callExternalService call should use "/discover" as the path
+    const lines = content.split("\n");
+    const routeIdx = lines.findIndex((l) => l.includes('router.post') && l.includes('"/journalists/discover"') && !l.includes("emails"));
+    expect(routeIdx).toBeGreaterThan(-1);
+    // Find the callExternalService line within the handler
+    const handlerLines = lines.slice(routeIdx + 1, routeIdx + 10);
+    const serviceLine = handlerLines.find((l) => l.includes("callExternalService"));
+    expect(serviceLine).toBeDefined();
+    // The next line or same block should reference "/discover" not "/journalists/discover"
+    const serviceBlock = handlerLines.join("\n");
+    expect(serviceBlock).toContain('"/discover"');
+  });
+
+  it("should forward runId query parameter on GET /journalists", () => {
+    expect(content).toContain("runId");
+    expect(content).toContain('params.set("run_id", runId)');
+  });
+
+  it("should proxy POST /journalists/buffer/next to /buffer/next on journalist-service", () => {
+    expect(content).toContain('"/buffer/next"');
+  });
+
   it("should use buildInternalHeaders for all endpoints", () => {
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(4);
+    expect(headerMatches!.length).toBe(5);
   });
 
   it("should proxy to externalServices.journalist", () => {
     expect(content).toContain("externalServices.journalist");
   });
 
-  it("should forward request body on discover and discover-emails endpoints", () => {
+  it("should forward request body on discover, discover-emails, and buffer/next endpoints", () => {
     const bodyMatches = content.match(/body: req\.body/g);
     expect(bodyMatches).not.toBeNull();
-    expect(bodyMatches!.length).toBe(2);
+    expect(bodyMatches!.length).toBe(3);
   });
 
   it("should translate resolve to GET /campaign-outlet-journalists on journalist-service", () => {
@@ -132,6 +165,11 @@ describe("Journalists OpenAPI schemas", () => {
     expect(schemaContent).toContain("DiscoverEmailsResponse");
   });
 
+  it("should register POST /v1/journalists/buffer/next", () => {
+    expect(schemaContent).toContain('path: "/v1/journalists/buffer/next"');
+    expect(schemaContent).toContain("BufferNextJournalistResponse");
+  });
+
   it("should register POST /v1/journalists/resolve", () => {
     expect(schemaContent).toContain('path: "/v1/journalists/resolve"');
     expect(schemaContent).toContain("ResolveJournalistsRequest");
@@ -154,6 +192,25 @@ describe("Journalists OpenAPI schemas", () => {
     const start = schemaContent.indexOf("DiscoverJournalistsRequest");
     const blockBefore = schemaContent.slice(Math.max(0, start - 400), start);
     expect(blockBefore).toContain("outletId:");
+  });
+
+  it("should have runId in DiscoverJournalistsResponse (new async response shape)", () => {
+    const start = schemaContent.indexOf("DiscoverJournalistsResponse");
+    const block = schemaContent.slice(Math.max(0, start - 600), start);
+    expect(block).toContain("runId:");
+    expect(block).toContain("discovered:");
+  });
+
+  it("should have runId in ListJournalistsResponse rows", () => {
+    const start = schemaContent.indexOf("ListJournalistsResponse");
+    const block = schemaContent.slice(Math.max(0, start - 800), start);
+    expect(block).toContain("runId:");
+  });
+
+  it("should have runId query param in ListJournalistsQuery", () => {
+    const start = schemaContent.indexOf("ListJournalistsQuery");
+    const block = schemaContent.slice(Math.max(0, start - 400), start);
+    expect(block).toContain("runId:");
   });
 
   it("should define journalist entity type enum", () => {


### PR DESCRIPTION
## Summary
- **POST /v1/journalists/discover**: Updated to proxy to new `/discover` path on journalists-service. Response changed from full journalist list to `{ runId, discovered }` (async discovery model).
- **GET /v1/journalists**: Added optional `runId` query filter and `runId` field on each response row.
- **POST /v1/journalists/buffer/next**: New proxy endpoint for getting the next buffered journalist. Response includes `runId`.
- Regenerated `openapi.json`.

## Test plan
- [x] All 31 journalists proxy tests pass
- [x] Pre-existing openapi-response-schemas failure unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)