### PR TITLE
feat: update outlets OpenAPI for discover/buffer/runId

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1625,13 +1625,48 @@
           "query"
         ]
       },
+      "DiscoverOutletsResponse": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child run ID for this discovery batch"
+          },
+          "discovered": {
+            "type": "integer",
+            "description": "Number of outlets discovered"
+          }
+        },
+        "required": [
+          "runId",
+          "discovered"
+        ]
+      },
       "DiscoverOutletsRequest": {
         "type": "object",
         "properties": {
-          "workflowSlug": {
-            "type": "string"
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 15,
+            "description": "Number of outlets to discover (1-200, default 15)"
           }
         }
+      },
+      "BufferNextOutletResponse": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Discovery run ID that originally found this outlet"
+          }
+        },
+        "required": [
+          "runId"
+        ]
       },
       "UpdateOutletRequest": {
         "type": "object",
@@ -8175,6 +8210,16 @@
           },
           {
             "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter outlets by discovery run ID"
+            },
+            "required": false,
+            "name": "runId",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "integer",
               "nullable": true,
               "default": 100
@@ -8715,7 +8760,7 @@
           "Outlets"
         ],
         "summary": "Discover relevant outlets via Google search + LLM scoring",
-        "description": "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. Brand and campaign context are resolved via x-brand-id and x-campaign-id headers.",
+        "description": "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. Requires x-campaign-id and x-brand-id headers.",
         "security": [
           {
             "bearerAuth": []
@@ -8732,7 +8777,14 @@
         },
         "responses": {
           "201": {
-            "description": "Outlets discovered and saved"
+            "description": "Outlets discovered and stored as buffered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverOutletsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -8756,6 +8808,101 @@
           },
           "502": {
             "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/outlets/buffer/next": {
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Get next buffered outlet",
+        "description": "Returns the next buffered outlet from the queue. Response includes the runId of the discovery run that originally found the outlet.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Next buffered outlet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BufferNextOutletResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No buffered outlets available"
+          },
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -12,6 +12,7 @@ router.get("/outlets", authenticate, requireOrg, requireUser, async (req: Authen
     if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
     if (req.query.brandId) params.set("brandId", req.query.brandId as string);
     if (req.query.status) params.set("status", req.query.status as string);
+    if (req.query.runId) params.set("runId", req.query.runId as string);
     if (req.query.limit) params.set("limit", req.query.limit as string);
     if (req.query.offset) params.set("offset", req.query.offset as string);
     const qs = params.toString() ? `?${params.toString()}` : "";
@@ -100,6 +101,20 @@ router.post("/outlets/discover", authenticate, requireOrg, requireUser, async (r
     res.status(201).json(result);
   } catch (error: any) {
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to discover outlets" });
+  }
+});
+
+// ── POST /v1/outlets/buffer/next — get next buffered outlet ──────────────────
+router.post("/outlets/buffer/next", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.outlet,
+      "/buffer/next",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get next buffered outlet" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -907,6 +907,7 @@ registry.registerPath({
       campaignId: z.string().uuid().optional(),
       brandId: z.string().uuid().optional(),
       status: z.enum(["open", "ended", "denied"]).optional(),
+      runId: z.string().uuid().optional().openapi({ description: "Filter outlets by discovery run ID" }),
       limit: z.coerce.number().int().optional().default(100),
       offset: z.coerce.number().int().optional().default(0),
     }),
@@ -1050,8 +1051,9 @@ registry.registerPath({
   path: "/v1/outlets/discover",
   tags: ["Outlets"],
   summary: "Discover relevant outlets via Google search + LLM scoring",
-  description: "Generates search queries via LLM, searches Google, scores results, and bulk upserts discovered outlets. " +
-    "Brand and campaign context are resolved via x-brand-id and x-campaign-id headers.",
+  description: "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. " +
+    "Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. " +
+    "Requires x-campaign-id and x-brand-id headers.",
   security: authed,
   request: {
     body: {
@@ -1059,7 +1061,7 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              workflowSlug: z.string().optional(),
+              count: z.number().int().min(1).max(200).optional().default(15).describe("Number of outlets to discover (1-200, default 15)"),
             })
             .openapi("DiscoverOutletsRequest"),
         },
@@ -1067,10 +1069,49 @@ registry.registerPath({
     },
   },
   responses: {
-    201: { description: "Outlets discovered and saved" },
+    201: {
+      description: "Outlets discovered and stored as buffered",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              runId: z.string().uuid().describe("Child run ID for this discovery batch"),
+              discovered: z.number().int().describe("Number of outlets discovered"),
+            })
+            .openapi("DiscoverOutletsResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/outlets/buffer/next",
+  tags: ["Outlets"],
+  summary: "Get next buffered outlet",
+  description: "Returns the next buffered outlet from the queue. Response includes the runId of the discovery run that originally found the outlet.",
+  security: authed,
+  request: {},
+  responses: {
+    200: {
+      description: "Next buffered outlet",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              runId: z.string().uuid().describe("Discovery run ID that originally found this outlet"),
+            })
+            .passthrough()
+            .openapi("BufferNextOutletResponse"),
+        },
+      },
+    },
+    204: { description: "No buffered outlets available" },
+    401: { description: "Unauthorized", content: errorContent },
   },
 });
 

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -26,7 +26,7 @@ describe("Outlets proxy routes", () => {
   });
 
   it("should forward query params on GET /outlets", () => {
-    for (const param of ["campaignId", "brandId", "status", "limit", "offset"]) {
+    for (const param of ["campaignId", "brandId", "status", "runId", "limit", "offset"]) {
       expect(content).toContain(`"${param}"`);
     }
   });
@@ -72,6 +72,16 @@ describe("Outlets proxy routes", () => {
     expect(content).toContain('"/outlets/discover"');
   });
 
+  it("should have POST /outlets/buffer/next with auth", () => {
+    const line = content.split("\n").find((l: string) =>
+      l.includes("router.post") && l.includes('"/outlets/buffer/next"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
   it("should have GET /outlets/:id with auth", () => {
     expect(content).toContain('"/outlets/:id"');
     const line = content.split("\n").find((l) =>
@@ -100,7 +110,7 @@ describe("Outlets proxy routes", () => {
   it("should use buildInternalHeaders for all endpoints", () => {
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(9);
+    expect(headerMatches!.length).toBe(10);
   });
 
   it("should proxy to externalServices.outlet", () => {
@@ -112,11 +122,13 @@ describe("Outlets proxy routes", () => {
     const bulkIdx = content.indexOf('"/outlets/bulk"');
     const searchIdx = content.indexOf('"/outlets/search"');
     const discoverIdx = content.indexOf('"/outlets/discover"');
+    const bufferNextIdx = content.indexOf('"/outlets/buffer/next"');
     const idIdx = content.indexOf('"/outlets/:id"');
     expect(statsIdx).toBeLessThan(idIdx);
     expect(bulkIdx).toBeLessThan(idIdx);
     expect(searchIdx).toBeLessThan(idIdx);
     expect(discoverIdx).toBeLessThan(idIdx);
+    expect(bufferNextIdx).toBeLessThan(idIdx);
   });
 
   it("should enforce requireOrg + requireUser on ALL outlet routes", () => {
@@ -159,9 +171,29 @@ describe("Outlets OpenAPI schemas", () => {
     expect(schemaContent).toContain("SearchOutletsRequest");
   });
 
-  it("should register POST /v1/outlets/discover", () => {
+  it("should register POST /v1/outlets/discover with count param and response schema", () => {
     expect(schemaContent).toContain('path: "/v1/outlets/discover"');
     expect(schemaContent).toContain("DiscoverOutletsRequest");
+    expect(schemaContent).toContain("DiscoverOutletsResponse");
+    // count param
+    const discoverSection = schemaContent.slice(
+      schemaContent.indexOf("DiscoverOutletsRequest") - 500,
+      schemaContent.indexOf("DiscoverOutletsRequest")
+    );
+    expect(discoverSection).toContain("count:");
+  });
+
+  it("should register POST /v1/outlets/buffer/next", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/buffer/next"');
+    expect(schemaContent).toContain("BufferNextOutletResponse");
+  });
+
+  it("should include runId filter on GET /v1/outlets query params", () => {
+    const getOutletsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/outlets"'),
+      schemaContent.indexOf('path: "/v1/outlets"') + 400
+    );
+    expect(getOutletsSection).toContain("runId:");
   });
 
   it("should register GET /v1/outlets/{id}", () => {


### PR DESCRIPTION
## Summary
- **POST /v1/outlets/discover**: Added `count` request param (1-200, default 15), added response schema with `runId` + `discovered`
- **GET /v1/outlets**: Added `runId` optional query filter to get outlets from a specific discovery run
- **POST /v1/outlets/buffer/next**: New proxy route + OpenAPI schema for the buffered outlet queue endpoint

## Test plan
- [x] All 34 outlets proxy tests pass
- [x] Full suite: 858/859 pass (1 pre-existing failure unrelated to this PR)
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)