### PR TITLE
feat: add GET /v1/outlets/stats/costs proxy route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1528,6 +1528,52 @@
           "relevanceScore"
         ]
       },
+      "OutletStatsCostsResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dimensions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Grouping dimensions (e.g. outletId, runId)"
+                },
+                "totalCostInUsdCents": {
+                  "type": "number",
+                  "description": "Total cost (actual + provisioned) in USD cents"
+                },
+                "actualCostInUsdCents": {
+                  "type": "number",
+                  "description": "Actual billed cost in USD cents"
+                },
+                "provisionedCostInUsdCents": {
+                  "type": "number",
+                  "description": "Provisioned (estimated) cost in USD cents"
+                },
+                "runCount": {
+                  "type": "integer",
+                  "description": "Number of discovery runs contributing to this group"
+                }
+              },
+              "required": [
+                "dimensions",
+                "totalCostInUsdCents",
+                "actualCostInUsdCents",
+                "provisionedCostInUsdCents",
+                "runCount"
+              ]
+            }
+          }
+        },
+        "required": [
+          "groups"
+        ]
+      },
       "BulkCreateOutletsRequest": {
         "type": "object",
         "properties": {
@@ -8554,6 +8600,134 @@
         "responses": {
           "200": {
             "description": "Stats (flat or grouped)"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/outlets/stats/costs": {
+      "get": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Get outlet discovery cost stats",
+        "description": "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, and runCount per run. Without groupBy, returns flat totals across all discovery runs. All costs are org-scoped — each org only sees costs from their own discovery runs.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by brand ID"
+            },
+            "required": false,
+            "description": "Filter by brand ID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by campaign ID"
+            },
+            "required": false,
+            "description": "Filter by campaign ID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "outletId",
+                "runId"
+              ],
+              "description": "Group results by outletId or runId"
+            },
+            "required": false,
+            "description": "Group results by outletId or runId",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cost statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletStatsCostsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -118,6 +118,25 @@ router.post("/outlets/buffer/next", authenticate, requireOrg, requireUser, async
   }
 });
 
+// ── GET /v1/outlets/stats/costs — outlet discovery cost stats ────────────────
+router.get("/outlets/stats/costs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "campaignId", "groupBy"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.outlet,
+      `/outlets/stats/costs${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get outlet cost stats" });
+  }
+});
+
 // ── GET /v1/outlets/:id — get outlet by ID ──────────────────────────────────
 router.get("/outlets/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -980,6 +980,50 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/v1/outlets/stats/costs",
+  tags: ["Outlets"],
+  summary: "Get outlet discovery cost stats",
+  description:
+    "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, " +
+    "and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets " +
+    "in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, " +
+    "and runCount per run. Without groupBy, returns flat totals across all discovery runs. " +
+    "All costs are org-scoped — each org only sees costs from their own discovery runs.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().optional().describe("Filter by brand ID"),
+      campaignId: z.string().uuid().optional().describe("Filter by campaign ID"),
+      groupBy: z.enum(["outletId", "runId"]).optional().describe("Group results by outletId or runId"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Cost statistics",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              groups: z.array(
+                z.object({
+                  dimensions: z.record(z.string()).describe("Grouping dimensions (e.g. outletId, runId)"),
+                  totalCostInUsdCents: z.number().describe("Total cost (actual + provisioned) in USD cents"),
+                  actualCostInUsdCents: z.number().describe("Actual billed cost in USD cents"),
+                  provisionedCostInUsdCents: z.number().describe("Provisioned (estimated) cost in USD cents"),
+                  runCount: z.number().int().describe("Number of discovery runs contributing to this group"),
+                }),
+              ),
+            })
+            .openapi("OutletStatsCostsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "post",
   path: "/v1/outlets/bulk",
   tags: ["Outlets"],

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -110,21 +110,40 @@ describe("Outlets proxy routes", () => {
   it("should use buildInternalHeaders for all endpoints", () => {
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(10);
+    expect(headerMatches!.length).toBe(11);
   });
 
   it("should proxy to externalServices.outlet", () => {
     expect(content).toContain("externalServices.outlet");
   });
 
+  it("should have GET /outlets/stats/costs with auth", () => {
+    const line = content.split("\n").find((l: string) =>
+      l.includes("router.get") && l.includes('"/outlets/stats/costs"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward query params on GET /outlets/stats/costs", () => {
+    const costSection = content.slice(content.indexOf('"/outlets/stats/costs"'));
+    expect(costSection).toContain('"brandId"');
+    expect(costSection).toContain('"campaignId"');
+    expect(costSection).toContain('"groupBy"');
+  });
+
   it("should register static routes before parameterized :id route", () => {
     const statsIdx = content.indexOf('"/outlets/stats"');
+    const statsCostsIdx = content.indexOf('"/outlets/stats/costs"');
     const bulkIdx = content.indexOf('"/outlets/bulk"');
     const searchIdx = content.indexOf('"/outlets/search"');
     const discoverIdx = content.indexOf('"/outlets/discover"');
     const bufferNextIdx = content.indexOf('"/outlets/buffer/next"');
     const idIdx = content.indexOf('"/outlets/:id"');
     expect(statsIdx).toBeLessThan(idIdx);
+    expect(statsCostsIdx).toBeLessThan(idIdx);
     expect(bulkIdx).toBeLessThan(idIdx);
     expect(searchIdx).toBeLessThan(idIdx);
     expect(discoverIdx).toBeLessThan(idIdx);
@@ -212,6 +231,11 @@ describe("Outlets OpenAPI schemas", () => {
 
   it("should register GET /v1/outlets/stats", () => {
     expect(schemaContent).toContain('path: "/v1/outlets/stats"');
+  });
+
+  it("should register GET /v1/outlets/stats/costs with response schema", () => {
+    expect(schemaContent).toContain('path: "/v1/outlets/stats/costs"');
+    expect(schemaContent).toContain("OutletStatsCostsResponse");
   });
 
   it("should use Outlets tag", () => {


### PR DESCRIPTION
## Summary
- Adds `GET /v1/outlets/stats/costs` proxy route to api-service
- Forwards `brandId`, `campaignId`, `groupBy` (outletId | runId) query params to outlets-service
- Full OpenAPI schema with typed response (`OutletStatsCostsResponse`)
- Tests updated for new route count and schema registration

## Test plan
- [x] Existing tests pass (outlets-proxy, openapi schemas)
- [x] New tests for route auth, query param forwarding, and schema registration
- [x] `openapi.json` regenerated with new endpoint


🤖 Generated with [Claude Code](https://claude.com/claude-code)