### PR TITLE
feat: add GET /v1/journalists/stats/costs proxy route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2080,6 +2080,48 @@
           "outletId"
         ]
       },
+      "JournalistStatsCostsResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dimensions": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Grouping dimensions (e.g. journalistId)"
+                },
+                "totalCostInUsdCents": {
+                  "type": "number"
+                },
+                "actualCostInUsdCents": {
+                  "type": "number"
+                },
+                "provisionedCostInUsdCents": {
+                  "type": "number"
+                },
+                "runCount": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "dimensions",
+                "totalCostInUsdCents",
+                "actualCostInUsdCents",
+                "provisionedCostInUsdCents",
+                "runCount"
+              ]
+            }
+          }
+        },
+        "required": [
+          "groups"
+        ]
+      },
       "CreateArticleRequest": {
         "type": "object",
         "properties": {
@@ -10052,6 +10094,141 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/journalists/stats/costs": {
+      "get": {
+        "tags": [
+          "Journalists"
+        ],
+        "summary": "Get journalist discovery cost stats",
+        "description": "Returns cost statistics for journalist discovery runs. Requires brandId. Supports optional campaignId filter and groupBy=journalistId to get per-journalist breakdowns. Costs are fetched from runs-service via POST /v1/runs/costs/batch.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand ID (required)"
+            },
+            "required": true,
+            "description": "Filter by brand ID (required)",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign ID"
+            },
+            "required": false,
+            "description": "Filter by campaign ID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "journalistId"
+              ],
+              "description": "Group results by journalistId"
+            },
+            "required": false,
+            "description": "Group results by journalistId",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cost statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JournalistStatsCostsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required brandId parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/articles": {

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -70,6 +70,28 @@ router.post("/journalists/buffer/next", authenticate, requireOrg, requireUser, a
   }
 });
 
+// ── GET /v1/journalists/stats/costs — journalist discovery cost stats ────────
+router.get("/journalists/stats/costs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "campaignId", "groupBy"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    if (!params.get("brandId")) {
+      return res.status(400).json({ error: "Missing required query parameter: brandId" });
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.journalist,
+      `/journalists/stats/costs${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get journalist cost stats" });
+  }
+});
+
 // ── POST /v1/journalists/resolve — resolve journalists for campaign+outlet or brand+outlet ──
 // Translates the POST body into a GET /campaign-outlet-journalists query on journalist-service
 router.post("/journalists/resolve", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1463,6 +1463,49 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/journalists/stats/costs",
+  tags: ["Journalists"],
+  summary: "Get journalist discovery cost stats",
+  description:
+    "Returns cost statistics for journalist discovery runs. Requires brandId. " +
+    "Supports optional campaignId filter and groupBy=journalistId to get per-journalist breakdowns. " +
+    "Costs are fetched from runs-service via POST /v1/runs/costs/batch.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().describe("Filter by brand ID (required)"),
+      campaignId: z.string().optional().describe("Filter by campaign ID"),
+      groupBy: z.enum(["journalistId"]).optional().describe("Group results by journalistId"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Cost statistics",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              groups: z.array(
+                z.object({
+                  dimensions: z.record(z.string()).describe("Grouping dimensions (e.g. journalistId)"),
+                  totalCostInUsdCents: z.number(),
+                  actualCostInUsdCents: z.number(),
+                  provisionedCostInUsdCents: z.number(),
+                  runCount: z.number(),
+                }),
+              ),
+            })
+            .openapi("JournalistStatsCostsResponse"),
+        },
+      },
+    },
+    400: { description: "Missing required brandId parameter", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
 // ===================================================================
 // ARTICLES (airtik)
 // ===================================================================

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -100,7 +100,7 @@ describe("Journalists proxy routes", () => {
   it("should use buildInternalHeaders for all endpoints", () => {
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(5);
+    expect(headerMatches!.length).toBe(6);
   });
 
   it("should proxy to externalServices.journalist", () => {
@@ -123,6 +123,36 @@ describe("Journalists proxy routes", () => {
     expect(content).toContain("req.campaignId");
     expect(content).toContain("brandId");
     expect(content).toContain("Either x-campaign-id header or brandId in request body is required");
+  });
+
+  it("should have GET /journalists/stats/costs with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/journalists/stats/costs"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should proxy GET /journalists/stats/costs to /journalists/stats/costs on journalist-service", () => {
+    expect(content).toContain('`/journalists/stats/costs${qs}`');
+  });
+
+  it("should require brandId on GET /journalists/stats/costs", () => {
+    // The route validates brandId is present
+    expect(content).toContain("Missing required query parameter: brandId");
+  });
+
+  it("should forward groupBy and campaignId query params on stats/costs", () => {
+    // The route forwards brandId, campaignId, groupBy
+    const statsBlock = content.slice(
+      content.indexOf('"/journalists/stats/costs"'),
+      content.indexOf('"/journalists/stats/costs"') + 600
+    );
+    expect(statsBlock).toContain('"brandId"');
+    expect(statsBlock).toContain('"campaignId"');
+    expect(statsBlock).toContain('"groupBy"');
   });
 
   it("should enforce requireOrg + requireUser on ALL journalist routes", () => {
@@ -211,6 +241,11 @@ describe("Journalists OpenAPI schemas", () => {
     const start = schemaContent.indexOf("ListJournalistsQuery");
     const block = schemaContent.slice(Math.max(0, start - 400), start);
     expect(block).toContain("runId:");
+  });
+
+  it("should register GET /v1/journalists/stats/costs", () => {
+    expect(schemaContent).toContain('path: "/v1/journalists/stats/costs"');
+    expect(schemaContent).toContain("JournalistStatsCostsResponse");
   });
 
   it("should define journalist entity type enum", () => {


### PR DESCRIPTION
## Summary
- Adds proxy route `GET /v1/journalists/stats/costs` forwarding to journalist-service
- Supports `brandId` (required), optional `campaignId` and `groupBy=journalistId`
- Includes Zod schema registration, regenerated `openapi.json`, and unit tests

## Test plan
- [x] Unit tests pass (36/36 in journalists-proxy.test.ts)
- [x] OpenAPI spec includes `/v1/journalists/stats/costs` path
- [x] Pre-existing unrelated test failure (`openapi-response-schemas`) confirmed on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)