### PR TITLE
docs: make x-campaign-id optional on discover endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8976,7 +8976,7 @@
           "Outlets"
         ],
         "summary": "Discover relevant outlets via Google search + LLM scoring",
-        "description": "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. Requires x-campaign-id and x-brand-id headers.",
+        "description": "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. Requires x-brand-id header. x-campaign-id is optional — when omitted, campaign-specific scoring is skipped.",
         "security": [
           {
             "bearerAuth": []
@@ -9655,7 +9655,7 @@
           "Journalists"
         ],
         "summary": "Discover relevant journalists for a brand on an outlet",
-        "description": "Triggers journalist discovery for a given outlet. Requires x-campaign-id and x-brand-id headers. Creates a child run, discovers journalists, and stores them as buffered. Use the returned runId to query journalists from this specific discovery run via GET /v1/journalists?runId={runId}.",
+        "description": "Triggers journalist discovery for a given outlet. Requires x-brand-id header. x-campaign-id is optional — when omitted, campaign-specific scoring is skipped. Creates a child run, discovers journalists, and stores them as buffered. Use the returned runId to query journalists from this specific discovery run via GET /v1/journalists?runId={runId}.",
         "security": [
           {
             "bearerAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1097,7 +1097,7 @@ registry.registerPath({
   summary: "Discover relevant outlets via Google search + LLM scoring",
   description: "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. " +
     "Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. " +
-    "Requires x-campaign-id and x-brand-id headers.",
+    "Requires x-brand-id header. x-campaign-id is optional — when omitted, campaign-specific scoring is skipped.",
   security: authed,
   request: {
     body: {
@@ -1293,7 +1293,7 @@ registry.registerPath({
   path: "/v1/journalists/discover",
   tags: ["Journalists"],
   summary: "Discover relevant journalists for a brand on an outlet",
-  description: "Triggers journalist discovery for a given outlet. Requires x-campaign-id and x-brand-id headers. Creates a child run, discovers journalists, and stores them as buffered. Use the returned runId to query journalists from this specific discovery run via GET /v1/journalists?runId={runId}.",
+  description: "Triggers journalist discovery for a given outlet. Requires x-brand-id header. x-campaign-id is optional — when omitted, campaign-specific scoring is skipped. Creates a child run, discovers journalists, and stores them as buffered. Use the returned runId to query journalists from this specific discovery run via GET /v1/journalists?runId={runId}.",
   security: authed,
   request: {
     body: {


### PR DESCRIPTION
## Summary
- Updated OpenAPI descriptions for `POST /v1/outlets/discover` and `POST /v1/journalists/discover` to document that `x-campaign-id` is optional (only `x-brand-id` is required)
- The api-service proxy layer already forwards `x-campaign-id` only when present — no code change needed here
- **Downstream action required**: outlets-service and journalists-service need to make `x-campaign-id` optional on their `/discover` endpoints (see below)

## Downstream changes needed (outlets-service + journalists-service)
The actual enforcement of `x-campaign-id` as required happens in the downstream services. Those services need to:
1. Make `x-campaign-id` optional in their `/discover` endpoint validation
2. When `x-campaign-id` is absent: skip campaign-specific relevance scoring, or use brand-level defaults
3. `x-brand-id` should be sufficient context for discovery

## Test plan
- [x] Verified pre-existing test failure (unrelated openapi-response-schemas test)
- [ ] Once downstream services are updated, test discover endpoints without `x-campaign-id` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)