### PR TITLE
fix: validate UUID on workflow :id params

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -14960,6 +14960,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Workflow ID"
             },
             "required": true,
@@ -15070,6 +15071,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Workflow ID"
             },
             "required": true,
@@ -15342,6 +15344,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Workflow ID"
             },
             "required": true,
@@ -15464,6 +15467,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Workflow ID"
             },
             "required": true,
@@ -15576,6 +15580,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Workflow ID"
             },
             "required": true,
@@ -15698,6 +15703,7 @@
           {
             "schema": {
               "type": "string",
+              "format": "uuid",
               "description": "Workflow ID"
             },
             "required": true,

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -10,6 +10,12 @@ const router = Router();
 // Helpers
 // ---------------------------------------------------------------------------
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUUID(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
 interface ProviderInfo {
   name: string;
   domain: string | null;
@@ -247,6 +253,7 @@ router.post("/workflows", authenticate, requireOrg, requireUser, async (req: Aut
 router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow ID — expected a UUID" });
 
     // Fetch workflow with DAG and required providers in parallel
     const [workflow, requiredProviders] = await Promise.all([
@@ -345,6 +352,7 @@ router.get("/workflows/:id/summary", authenticate, requireOrg, requireUser, asyn
 router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow ID — expected a UUID" });
 
     const internalHeaders = buildInternalHeaders(req);
     const [requiredProviders, orgKeys, keySources] = await Promise.all([
@@ -403,6 +411,7 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
 router.post("/workflows/:id/validate", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow ID — expected a UUID" });
 
     const result = await callExternalService(
       externalServices.workflow,
@@ -428,6 +437,7 @@ router.post("/workflows/:id/validate", authenticate, requireOrg, requireUser, as
 router.put("/workflows/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow ID — expected a UUID" });
 
     const parsed = UpdateWorkflowRequestSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -462,6 +472,7 @@ router.put("/workflows/:id", authenticate, requireOrg, requireUser, async (req: 
 router.get("/workflows/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow ID — expected a UUID" });
 
     const [workflow, requiredProviders] = await Promise.all([
       callExternalService(
@@ -491,6 +502,8 @@ router.get("/workflows/:id", authenticate, requireOrg, requireUser, async (req: 
 router.post("/workflows/:id/execute", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow ID — expected a UUID" });
+
     const result = await callExternalService(
       externalServices.workflow,
       `/workflows/${id}/execute`,
@@ -541,6 +554,7 @@ router.get("/workflow-runs", authenticate, requireOrg, requireUser, async (req: 
 router.get("/workflow-runs/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow run ID — expected a UUID" });
     const result = await callExternalService(
       externalServices.workflow,
       `/workflow-runs/${id}`,
@@ -560,6 +574,7 @@ router.get("/workflow-runs/:id", authenticate, requireOrg, requireUser, async (r
 router.post("/workflow-runs/:id/cancel", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow run ID — expected a UUID" });
     const result = await callExternalService(
       externalServices.workflow,
       `/workflow-runs/${id}/cancel`,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2971,7 +2971,7 @@ registry.registerPath({
   description: "Get a single workflow with full DAG definition",
   security: authed,
   request: {
-    params: z.object({ id: z.string().describe("Workflow ID") }),
+    params: z.object({ id: z.string().uuid().describe("Workflow ID") }),
   },
   responses: {
     200: {
@@ -3097,7 +3097,7 @@ registry.registerPath({
 // ===================================================================
 
 const WorkflowIdParam = z.object({
-  id: z.string().describe("Workflow ID"),
+  id: z.string().uuid().describe("Workflow ID"),
 });
 
 const ProviderInfoSchema = z

--- a/tests/unit/workflow-enrichment.test.ts
+++ b/tests/unit/workflow-enrichment.test.ts
@@ -65,8 +65,8 @@ describe("GET /v1/workflows — enrichment with requiredProviders", () => {
           json: () =>
             Promise.resolve({
               workflows: [
-                { id: "wf-1", name: "cold-outreach-v1", category: "sales" },
-                { id: "wf-2", name: "pr-outreach-v1", category: "pr" },
+                { id: "00000000-0000-4000-8000-000000000001", name: "cold-outreach-v1", category: "sales" },
+                { id: "00000000-0000-4000-8000-000000000002", name: "pr-outreach-v1", category: "pr" },
               ],
             }),
         };
@@ -98,7 +98,7 @@ describe("GET /v1/workflows — enrichment with requiredProviders", () => {
             Promise.resolve({
               workflows: [
                 {
-                  id: "wf-1",
+                  id: "00000000-0000-4000-8000-000000000001",
                   name: "cold-outreach-v3",
                   slug: "cold-outreach-hormozi-v3",
                   dynastyName: "Cold Outreach Hormozi",
@@ -129,8 +129,8 @@ describe("GET /v1/workflows — enrichment with requiredProviders", () => {
 
     const providerCalls = fetchCalls.filter((c) => c.url.includes("/required-providers"));
     expect(providerCalls).toHaveLength(2);
-    expect(providerCalls[0].url).toContain("/workflows/wf-1/required-providers");
-    expect(providerCalls[1].url).toContain("/workflows/wf-2/required-providers");
+    expect(providerCalls[0].url).toContain("/workflows/00000000-0000-4000-8000-000000000001/required-providers");
+    expect(providerCalls[1].url).toContain("/workflows/00000000-0000-4000-8000-000000000002/required-providers");
   });
 
   it("should return empty requiredProviders if provider call fails", async () => {
@@ -148,8 +148,8 @@ describe("GET /v1/workflows — enrichment with requiredProviders", () => {
         json: () =>
           Promise.resolve({
             workflows: [
-              { id: "wf-1", name: "flow-1" },
-              { id: "wf-2", name: "flow-2" },
+              { id: "00000000-0000-4000-8000-000000000001", name: "flow-1" },
+              { id: "00000000-0000-4000-8000-000000000002", name: "flow-2" },
             ],
           }),
       };
@@ -183,10 +183,10 @@ describe("GET /v1/workflows/:id — enrichment with requiredProviders", () => {
           json: () => Promise.resolve({ providers: [{ name: "instantly", domain: "instantly.ai" }, { name: "anthropic", domain: "anthropic.com" }] }),
         };
       }
-      if (url.match(/\/workflows\/wf-\d+$/)) {
+      if (url.match(/\/workflows\/[0-9a-f-]+$/) && !url.includes("/required-providers")) {
         return {
           ok: true,
-          json: () => Promise.resolve({ workflow: { id: "wf-1", name: "cold-outreach-v1" } }),
+          json: () => Promise.resolve({ workflow: { id: "00000000-0000-4000-8000-000000000001", name: "cold-outreach-v1" } }),
         };
       }
       return { ok: true, json: () => Promise.resolve({}) };
@@ -196,7 +196,7 @@ describe("GET /v1/workflows/:id — enrichment with requiredProviders", () => {
   });
 
   it("should enrich single workflow with requiredProviders", async () => {
-    const res = await request(app).get("/v1/workflows/wf-1");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001");
 
     expect(res.status).toBe(200);
     expect(res.body.workflow.requiredProviders).toEqual([{ name: "instantly", domain: "instantly.ai" }, { name: "anthropic", domain: "anthropic.com" }]);
@@ -220,12 +220,12 @@ describe("GET /v1/workflows/:id/summary", () => {
           json: () => Promise.resolve({ providers: [{ name: "apollo", domain: "apollo.io" }, { name: "anthropic", domain: "anthropic.com" }, { name: "instantly", domain: "instantly.ai" }] }),
         };
       }
-      if (url.match(/\/workflows\/wf-1$/)) {
+      if (url.match(/\/workflows\/00000000-0000-4000-8000-000000000001$/)) {
         return {
           ok: true,
           json: () =>
             Promise.resolve({
-              id: "wf-1",
+              id: "00000000-0000-4000-8000-000000000001",
               name: "sales-email-cold-outreach-v1",
               dag: {
                 nodes: [
@@ -250,7 +250,7 @@ describe("GET /v1/workflows/:id/summary", () => {
   });
 
   it("should return a structured summary with steps", async () => {
-    const res = await request(app).get("/v1/workflows/wf-1/summary");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/summary");
 
     expect(res.status).toBe(200);
     expect(res.body.workflowSlug).toBe("sales-email-cold-outreach-v1");
@@ -274,7 +274,7 @@ describe("GET /v1/workflows/:id/summary", () => {
         ok: true,
         json: () =>
           Promise.resolve({
-            id: "wf-regression",
+            id: "00000000-0000-4000-8000-000000000099",
             name: "regression-flow",
             dag: {
               nodes: [{ id: "step-1", type: "http.call", config: { service: "apollo", method: "GET", path: "/test" } }],
@@ -285,7 +285,7 @@ describe("GET /v1/workflows/:id/summary", () => {
     });
     app = createApp();
 
-    const res = await request(app).get("/v1/workflows/wf-regression/summary");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000099/summary");
 
     expect(res.status).toBe(200);
     expect(res.body.workflowSlug).toBe("regression-flow");
@@ -299,12 +299,12 @@ describe("GET /v1/workflows/:id/summary", () => {
       }
       return {
         ok: true,
-        json: () => Promise.resolve({ id: "wf-1", name: "empty-flow", dag: null }),
+        json: () => Promise.resolve({ id: "00000000-0000-4000-8000-000000000001", name: "empty-flow", dag: null }),
       };
     });
     app = createApp();
 
-    const res = await request(app).get("/v1/workflows/wf-1/summary");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/summary");
 
     expect(res.status).toBe(200);
     expect(res.body.steps).toEqual([]);
@@ -347,7 +347,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
       if (url.match(/\/keys$/) || url.includes("/keys?")) {
         return { ok: true, json: () => Promise.resolve({ keys: orgKeys }) };
       }
-      if (url.match(/\/workflows\/wf-1$/)) {
+      if (url.match(/\/workflows\/00000000-0000-4000-8000-000000000001$/)) {
         return { ok: true, json: () => Promise.resolve({ workflow: { name: workflowSlug } }) };
       }
       return { ok: true, json: () => Promise.resolve({}) };
@@ -372,7 +372,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
     });
     app = createApp();
 
-    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/key-status");
 
     expect(res.status).toBe(200);
     expect(res.body.workflowSlug).toBe("sales-email-cold-outreach-v1");
@@ -393,7 +393,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
     });
     app = createApp();
 
-    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/key-status");
 
     expect(res.status).toBe(200);
     expect(res.body.ready).toBe(true);
@@ -411,7 +411,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
     });
     app = createApp();
 
-    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/key-status");
 
     expect(res.status).toBe(200);
     expect(res.body.ready).toBe(true);
@@ -430,7 +430,7 @@ describe("GET /v1/workflows/:id/key-status", () => {
     });
     app = createApp();
 
-    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/key-status");
 
     expect(res.status).toBe(200);
     expect(res.body.ready).toBe(false);
@@ -440,14 +440,14 @@ describe("GET /v1/workflows/:id/key-status", () => {
   });
 
   it("should fetch key sources from /keys/sources", async () => {
-    await request(app).get("/v1/workflows/wf-1/key-status");
+    await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/key-status");
 
     const sourcesCall = fetchCalls.find((c) => c.url.includes("/keys/sources"));
     expect(sourcesCall).toBeDefined();
   });
 
   it("should fetch org keys via /keys without orgId in query (uses headers)", async () => {
-    await request(app).get("/v1/workflows/wf-1/key-status");
+    await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/key-status");
 
     const keysCall = fetchCalls.find((c) => c.url.match(/\/keys$/) && !c.url.includes("/keys/sources"));
     expect(keysCall).toBeDefined();
@@ -468,14 +468,14 @@ describe("GET /v1/workflows/:id/key-status", () => {
       if (url.match(/\/keys$/) || url.includes("/keys?")) {
         return { ok: true, json: () => Promise.resolve({ keys: [] }) };
       }
-      if (url.match(/\/workflows\/wf-1$/)) {
+      if (url.match(/\/workflows\/00000000-0000-4000-8000-000000000001$/)) {
         return { ok: true, json: () => Promise.resolve({ workflow: { name: "test-flow" } }) };
       }
       return { ok: true, json: () => Promise.resolve({}) };
     });
     app = createApp();
 
-    const res = await request(app).get("/v1/workflows/wf-1/key-status");
+    const res = await request(app).get("/v1/workflows/00000000-0000-4000-8000-000000000001/key-status");
 
     // Should default to platform → configured = true
     expect(res.status).toBe(200);

--- a/tests/unit/workflow-runs-proxy.test.ts
+++ b/tests/unit/workflow-runs-proxy.test.ts
@@ -64,7 +64,7 @@ beforeEach(() => {
 
 describe("POST /v1/workflows", () => {
   it("should proxy to workflow-service POST /workflows", async () => {
-    mockFetchWith({ id: "wf-123", name: "test-flow" });
+    mockFetchWith({ id: "00000000-0000-4000-8000-000000000001", name: "test-flow" });
     const app = createApp();
     const res = await request(app)
       .post("/v1/workflows")
@@ -84,7 +84,7 @@ describe("POST /v1/workflows", () => {
 describe("DELETE /v1/workflows/:id", () => {
   it("should NOT be exposed — returns 404", async () => {
     const app = createApp();
-    const res = await request(app).delete("/v1/workflows/wf-123");
+    const res = await request(app).delete("/v1/workflows/00000000-0000-4000-8000-000000000001");
     expect(res.status).toBe(404);
   });
 });
@@ -95,16 +95,16 @@ describe("DELETE /v1/workflows/:id", () => {
 
 describe("POST /v1/workflows/:id/execute", () => {
   it("should proxy to workflow-service POST /workflows/:id/execute", async () => {
-    mockFetchWith({ id: "run-456", status: "queued" });
+    mockFetchWith({ id: "00000000-0000-4000-8000-000000000456", status: "queued" });
     const app = createApp();
     const res = await request(app)
-      .post("/v1/workflows/wf-123/execute")
+      .post("/v1/workflows/00000000-0000-4000-8000-000000000001/execute")
       .send({ inputs: { email: "test@example.com" } });
 
     expect(res.status).toBe(201);
     const call = fetchCalls.find((c) => c.method === "POST" && c.url.includes("/execute"));
     expect(call).toBeDefined();
-    expect(call!.url).toContain("/workflows/wf-123/execute");
+    expect(call!.url).toContain("/workflows/00000000-0000-4000-8000-000000000001/execute");
     expect(call!.body.inputs.email).toBe("test@example.com");
   });
 });
@@ -127,10 +127,10 @@ describe("GET /v1/workflow-runs", () => {
   it("should forward query params", async () => {
     mockFetchWith({ workflowRuns: [] });
     const app = createApp();
-    await request(app).get("/v1/workflow-runs?workflowId=wf-123&status=failed&featureSlug=pr-outreach");
+    await request(app).get("/v1/workflow-runs?workflowId=00000000-0000-4000-8000-000000000001&status=failed&featureSlug=pr-outreach");
 
     const call = fetchCalls[0];
-    expect(call.url).toContain("workflowId=wf-123");
+    expect(call.url).toContain("workflowId=00000000-0000-4000-8000-000000000001");
     expect(call.url).toContain("status=failed");
     expect(call.url).toContain("featureSlug=pr-outreach");
   });
@@ -142,13 +142,13 @@ describe("GET /v1/workflow-runs", () => {
 
 describe("GET /v1/workflow-runs/:id", () => {
   it("should proxy to workflow-service GET /workflow-runs/:id", async () => {
-    mockFetchWith({ id: "run-456", status: "completed", result: { ok: true } });
+    mockFetchWith({ id: "00000000-0000-4000-8000-000000000456", status: "completed", result: { ok: true } });
     const app = createApp();
-    const res = await request(app).get("/v1/workflow-runs/run-456");
+    const res = await request(app).get("/v1/workflow-runs/00000000-0000-4000-8000-000000000456");
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("completed");
-    expect(fetchCalls[0].url).toContain("/workflow-runs/run-456");
+    expect(fetchCalls[0].url).toContain("/workflow-runs/00000000-0000-4000-8000-000000000456");
   });
 });
 
@@ -159,7 +159,7 @@ describe("GET /v1/workflow-runs/:id", () => {
 describe("GET /v1/workflow-runs/:id/debug", () => {
   it("should NOT be exposed — returns 404", async () => {
     const app = createApp();
-    const res = await request(app).get("/v1/workflow-runs/run-456/debug");
+    const res = await request(app).get("/v1/workflow-runs/00000000-0000-4000-8000-000000000456/debug");
     expect(res.status).toBe(404);
   });
 });
@@ -170,14 +170,14 @@ describe("GET /v1/workflow-runs/:id/debug", () => {
 
 describe("POST /v1/workflow-runs/:id/cancel", () => {
   it("should proxy to workflow-service POST /workflow-runs/:id/cancel", async () => {
-    mockFetchWith({ id: "run-456", status: "cancelled" });
+    mockFetchWith({ id: "00000000-0000-4000-8000-000000000456", status: "cancelled" });
     const app = createApp();
-    const res = await request(app).post("/v1/workflow-runs/run-456/cancel");
+    const res = await request(app).post("/v1/workflow-runs/00000000-0000-4000-8000-000000000456/cancel");
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("cancelled");
     const call = fetchCalls.find((c) => c.method === "POST" && c.url.includes("/cancel"));
     expect(call).toBeDefined();
-    expect(call!.url).toContain("/workflow-runs/run-456/cancel");
+    expect(call!.url).toContain("/workflow-runs/00000000-0000-4000-8000-000000000456/cancel");
   });
 });

--- a/tests/unit/workflow-uuid-validation.regression.test.ts
+++ b/tests/unit/workflow-uuid-validation.regression.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Regression test: non-UUID strings like "new" must NOT be forwarded to
+ * workflow-service as a workflow ID.  Without validation, Express captures
+ * "new" via the `:id` param and workflow-service blows up with
+ * `PostgresError: invalid input syntax for type uuid: "new"`.
+ */
+describe("Workflow :id routes validate UUID format", () => {
+  const routePath = path.join(__dirname, "../../src/routes/workflows.ts");
+  const content = fs.readFileSync(routePath, "utf-8");
+
+  it("should define a UUID regex or validation helper", () => {
+    expect(content).toMatch(/UUID_RE|isUUID/);
+  });
+
+  const idRoutes = [
+    '/workflows/:id/summary"',
+    '/workflows/:id/key-status"',
+    '/workflows/:id/validate"',
+    '/workflows/:id"',  // GET and PUT
+    '/workflows/:id/execute"',
+    '/workflow-runs/:id"',
+    '/workflow-runs/:id/cancel"',
+  ];
+
+  for (const route of idRoutes) {
+    it(`should validate UUID on route containing ${route}`, () => {
+      // Find handler block for this route
+      const idx = content.indexOf(route);
+      expect(idx).toBeGreaterThan(-1);
+      // Check that isUUID appears between this route and the next route or end
+      const nextRouteIdx = content.indexOf("router.", idx + 1);
+      const block = content.slice(idx, nextRouteIdx > idx ? nextRouteIdx : undefined);
+      expect(block).toContain("isUUID");
+    });
+  }
+});
+
+describe("Workflow OpenAPI schemas use uuid format for {id} param", () => {
+  const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+  const content = fs.readFileSync(schemaPath, "utf-8");
+
+  it("WorkflowIdParam should use z.string().uuid()", () => {
+    const section = content.slice(
+      content.indexOf("WorkflowIdParam"),
+      content.indexOf("WorkflowIdParam") + 100,
+    );
+    expect(section).toContain(".uuid()");
+  });
+
+  it("GET /v1/workflows/{id} inline param should use .uuid()", () => {
+    const start = content.indexOf('path: "/v1/workflows/{id}"');
+    // Find the next path definition to bound the search
+    const nextPath = content.indexOf("path:", start + 1);
+    const getSection = content.slice(start, nextPath > start ? nextPath : start + 500);
+    expect(getSection).toContain(".uuid()");
+  });
+});


### PR DESCRIPTION
## Summary
- Non-UUID strings (e.g. `"new"`) captured by `/workflows/:id` routes were forwarded to workflow-service, causing `PostgresError: invalid input syntax for type uuid`
- Added UUID format validation on all `:id` param routes (workflows + workflow-runs) — returns 400 immediately with a clear error
- Updated OpenAPI `WorkflowIdParam` schema to use `z.string().uuid()`
- Regenerated `openapi.json`

## Test plan
- [x] New regression test `workflow-uuid-validation.regression.test.ts` verifies all `:id` routes have UUID validation
- [x] Updated existing tests to use valid UUIDs instead of non-UUID IDs
- [x] All 89 workflow-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)