### PR TITLE
fix: remove UUID fallback from key-status workflowSlug

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -355,10 +355,15 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
     if (!isUUID(id)) return res.status(400).json({ error: "Invalid workflow ID — expected a UUID" });
 
     const internalHeaders = buildInternalHeaders(req);
-    const [requiredProviders, orgKeys, keySources] = await Promise.all([
+    const [requiredProviders, orgKeys, keySources, workflow] = await Promise.all([
       fetchRequiredProviders(id, internalHeaders),
       fetchOrgKeys(internalHeaders),
       fetchKeySources(internalHeaders),
+      callExternalService<{ slug: string }>(
+        externalServices.workflow,
+        `/workflows/${id}`,
+        { headers: internalHeaders },
+      ),
     ]);
 
     const configuredMap = new Map(orgKeys.map((k) => [k.provider, k.maskedKey]));
@@ -380,20 +385,8 @@ router.get("/workflows/:id/key-status", authenticate, requireOrg, requireUser, a
 
     const missing = keys.filter((k) => !k.configured).map((k) => k.provider);
 
-    let workflowSlug = id;
-    try {
-      const wf = await callExternalService<{ slug: string }>(
-        externalServices.workflow,
-        `/workflows/${id}`,
-        { headers: buildInternalHeaders(req) },
-      );
-      workflowSlug = wf.slug ?? id;
-    } catch {
-      // Fall back to id
-    }
-
     res.json({
-      workflowSlug,
+      workflowSlug: workflow.slug,
       ready: missing.length === 0,
       keys,
       missing,


### PR DESCRIPTION
## Summary
- Follows up on #248: removes the silent UUID fallback in the key-status endpoint
- Moves the workflow fetch into the existing `Promise.all` instead of a separate try/catch
- If workflow-service is unreachable, the endpoint now properly 500s instead of returning a misleading UUID as `workflowSlug`

## Test plan
- [x] All 16 workflow-enrichment tests passing
- [x] No test changes needed — existing mocks already cover this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)