### PR TITLE
feat: support fork/conflict responses on PUT /workflows/{id}

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4187,6 +4187,13 @@
           {
             "type": "object",
             "properties": {
+              "_action": {
+                "type": "string",
+                "enum": [
+                  "updated"
+                ],
+                "description": "Indicates the workflow was updated in-place"
+              },
               "dag": {
                 "type": "object",
                 "properties": {
@@ -4208,7 +4215,68 @@
                   "edges"
                 ]
               }
-            }
+            },
+            "required": [
+              "_action"
+            ]
+          }
+        ]
+      },
+      "ForkedWorkflowResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/WorkflowMetadata"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "_action": {
+                "type": "string",
+                "enum": [
+                  "forked"
+                ],
+                "description": "Indicates a new workflow was created (forked) due to a DAG signature change"
+              },
+              "_forkedFromName": {
+                "type": "string",
+                "description": "Name of the source workflow that was forked"
+              },
+              "_forkedFromId": {
+                "type": "string",
+                "description": "ID of the source workflow that was forked"
+              },
+              "_sourceDynastyDeprecated": {
+                "type": "boolean",
+                "description": "Whether the source dynasty was deprecated as a result"
+              },
+              "dag": {
+                "type": "object",
+                "properties": {
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "nullable": true
+                    }
+                  },
+                  "edges": {
+                    "type": "array",
+                    "items": {
+                      "nullable": true
+                    }
+                  }
+                },
+                "required": [
+                  "nodes",
+                  "edges"
+                ]
+              }
+            },
+            "required": [
+              "_action",
+              "_forkedFromName",
+              "_forkedFromId",
+              "_sourceDynastyDeprecated"
+            ]
           }
         ]
       },
@@ -15061,7 +15129,7 @@
           "Workflows"
         ],
         "summary": "Update a workflow",
-        "description": "Update a workflow's name, description, tags, or DAG. Send only the fields you want to change. After updating the DAG, call POST /v1/workflows/{id}/validate to verify consistency.",
+        "description": "Update a workflow's metadata or DAG. Without `dag` in the body → metadata-only update (200). With `dag` and same signature → in-place update (200). With `dag` and new signature → fork: creates a new workflow (201, `_action: \"forked\"`). Returns 409 if an active workflow with the same DAG signature already exists.",
         "security": [
           {
             "bearerAuth": []
@@ -15145,11 +15213,21 @@
         },
         "responses": {
           "200": {
-            "description": "Updated workflow",
+            "description": "Updated in-place (`_action: \"updated\"`)",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UpdateWorkflowResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Forked — new workflow created because the DAG signature changed (`_action: \"forked\"`)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForkedWorkflowResponse"
                 }
               }
             }
@@ -15176,6 +15254,16 @@
           },
           "404": {
             "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — an active workflow with the same DAG signature already exists",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
-import { callExternalService, externalServices } from "../lib/service-client.js";
+import { callExternalService, callExternalServiceWithStatus, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { GenerateWorkflowRequestSchema, UpdateWorkflowRequestSchema } from "../schemas.js";
 
@@ -440,7 +440,7 @@ router.put("/workflows/:id", authenticate, requireOrg, requireUser, async (req: 
       });
     }
 
-    const result = await callExternalService(
+    const { status, data } = await callExternalServiceWithStatus(
       externalServices.workflow,
       `/workflows/${id}`,
       {
@@ -450,7 +450,7 @@ router.put("/workflows/:id", authenticate, requireOrg, requireUser, async (req: 
       },
     );
 
-    res.json(result);
+    res.status(status).json(data);
   } catch (error: any) {
     console.error("Update workflow error:", error.message);
     const status = error.statusCode || 500;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3300,9 +3300,11 @@ registry.registerPath({
   tags: ["Workflows"],
   summary: "Update a workflow",
   description:
-    "Update a workflow's name, description, tags, or DAG. " +
-    "Send only the fields you want to change. " +
-    "After updating the DAG, call POST /v1/workflows/{id}/validate to verify consistency.",
+    "Update a workflow's metadata or DAG. " +
+    "Without `dag` in the body → metadata-only update (200). " +
+    "With `dag` and same signature → in-place update (200). " +
+    "With `dag` and new signature → fork: creates a new workflow (201, `_action: \"forked\"`). " +
+    "Returns 409 if an active workflow with the same DAG signature already exists.",
   security: authed,
   request: {
     params: WorkflowIdParam,
@@ -3314,10 +3316,11 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "Updated workflow",
+      description: "Updated in-place (`_action: \"updated\"`)",
       content: {
         "application/json": {
           schema: WorkflowMetadataSchema.extend({
+            _action: z.literal("updated").describe("Indicates the workflow was updated in-place"),
             dag: z.object({
               nodes: z.array(z.any()),
               edges: z.array(z.any()),
@@ -3326,9 +3329,27 @@ registry.registerPath({
         },
       },
     },
+    201: {
+      description: "Forked — new workflow created because the DAG signature changed (`_action: \"forked\"`)",
+      content: {
+        "application/json": {
+          schema: WorkflowMetadataSchema.extend({
+            _action: z.literal("forked").describe("Indicates a new workflow was created (forked) due to a DAG signature change"),
+            _forkedFromName: z.string().describe("Name of the source workflow that was forked"),
+            _forkedFromId: z.string().describe("ID of the source workflow that was forked"),
+            _sourceDynastyDeprecated: z.boolean().describe("Whether the source dynasty was deprecated as a result"),
+            dag: z.object({
+              nodes: z.array(z.any()),
+              edges: z.array(z.any()),
+            }).optional(),
+          }).openapi("ForkedWorkflowResponse"),
+        },
+      },
+    },
     400: { description: "Invalid request", content: errorContent },
-    404: { description: "Workflow not found", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Workflow not found", content: errorContent },
+    409: { description: "Conflict — an active workflow with the same DAG signature already exists", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
 });

--- a/tests/unit/workflow-put-fork.test.ts
+++ b/tests/unit/workflow-put-fork.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("PUT /workflows/:id — fork/conflict support", () => {
+  const routePath = path.join(__dirname, "../../src/routes/workflows.ts");
+  const content = fs.readFileSync(routePath, "utf-8");
+
+  it("should use callExternalServiceWithStatus for PUT /workflows/:id", () => {
+    const putStart = content.indexOf('router.put("/workflows/:id"');
+    const putEnd = content.indexOf("router.", putStart + 10);
+    const block = content.slice(putStart, putEnd);
+
+    expect(block).toContain("callExternalServiceWithStatus");
+  });
+
+  it("should forward the upstream status code (200 or 201)", () => {
+    const putStart = content.indexOf('router.put("/workflows/:id"');
+    const putEnd = content.indexOf("router.", putStart + 10);
+    const block = content.slice(putStart, putEnd);
+
+    expect(block).toContain("res.status(status).json(data)");
+  });
+
+  it("should import callExternalServiceWithStatus", () => {
+    expect(content).toContain("callExternalServiceWithStatus");
+    const importLine = content.slice(0, content.indexOf("\n\n"));
+    expect(importLine).toContain("callExternalServiceWithStatus");
+  });
+});
+
+describe("PUT /workflows/{id} OpenAPI spec — fork/conflict responses", () => {
+  const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+  const content = fs.readFileSync(schemaPath, "utf-8");
+
+  // Find the PUT /workflows/{id} block by locating 'summary: "Update a workflow"'
+  const updateSummaryIdx = content.indexOf('summary: "Update a workflow"');
+  const putBlockStart = content.lastIndexOf("registry.registerPath", updateSummaryIdx);
+  const putEnd = content.indexOf("registry.registerPath", updateSummaryIdx + 30);
+  const putBlock = content.slice(putBlockStart, putEnd);
+
+  it("should document 200 response with _action: updated", () => {
+    expect(putBlock).toContain("200:");
+    expect(putBlock).toContain('"updated"');
+    expect(putBlock).toContain("UpdateWorkflowResponse");
+  });
+
+  it("should document 201 response with _action: forked", () => {
+    expect(putBlock).toContain("201:");
+    expect(putBlock).toContain('"forked"');
+    expect(putBlock).toContain("ForkedWorkflowResponse");
+  });
+
+  it("should include _forkedFromName and _forkedFromId in 201 response", () => {
+    expect(putBlock).toContain("_forkedFromName");
+    expect(putBlock).toContain("_forkedFromId");
+    expect(putBlock).toContain("_sourceDynastyDeprecated");
+  });
+
+  it("should document 409 conflict response", () => {
+    expect(putBlock).toContain("409:");
+    expect(putBlock).toContain("Conflict");
+  });
+
+  it("should mention fork behavior in the endpoint description", () => {
+    expect(putBlock).toContain("forked");
+    expect(putBlock).toContain("signature");
+  });
+});
+
+describe("Generated openapi.json reflects fork/conflict changes", () => {
+  const openapiPath = path.join(__dirname, "../../openapi.json");
+  const spec = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+  const putResponses = spec.paths["/v1/workflows/{id}"]?.put?.responses;
+
+  it("should have 200 response", () => {
+    expect(putResponses).toHaveProperty("200");
+  });
+
+  it("should have 201 response", () => {
+    expect(putResponses).toHaveProperty("201");
+    expect(putResponses["201"].description).toContain("forked");
+  });
+
+  it("should have 409 response", () => {
+    expect(putResponses).toHaveProperty("409");
+    expect(putResponses["409"].description).toContain("Conflict");
+  });
+
+  it("should reference ForkedWorkflowResponse schema", () => {
+    const ref201 = putResponses["201"]?.content?.["application/json"]?.schema?.$ref;
+    expect(ref201).toContain("ForkedWorkflowResponse");
+  });
+});


### PR DESCRIPTION
## Summary
- Updated PUT /workflows/{id} proxy to use `callExternalServiceWithStatus` to forward upstream 200 (updated) vs 201 (forked) status codes
- Added 201 (forked) and 409 (conflict) response schemas to the OpenAPI spec, with `_action`, `_forkedFromName`, `_forkedFromId`, and `_sourceDynastyDeprecated` fields
- Regenerated `openapi.json`
- Added 12 tests covering the new behavior

Reflects workflow-service PR #190 changes.

## Test plan
- [x] All 121 existing workflow tests pass
- [x] 12 new tests for fork/conflict proxy behavior and OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)