### PR TITLE
docs: enrich PUT /workflows/{id} OpenAPI spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4280,6 +4280,29 @@
           }
         ]
       },
+      "WorkflowConflictResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message"
+          },
+          "existingWorkflowId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the existing workflow that already has this DAG signature"
+          },
+          "existingWorkflowSlug": {
+            "type": "string",
+            "description": "Slug of the existing workflow that already has this DAG signature"
+          }
+        },
+        "required": [
+          "error",
+          "existingWorkflowId",
+          "existingWorkflowSlug"
+        ]
+      },
       "DAGNode": {
         "type": "object",
         "properties": {
@@ -4364,7 +4387,7 @@
           "nodes",
           "edges"
         ],
-        "description": "Updated DAG definition"
+        "description": "Optional new DAG. When omitted, only metadata (description, tags) is updated in-place. When provided with the same structural signature, the DAG is updated in-place. When provided with a different structural signature, a new workflow is created (fork) and the original is kept active (unless its dynasty has zero campaign runs, in which case it is deprecated)."
       },
       "UpdateWorkflowRequest": {
         "type": "object",
@@ -4387,6 +4410,48 @@
           },
           "dag": {
             "$ref": "#/components/schemas/DAG"
+          }
+        },
+        "example": {
+          "description": "Updated workflow description",
+          "tags": [
+            "email",
+            "outreach"
+          ],
+          "dag": {
+            "nodes": [
+              {
+                "id": "fetch-lead",
+                "type": "http.call",
+                "config": {
+                  "service": "lead",
+                  "method": "POST",
+                  "path": "/buffer/next"
+                },
+                "inputMapping": {
+                  "body.campaignId": "$ref:flow_input.campaignId"
+                }
+              },
+              {
+                "id": "send-email",
+                "type": "http.call",
+                "config": {
+                  "service": "email-gateway",
+                  "method": "POST",
+                  "path": "/send"
+                },
+                "inputMapping": {
+                  "body.to": "$ref:fetch-lead.output.lead.email"
+                },
+                "retries": 0
+              }
+            ],
+            "edges": [
+              {
+                "from": "fetch-lead",
+                "to": "send-email"
+              }
+            ]
           }
         }
       },
@@ -15129,7 +15194,7 @@
           "Workflows"
         ],
         "summary": "Update a workflow",
-        "description": "Update a workflow's metadata or DAG. Without `dag` in the body → metadata-only update (200). With `dag` and same signature → in-place update (200). With `dag` and new signature → fork: creates a new workflow (201, `_action: \"forked\"`). Returns 409 if an active workflow with the same DAG signature already exists.",
+        "description": "The single endpoint for modifying a workflow. Behavior depends on what you send:\n\n**Metadata only** (no `dag` in body): updates description/tags in-place. Returns 200 with `_action: 'updated'`.\n\n**DAG with same signature**: the DAG structure hasn't changed (e.g. only config tweaks that don't affect the hash). Updates in-place. Returns 200 with `_action: 'updated'`.\n\n**DAG with new signature**: creates a new workflow in a new dynasty (fork). The original workflow is kept active unless its entire dynasty has zero campaign runs, in which case it is deprecated. Returns 201 with `_action: 'forked'`, plus `_forkedFromName`, `_forkedFromId`, and `_sourceDynastyDeprecated`.\n\nReturns 409 if an active workflow with the same DAG signature already exists, with `existingWorkflowId` and `existingWorkflowSlug` in the response body.",
         "security": [
           {
             "bearerAuth": []
@@ -15267,7 +15332,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/WorkflowConflictResponse"
                 }
               }
             }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3290,9 +3290,26 @@ export const UpdateWorkflowRequestSchema = z
     name: z.string().min(1).optional().describe("Workflow name"),
     description: z.string().optional().describe("Workflow description"),
     tags: z.array(z.string()).optional().describe("Tags for filtering/grouping"),
-    dag: DAGSchema.optional().describe("Updated DAG definition"),
+    dag: DAGSchema.optional().describe(
+      "Optional new DAG. When omitted, only metadata (description, tags) is updated in-place. " +
+      "When provided with the same structural signature, the DAG is updated in-place. " +
+      "When provided with a different structural signature, a new workflow is created (fork) " +
+      "and the original is kept active (unless its dynasty has zero campaign runs, in which case it is deprecated)."
+    ),
   })
-  .openapi("UpdateWorkflowRequest");
+  .openapi("UpdateWorkflowRequest", {
+    example: {
+      description: "Updated workflow description",
+      tags: ["email", "outreach"],
+      dag: {
+        nodes: [
+          { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/buffer/next" }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+          { id: "send-email", type: "http.call", config: { service: "email-gateway", method: "POST", path: "/send" }, inputMapping: { "body.to": "$ref:fetch-lead.output.lead.email" }, retries: 0 },
+        ],
+        edges: [{ from: "fetch-lead", to: "send-email" }],
+      },
+    },
+  });
 
 registry.registerPath({
   method: "put",
@@ -3300,11 +3317,11 @@ registry.registerPath({
   tags: ["Workflows"],
   summary: "Update a workflow",
   description:
-    "Update a workflow's metadata or DAG. " +
-    "Without `dag` in the body → metadata-only update (200). " +
-    "With `dag` and same signature → in-place update (200). " +
-    "With `dag` and new signature → fork: creates a new workflow (201, `_action: \"forked\"`). " +
-    "Returns 409 if an active workflow with the same DAG signature already exists.",
+    "The single endpoint for modifying a workflow. Behavior depends on what you send:\n\n" +
+    "**Metadata only** (no `dag` in body): updates description/tags in-place. Returns 200 with `_action: 'updated'`.\n\n" +
+    "**DAG with same signature**: the DAG structure hasn't changed (e.g. only config tweaks that don't affect the hash). Updates in-place. Returns 200 with `_action: 'updated'`.\n\n" +
+    "**DAG with new signature**: creates a new workflow in a new dynasty (fork). The original workflow is kept active unless its entire dynasty has zero campaign runs, in which case it is deprecated. Returns 201 with `_action: 'forked'`, plus `_forkedFromName`, `_forkedFromId`, and `_sourceDynastyDeprecated`.\n\n" +
+    "Returns 409 if an active workflow with the same DAG signature already exists, with `existingWorkflowId` and `existingWorkflowSlug` in the response body.",
   security: authed,
   request: {
     params: WorkflowIdParam,
@@ -3349,7 +3366,18 @@ registry.registerPath({
     400: { description: "Invalid request", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Workflow not found", content: errorContent },
-    409: { description: "Conflict — an active workflow with the same DAG signature already exists", content: errorContent },
+    409: {
+      description: "Conflict — an active workflow with the same DAG signature already exists",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string().describe("Error message"),
+            existingWorkflowId: z.string().uuid().describe("ID of the existing workflow that already has this DAG signature"),
+            existingWorkflowSlug: z.string().describe("Slug of the existing workflow that already has this DAG signature"),
+          }).openapi("WorkflowConflictResponse"),
+        },
+      },
+    },
     500: { description: "Internal error", content: errorContent },
   },
 });

--- a/tests/unit/workflow-put-fork.test.ts
+++ b/tests/unit/workflow-put-fork.test.ts
@@ -71,7 +71,9 @@ describe("PUT /workflows/{id} OpenAPI spec — fork/conflict responses", () => {
 describe("Generated openapi.json reflects fork/conflict changes", () => {
   const openapiPath = path.join(__dirname, "../../openapi.json");
   const spec = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
-  const putResponses = spec.paths["/v1/workflows/{id}"]?.put?.responses;
+  const putEndpoint = spec.paths["/v1/workflows/{id}"]?.put;
+  const putResponses = putEndpoint?.responses;
+  const schemas = spec.components?.schemas;
 
   it("should have 200 response", () => {
     expect(putResponses).toHaveProperty("200");
@@ -90,5 +92,35 @@ describe("Generated openapi.json reflects fork/conflict changes", () => {
   it("should reference ForkedWorkflowResponse schema", () => {
     const ref201 = putResponses["201"]?.content?.["application/json"]?.schema?.$ref;
     expect(ref201).toContain("ForkedWorkflowResponse");
+  });
+
+  it("should have WorkflowConflictResponse schema with existingWorkflowId and existingWorkflowSlug", () => {
+    const conflictSchema = schemas?.WorkflowConflictResponse;
+    expect(conflictSchema).toBeDefined();
+    expect(conflictSchema.properties).toHaveProperty("existingWorkflowId");
+    expect(conflictSchema.properties).toHaveProperty("existingWorkflowSlug");
+    expect(conflictSchema.required).toContain("error");
+    expect(conflictSchema.required).toContain("existingWorkflowId");
+    expect(conflictSchema.required).toContain("existingWorkflowSlug");
+  });
+
+  it("should reference WorkflowConflictResponse in 409 response", () => {
+    const ref409 = putResponses["409"]?.content?.["application/json"]?.schema?.$ref;
+    expect(ref409).toContain("WorkflowConflictResponse");
+  });
+
+  it("should have an example on UpdateWorkflowRequest schema", () => {
+    const reqSchema = schemas?.UpdateWorkflowRequest;
+    expect(reqSchema).toBeDefined();
+    expect(reqSchema.example).toBeDefined();
+    expect(reqSchema.example.dag).toBeDefined();
+    expect(reqSchema.example.dag.nodes).toBeInstanceOf(Array);
+  });
+
+  it("should have a detailed description with markdown formatting", () => {
+    expect(putEndpoint.description).toContain("**Metadata only**");
+    expect(putEndpoint.description).toContain("**DAG with same signature**");
+    expect(putEndpoint.description).toContain("**DAG with new signature**");
+    expect(putEndpoint.description).toContain("existingWorkflowId");
   });
 });


### PR DESCRIPTION
## Summary
- Enriched the PUT /workflows/{id} description with detailed markdown explaining the 3 behavior modes (metadata-only, same-signature DAG, new-signature fork)
- Added request body example with realistic DAG nodes/edges
- Replaced generic ErrorResponse on 409 with a dedicated `WorkflowConflictResponse` schema exposing `existingWorkflowId` and `existingWorkflowSlug`
- Improved `dag` field description explaining the signature-based fork behavior

Aligns with the upstream workflow-service OpenAPI spec (PR #190).

## Test plan
- [x] 125 workflow tests pass (including 16 fork/conflict tests)
- [x] openapi.json regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)