### PR TITLE
feat: add campaignId filter to GET /v1/journalists

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1851,6 +1851,17 @@
                     "type": "string"
                   }
                 },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "buffered",
+                    "claimed",
+                    "served",
+                    "contacted",
+                    "skipped"
+                  ],
+                  "description": "Current status of this journalist in the campaign pipeline"
+                },
                 "runId": {
                   "type": "string",
                   "nullable": true,
@@ -1869,6 +1880,7 @@
                 "whyRelevant",
                 "whyNotRelevant",
                 "articleUrls",
+                "status",
                 "runId"
               ]
             }
@@ -9867,7 +9879,7 @@
           "Journalists"
         ],
         "summary": "List journalists by brand",
-        "description": "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}. Optionally filter by runId to get journalists from a specific discovery run.",
+        "description": "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}. Optionally filter by runId to get journalists from a specific discovery run, or by campaignId to get journalists from a specific campaign.",
         "security": [
           {
             "bearerAuth": []
@@ -9894,6 +9906,17 @@
             "required": false,
             "description": "Filter journalists by discovery run ID",
             "name": "runId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter journalists by campaign ID"
+            },
+            "required": false,
+            "description": "Filter journalists by campaign ID",
+            "name": "campaignId",
             "in": "query"
           },
           {

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -8,7 +8,7 @@ const router = Router();
 // ── GET /v1/journalists — list journalists by brand ─────────────────────────
 router.get("/journalists", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId, runId } = req.query as { brandId?: string; runId?: string };
+    const { brandId, runId, campaignId } = req.query as { brandId?: string; runId?: string; campaignId?: string };
     if (!brandId) {
       return res.status(400).json({ error: "Missing required query parameter: brandId" });
     }
@@ -16,6 +16,7 @@ router.get("/journalists", authenticate, requireOrg, requireUser, async (req: Au
     const params = new URLSearchParams();
     params.set("brand_id", brandId);
     if (runId) params.set("run_id", runId);
+    if (campaignId) params.set("campaign_id", campaignId);
 
     const result = await callExternalService(
       externalServices.journalist,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1285,12 +1285,13 @@ registry.registerPath({
   path: "/v1/journalists",
   tags: ["Journalists"],
   summary: "List journalists by brand",
-  description: "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}. Optionally filter by runId to get journalists from a specific discovery run.",
+  description: "Returns all discovered journalists for a given brand across all campaigns. Proxies to journalists-service GET /campaign-outlet-journalists?brand_id={brandId}. Optionally filter by runId to get journalists from a specific discovery run, or by campaignId to get journalists from a specific campaign.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().uuid().describe("Brand ID to filter journalists by"),
       runId: z.string().uuid().optional().describe("Filter journalists by discovery run ID"),
+      campaignId: z.string().uuid().optional().describe("Filter journalists by campaign ID"),
     }).openapi("ListJournalistsQuery"),
   },
   responses: {
@@ -1312,6 +1313,7 @@ registry.registerPath({
                   whyRelevant: z.string().nullable(),
                   whyNotRelevant: z.string().nullable(),
                   articleUrls: z.array(z.string()).nullable(),
+                  status: z.enum(["buffered", "claimed", "served", "contacted", "skipped"]).describe("Current status of this journalist in the campaign pipeline"),
                   runId: z.string().uuid().nullable().describe("The discovery run that created this journalist entry"),
                 }).passthrough(),
               ),

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -93,6 +93,11 @@ describe("Journalists proxy routes", () => {
     expect(content).toContain('params.set("run_id", runId)');
   });
 
+  it("should forward campaignId query parameter on GET /journalists", () => {
+    expect(content).toContain("campaignId");
+    expect(content).toContain('params.set("campaign_id", campaignId)');
+  });
+
   it("should proxy POST /journalists/buffer/next to /buffer/next on journalist-service", () => {
     expect(content).toContain('"/buffer/next"');
   });
@@ -241,6 +246,21 @@ describe("Journalists OpenAPI schemas", () => {
     const start = schemaContent.indexOf("ListJournalistsQuery");
     const block = schemaContent.slice(Math.max(0, start - 400), start);
     expect(block).toContain("runId:");
+  });
+
+  it("should have campaignId query param in ListJournalistsQuery", () => {
+    const start = schemaContent.indexOf("ListJournalistsQuery");
+    const block = schemaContent.slice(Math.max(0, start - 400), start);
+    expect(block).toContain("campaignId:");
+  });
+
+  it("should have status enum in ListJournalistsResponse", () => {
+    const start = schemaContent.indexOf("ListJournalistsResponse");
+    const block = schemaContent.slice(Math.max(0, start - 800), start);
+    expect(block).toContain("status:");
+    expect(block).toContain('"buffered"');
+    expect(block).toContain('"contacted"');
+    expect(block).toContain('"skipped"');
   });
 
   it("should register GET /v1/journalists/stats/costs", () => {


### PR DESCRIPTION
## Summary
- Adds `campaignId` as an optional query parameter on `GET /v1/journalists`, passing it through to journalists-service as `campaign_id`
- Documents the `status` enum field (`buffered|claimed|served|contacted|skipped`) in the OpenAPI response schema — it was already returned at runtime but missing from the spec
- Adds corresponding tests

## Why
The frontend dashboard now filters journalists by campaign (PR #675). Without server-side filtering, the client fetches all journalists for a brand and filters client-side — wasteful for brands with many campaigns.

## Test plan
- [x] `journalists-proxy.test.ts` passes with new tests for `campaignId` pass-through and `status` in schema
- [x] Full test suite passes (1 pre-existing unrelated failure in `openapi-response-schemas.test.ts`)
- [x] `openapi.json` regenerated and includes the new query param + status enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)