### PR TITLE
feat: pipe through lead fields and add leads/status proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1169,8 +1169,19 @@
                 "id": {
                   "type": "string"
                 },
+                "leadId": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Lead UUID for cross-referencing with delivery status"
+                },
                 "email": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Recipient email address"
+                },
+                "namespace": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Lead source (e.g. 'apollo', 'journalist')"
                 },
                 "externalId": {
                   "type": "string",
@@ -1198,7 +1209,13 @@
                 },
                 "organizationDomain": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "Company domain from enrichment"
+                },
+                "organizationLogoUrl": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Company logo URL from enrichment"
                 },
                 "organizationIndustry": {
                   "type": "string",
@@ -1239,7 +1256,9 @@
               },
               "required": [
                 "id",
+                "leadId",
                 "email",
+                "namespace",
                 "externalId",
                 "firstName",
                 "lastName",
@@ -1247,6 +1266,7 @@
                 "title",
                 "organizationName",
                 "organizationDomain",
+                "organizationLogoUrl",
                 "organizationIndustry",
                 "organizationSize",
                 "linkedinUrl",
@@ -1260,6 +1280,60 @@
         },
         "required": [
           "leads"
+        ]
+      },
+      "CampaignLeadsStatusResponse": {
+        "type": "object",
+        "properties": {
+          "statuses": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "leadId": {
+                  "type": "string",
+                  "description": "Lead UUID"
+                },
+                "email": {
+                  "type": "string",
+                  "description": "Recipient email"
+                },
+                "contacted": {
+                  "type": "boolean",
+                  "description": "Whether the lead has been contacted"
+                },
+                "delivered": {
+                  "type": "boolean",
+                  "description": "Whether the email was delivered"
+                },
+                "bounced": {
+                  "type": "boolean",
+                  "description": "Whether the email bounced"
+                },
+                "replied": {
+                  "type": "boolean",
+                  "description": "Whether the lead replied"
+                },
+                "lastDeliveredAt": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "ISO timestamp of last delivery"
+                }
+              },
+              "required": [
+                "leadId",
+                "email",
+                "contacted",
+                "delivered",
+                "bounced",
+                "replied",
+                "lastDeliveredAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "statuses"
         ]
       },
       "CampaignEmailsResponse": {
@@ -8238,6 +8312,128 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CampaignLeadsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/campaigns/{id}/leads/status": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get per-lead delivery status",
+        "description": "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. Proxies to lead-service GET /leads/status.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID"
+            },
+            "required": true,
+            "description": "Campaign ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optional brand ID filter"
+            },
+            "required": false,
+            "description": "Optional brand ID filter",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-lead delivery statuses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignLeadsStatusResponse"
                 }
               }
             }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -555,7 +555,9 @@ router.get("/campaigns/:id/leads", authenticate, requireOrg, requireUser, async 
       const enrichment = (raw.enrichment as Record<string, unknown>) || {};
       return {
         id: raw.id,
+        leadId: raw.leadId ?? null,
         email: raw.email,
+        namespace: raw.namespace ?? null,
         externalId: raw.externalId,
         firstName: enrichment.firstName ?? null,
         lastName: enrichment.lastName ?? null,
@@ -563,6 +565,7 @@ router.get("/campaigns/:id/leads", authenticate, requireOrg, requireUser, async 
         title: enrichment.title ?? null,
         organizationName: enrichment.organizationName ?? null,
         organizationDomain: enrichment.organizationDomain ?? null,
+        organizationLogoUrl: enrichment.organizationLogoUrl ?? null,
         organizationIndustry: enrichment.organizationIndustry ?? null,
         organizationSize: enrichment.organizationSize ?? null,
         linkedinUrl: enrichment.linkedinUrl ?? null,
@@ -610,6 +613,31 @@ router.get("/campaigns/:id/leads", authenticate, requireOrg, requireUser, async 
   } catch (error: any) {
     console.error("Get campaign leads error:", error);
     res.status(500).json({ error: error.message || "Failed to get campaign leads" });
+  }
+});
+
+/**
+ * GET /v1/campaigns/:id/leads/status
+ * Get per-lead delivery status for a campaign
+ */
+router.get("/campaigns/:id/leads/status", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const brandId = req.query.brandId as string | undefined;
+
+    const params = new URLSearchParams({ campaignId: id });
+    if (brandId) params.set("brandId", brandId);
+
+    const result = await callExternalService(
+      externalServices.lead,
+      `/leads/status?${params}`,
+      { headers: buildInternalHeaders(req) },
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Get campaign leads status error:", error);
+    res.status(500).json({ error: error.message || "Failed to get campaign leads status" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -775,14 +775,17 @@ registry.registerPath({
               leads: z.array(
                 z.object({
                   id: z.string(),
-                  email: z.string(),
+                  leadId: z.string().nullable().describe("Lead UUID for cross-referencing with delivery status"),
+                  email: z.string().describe("Recipient email address"),
+                  namespace: z.string().nullable().describe("Lead source (e.g. 'apollo', 'journalist')"),
                   externalId: z.string().nullable(),
                   firstName: z.string().nullable(),
                   lastName: z.string().nullable(),
                   emailStatus: z.string().nullable(),
                   title: z.string().nullable(),
                   organizationName: z.string().nullable(),
-                  organizationDomain: z.string().nullable(),
+                  organizationDomain: z.string().nullable().describe("Company domain from enrichment"),
+                  organizationLogoUrl: z.string().nullable().describe("Company logo URL from enrichment"),
                   organizationIndustry: z.string().nullable(),
                   organizationSize: z.string().nullable(),
                   linkedinUrl: z.string().nullable(),
@@ -794,6 +797,48 @@ registry.registerPath({
               ),
             })
             .openapi("CampaignLeadsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/campaigns/{id}/leads/status",
+  tags: ["Campaigns"],
+  summary: "Get per-lead delivery status",
+  description:
+    "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. Proxies to lead-service GET /leads/status.",
+  security: authed,
+  request: {
+    params: CampaignIdParam,
+    query: z.object({
+      brandId: z.string().optional().describe("Optional brand ID filter"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Per-lead delivery statuses",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              statuses: z.array(
+                z.object({
+                  leadId: z.string().describe("Lead UUID"),
+                  email: z.string().describe("Recipient email"),
+                  contacted: z.boolean().describe("Whether the lead has been contacted"),
+                  delivered: z.boolean().describe("Whether the email was delivered"),
+                  bounced: z.boolean().describe("Whether the email bounced"),
+                  replied: z.boolean().describe("Whether the lead replied"),
+                  lastDeliveredAt: z.string().nullable().describe("ISO timestamp of last delivery"),
+                }),
+              ),
+            })
+            .openapi("CampaignLeadsStatusResponse"),
         },
       },
     },

--- a/tests/unit/campaign-emails-leads-openapi.test.ts
+++ b/tests/unit/campaign-emails-leads-openapi.test.ts
@@ -66,14 +66,48 @@ describe("Campaign leads/emails OpenAPI response schemas", () => {
       leadsSchema.properties.leads.items.properties;
     for (const field of [
       "id",
+      "leadId",
       "email",
+      "namespace",
       "firstName",
       "lastName",
       "title",
       "organizationName",
+      "organizationDomain",
+      "organizationLogoUrl",
       "enrichmentRun",
     ]) {
       expect(leadProps).toHaveProperty(field);
+    }
+  });
+
+  it("GET /v1/campaigns/{id}/leads/status should have a 200 response schema", () => {
+    const endpoint = spec.paths?.["/v1/campaigns/{id}/leads/status"]?.get;
+    expect(endpoint).toBeDefined();
+    const schema =
+      endpoint.responses?.["200"]?.content?.["application/json"]?.schema;
+    expect(schema).toBeDefined();
+    const resolved = schema.$ref
+      ? spec.components.schemas[schema.$ref.split("/").pop()!]
+      : schema;
+    expect(resolved.properties?.statuses).toBeDefined();
+  });
+
+  it("CampaignLeadsStatusResponse should document delivery status fields", () => {
+    const statusSchema = spec.components?.schemas?.CampaignLeadsStatusResponse;
+    expect(statusSchema).toBeDefined();
+    const statusProps =
+      statusSchema.properties.statuses.items.properties;
+    for (const field of [
+      "leadId",
+      "email",
+      "contacted",
+      "delivered",
+      "bounced",
+      "replied",
+      "lastDeliveredAt",
+    ]) {
+      expect(statusProps).toHaveProperty(field);
     }
   });
 


### PR DESCRIPTION
## Summary
- **GET /v1/campaigns/{id}/leads** now returns `leadId`, `namespace`, and `organizationLogoUrl` from lead-service (previously stripped) — unblocks dashboard Source column and company logo display
- **New GET /v1/campaigns/{id}/leads/status** proxies lead-service's `/leads/status` endpoint, returning per-lead delivery status (`contacted`, `delivered`, `bounced`, `replied`, `lastDeliveredAt`)
- OpenAPI spec and tests updated for both changes

## Test plan
- [x] Existing `campaign-emails-leads-openapi` tests updated and passing (7/7)
- [x] Full test suite passes (pre-existing dynasty-slug failures unchanged)
- [x] `openapi.json` regenerated with new fields and endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)