### PR TITLE
fix: align press-kits proxy and OpenAPI with upstream spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -21376,16 +21376,6 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by organization ID (alias for org_id)"
-            },
-            "required": false,
-            "description": "Filter by organization ID (alias for org_id)",
-            "name": "organization_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
               "description": "Filter by campaign ID — returns media kit(s) linked to this campaign"
             },
             "required": false,
@@ -22382,29 +22372,27 @@
             "bearerAuth": []
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Media kit",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PressKitInternalCurrentResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
         "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand UUID"
+            },
+            "required": false,
+            "description": "Filter by brand UUID",
+            "name": "brand_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign UUID"
+            },
+            "required": false,
+            "description": "Filter by campaign UUID",
+            "name": "campaign_id",
+            "in": "query"
+          },
           {
             "name": "x-org-id",
             "in": "header",
@@ -22459,7 +22447,29 @@
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
-        ]
+        ],
+        "responses": {
+          "200": {
+            "description": "Media kit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PressKitInternalCurrentResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/press-kits/internal/media-kits/generation-data": {
@@ -22472,6 +22482,72 @@
         "security": [
           {
             "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Target a specific kit. If omitted, finds the generating kit for the org."
+            },
+            "required": false,
+            "description": "Target a specific kit. If omitted, finds the generating kit for the org.",
+            "name": "media_kit_id",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "responses": {
@@ -22495,63 +22571,7 @@
               }
             }
           }
-        },
-        "parameters": [
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
+        }
       }
     },
     "/v1/press-kits/internal/media-kits/generation-result": {
@@ -22791,6 +22811,46 @@
           {
             "schema": {
               "type": "string",
+              "description": "Filter by feature slug"
+            },
+            "required": false,
+            "description": "Filter by feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow slug"
+            },
+            "required": false,
+            "description": "Filter by workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "description": "Start date (ISO 8601)"
             },
             "required": false,
@@ -22943,6 +23003,46 @@
             "required": false,
             "description": "Filter by campaign ID",
             "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug"
+            },
+            "required": false,
+            "description": "Filter by feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow slug"
+            },
+            "required": false,
+            "description": "Filter by workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug",
+            "name": "workflowDynastySlug",
             "in": "query"
           },
           {

--- a/src/routes/press-kits.ts
+++ b/src/routes/press-kits.ts
@@ -27,7 +27,6 @@ router.get("/press-kits/media-kits", authenticate, requireOrg, async (req: Authe
   try {
     const params = new URLSearchParams();
     if (req.query.org_id) params.set("org_id", req.query.org_id as string);
-    if (req.query.organization_id) params.set("organization_id", req.query.organization_id as string);
     if (req.query.campaign_id) params.set("campaign_id", req.query.campaign_id as string);
     if (req.query.brand_id) params.set("brand_id", req.query.brand_id as string);
     if (req.query.title) params.set("title", req.query.title as string);
@@ -133,7 +132,7 @@ router.post("/press-kits/media-kits/:id/cancel", authenticate, requireOrg, async
 router.get("/press-kits/media-kits/stats/views", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "campaignId", "mediaKitId", "from", "to", "groupBy"]) {
+    for (const key of ["brandId", "campaignId", "mediaKitId", "featureSlug", "workflowSlug", "featureDynastySlug", "workflowDynastySlug", "from", "to", "groupBy"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";
@@ -152,7 +151,7 @@ router.get("/press-kits/media-kits/stats/views", authenticate, requireOrg, async
 router.get("/press-kits/media-kits/stats/costs", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["mediaKitId", "brandId", "campaignId", "groupBy"]) {
+    for (const key of ["mediaKitId", "brandId", "campaignId", "featureSlug", "workflowSlug", "featureDynastySlug", "workflowDynastySlug", "groupBy"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";
@@ -204,9 +203,13 @@ router.delete("/press-kits/admin/media-kits/:id", authenticate, requireOrg, asyn
 // GET /v1/press-kits/internal/media-kits/current — latest kit for org (uses x-org-id header)
 router.get("/press-kits/internal/media-kits/current", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
+    const params = new URLSearchParams();
+    if (req.query.brand_id) params.set("brand_id", req.query.brand_id as string);
+    if (req.query.campaign_id) params.set("campaign_id", req.query.campaign_id as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
     const result = await callExternalService(
       externalServices.pressKits,
-      "/internal/media-kits/current",
+      `/internal/media-kits/current${qs}`,
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);
@@ -218,9 +221,12 @@ router.get("/press-kits/internal/media-kits/current", authenticate, requireOrg, 
 // GET /v1/press-kits/internal/media-kits/generation-data — generation workflow data (uses x-org-id header)
 router.get("/press-kits/internal/media-kits/generation-data", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
+    const params = new URLSearchParams();
+    if (req.query.media_kit_id) params.set("media_kit_id", req.query.media_kit_id as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
     const result = await callExternalService(
       externalServices.pressKits,
-      "/internal/media-kits/generation-data",
+      `/internal/media-kits/generation-data${qs}`,
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5218,7 +5218,6 @@ registry.registerPath({
   request: {
     query: z.object({
       org_id: z.string().optional().describe("Filter by org ID"),
-      organization_id: z.string().optional().describe("Filter by organization ID (alias for org_id)"),
       campaign_id: z.string().optional().describe("Filter by campaign ID — returns media kit(s) linked to this campaign"),
       brand_id: z.string().optional().describe("Filter by brand ID — returns media kit(s) linked to this brand"),
       title: z.string().optional().describe("Filter by title"),
@@ -5365,6 +5364,12 @@ registry.registerPath({
   summary: "Get latest media kit for org (internal)",
   description: "Uses x-org-id header to identify the org. No path param needed.",
   security: authed,
+  request: {
+    query: z.object({
+      brand_id: z.string().optional().describe("Filter by brand UUID"),
+      campaign_id: z.string().optional().describe("Filter by campaign UUID"),
+    }),
+  },
   responses: {
     200: { description: "Media kit", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitInternalCurrentResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
@@ -5378,6 +5383,11 @@ registry.registerPath({
   summary: "Get generation workflow data (internal)",
   description: "Uses x-org-id header to identify the org.",
   security: authed,
+  request: {
+    query: z.object({
+      media_kit_id: z.string().optional().describe("Target a specific kit. If omitted, finds the generating kit for the org."),
+    }),
+  },
   responses: {
     200: { description: "Generation data", content: { "application/json": { schema: z.object({}).passthrough().openapi("PressKitGenerationDataResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
@@ -5425,6 +5435,10 @@ registry.registerPath({
       brandId: z.string().optional().describe("Filter by brand ID"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),
       mediaKitId: z.string().optional().describe("Filter by media kit ID"),
+      featureSlug: z.string().optional().describe("Filter by feature slug"),
+      workflowSlug: z.string().optional().describe("Filter by workflow slug"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug"),
       from: z.string().optional().describe("Start date (ISO 8601)"),
       to: z.string().optional().describe("End date (ISO 8601)"),
       groupBy: z.enum(["country", "mediaKitId", "day"]).optional().describe("Group results by country, mediaKitId, or day"),
@@ -5451,6 +5465,10 @@ registry.registerPath({
       mediaKitId: z.string().optional().describe("Filter by media kit ID"),
       brandId: z.string().optional().describe("Filter by brand ID"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),
+      featureSlug: z.string().optional().describe("Filter by feature slug"),
+      workflowSlug: z.string().optional().describe("Filter by workflow slug"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug"),
       groupBy: z.enum(["mediaKitId"]).optional().describe("Group results by mediaKitId"),
     }),
   },

--- a/tests/unit/press-kits-proxy.test.ts
+++ b/tests/unit/press-kits-proxy.test.ts
@@ -94,8 +94,8 @@ describe("Press Kits proxy routes", () => {
     expect(content).toContain('"/press-kits/media-kits/stats/views"');
   });
 
-  it("should forward stats query params (brandId, campaignId, mediaKitId, from, to, groupBy)", () => {
-    for (const key of ["brandId", "campaignId", "mediaKitId", "from", "to", "groupBy"]) {
+  it("should forward stats query params (brandId, campaignId, mediaKitId, featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, from, to, groupBy)", () => {
+    for (const key of ["brandId", "campaignId", "mediaKitId", "featureSlug", "workflowSlug", "featureDynastySlug", "workflowDynastySlug", "from", "to", "groupBy"]) {
       expect(content).toContain(`"${key}"`);
     }
   });
@@ -104,8 +104,8 @@ describe("Press Kits proxy routes", () => {
     expect(content).toContain('"/press-kits/media-kits/stats/costs"');
   });
 
-  it("should forward cost stats query params (mediaKitId, brandId, campaignId, groupBy)", () => {
-    for (const key of ["mediaKitId", "brandId", "campaignId", "groupBy"]) {
+  it("should forward cost stats query params (mediaKitId, brandId, campaignId, featureSlug, workflowSlug, featureDynastySlug, workflowDynastySlug, groupBy)", () => {
+    for (const key of ["mediaKitId", "brandId", "campaignId", "featureSlug", "workflowSlug", "featureDynastySlug", "workflowDynastySlug", "groupBy"]) {
       expect(content).toContain(`"${key}"`);
     }
   });
@@ -132,8 +132,17 @@ describe("Press Kits proxy routes", () => {
     expect(content).toContain('"/press-kits/internal/media-kits/current"');
   });
 
+  it("should forward brand_id and campaign_id query params on internal/current", () => {
+    expect(content).toContain('"brand_id"');
+    expect(content).toContain('"campaign_id"');
+  });
+
   it("should have GET /press-kits/internal/media-kits/generation-data with auth", () => {
     expect(content).toContain('"/press-kits/internal/media-kits/generation-data"');
+  });
+
+  it("should forward media_kit_id query param on internal/generation-data", () => {
+    expect(content).toContain('"media_kit_id"');
   });
 
   it("should have POST /press-kits/internal/media-kits/generation-result with auth", () => {


### PR DESCRIPTION
## Summary
- Forward missing query params on 4 press-kits proxy endpoints to match upstream spec: `brand_id`/`campaign_id` on internal/current, `media_kit_id` on internal/generation-data, and `featureSlug`/`workflowSlug`/`featureDynastySlug`/`workflowDynastySlug` on both stats endpoints
- Remove spurious `organization_id` param from GET /media-kits (not in upstream spec)
- Update OpenAPI schemas and regenerate openapi.json to match

## Test plan
- [x] All 53 press-kits proxy tests pass
- [x] openapi.json regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)