### PR TITLE
feat: proxy brand-service extract-images endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3627,6 +3627,113 @@
           "fields"
         ]
       },
+      "ExtractedImage": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Permanent R2 URL of the extracted image"
+          },
+          "category": {
+            "type": "string",
+            "description": "Image category key"
+          },
+          "sourceUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Original source URL where the image was found"
+          },
+          "extractedAt": {
+            "type": "string",
+            "description": "ISO timestamp of extraction"
+          }
+        },
+        "required": [
+          "url",
+          "category",
+          "sourceUrl",
+          "extractedAt"
+        ]
+      },
+      "ExtractImagesResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "description": "Brand ID"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtractedImage"
+            },
+            "description": "Extracted images"
+          }
+        },
+        "required": [
+          "brandId",
+          "images"
+        ]
+      },
+      "ExtractImageCategory": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Image category key (e.g. 'logo', 'product_shots', 'hero_image')"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of what kind of image to extract"
+          },
+          "maxCount": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "description": "Maximum number of images to extract for this category"
+          }
+        },
+        "required": [
+          "key",
+          "description",
+          "maxCount"
+        ]
+      },
+      "ExtractImagesRequest": {
+        "type": "object",
+        "properties": {
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtractImageCategory"
+            },
+            "description": "Image categories to extract"
+          }
+        },
+        "required": [
+          "categories"
+        ]
+      },
+      "ExtractedImagesResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "description": "Brand ID"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtractedImage"
+            },
+            "description": "Previously extracted and cached images"
+          }
+        },
+        "required": [
+          "brandId",
+          "images"
+        ]
+      },
       "IcpSuggestionResponse": {
         "type": "object",
         "properties": {
@@ -15016,6 +15123,269 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExtractedFieldsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/extract-images": {
+      "post": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Extract images from brand",
+        "description": "Extract brand images by category (logo, product shots, hero image, etc.) via scraping + vision AI. Returns permanent R2 URLs.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExtractImagesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Extracted image results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtractImagesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Anthropic API key not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/extracted-images": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "List extracted images for a brand",
+        "description": "Lists all previously extracted and cached images for a brand. Supports ?campaignId= query param to filter by campaign.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign ID"
+            },
+            "required": false,
+            "description": "Filter by campaign ID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cached extracted images",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtractedImagesResponse"
                 }
               }
             }

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -187,6 +187,56 @@ router.get("/brands/:id/extracted-fields", authenticate, requireOrg, requireUser
 });
 
 /**
+ * POST /v1/brands/:id/extract-images
+ * Extract brand images by category (logo, product shots, hero image, etc.)
+ * via scraping + vision AI. Returns permanent R2 URLs.
+ */
+router.post("/brands/:id/extract-images", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.brand,
+      `/brands/${req.params.id}/extract-images`,
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Extract images error:", error);
+    const msg = error.message || "Failed to extract images";
+    if (msg.includes("No Anthropic API key found")) {
+      return res.status(400).json({
+        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
+      });
+    }
+    res.status(error.statusCode || 500).json({ error: msg });
+  }
+});
+
+/**
+ * GET /v1/brands/:id/extracted-images
+ * List extracted images in cache. Supports ?campaignId= query param.
+ */
+router.get("/brands/:id/extracted-images", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.brand,
+      `/brands/${req.params.id}/extracted-images${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Get extracted images error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get extracted images" });
+  }
+});
+
+/**
  * POST /v1/brand/icp-suggestion
  * Get ICP suggestion (Apollo-compatible search params) for a brand URL
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2877,6 +2877,89 @@ registry.registerPath({
   },
 });
 
+const ExtractImageCategorySchema = z.object({
+  key: z.string().describe("Image category key (e.g. 'logo', 'product_shots', 'hero_image')"),
+  description: z.string().describe("Description of what kind of image to extract"),
+  maxCount: z.number().int().positive().describe("Maximum number of images to extract for this category"),
+}).openapi("ExtractImageCategory");
+
+const ExtractedImageSchema = z.object({
+  url: z.string().describe("Permanent R2 URL of the extracted image"),
+  category: z.string().describe("Image category key"),
+  sourceUrl: z.string().nullable().describe("Original source URL where the image was found"),
+  extractedAt: z.string().describe("ISO timestamp of extraction"),
+}).openapi("ExtractedImage");
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{id}/extract-images",
+  tags: ["Brand"],
+  summary: "Extract images from brand",
+  description:
+    "Extract brand images by category (logo, product shots, hero image, etc.) via scraping + vision AI. Returns permanent R2 URLs.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            categories: z.array(ExtractImageCategorySchema).describe("Image categories to extract"),
+          }).openapi("ExtractImagesRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Extracted image results",
+      content: {
+        "application/json": {
+          schema: z.object({
+            brandId: z.string().describe("Brand ID"),
+            images: z.array(ExtractedImageSchema).describe("Extracted images"),
+          }).openapi("ExtractImagesResponse"),
+        },
+      },
+    },
+    400: { description: "Anthropic API key not configured", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{id}/extracted-images",
+  tags: ["Brand"],
+  summary: "List extracted images for a brand",
+  description:
+    "Lists all previously extracted and cached images for a brand. Supports ?campaignId= query param to filter by campaign.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    query: z.object({
+      campaignId: z.string().optional().describe("Filter by campaign ID"),
+    }).openapi("ExtractedImagesQuery"),
+  },
+  responses: {
+    200: {
+      description: "Cached extracted images",
+      content: {
+        "application/json": {
+          schema: z.object({
+            brandId: z.string().describe("Brand ID"),
+            images: z.array(ExtractedImageSchema).describe("Previously extracted and cached images"),
+          }).openapi("ExtractedImagesResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 registry.registerPath({
   method: "post",
   path: "/v1/brand/icp-suggestion",

--- a/tests/unit/brand-extracted-images.test.ts
+++ b/tests/unit/brand-extracted-images.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+const mockImages = [
+  {
+    url: "https://r2.example.com/logo.png",
+    category: "logo",
+    sourceUrl: "https://acme.com",
+    extractedAt: "2026-03-01T00:00:00Z",
+  },
+  {
+    url: "https://r2.example.com/hero.jpg",
+    category: "hero_image",
+    sourceUrl: "https://acme.com/about",
+    extractedAt: "2026-03-01T00:00:00Z",
+  },
+];
+
+describe("POST /v1/brands/:id/extract-images", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("should proxy the request body to brand-service and return results", async () => {
+    let capturedBody: any;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, opts: any) => {
+      capturedBody = JSON.parse(opts.body);
+      return {
+        ok: true,
+        json: () => Promise.resolve({ brandId: "brand-abc", images: mockImages }),
+      };
+    });
+
+    const body = {
+      categories: [
+        { key: "logo", description: "Company logo", maxCount: 1 },
+        { key: "hero_image", description: "Main hero/banner image", maxCount: 1 },
+      ],
+    };
+
+    const res = await request(app).post("/v1/brands/brand-abc/extract-images").send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.brandId).toBe("brand-abc");
+    expect(res.body.images).toHaveLength(2);
+    expect(capturedBody.categories).toHaveLength(2);
+    expect(capturedBody.categories[0].key).toBe("logo");
+  });
+
+  it("should forward the brand ID in the URL", async () => {
+    let capturedUrl = "";
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, json: () => Promise.resolve({ brandId: "brand-xyz", images: [] }) };
+    });
+
+    await request(app).post("/v1/brands/brand-xyz/extract-images").send({ categories: [] });
+
+    expect(capturedUrl).toContain("/brands/brand-xyz/extract-images");
+  });
+
+  it("should return 400 when Anthropic key is not configured", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"error":"No Anthropic API key found"}'),
+    }));
+
+    const res = await request(app).post("/v1/brands/brand-abc/extract-images").send({ categories: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Anthropic API key not configured");
+  });
+
+  it("should return 500 when brand-service fails", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('{"error":"Internal error"}'),
+    }));
+
+    const res = await request(app).post("/v1/brands/brand-abc/extract-images").send({ categories: [] });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Internal error");
+  });
+});
+
+describe("GET /v1/brands/:id/extracted-images", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("should proxy the response from brand-service", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve({ brandId: "brand-abc", images: mockImages }),
+    }));
+
+    const res = await request(app).get("/v1/brands/brand-abc/extracted-images");
+
+    expect(res.status).toBe(200);
+    expect(res.body.brandId).toBe("brand-abc");
+    expect(res.body.images).toHaveLength(2);
+    expect(res.body.images[0].category).toBe("logo");
+  });
+
+  it("should forward campaignId query param", async () => {
+    let capturedUrl = "";
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, json: () => Promise.resolve({ brandId: "brand-abc", images: [] }) };
+    });
+
+    await request(app).get("/v1/brands/brand-abc/extracted-images?campaignId=camp-123");
+
+    expect(capturedUrl).toContain("/brands/brand-abc/extracted-images?campaignId=camp-123");
+  });
+
+  it("should not append query string when no campaignId", async () => {
+    let capturedUrl = "";
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, json: () => Promise.resolve({ brandId: "brand-abc", images: [] }) };
+    });
+
+    await request(app).get("/v1/brands/brand-abc/extracted-images");
+
+    expect(capturedUrl).toContain("/brands/brand-abc/extracted-images");
+    expect(capturedUrl).not.toContain("?");
+  });
+
+  it("should return 404 when brand-service returns 404", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"Brand not found"}'),
+    }));
+
+    const res = await request(app).get("/v1/brands/nonexistent/extracted-images");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("Brand not found");
+  });
+
+  it("should return 500 when brand-service fails", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('{"error":"Internal error"}'),
+    }));
+
+    const res = await request(app).get("/v1/brands/brand-abc/extracted-images");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Internal error");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /v1/brands/{id}/extract-images` proxy — extracts brand images by category (logo, product shots, hero) via scraping + vision AI, returns permanent R2 URLs
- Adds `GET /v1/brands/{id}/extracted-images` proxy — lists cached extracted images, supports `?campaignId=` filter
- Zod schemas + OpenAPI registration for both endpoints
- 9 tests covering happy path, error forwarding, query param forwarding

## Test plan
- [x] `npx vitest run tests/unit/brand-extracted-images.test.ts` — 9/9 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)