### PR TITLE
feat: sync articles OpenAPI proxy docs with upstream spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2306,55 +2306,284 @@
           "groups"
         ]
       },
+      "Article": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique article identifier",
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          },
+          "articleUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Canonical URL of the article",
+            "example": "https://techcrunch.com/2025/03/15/ai-funding-roundup"
+          },
+          "snippet": {
+            "type": "string",
+            "nullable": true,
+            "description": "Short text excerpt from the article or search result"
+          },
+          "ogDescription": {
+            "type": "string",
+            "nullable": true,
+            "description": "OpenGraph og:description meta tag value"
+          },
+          "twitterCreator": {
+            "type": "string",
+            "nullable": true,
+            "description": "Twitter/X @handle of the article creator",
+            "example": "@johndoe"
+          },
+          "newsKeywords": {
+            "type": "string",
+            "nullable": true,
+            "description": "Comma-separated news keywords meta tag"
+          },
+          "articlePublished": {
+            "type": "string",
+            "nullable": true,
+            "description": "Published date from article metadata",
+            "example": "2025-03-15T10:00:00Z"
+          },
+          "articleChannel": {
+            "type": "string",
+            "nullable": true,
+            "description": "Channel or vertical the article belongs to",
+            "example": "Technology"
+          },
+          "twitterTitle": {
+            "type": "string",
+            "nullable": true,
+            "description": "Twitter/X card title meta tag"
+          },
+          "articleSection": {
+            "type": "string",
+            "nullable": true,
+            "description": "Section of the publication",
+            "example": "Startups"
+          },
+          "author": {
+            "type": "string",
+            "nullable": true,
+            "description": "Serialized author data extracted via scraping (JSON array of ExtractedAuthor objects)"
+          },
+          "ogTitle": {
+            "type": "string",
+            "nullable": true,
+            "description": "OpenGraph og:title meta tag value",
+            "example": "AI Funding Hits Record High in Q1 2025"
+          },
+          "articleAuthor": {
+            "type": "string",
+            "nullable": true,
+            "description": "Raw author string from article:author meta tag"
+          },
+          "twitterDescription": {
+            "type": "string",
+            "nullable": true,
+            "description": "Twitter/X card description meta tag"
+          },
+          "articleModified": {
+            "type": "string",
+            "nullable": true,
+            "description": "Last modified date from article metadata"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this article record was first created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this article record was last updated"
+          }
+        },
+        "required": [
+          "id",
+          "articleUrl",
+          "snippet",
+          "ogDescription",
+          "twitterCreator",
+          "newsKeywords",
+          "articlePublished",
+          "articleChannel",
+          "twitterTitle",
+          "articleSection",
+          "author",
+          "ogTitle",
+          "articleAuthor",
+          "twitterDescription",
+          "articleModified",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ListArticlesResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Article"
+            }
+          }
+        },
+        "required": [
+          "articles"
+        ]
+      },
       "CreateArticleRequest": {
         "type": "object",
         "properties": {
           "articleUrl": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "Canonical URL of the article (used as upsert key)",
+            "example": "https://techcrunch.com/2025/03/15/ai-funding-roundup"
           },
           "snippet": {
-            "type": "string"
+            "type": "string",
+            "description": "Short text excerpt from the article"
           },
           "ogDescription": {
-            "type": "string"
+            "type": "string",
+            "description": "OpenGraph og:description meta tag"
           },
           "twitterCreator": {
-            "type": "string"
+            "type": "string",
+            "description": "Twitter/X @handle of the creator"
           },
           "newsKeywords": {
-            "type": "string"
+            "type": "string",
+            "description": "Comma-separated news keywords"
           },
           "articlePublished": {
-            "type": "string"
+            "type": "string",
+            "description": "Published date string from metadata"
           },
           "articleChannel": {
-            "type": "string"
+            "type": "string",
+            "description": "Channel or vertical"
           },
           "twitterTitle": {
-            "type": "string"
+            "type": "string",
+            "description": "Twitter/X card title"
           },
           "articleSection": {
-            "type": "string"
+            "type": "string",
+            "description": "Section of the publication"
           },
           "author": {
-            "type": "string"
+            "type": "string",
+            "description": "Serialized author data"
           },
           "ogTitle": {
-            "type": "string"
+            "type": "string",
+            "description": "OpenGraph og:title"
           },
           "articleAuthor": {
-            "type": "string"
+            "type": "string",
+            "description": "Raw author string from article:author meta tag"
           },
           "twitterDescription": {
-            "type": "string"
+            "type": "string",
+            "description": "Twitter/X card description"
           },
           "articleModified": {
-            "type": "string"
+            "type": "string",
+            "description": "Last modified date from metadata"
           }
         },
         "required": [
           "articleUrl"
+        ]
+      },
+      "ArticleAuthorView": {
+        "type": "object",
+        "properties": {
+          "articleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Article identifier"
+          },
+          "articleUrl": {
+            "type": "string",
+            "description": "Canonical URL of the article"
+          },
+          "computedTitle": {
+            "type": "string",
+            "nullable": true,
+            "description": "Best-effort title derived from og:title, twitter:title, or snippet"
+          },
+          "computedLargestContent": {
+            "type": "string",
+            "nullable": true,
+            "description": "Longest content field available (for display/preview)"
+          },
+          "computedAuthors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Deduplicated list of author names extracted from all metadata sources"
+          },
+          "computedPublishedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "Best-effort publication date from available metadata"
+          },
+          "lastActivityAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Most recent update across all linked records"
+          },
+          "articleCreatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the article was first indexed"
+          }
+        },
+        "required": [
+          "articleId",
+          "articleUrl",
+          "computedTitle",
+          "computedLargestContent",
+          "computedAuthors",
+          "computedPublishedAt",
+          "lastActivityAt",
+          "articleCreatedAt"
+        ]
+      },
+      "ListArticleAuthorsResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleAuthorView"
+            }
+          }
+        },
+        "required": [
+          "articles"
+        ]
+      },
+      "BulkCreateArticlesResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Article"
+            }
+          }
+        },
+        "required": [
+          "articles"
         ]
       },
       "BulkCreateArticlesRequest": {
@@ -2367,51 +2596,81 @@
               "properties": {
                 "articleUrl": {
                   "type": "string",
-                  "format": "uri"
+                  "format": "uri",
+                  "description": "Canonical URL of the article (used as upsert key)",
+                  "example": "https://techcrunch.com/2025/03/15/ai-funding-roundup"
                 },
                 "snippet": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Short text excerpt from the article"
                 },
                 "ogDescription": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "OpenGraph og:description meta tag"
                 },
                 "twitterCreator": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Twitter/X @handle of the creator"
                 },
                 "newsKeywords": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Comma-separated news keywords"
                 },
                 "articlePublished": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Published date string from metadata"
                 },
                 "articleChannel": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Channel or vertical"
                 },
                 "twitterTitle": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Twitter/X card title"
                 },
                 "articleSection": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Section of the publication"
                 },
                 "author": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Serialized author data"
                 },
                 "ogTitle": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "OpenGraph og:title"
                 },
                 "articleAuthor": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Raw author string from article:author meta tag"
                 },
                 "twitterDescription": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Twitter/X card description"
                 },
                 "articleModified": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Last modified date from metadata"
                 }
               },
               "required": [
                 "articleUrl"
               ]
+            },
+            "description": "Array of articles to upsert"
+          }
+        },
+        "required": [
+          "articles"
+        ]
+      },
+      "SearchArticlesResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Article"
             }
           }
         },
@@ -2424,17 +2683,66 @@
         "properties": {
           "query": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Full-text search query",
+            "example": "AI funding startup"
           },
           "limit": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Max results to return (default 20, max 100)"
           },
           "offset": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Number of results to skip for pagination"
           }
         },
         "required": [
           "query"
+        ]
+      },
+      "Topic": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique topic identifier"
+          },
+          "topicName": {
+            "type": "string",
+            "description": "Human-readable topic name",
+            "example": "Artificial Intelligence"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this topic was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this topic was last updated"
+          }
+        },
+        "required": [
+          "id",
+          "topicName",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ListTopicsResponse": {
+        "type": "object",
+        "properties": {
+          "topics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Topic"
+            }
+          }
+        },
+        "required": [
+          "topics"
         ]
       },
       "CreateTopicRequest": {
@@ -2442,11 +2750,27 @@
         "properties": {
           "topicName": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Topic name (used as upsert key)",
+            "example": "Artificial Intelligence"
           }
         },
         "required": [
           "topicName"
+        ]
+      },
+      "BulkCreateTopicsResponse": {
+        "type": "object",
+        "properties": {
+          "topics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Topic"
+            }
+          }
+        },
+        "required": [
+          "topics"
         ]
       },
       "BulkCreateTopicsRequest": {
@@ -2459,17 +2783,122 @@
               "properties": {
                 "topicName": {
                   "type": "string",
-                  "minLength": 1
+                  "minLength": 1,
+                  "description": "Topic name (used as upsert key)",
+                  "example": "Artificial Intelligence"
                 }
               },
               "required": [
                 "topicName"
               ]
-            }
+            },
+            "description": "Array of topics to upsert"
           }
         },
         "required": [
           "topics"
+        ]
+      },
+      "ArticleDiscovery": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique discovery record identifier"
+          },
+          "articleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the discovered article"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Organization that owns this discovery"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Brand this discovery is scoped to"
+          },
+          "featureSlug": {
+            "type": "string",
+            "description": "Feature that triggered this discovery",
+            "example": "press-outreach-v3"
+          },
+          "workflowSlug": {
+            "type": "string",
+            "nullable": true,
+            "description": "Workflow that triggered this discovery"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Campaign this discovery belongs to"
+          },
+          "outletId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "description": "Outlet linked to this discovery (if from outlet discovery)"
+          },
+          "journalistId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "description": "Journalist linked to this discovery (if from journalist discovery)"
+          },
+          "topicId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "description": "Topic linked to this discovery"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this discovery was created"
+          }
+        },
+        "required": [
+          "id",
+          "articleId",
+          "orgId",
+          "brandId",
+          "featureSlug",
+          "workflowSlug",
+          "campaignId",
+          "outletId",
+          "journalistId",
+          "topicId",
+          "createdAt"
+        ]
+      },
+      "ListDiscoveriesResponse": {
+        "type": "object",
+        "properties": {
+          "discoveries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "discovery": {
+                  "$ref": "#/components/schemas/ArticleDiscovery"
+                },
+                "article": {
+                  "$ref": "#/components/schemas/Article"
+                }
+              },
+              "required": [
+                "discovery",
+                "article"
+              ]
+            }
+          }
+        },
+        "required": [
+          "discoveries"
         ]
       },
       "CreateDiscoveryRequest": {
@@ -2477,33 +2906,53 @@
         "properties": {
           "articleId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "ID of the article to link"
           },
           "brandId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Brand to scope this discovery to"
           },
           "campaignId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Campaign to scope this discovery to"
           },
           "outletId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Outlet to associate with this discovery"
           },
           "journalistId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Journalist to associate with this discovery"
           },
           "topicId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Topic to associate with this discovery"
           }
         },
         "required": [
           "articleId",
           "brandId",
           "campaignId"
+        ]
+      },
+      "BulkCreateDiscoveriesResponse": {
+        "type": "object",
+        "properties": {
+          "discoveries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArticleDiscovery"
+            }
+          }
+        },
+        "required": [
+          "discoveries"
         ]
       },
       "BulkCreateDiscoveriesRequest": {
@@ -2516,27 +2965,33 @@
               "properties": {
                 "articleId": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "ID of the article to link"
                 },
                 "brandId": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "Brand to scope this discovery to"
                 },
                 "campaignId": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "Campaign to scope this discovery to"
                 },
                 "outletId": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "Outlet to associate with this discovery"
                 },
                 "journalistId": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "Journalist to associate with this discovery"
                 },
                 "topicId": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "Topic to associate with this discovery"
                 }
               },
               "required": [
@@ -2544,34 +2999,199 @@
                 "brandId",
                 "campaignId"
               ]
-            }
+            },
+            "description": "Array of discovery records to create"
           }
         },
         "required": [
           "discoveries"
         ]
       },
-      "ArticleStatsResponse": {
+      "DiscoveryStats": {
         "type": "object",
-        "properties": {}
+        "properties": {
+          "totalDiscoveries": {
+            "type": "number",
+            "description": "Total number of article discoveries"
+          },
+          "uniqueArticles": {
+            "type": "number",
+            "description": "Number of unique articles"
+          },
+          "uniqueOutlets": {
+            "type": "number",
+            "description": "Number of unique outlets"
+          },
+          "uniqueJournalists": {
+            "type": "number",
+            "description": "Number of unique journalists"
+          }
+        },
+        "required": [
+          "totalDiscoveries",
+          "uniqueArticles",
+          "uniqueOutlets",
+          "uniqueJournalists"
+        ]
+      },
+      "FlatArticleStatsResponse": {
+        "type": "object",
+        "properties": {
+          "stats": {
+            "$ref": "#/components/schemas/DiscoveryStats"
+          }
+        },
+        "required": [
+          "stats"
+        ]
+      },
+      "GroupedArticleStatsResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "stats": {
+                  "$ref": "#/components/schemas/DiscoveryStats"
+                }
+              },
+              "required": [
+                "key",
+                "stats"
+              ]
+            }
+          }
+        },
+        "required": [
+          "groups"
+        ]
+      },
+      "ArticleStatsResponse": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/FlatArticleStatsResponse"
+          },
+          {
+            "$ref": "#/components/schemas/GroupedArticleStatsResponse"
+          }
+        ]
+      },
+      "ExtractedAuthor": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "person",
+              "organization"
+            ],
+            "description": "Whether this author is a person or an organization",
+            "example": "person"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "First name (empty string for organizations or single-name authors)",
+            "example": "Sarah"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "Last name, or full name for organizations",
+            "example": "Perez"
+          }
+        },
+        "required": [
+          "type",
+          "firstName",
+          "lastName"
+        ]
+      },
+      "DiscoveredArticle": {
+        "type": "object",
+        "properties": {
+          "articleId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the upserted article record"
+          },
+          "articleUrl": {
+            "type": "string",
+            "description": "URL of the discovered article",
+            "example": "https://techcrunch.com/2025/03/15/ai-funding-roundup"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true,
+            "description": "Article title from OpenGraph or search result"
+          },
+          "snippet": {
+            "type": "string",
+            "nullable": true,
+            "description": "Short excerpt from the article"
+          },
+          "authors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtractedAuthor"
+            },
+            "description": "Authors extracted via scraping + LLM analysis"
+          },
+          "publishedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "Publication date extracted from article metadata",
+            "example": "2025-03-15T10:00:00Z"
+          }
+        },
+        "required": [
+          "articleId",
+          "articleUrl",
+          "title",
+          "snippet",
+          "authors",
+          "publishedAt"
+        ]
+      },
+      "DiscoverOutletArticlesResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscoveredArticle"
+            }
+          }
+        },
+        "required": [
+          "articles"
+        ]
       },
       "DiscoverOutletArticlesRequest": {
         "type": "object",
         "properties": {
           "outletDomain": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Domain of the outlet (e.g. techcrunch.com)",
+            "example": "techcrunch.com"
           },
           "brandId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Brand to scope discoveries to"
           },
           "campaignId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Campaign to scope discoveries to"
           },
           "maxArticles": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Max articles to discover (default 10, max 20)"
           }
         },
         "required": [
@@ -2580,31 +3200,53 @@
           "campaignId"
         ]
       },
+      "DiscoverJournalistPublicationsResponse": {
+        "type": "object",
+        "properties": {
+          "articles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscoveredArticle"
+            }
+          }
+        },
+        "required": [
+          "articles"
+        ]
+      },
       "DiscoverJournalistPublicationsRequest": {
         "type": "object",
         "properties": {
           "journalistFirstName": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Journalist first name",
+            "example": "Sarah"
           },
           "journalistLastName": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Journalist last name",
+            "example": "Perez"
           },
           "journalistId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Journalist UUID for linking discoveries back to the journalist record"
           },
           "brandId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Brand to scope discoveries to"
           },
           "campaignId": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Campaign to scope discoveries to"
           },
           "maxResults": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Max publications to find (default 10, max 20)"
           }
         },
         "required": [
@@ -11281,7 +11923,14 @@
         ],
         "responses": {
           "200": {
-            "description": "List of articles"
+            "description": "List of articles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListArticlesResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -11300,6 +11949,7 @@
           "Articles"
         ],
         "summary": "Create or upsert an article by URL",
+        "description": "Inserts a new article or updates an existing one based on the articleUrl (unique key). Returns the full article record.",
         "security": [
           {
             "bearerAuth": []
@@ -11316,7 +11966,14 @@
         },
         "responses": {
           "200": {
-            "description": "Article created or updated"
+            "description": "Article created or updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Article"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -11402,7 +12059,7 @@
         "tags": [
           "Articles"
         ],
-        "summary": "Articles with computed authors",
+        "summary": "Articles with computed authors (v_articles_authors)",
         "security": [
           {
             "bearerAuth": []
@@ -11484,7 +12141,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Articles with computed authors view"
+            "description": "Articles with computed authors view",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListArticleAuthorsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -11578,7 +12242,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Article found"
+            "description": "Article found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Article"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -11609,6 +12280,7 @@
           "Articles"
         ],
         "summary": "Bulk upsert articles",
+        "description": "Upserts multiple articles in a single transaction. Each article is matched by articleUrl.",
         "security": [
           {
             "bearerAuth": []
@@ -11625,7 +12297,14 @@
         },
         "responses": {
           "200": {
-            "description": "Articles upserted"
+            "description": "Articles upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCreateArticlesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -11728,7 +12407,14 @@
         },
         "responses": {
           "200": {
-            "description": "Search results"
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchArticlesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -11822,7 +12508,14 @@
         ],
         "responses": {
           "200": {
-            "description": "List of topics"
+            "description": "List of topics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTopicsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -11913,7 +12606,14 @@
         },
         "responses": {
           "200": {
-            "description": "Topic created or updated"
+            "description": "Topic created or updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Topic"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -12016,7 +12716,14 @@
         },
         "responses": {
           "200": {
-            "description": "Topics upserted"
+            "description": "Topics upserted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCreateTopicsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -12112,7 +12819,8 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "description": "Filter by brand ID"
             },
             "required": false,
             "name": "brandId",
@@ -12121,7 +12829,8 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "description": "Filter by campaign ID"
             },
             "required": false,
             "name": "campaignId",
@@ -12130,7 +12839,8 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "description": "Filter by outlet ID"
             },
             "required": false,
             "name": "outletId",
@@ -12139,7 +12849,8 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "description": "Filter by journalist ID"
             },
             "required": false,
             "name": "journalistId",
@@ -12148,7 +12859,8 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "description": "Filter by topic ID"
             },
             "required": false,
             "name": "topicId",
@@ -12229,7 +12941,14 @@
         ],
         "responses": {
           "200": {
-            "description": "List of discoveries"
+            "description": "List of discoveries with their associated articles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDiscoveriesResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -12248,6 +12967,7 @@
           "Articles"
         ],
         "summary": "Link an article to a campaign context",
+        "description": "Creates a discovery record that links an article to a specific org/brand/campaign context. Requires x-brand-id and x-campaign-id headers. Optionally associates the discovery with an outlet, journalist, or topic.",
         "security": [
           {
             "bearerAuth": []
@@ -12264,7 +12984,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discovery created"
+            "description": "Discovery created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleDiscovery"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -12367,7 +13094,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discoveries created"
+            "description": "Discoveries created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCreateDiscoveriesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -12454,7 +13188,7 @@
           "Articles"
         ],
         "summary": "Get aggregated article discovery stats",
-        "description": "Returns aggregated discovery stats (totalDiscoveries, uniqueArticles, uniqueOutlets, uniqueJournalists). Supports filtering by orgId, brandId, campaignId, workflowSlug, featureSlug, and dynasty slugs. Optional groupBy returns grouped results.",
+        "description": "Returns aggregated discovery stats (totalDiscoveries, uniqueArticles, uniqueOutlets, uniqueJournalists). Supports filtering by orgId, brandId, campaignId, workflowSlug, featureSlug, and dynasty slugs. Optional groupBy returns grouped results. Dynasty slug filters resolve to all versioned slugs via the respective service.",
         "security": [
           {
             "bearerAuth": []
@@ -12609,7 +13343,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Aggregated stats (flat or grouped)",
+            "description": "Aggregated stats — flat when no groupBy, grouped array when groupBy is provided",
             "content": {
               "application/json": {
                 "schema": {
@@ -12647,6 +13381,7 @@
           "Articles"
         ],
         "summary": "Discover recent articles from an outlet via Google News + scraping",
+        "description": "Pipeline endpoint: (1) searches Google News for recent articles from the given outlet domain, (2) scrapes each article URL to extract authors and publication dates via LLM, (3) upserts the articles in the database, and (4) creates discovery records scoped to the campaign (x-brand-id, x-campaign-id headers required). Returns the discovered articles with extracted author details.",
         "security": [
           {
             "bearerAuth": []
@@ -12663,7 +13398,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discovered articles"
+            "description": "Discovered articles with extracted author details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverOutletArticlesResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",
@@ -12759,7 +13501,8 @@
         "tags": [
           "Articles"
         ],
-        "summary": "Discover recent publications by a journalist",
+        "summary": "Discover recent publications by a journalist and create scoped discoveries",
+        "description": "Pipeline endpoint: (1) searches Google News for recent articles by the given journalist (by name), (2) scrapes each article URL to extract authors and publication dates via LLM, (3) upserts the articles in the database, and (4) creates discovery records scoped to the campaign and journalist (x-brand-id, x-campaign-id headers required). Ideal for enriching pitch generation with a journalist's recent work.",
         "security": [
           {
             "bearerAuth": []
@@ -12776,7 +13519,14 @@
         },
         "responses": {
           "200": {
-            "description": "Discovered publications"
+            "description": "Discovered publications with extracted author details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverJournalistPublicationsResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Validation error",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1643,8 +1643,96 @@ registry.registerPath({
 });
 
 // ===================================================================
-// ARTICLES (airtik)
+// ARTICLES (airtik) — schemas synced from articles-service openapi.json
 // ===================================================================
+
+const ArticleSchema = z
+  .object({
+    id: z.string().uuid().openapi({ description: "Unique article identifier", example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
+    articleUrl: z.string().url().openapi({ description: "Canonical URL of the article", example: "https://techcrunch.com/2025/03/15/ai-funding-roundup" }),
+    snippet: z.string().nullable().openapi({ description: "Short text excerpt from the article or search result" }),
+    ogDescription: z.string().nullable().openapi({ description: "OpenGraph og:description meta tag value" }),
+    twitterCreator: z.string().nullable().openapi({ description: "Twitter/X @handle of the article creator", example: "@johndoe" }),
+    newsKeywords: z.string().nullable().openapi({ description: "Comma-separated news keywords meta tag" }),
+    articlePublished: z.string().nullable().openapi({ description: "Published date from article metadata", example: "2025-03-15T10:00:00Z" }),
+    articleChannel: z.string().nullable().openapi({ description: "Channel or vertical the article belongs to", example: "Technology" }),
+    twitterTitle: z.string().nullable().openapi({ description: "Twitter/X card title meta tag" }),
+    articleSection: z.string().nullable().openapi({ description: "Section of the publication", example: "Startups" }),
+    author: z.string().nullable().openapi({ description: "Serialized author data extracted via scraping (JSON array of ExtractedAuthor objects)" }),
+    ogTitle: z.string().nullable().openapi({ description: "OpenGraph og:title meta tag value", example: "AI Funding Hits Record High in Q1 2025" }),
+    articleAuthor: z.string().nullable().openapi({ description: "Raw author string from article:author meta tag" }),
+    twitterDescription: z.string().nullable().openapi({ description: "Twitter/X card description meta tag" }),
+    articleModified: z.string().nullable().openapi({ description: "Last modified date from article metadata" }),
+    createdAt: z.string().datetime().openapi({ description: "When this article record was first created" }),
+    updatedAt: z.string().datetime().openapi({ description: "When this article record was last updated" }),
+  })
+  .openapi("Article");
+
+const ExtractedAuthorSchema = z
+  .object({
+    type: z.enum(["person", "organization"]).openapi({ description: "Whether this author is a person or an organization", example: "person" }),
+    firstName: z.string().openapi({ description: "First name (empty string for organizations or single-name authors)", example: "Sarah" }),
+    lastName: z.string().openapi({ description: "Last name, or full name for organizations", example: "Perez" }),
+  })
+  .openapi("ExtractedAuthor");
+
+const DiscoveredArticleSchema = z
+  .object({
+    articleId: z.string().uuid().openapi({ description: "ID of the upserted article record" }),
+    articleUrl: z.string().openapi({ description: "URL of the discovered article", example: "https://techcrunch.com/2025/03/15/ai-funding-roundup" }),
+    title: z.string().nullable().openapi({ description: "Article title from OpenGraph or search result" }),
+    snippet: z.string().nullable().openapi({ description: "Short excerpt from the article" }),
+    authors: z.array(ExtractedAuthorSchema).openapi({ description: "Authors extracted via scraping + LLM analysis" }),
+    publishedAt: z.string().nullable().openapi({ description: "Publication date extracted from article metadata", example: "2025-03-15T10:00:00Z" }),
+  })
+  .openapi("DiscoveredArticle");
+
+const ArticleAuthorViewSchema = z
+  .object({
+    articleId: z.string().uuid().openapi({ description: "Article identifier" }),
+    articleUrl: z.string().openapi({ description: "Canonical URL of the article" }),
+    computedTitle: z.string().nullable().openapi({ description: "Best-effort title derived from og:title, twitter:title, or snippet" }),
+    computedLargestContent: z.string().nullable().openapi({ description: "Longest content field available (for display/preview)" }),
+    computedAuthors: z.array(z.string()).openapi({ description: "Deduplicated list of author names extracted from all metadata sources" }),
+    computedPublishedAt: z.string().nullable().openapi({ description: "Best-effort publication date from available metadata" }),
+    lastActivityAt: z.string().datetime().openapi({ description: "Most recent update across all linked records" }),
+    articleCreatedAt: z.string().datetime().openapi({ description: "When the article was first indexed" }),
+  })
+  .openapi("ArticleAuthorView");
+
+const TopicSchema = z
+  .object({
+    id: z.string().uuid().openapi({ description: "Unique topic identifier" }),
+    topicName: z.string().openapi({ description: "Human-readable topic name", example: "Artificial Intelligence" }),
+    createdAt: z.string().datetime().openapi({ description: "When this topic was created" }),
+    updatedAt: z.string().datetime().openapi({ description: "When this topic was last updated" }),
+  })
+  .openapi("Topic");
+
+const ArticleDiscoverySchema = z
+  .object({
+    id: z.string().uuid().openapi({ description: "Unique discovery record identifier" }),
+    articleId: z.string().uuid().openapi({ description: "ID of the discovered article" }),
+    orgId: z.string().uuid().openapi({ description: "Organization that owns this discovery" }),
+    brandId: z.string().uuid().openapi({ description: "Brand this discovery is scoped to" }),
+    featureSlug: z.string().openapi({ description: "Feature that triggered this discovery", example: "press-outreach-v3" }),
+    workflowSlug: z.string().nullable().openapi({ description: "Workflow that triggered this discovery" }),
+    campaignId: z.string().uuid().openapi({ description: "Campaign this discovery belongs to" }),
+    outletId: z.string().uuid().nullable().openapi({ description: "Outlet linked to this discovery (if from outlet discovery)" }),
+    journalistId: z.string().uuid().nullable().openapi({ description: "Journalist linked to this discovery (if from journalist discovery)" }),
+    topicId: z.string().uuid().nullable().openapi({ description: "Topic linked to this discovery" }),
+    createdAt: z.string().datetime().openapi({ description: "When this discovery was created" }),
+  })
+  .openapi("ArticleDiscovery");
+
+const DiscoveryStatsSchema = z
+  .object({
+    totalDiscoveries: z.number().openapi({ description: "Total number of article discoveries" }),
+    uniqueArticles: z.number().openapi({ description: "Number of unique articles" }),
+    uniqueOutlets: z.number().openapi({ description: "Number of unique outlets" }),
+    uniqueJournalists: z.number().openapi({ description: "Number of unique journalists" }),
+  })
+  .openapi("DiscoveryStats");
 
 registry.registerPath({
   method: "get",
@@ -1659,7 +1747,14 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "List of articles" },
+    200: {
+      description: "List of articles",
+      content: {
+        "application/json": {
+          schema: z.object({ articles: z.array(ArticleSchema) }).openapi("ListArticlesResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
   },
 });
@@ -1669,6 +1764,7 @@ registry.registerPath({
   path: "/v1/articles",
   tags: ["Articles"],
   summary: "Create or upsert an article by URL",
+  description: "Inserts a new article or updates an existing one based on the articleUrl (unique key). Returns the full article record.",
   security: authed,
   request: {
     body: {
@@ -1676,20 +1772,20 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              articleUrl: z.string().url(),
-              snippet: z.string().optional(),
-              ogDescription: z.string().optional(),
-              twitterCreator: z.string().optional(),
-              newsKeywords: z.string().optional(),
-              articlePublished: z.string().optional(),
-              articleChannel: z.string().optional(),
-              twitterTitle: z.string().optional(),
-              articleSection: z.string().optional(),
-              author: z.string().optional(),
-              ogTitle: z.string().optional(),
-              articleAuthor: z.string().optional(),
-              twitterDescription: z.string().optional(),
-              articleModified: z.string().optional(),
+              articleUrl: z.string().url().openapi({ description: "Canonical URL of the article (used as upsert key)", example: "https://techcrunch.com/2025/03/15/ai-funding-roundup" }),
+              snippet: z.string().optional().openapi({ description: "Short text excerpt from the article" }),
+              ogDescription: z.string().optional().openapi({ description: "OpenGraph og:description meta tag" }),
+              twitterCreator: z.string().optional().openapi({ description: "Twitter/X @handle of the creator" }),
+              newsKeywords: z.string().optional().openapi({ description: "Comma-separated news keywords" }),
+              articlePublished: z.string().optional().openapi({ description: "Published date string from metadata" }),
+              articleChannel: z.string().optional().openapi({ description: "Channel or vertical" }),
+              twitterTitle: z.string().optional().openapi({ description: "Twitter/X card title" }),
+              articleSection: z.string().optional().openapi({ description: "Section of the publication" }),
+              author: z.string().optional().openapi({ description: "Serialized author data" }),
+              ogTitle: z.string().optional().openapi({ description: "OpenGraph og:title" }),
+              articleAuthor: z.string().optional().openapi({ description: "Raw author string from article:author meta tag" }),
+              twitterDescription: z.string().optional().openapi({ description: "Twitter/X card description" }),
+              articleModified: z.string().optional().openapi({ description: "Last modified date from metadata" }),
             })
             .openapi("CreateArticleRequest"),
         },
@@ -1697,7 +1793,10 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Article created or updated" },
+    200: {
+      description: "Article created or updated",
+      content: { "application/json": { schema: ArticleSchema } },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
@@ -1707,7 +1806,7 @@ registry.registerPath({
   method: "get",
   path: "/v1/articles/authors",
   tags: ["Articles"],
-  summary: "Articles with computed authors",
+  summary: "Articles with computed authors (v_articles_authors)",
   security: authed,
   request: {
     query: z.object({
@@ -1716,7 +1815,14 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "Articles with computed authors view" },
+    200: {
+      description: "Articles with computed authors view",
+      content: {
+        "application/json": {
+          schema: z.object({ articles: z.array(ArticleAuthorViewSchema) }).openapi("ListArticleAuthorsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
   },
 });
@@ -1733,7 +1839,10 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "Article found" },
+    200: {
+      description: "Article found",
+      content: { "application/json": { schema: ArticleSchema } },
+    },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Article not found", content: errorContent },
   },
@@ -1744,6 +1853,7 @@ registry.registerPath({
   path: "/v1/articles/bulk",
   tags: ["Articles"],
   summary: "Bulk upsert articles",
+  description: "Upserts multiple articles in a single transaction. Each article is matched by articleUrl.",
   security: authed,
   request: {
     body: {
@@ -1753,22 +1863,22 @@ registry.registerPath({
             .object({
               articles: z.array(
                 z.object({
-                  articleUrl: z.string().url(),
-                  snippet: z.string().optional(),
-                  ogDescription: z.string().optional(),
-                  twitterCreator: z.string().optional(),
-                  newsKeywords: z.string().optional(),
-                  articlePublished: z.string().optional(),
-                  articleChannel: z.string().optional(),
-                  twitterTitle: z.string().optional(),
-                  articleSection: z.string().optional(),
-                  author: z.string().optional(),
-                  ogTitle: z.string().optional(),
-                  articleAuthor: z.string().optional(),
-                  twitterDescription: z.string().optional(),
-                  articleModified: z.string().optional(),
+                  articleUrl: z.string().url().openapi({ description: "Canonical URL of the article (used as upsert key)", example: "https://techcrunch.com/2025/03/15/ai-funding-roundup" }),
+                  snippet: z.string().optional().openapi({ description: "Short text excerpt from the article" }),
+                  ogDescription: z.string().optional().openapi({ description: "OpenGraph og:description meta tag" }),
+                  twitterCreator: z.string().optional().openapi({ description: "Twitter/X @handle of the creator" }),
+                  newsKeywords: z.string().optional().openapi({ description: "Comma-separated news keywords" }),
+                  articlePublished: z.string().optional().openapi({ description: "Published date string from metadata" }),
+                  articleChannel: z.string().optional().openapi({ description: "Channel or vertical" }),
+                  twitterTitle: z.string().optional().openapi({ description: "Twitter/X card title" }),
+                  articleSection: z.string().optional().openapi({ description: "Section of the publication" }),
+                  author: z.string().optional().openapi({ description: "Serialized author data" }),
+                  ogTitle: z.string().optional().openapi({ description: "OpenGraph og:title" }),
+                  articleAuthor: z.string().optional().openapi({ description: "Raw author string from article:author meta tag" }),
+                  twitterDescription: z.string().optional().openapi({ description: "Twitter/X card description" }),
+                  articleModified: z.string().optional().openapi({ description: "Last modified date from metadata" }),
                 }),
-              ),
+              ).openapi({ description: "Array of articles to upsert" }),
             })
             .openapi("BulkCreateArticlesRequest"),
         },
@@ -1776,7 +1886,14 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Articles upserted" },
+    200: {
+      description: "Articles upserted",
+      content: {
+        "application/json": {
+          schema: z.object({ articles: z.array(ArticleSchema) }).openapi("BulkCreateArticlesResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
@@ -1794,9 +1911,9 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              query: z.string().min(1),
-              limit: z.number().int().optional(),
-              offset: z.number().int().optional(),
+              query: z.string().min(1).openapi({ description: "Full-text search query", example: "AI funding startup" }),
+              limit: z.number().int().optional().openapi({ description: "Max results to return (default 20, max 100)" }),
+              offset: z.number().int().optional().openapi({ description: "Number of results to skip for pagination" }),
             })
             .openapi("SearchArticlesRequest"),
         },
@@ -1804,7 +1921,14 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Search results" },
+    200: {
+      description: "Search results",
+      content: {
+        "application/json": {
+          schema: z.object({ articles: z.array(ArticleSchema) }).openapi("SearchArticlesResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
@@ -1819,7 +1943,14 @@ registry.registerPath({
   summary: "List all topics",
   security: authed,
   responses: {
-    200: { description: "List of topics" },
+    200: {
+      description: "List of topics",
+      content: {
+        "application/json": {
+          schema: z.object({ topics: z.array(TopicSchema) }).openapi("ListTopicsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
   },
 });
@@ -1836,7 +1967,7 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              topicName: z.string().min(1),
+              topicName: z.string().min(1).openapi({ description: "Topic name (used as upsert key)", example: "Artificial Intelligence" }),
             })
             .openapi("CreateTopicRequest"),
         },
@@ -1844,7 +1975,10 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Topic created or updated" },
+    200: {
+      description: "Topic created or updated",
+      content: { "application/json": { schema: TopicSchema } },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
@@ -1864,9 +1998,9 @@ registry.registerPath({
             .object({
               topics: z.array(
                 z.object({
-                  topicName: z.string().min(1),
+                  topicName: z.string().min(1).openapi({ description: "Topic name (used as upsert key)", example: "Artificial Intelligence" }),
                 }),
-              ),
+              ).openapi({ description: "Array of topics to upsert" }),
             })
             .openapi("BulkCreateTopicsRequest"),
         },
@@ -1874,7 +2008,14 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Topics upserted" },
+    200: {
+      description: "Topics upserted",
+      content: {
+        "application/json": {
+          schema: z.object({ topics: z.array(TopicSchema) }).openapi("BulkCreateTopicsResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
@@ -1890,17 +2031,31 @@ registry.registerPath({
   security: authed,
   request: {
     query: z.object({
-      brandId: z.string().uuid().optional(),
-      campaignId: z.string().uuid().optional(),
-      outletId: z.string().uuid().optional(),
-      journalistId: z.string().uuid().optional(),
-      topicId: z.string().uuid().optional(),
+      brandId: z.string().uuid().optional().openapi({ description: "Filter by brand ID" }),
+      campaignId: z.string().uuid().optional().openapi({ description: "Filter by campaign ID" }),
+      outletId: z.string().uuid().optional().openapi({ description: "Filter by outlet ID" }),
+      journalistId: z.string().uuid().optional().openapi({ description: "Filter by journalist ID" }),
+      topicId: z.string().uuid().optional().openapi({ description: "Filter by topic ID" }),
       limit: z.coerce.number().int().optional(),
       offset: z.coerce.number().int().optional(),
     }),
   },
   responses: {
-    200: { description: "List of discoveries" },
+    200: {
+      description: "List of discoveries with their associated articles",
+      content: {
+        "application/json": {
+          schema: z.object({
+            discoveries: z.array(
+              z.object({
+                discovery: ArticleDiscoverySchema,
+                article: ArticleSchema,
+              }),
+            ),
+          }).openapi("ListDiscoveriesResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
   },
 });
@@ -1910,6 +2065,7 @@ registry.registerPath({
   path: "/v1/discoveries",
   tags: ["Articles"],
   summary: "Link an article to a campaign context",
+  description: "Creates a discovery record that links an article to a specific org/brand/campaign context. Requires x-brand-id and x-campaign-id headers. Optionally associates the discovery with an outlet, journalist, or topic.",
   security: authed,
   request: {
     body: {
@@ -1917,12 +2073,12 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              articleId: z.string().uuid(),
-              brandId: z.string().uuid(),
-              campaignId: z.string().uuid(),
-              outletId: z.string().uuid().optional(),
-              journalistId: z.string().uuid().optional(),
-              topicId: z.string().uuid().optional(),
+              articleId: z.string().uuid().openapi({ description: "ID of the article to link" }),
+              brandId: z.string().uuid().openapi({ description: "Brand to scope this discovery to" }),
+              campaignId: z.string().uuid().openapi({ description: "Campaign to scope this discovery to" }),
+              outletId: z.string().uuid().optional().openapi({ description: "Outlet to associate with this discovery" }),
+              journalistId: z.string().uuid().optional().openapi({ description: "Journalist to associate with this discovery" }),
+              topicId: z.string().uuid().optional().openapi({ description: "Topic to associate with this discovery" }),
             })
             .openapi("CreateDiscoveryRequest"),
         },
@@ -1930,7 +2086,10 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Discovery created" },
+    200: {
+      description: "Discovery created",
+      content: { "application/json": { schema: ArticleDiscoverySchema } },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
@@ -1950,14 +2109,14 @@ registry.registerPath({
             .object({
               discoveries: z.array(
                 z.object({
-                  articleId: z.string().uuid(),
-                  brandId: z.string().uuid(),
-                  campaignId: z.string().uuid(),
-                  outletId: z.string().uuid().optional(),
-                  journalistId: z.string().uuid().optional(),
-                  topicId: z.string().uuid().optional(),
+                  articleId: z.string().uuid().openapi({ description: "ID of the article to link" }),
+                  brandId: z.string().uuid().openapi({ description: "Brand to scope this discovery to" }),
+                  campaignId: z.string().uuid().openapi({ description: "Campaign to scope this discovery to" }),
+                  outletId: z.string().uuid().optional().openapi({ description: "Outlet to associate with this discovery" }),
+                  journalistId: z.string().uuid().optional().openapi({ description: "Journalist to associate with this discovery" }),
+                  topicId: z.string().uuid().optional().openapi({ description: "Topic to associate with this discovery" }),
                 }),
-              ),
+              ).openapi({ description: "Array of discovery records to create" }),
             })
             .openapi("BulkCreateDiscoveriesRequest"),
         },
@@ -1965,7 +2124,14 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Discoveries created" },
+    200: {
+      description: "Discoveries created",
+      content: {
+        "application/json": {
+          schema: z.object({ discoveries: z.array(ArticleDiscoverySchema) }).openapi("BulkCreateDiscoveriesResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
@@ -1981,7 +2147,7 @@ registry.registerPath({
   description:
     "Returns aggregated discovery stats (totalDiscoveries, uniqueArticles, uniqueOutlets, uniqueJournalists). " +
     "Supports filtering by orgId, brandId, campaignId, workflowSlug, featureSlug, and dynasty slugs. " +
-    "Optional groupBy returns grouped results.",
+    "Optional groupBy returns grouped results. Dynasty slug filters resolve to all versioned slugs via the respective service.",
   security: authed,
   request: {
     query: z.object({
@@ -1997,10 +2163,15 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "Aggregated stats (flat or grouped)",
+      description: "Aggregated stats — flat when no groupBy, grouped array when groupBy is provided",
       content: {
         "application/json": {
-          schema: z.object({}).passthrough().openapi("ArticleStatsResponse"),
+          schema: z.union([
+            z.object({ stats: DiscoveryStatsSchema }).openapi("FlatArticleStatsResponse"),
+            z.object({
+              groups: z.array(z.object({ key: z.string(), stats: DiscoveryStatsSchema })),
+            }).openapi("GroupedArticleStatsResponse"),
+          ]).openapi("ArticleStatsResponse"),
         },
       },
     },
@@ -2016,6 +2187,11 @@ registry.registerPath({
   path: "/v1/discover/outlet-articles",
   tags: ["Articles"],
   summary: "Discover recent articles from an outlet via Google News + scraping",
+  description:
+    "Pipeline endpoint: (1) searches Google News for recent articles from the given outlet domain, " +
+    "(2) scrapes each article URL to extract authors and publication dates via LLM, " +
+    "(3) upserts the articles in the database, and (4) creates discovery records scoped to the campaign " +
+    "(x-brand-id, x-campaign-id headers required). Returns the discovered articles with extracted author details.",
   security: authed,
   request: {
     body: {
@@ -2023,10 +2199,10 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              outletDomain: z.string().min(1),
-              brandId: z.string().uuid(),
-              campaignId: z.string().uuid(),
-              maxArticles: z.number().int().optional(),
+              outletDomain: z.string().min(1).openapi({ description: "Domain of the outlet (e.g. techcrunch.com)", example: "techcrunch.com" }),
+              brandId: z.string().uuid().openapi({ description: "Brand to scope discoveries to" }),
+              campaignId: z.string().uuid().openapi({ description: "Campaign to scope discoveries to" }),
+              maxArticles: z.number().int().optional().openapi({ description: "Max articles to discover (default 10, max 20)" }),
             })
             .openapi("DiscoverOutletArticlesRequest"),
         },
@@ -2034,7 +2210,14 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Discovered articles" },
+    200: {
+      description: "Discovered articles with extracted author details",
+      content: {
+        "application/json": {
+          schema: z.object({ articles: z.array(DiscoveredArticleSchema) }).openapi("DiscoverOutletArticlesResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },
@@ -2045,7 +2228,12 @@ registry.registerPath({
   method: "post",
   path: "/v1/discover/journalist-publications",
   tags: ["Articles"],
-  summary: "Discover recent publications by a journalist",
+  summary: "Discover recent publications by a journalist and create scoped discoveries",
+  description:
+    "Pipeline endpoint: (1) searches Google News for recent articles by the given journalist (by name), " +
+    "(2) scrapes each article URL to extract authors and publication dates via LLM, " +
+    "(3) upserts the articles in the database, and (4) creates discovery records scoped to the campaign and journalist " +
+    "(x-brand-id, x-campaign-id headers required). Ideal for enriching pitch generation with a journalist's recent work.",
   security: authed,
   request: {
     body: {
@@ -2053,12 +2241,12 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              journalistFirstName: z.string().min(1),
-              journalistLastName: z.string().min(1),
-              journalistId: z.string().uuid(),
-              brandId: z.string().uuid(),
-              campaignId: z.string().uuid(),
-              maxResults: z.number().int().optional(),
+              journalistFirstName: z.string().min(1).openapi({ description: "Journalist first name", example: "Sarah" }),
+              journalistLastName: z.string().min(1).openapi({ description: "Journalist last name", example: "Perez" }),
+              journalistId: z.string().uuid().openapi({ description: "Journalist UUID for linking discoveries back to the journalist record" }),
+              brandId: z.string().uuid().openapi({ description: "Brand to scope discoveries to" }),
+              campaignId: z.string().uuid().openapi({ description: "Campaign to scope discoveries to" }),
+              maxResults: z.number().int().optional().openapi({ description: "Max publications to find (default 10, max 20)" }),
             })
             .openapi("DiscoverJournalistPublicationsRequest"),
         },
@@ -2066,7 +2254,14 @@ registry.registerPath({
     },
   },
   responses: {
-    200: { description: "Discovered publications" },
+    200: {
+      description: "Discovered publications with extracted author details",
+      content: {
+        "application/json": {
+          schema: z.object({ articles: z.array(DiscoveredArticleSchema) }).openapi("DiscoverJournalistPublicationsResponse"),
+        },
+      },
+    },
     400: { description: "Validation error", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },


### PR DESCRIPTION
## Summary
- Added descriptions, examples, and response schemas for all 15 articles proxy endpoints (articles, topics, discoveries, discover workflows, stats)
- Defined reusable Zod schemas matching upstream articles-service spec: `Article`, `ExtractedAuthor`, `DiscoveredArticle`, `ArticleAuthorView`, `Topic`, `ArticleDiscovery`, `DiscoveryStats`
- Added detailed pipeline descriptions to discover endpoints explaining the Google News → scraping → LLM → upsert → discovery flow

## Test plan
- [x] `npx tsx scripts/generate-openapi.ts` regenerates successfully
- [x] `npx vitest run` passes (1 pre-existing failure in outlets response schemas, unrelated)
- [ ] Verify openapi.json shows descriptions/examples/response schemas for articles endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)