### PR TITLE
feat: proxy public features endpoints for landing page

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7351,6 +7351,86 @@
       "FeaturesBatchUpsertRequest": {
         "type": "object",
         "properties": {}
+      },
+      "PublicFeatureItem": {
+        "type": "object",
+        "properties": {
+          "dynastyName": {
+            "type": "string",
+            "description": "Stable dynasty display name",
+            "example": "Sales Cold Email"
+          },
+          "dynastySlug": {
+            "type": "string",
+            "description": "Stable dynasty slug (unversioned)",
+            "example": "sales-cold-email"
+          },
+          "description": {
+            "type": "string",
+            "example": "AI-powered cold email outreach campaigns"
+          },
+          "icon": {
+            "type": "string",
+            "description": "Lucide icon name",
+            "example": "mail"
+          },
+          "category": {
+            "type": "string",
+            "example": "sales"
+          },
+          "channel": {
+            "type": "string",
+            "example": "email"
+          },
+          "audienceType": {
+            "type": "string",
+            "example": "cold-outreach"
+          },
+          "displayOrder": {
+            "type": "integer",
+            "example": 0
+          }
+        },
+        "required": [
+          "dynastyName",
+          "dynastySlug",
+          "description",
+          "icon",
+          "category",
+          "channel",
+          "audienceType",
+          "displayOrder"
+        ]
+      },
+      "PublicFeaturesListResponse": {
+        "type": "object",
+        "properties": {
+          "features": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicFeatureItem"
+            },
+            "description": "Active features sorted by displayOrder"
+          }
+        },
+        "required": [
+          "features"
+        ]
+      },
+      "PublicDynastySlugsResponse": {
+        "type": "object",
+        "properties": {
+          "slugs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "All versioned slugs in the dynasty, sorted by version ascending"
+          }
+        },
+        "required": [
+          "slugs"
+        ]
       }
     },
     "parameters": {}
@@ -26110,6 +26190,101 @@
           },
           "404": {
             "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/features": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "List active features (public, no auth)",
+        "description": "Returns all active features with display-safe fields only. Designed for landing pages and public-facing UIs. Sorted by displayOrder ascending. No authentication required. Proxied from features-service.",
+        "responses": {
+          "200": {
+            "description": "Active features",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicFeaturesListResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/features/dynasty/slugs": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "List dynasty versioned slugs (public, no auth)",
+        "description": "Returns all versioned feature slugs (active + deprecated) belonging to a dynasty. No authentication required. Proxied from features-service.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "The stable dynasty slug (unversioned)",
+              "example": "sales-cold-email"
+            },
+            "required": true,
+            "description": "The stable dynasty slug (unversioned)",
+            "name": "dynastySlug",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dynasty slugs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDynastySlugsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing dynastySlug parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No features found for this dynasty slug",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,7 @@ app.use(
 // Public routes
 app.use(healthRoutes);
 app.use(pressKitsRoutes); // public press-kit endpoints (no auth)
+app.use(featuresRoutes);  // public features endpoints (no auth)
 
 // Internal platform routes (API key only, no identity)
 app.use("/internal", internalEmailsRoutes);

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -1,9 +1,52 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, callExternalServiceWithStatus, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
 
 const router = Router();
+
+// ── Public routes (no auth) ─────────────────────────────────────────────────
+
+/**
+ * GET /public/features
+ * List active features with display-safe fields (public, no auth).
+ * Designed for landing pages and public-facing UIs.
+ */
+router.get("/public/features", async (req: Request, res: Response) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      "/public/features",
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public features list error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list public features" });
+  }
+});
+
+/**
+ * GET /public/features/dynasty/slugs?dynastySlug=...
+ * List all versioned slugs for a dynasty (public, no auth).
+ */
+router.get("/public/features/dynasty/slugs", async (req: Request, res: Response) => {
+  try {
+    const dynastySlug = req.query.dynastySlug as string | undefined;
+    if (!dynastySlug) {
+      return res.status(400).json({ error: "Missing required query parameter: dynastySlug" });
+    }
+    const result = await callExternalService(
+      externalServices.features,
+      `/public/features/dynasty/slugs?dynastySlug=${encodeURIComponent(dynastySlug)}`,
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public dynasty slugs error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list dynasty slugs" });
+  }
+});
+
+// ── Authenticated routes (mounted at /v1) ────────────────────────────────────
 
 /**
  * GET /v1/features

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6135,3 +6135,72 @@ registry.registerPath({
     500: { description: "Internal error", content: errorContent },
   },
 });
+
+// ---------------------------------------------------------------------------
+// PUBLIC FEATURES (no auth — landing page endpoints)
+// ---------------------------------------------------------------------------
+
+const PublicFeatureItemSchema = z.object({
+  dynastyName: z.string().openapi({ example: "Sales Cold Email" }).describe("Stable dynasty display name"),
+  dynastySlug: z.string().openapi({ example: "sales-cold-email" }).describe("Stable dynasty slug (unversioned)"),
+  description: z.string().openapi({ example: "AI-powered cold email outreach campaigns" }),
+  icon: z.string().openapi({ example: "mail" }).describe("Lucide icon name"),
+  category: z.string().openapi({ example: "sales" }),
+  channel: z.string().openapi({ example: "email" }),
+  audienceType: z.string().openapi({ example: "cold-outreach" }),
+  displayOrder: z.number().int().openapi({ example: 0 }),
+}).openapi("PublicFeatureItem");
+
+registry.registerPath({
+  method: "get",
+  path: "/public/features",
+  tags: ["Features"],
+  summary: "List active features (public, no auth)",
+  description:
+    "Returns all active features with display-safe fields only. " +
+    "Designed for landing pages and public-facing UIs. Sorted by displayOrder ascending. " +
+    "No authentication required. Proxied from features-service.",
+  responses: {
+    200: {
+      description: "Active features",
+      content: {
+        "application/json": {
+          schema: z.object({
+            features: z.array(PublicFeatureItemSchema).describe("Active features sorted by displayOrder"),
+          }).openapi("PublicFeaturesListResponse"),
+        },
+      },
+    },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/public/features/dynasty/slugs",
+  tags: ["Features"],
+  summary: "List dynasty versioned slugs (public, no auth)",
+  description:
+    "Returns all versioned feature slugs (active + deprecated) belonging to a dynasty. " +
+    "No authentication required. Proxied from features-service.",
+  request: {
+    query: z.object({
+      dynastySlug: z.string().openapi({ example: "sales-cold-email" }).describe("The stable dynasty slug (unversioned)"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Dynasty slugs",
+      content: {
+        "application/json": {
+          schema: z.object({
+            slugs: z.array(z.string()).describe("All versioned slugs in the dynasty, sorted by version ascending"),
+          }).openapi("PublicDynastySlugsResponse"),
+        },
+      },
+    },
+    400: { description: "Missing dynastySlug parameter", content: errorContent },
+    404: { description: "No features found for this dynasty slug", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -184,10 +184,10 @@ describe("Features proxy routes", () => {
     expect(content).toContain('"workflowDynastySlug"');
   });
 
-  it("should enforce requireOrg + requireUser on ALL feature routes", () => {
-    // Every router.get / router.post / router.put line must include both guards
+  it("should enforce requireOrg + requireUser on ALL authenticated feature routes", () => {
+    // Every non-public router.get / router.post / router.put line must include both guards
     const routeLines = content.split("\n").filter((l) =>
-      /router\.(get|post|put)\(/.test(l) && l.includes('"/')
+      /router\.(get|post|put)\(/.test(l) && l.includes('"/') && !l.includes("/public/")
     );
     expect(routeLines.length).toBeGreaterThan(0);
     for (const line of routeLines) {
@@ -303,6 +303,73 @@ describe("Features OpenAPI schemas", () => {
   });
 });
 
+describe("Public features proxy routes", () => {
+  it("should have GET /public/features without auth middleware", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/public/features"') && !l.includes("dynasty")
+    );
+    expect(line).toBeDefined();
+    expect(line).not.toContain("authenticate");
+    expect(line).not.toContain("requireOrg");
+  });
+
+  it("should proxy to /public/features on features-service", () => {
+    expect(content).toContain('"/public/features"');
+  });
+
+  it("should have GET /public/features/dynasty/slugs without auth middleware", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/public/features/dynasty/slugs"')
+    );
+    expect(line).toBeDefined();
+    expect(line).not.toContain("authenticate");
+    expect(line).not.toContain("requireOrg");
+  });
+
+  it("should validate dynastySlug query param on GET /public/features/dynasty/slugs", () => {
+    const publicDynastySection = content.slice(content.indexOf('"/public/features/dynasty/slugs"'));
+    expect(publicDynastySection).toContain("req.query.dynastySlug");
+    expect(publicDynastySection).toContain("dynastySlug=");
+  });
+
+  it("should return 400 when dynastySlug is missing on GET /public/features/dynasty/slugs", () => {
+    const publicDynastySection = content.slice(content.indexOf('"/public/features/dynasty/slugs"'));
+    expect(publicDynastySection).toContain("400");
+    expect(publicDynastySection).toContain("Missing required query parameter: dynastySlug");
+  });
+});
+
+describe("Public features OpenAPI schemas", () => {
+  it("should register GET /public/features", () => {
+    expect(schemaContent).toContain('path: "/public/features"');
+  });
+
+  it("should register GET /public/features/dynasty/slugs", () => {
+    expect(schemaContent).toContain('path: "/public/features/dynasty/slugs"');
+  });
+
+  it("should define PublicFeatureItem schema with all display fields", () => {
+    expect(schemaContent).toContain("PublicFeatureItem");
+    expect(schemaContent).toContain("dynastyName");
+    expect(schemaContent).toContain("dynastySlug");
+    expect(schemaContent).toContain("displayOrder");
+    expect(schemaContent).toContain("audienceType");
+  });
+
+  it("should define PublicDynastySlugsResponse schema", () => {
+    expect(schemaContent).toContain("PublicDynastySlugsResponse");
+  });
+
+  it("should not require auth on public feature endpoints", () => {
+    // The public feature registerPath calls should NOT have security: authed
+    const publicFeaturesBlock = schemaContent.slice(
+      schemaContent.indexOf('path: "/public/features"'),
+      schemaContent.indexOf('path: "/public/features"') + 500
+    );
+    expect(publicFeaturesBlock).not.toContain("security:");
+  });
+});
+
 describe("Features routes are mounted in index.ts", () => {
   it("should import and mount features routes", () => {
     expect(indexContent).toContain("featuresRoutes");
@@ -311,5 +378,10 @@ describe("Features routes are mounted in index.ts", () => {
 
   it("should mount at /v1", () => {
     expect(indexContent).toContain('app.use("/v1", featuresRoutes)');
+  });
+
+  it("should mount at root for public endpoints", () => {
+    // featuresRoutes should be mounted without prefix for public routes
+    expect(indexContent).toContain("app.use(featuresRoutes)");
   });
 });


### PR DESCRIPTION
## Summary
- Proxy `GET /public/features` from features-service — lists active features with display-safe fields (no auth)
- Proxy `GET /public/features/dynasty/slugs?dynastySlug=...` — lists versioned slugs for a dynasty (no auth)
- Full OpenAPI schemas + tests for both endpoints

## Test plan
- [x] 55 features proxy tests pass (including 12 new tests for public endpoints)
- [x] Full test suite green (1 pre-existing outlets failure unrelated)
- [x] `openapi.json` regenerated with both public paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)