### PR TITLE
feat: add leadOrganizationDomain to campaign emails response

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1407,6 +1407,11 @@
                   "type": "string",
                   "nullable": true
                 },
+                "leadOrganizationDomain": {
+                  "type": "string",
+                  "nullable": true,
+                  "description": "Company domain from lead enrichment"
+                },
                 "leadTitle": {
                   "type": "string",
                   "nullable": true
@@ -1449,6 +1454,7 @@
                 "leadFirstName",
                 "leadLastName",
                 "leadCompany",
+                "leadOrganizationDomain",
                 "leadTitle",
                 "leadIndustry",
                 "clientCompanyName",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -878,6 +878,7 @@ registry.registerPath({
                   leadFirstName: z.string().nullable(),
                   leadLastName: z.string().nullable(),
                   leadCompany: z.string().nullable(),
+                  leadOrganizationDomain: z.string().nullable().describe("Company domain from lead enrichment"),
                   leadTitle: z.string().nullable(),
                   leadIndustry: z.string().nullable(),
                   clientCompanyName: z.string().nullable(),

--- a/tests/unit/campaign-emails-leads-openapi.test.ts
+++ b/tests/unit/campaign-emails-leads-openapi.test.ts
@@ -49,6 +49,7 @@ describe("Campaign leads/emails OpenAPI response schemas", () => {
       "leadFirstName",
       "leadLastName",
       "leadCompany",
+      "leadOrganizationDomain",
       "leadTitle",
       "leadIndustry",
       "clientCompanyName",

--- a/tests/unit/email-lead-fields.regression.test.ts
+++ b/tests/unit/email-lead-fields.regression.test.ts
@@ -85,6 +85,7 @@ describe("Email lead fields: passed through from emailgen dedicated columns", ()
               leadLastName: "Bailey",
               leadTitle: "Outreach Director",
               leadCompany: "ECMC",
+              leadOrganizationDomain: "ecmc.org",
               leadIndustry: "financial services",
               clientCompanyName: "Sortes",
               generationRunId: null,
@@ -108,6 +109,7 @@ describe("Email lead fields: passed through from emailgen dedicated columns", ()
     expect(email.leadLastName).toBe("Bailey");
     expect(email.leadTitle).toBe("Outreach Director");
     expect(email.leadCompany).toBe("ECMC");
+    expect(email.leadOrganizationDomain).toBe("ecmc.org");
     expect(email.leadIndustry).toBe("financial services");
     expect(email.clientCompanyName).toBe("Sortes");
   });


### PR DESCRIPTION
## Summary
- Adds `leadOrganizationDomain` (string | null) to the `CampaignEmailsResponse` schema so the frontend can display company logos via Logo.dev
- Updates openapi.json with the new field
- Adds test coverage for the new field in both regression and OpenAPI spec tests

**Note:** The api-service already passes through all fields from content-generation via `...email` spread. A corresponding change in content-generation-service is needed to actually populate this field from lead enrichment data.

## Test plan
- [x] `email-lead-fields.regression.test.ts` — verifies field passthrough
- [x] `campaign-emails-leads-openapi.test.ts` — verifies field in OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)