### PR TITLE
feat: add optional outletDomain to journalist-publications proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3240,15 +3240,11 @@
             "format": "uuid",
             "description": "Journalist UUID for linking discoveries back to the journalist record"
           },
-          "brandId": {
+          "outletDomain": {
             "type": "string",
-            "format": "uuid",
-            "description": "Brand to scope discoveries to"
-          },
-          "campaignId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Campaign to scope discoveries to"
+            "minLength": 1,
+            "description": "Outlet domain to scope the Google News search via site: filter (e.g. 'techcrunch.com')",
+            "example": "techcrunch.com"
           },
           "maxResults": {
             "type": "integer",
@@ -3258,9 +3254,7 @@
         "required": [
           "journalistFirstName",
           "journalistLastName",
-          "journalistId",
-          "brandId",
-          "campaignId"
+          "journalistId"
         ]
       },
       "OrgKeyItem": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2245,8 +2245,7 @@ registry.registerPath({
               journalistFirstName: z.string().min(1).openapi({ description: "Journalist first name", example: "Sarah" }),
               journalistLastName: z.string().min(1).openapi({ description: "Journalist last name", example: "Perez" }),
               journalistId: z.string().uuid().openapi({ description: "Journalist UUID for linking discoveries back to the journalist record" }),
-              brandId: z.string().uuid().openapi({ description: "Brand to scope discoveries to" }),
-              campaignId: z.string().uuid().openapi({ description: "Campaign to scope discoveries to" }),
+              outletDomain: z.string().min(1).optional().openapi({ description: "Outlet domain to scope the Google News search via site: filter (e.g. 'techcrunch.com')", example: "techcrunch.com" }),
               maxResults: z.number().int().optional().openapi({ description: "Max publications to find (default 10, max 20)" }),
             })
             .openapi("DiscoverJournalistPublicationsRequest"),

--- a/tests/unit/articles-proxy.test.ts
+++ b/tests/unit/articles-proxy.test.ts
@@ -257,6 +257,12 @@ describe("Articles OpenAPI schemas", () => {
     expect(schemaContent).toContain("DiscoverJournalistPublicationsRequest");
   });
 
+  it("should include optional outletDomain in DiscoverJournalistPublicationsRequest schema", () => {
+    // outletDomain must be present and optional in the journalist-publications request schema
+    const line = schemaContent.split("\n").find((l) => l.includes("outletDomain") && l.includes("optional"));
+    expect(line).toBeDefined();
+  });
+
   it("should register GET /v1/articles/stats", () => {
     expect(schemaContent).toContain('path: "/v1/articles/stats"');
     expect(schemaContent).toContain("ArticleStatsResponse");


### PR DESCRIPTION
## Summary
- Adds optional `outletDomain` field to `POST /v1/discover/journalist-publications` proxy, syncing with articles-service PR #24
- When provided, upstream scopes Google News search via `site:` filter for more precise results
- Removes `brandId`/`campaignId` from request body (now passed via headers upstream)
- Updates OpenAPI spec and adds test coverage

## Test plan
- [x] `outletDomain` is optional in Zod schema and OpenAPI spec
- [x] `brandId`/`campaignId` removed from body (upstream uses headers)
- [x] All articles proxy tests pass
- [x] `openapi.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)