### PR TITLE
feat: outletDomain required, journalistId removed from journalist-publications

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3235,11 +3235,6 @@
             "description": "Journalist last name",
             "example": "Perez"
           },
-          "journalistId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Journalist UUID for linking discoveries back to the journalist record"
-          },
           "outletDomain": {
             "type": "string",
             "minLength": 1,
@@ -3254,7 +3249,7 @@
         "required": [
           "journalistFirstName",
           "journalistLastName",
-          "journalistId"
+          "outletDomain"
         ]
       },
       "OrgKeyItem": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2244,8 +2244,7 @@ registry.registerPath({
             .object({
               journalistFirstName: z.string().min(1).openapi({ description: "Journalist first name", example: "Sarah" }),
               journalistLastName: z.string().min(1).openapi({ description: "Journalist last name", example: "Perez" }),
-              journalistId: z.string().uuid().openapi({ description: "Journalist UUID for linking discoveries back to the journalist record" }),
-              outletDomain: z.string().min(1).optional().openapi({ description: "Outlet domain to scope the Google News search via site: filter (e.g. 'techcrunch.com')", example: "techcrunch.com" }),
+              outletDomain: z.string().min(1).openapi({ description: "Outlet domain to scope the Google News search via site: filter (e.g. 'techcrunch.com')", example: "techcrunch.com" }),
               maxResults: z.number().int().optional().openapi({ description: "Max publications to find (default 10, max 20)" }),
             })
             .openapi("DiscoverJournalistPublicationsRequest"),

--- a/tests/unit/articles-proxy.test.ts
+++ b/tests/unit/articles-proxy.test.ts
@@ -257,10 +257,16 @@ describe("Articles OpenAPI schemas", () => {
     expect(schemaContent).toContain("DiscoverJournalistPublicationsRequest");
   });
 
-  it("should include optional outletDomain in DiscoverJournalistPublicationsRequest schema", () => {
-    // outletDomain must be present and optional in the journalist-publications request schema
-    const line = schemaContent.split("\n").find((l) => l.includes("outletDomain") && l.includes("optional"));
-    expect(line).toBeDefined();
+  it("should include required outletDomain and exclude journalistId in DiscoverJournalistPublicationsRequest schema", () => {
+    // outletDomain is required (no .optional())
+    const outletLine = schemaContent.split("\n").find((l) => l.includes("outletDomain") && !l.includes("optional"));
+    expect(outletLine).toBeDefined();
+    // journalistId was removed from this endpoint's request body
+    const block = schemaContent.slice(
+      schemaContent.indexOf("DiscoverJournalistPublicationsRequest") - 300,
+      schemaContent.indexOf("DiscoverJournalistPublicationsRequest")
+    );
+    expect(block).not.toContain("journalistId");
   });
 
   it("should register GET /v1/articles/stats", () => {


### PR DESCRIPTION
## Summary
- Syncs proxy with articles-service PR #26 breaking changes on `POST /v1/discover/journalist-publications`
- `outletDomain` is now **required** (was optional) — calls without it return 400
- `journalistId` **removed** from request body — field no longer accepted upstream
- OpenAPI spec regenerated, tests updated

## Test plan
- [x] `outletDomain` is required in Zod schema (no `.optional()`)
- [x] `journalistId` removed from schema
- [x] `openapi.json` regenerated and matches
- [x] All articles proxy tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)