### PR TITLE
feat: update extract-fields response schema for byBrand metadata

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4214,16 +4214,137 @@
       "ExtractFieldsFromHeaderResponse": {
         "type": "object",
         "properties": {
-          "results": {
+          "brands": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "brandId": {
+                  "type": "string",
+                  "description": "Internal brand UUID"
+                },
+                "domain": {
+                  "type": "string",
+                  "description": "Brand domain (e.g. acme.com)"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Brand display name"
+                }
+              },
+              "required": [
+                "brandId",
+                "domain",
+                "name"
+              ]
+            },
+            "description": "Metadata for each brand included in the extraction"
+          },
+          "fields": {
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/ExtractFieldResult"
+              "type": "object",
+              "properties": {
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "nullable": true
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      }
+                    },
+                    {
+                      "nullable": true
+                    },
+                    {
+                      "nullable": true
+                    }
+                  ],
+                  "description": "Merged/primary extracted value across all brands"
+                },
+                "byBrand": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "nullable": true
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "additionalProperties": {
+                              "nullable": true
+                            }
+                          },
+                          {
+                            "nullable": true
+                          },
+                          {
+                            "nullable": true
+                          }
+                        ],
+                        "description": "Extracted value for this brand"
+                      },
+                      "cached": {
+                        "type": "boolean",
+                        "description": "Whether this result was served from cache"
+                      },
+                      "extractedAt": {
+                        "type": "string",
+                        "description": "ISO timestamp of extraction"
+                      },
+                      "expiresAt": {
+                        "type": "string",
+                        "description": "ISO timestamp when cached result expires"
+                      },
+                      "sourceUrls": {
+                        "type": "array",
+                        "nullable": true,
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "URLs scraped to extract this field"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "cached",
+                      "extractedAt",
+                      "expiresAt",
+                      "sourceUrls"
+                    ]
+                  },
+                  "description": "Per-brand extraction details keyed by domain"
+                }
+              },
+              "required": [
+                "value",
+                "byBrand"
+              ]
             },
             "description": "Extraction results keyed by field name"
           }
         },
         "required": [
-          "results"
+          "brands",
+          "fields"
         ]
       },
       "ExtractFieldsFromHeaderRequest": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3073,7 +3073,31 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
-            results: z.record(z.string(), ExtractFieldResultSchema).describe("Extraction results keyed by field name"),
+            brands: z.array(z.object({
+              brandId: z.string().describe("Internal brand UUID"),
+              domain: z.string().describe("Brand domain (e.g. acme.com)"),
+              name: z.string().describe("Brand display name"),
+            })).describe("Metadata for each brand included in the extraction"),
+            fields: z.record(z.string(), z.object({
+              value: z.union([
+                z.string(),
+                z.array(z.unknown()),
+                z.record(z.unknown()),
+                z.null(),
+              ]).describe("Merged/primary extracted value across all brands"),
+              byBrand: z.record(z.string(), z.object({
+                value: z.union([
+                  z.string(),
+                  z.array(z.unknown()),
+                  z.record(z.unknown()),
+                  z.null(),
+                ]).describe("Extracted value for this brand"),
+                cached: z.boolean().describe("Whether this result was served from cache"),
+                extractedAt: z.string().describe("ISO timestamp of extraction"),
+                expiresAt: z.string().describe("ISO timestamp when cached result expires"),
+                sourceUrls: z.array(z.string()).nullable().describe("URLs scraped to extract this field"),
+              })).describe("Per-brand extraction details keyed by domain"),
+            })).describe("Extraction results keyed by field name"),
           }).openapi("ExtractFieldsFromHeaderResponse"),
         },
       },

--- a/tests/unit/brand-extract-fields-byBrand.test.ts
+++ b/tests/unit/brand-extract-fields-byBrand.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    req.brandId = "brand-uuid-1,brand-uuid-2";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+describe("POST /v1/brands/extract-fields — byBrand response format", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("should proxy the new byBrand response shape from brand-service", async () => {
+    const brandServiceResponse = {
+      brands: [
+        { brandId: "brand-uuid-1", domain: "acme.com", name: "Acme" },
+        { brandId: "brand-uuid-2", domain: "globex.com", name: "Globex" },
+      ],
+      fields: {
+        industry: {
+          value: "SaaS tools",
+          byBrand: {
+            "acme.com": {
+              value: "SaaS tools",
+              cached: true,
+              extractedAt: "2026-03-15T10:00:00Z",
+              expiresAt: "2026-04-14T10:00:00Z",
+              sourceUrls: ["https://acme.com/about"],
+            },
+            "globex.com": {
+              value: "Industrial automation",
+              cached: false,
+              extractedAt: "2026-03-31T12:00:00Z",
+              expiresAt: "2026-04-30T12:00:00Z",
+              sourceUrls: ["https://globex.com"],
+            },
+          },
+        },
+      },
+    };
+
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve(brandServiceResponse),
+    }));
+
+    const res = await request(app)
+      .post("/v1/brands/extract-fields")
+      .send({ fields: [{ key: "industry", description: "Primary industry" }] });
+
+    expect(res.status).toBe(200);
+
+    // brands array
+    expect(res.body.brands).toHaveLength(2);
+    expect(res.body.brands[0].domain).toBe("acme.com");
+    expect(res.body.brands[1].brandId).toBe("brand-uuid-2");
+
+    // fields with byBrand
+    expect(res.body.fields.industry.value).toBe("SaaS tools");
+    expect(res.body.fields.industry.byBrand["acme.com"].value).toBe("SaaS tools");
+    expect(res.body.fields.industry.byBrand["acme.com"].cached).toBe(true);
+    expect(res.body.fields.industry.byBrand["acme.com"].sourceUrls).toEqual(["https://acme.com/about"]);
+    expect(res.body.fields.industry.byBrand["globex.com"].value).toBe("Industrial automation");
+    expect(res.body.fields.industry.byBrand["globex.com"].cached).toBe(false);
+  });
+
+  it("should include extractedAt and expiresAt in byBrand entries", async () => {
+    const brandServiceResponse = {
+      brands: [{ brandId: "brand-uuid-1", domain: "acme.com", name: "Acme" }],
+      fields: {
+        valueProposition: {
+          value: "All-in-one platform",
+          byBrand: {
+            "acme.com": {
+              value: "All-in-one platform",
+              cached: true,
+              extractedAt: "2026-03-15T10:00:00Z",
+              expiresAt: "2026-04-14T10:00:00Z",
+              sourceUrls: null,
+            },
+          },
+        },
+      },
+    };
+
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve(brandServiceResponse),
+    }));
+
+    const res = await request(app)
+      .post("/v1/brands/extract-fields")
+      .send({ fields: [{ key: "valueProposition", description: "Core value proposition" }] });
+
+    expect(res.status).toBe(200);
+    const entry = res.body.fields.valueProposition.byBrand["acme.com"];
+    expect(entry.extractedAt).toBe("2026-03-15T10:00:00Z");
+    expect(entry.expiresAt).toBe("2026-04-14T10:00:00Z");
+    expect(entry.sourceUrls).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Updated OpenAPI schema for `POST /v1/brands/extract-fields` to match brand-service PR #109
- Response now returns `{ brands, fields }` where `byBrand` entries are full metadata objects (`value`, `cached`, `extractedAt`, `expiresAt`, `sourceUrls`) instead of raw values
- Added tests verifying the new response shape is proxied correctly

## Test plan
- [x] Existing brand extract-fields tests pass (10/10)
- [x] New `brand-extract-fields-byBrand.test.ts` verifies multi-brand response with byBrand metadata
- [x] `openapi.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)