### PR TITLE
feat: migrate public ranked/best proxy to features-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -209,6 +209,119 @@
           "signatureName"
         ]
       },
+      "PublicWorkflowStats": {
+        "type": "object",
+        "properties": {
+          "totalCostInUsdCents": {
+            "type": "number",
+            "description": "Total cost across all completed runs"
+          },
+          "totalOutcomes": {
+            "type": "number",
+            "description": "Total outcome count for the ranked metric"
+          },
+          "costPerOutcome": {
+            "type": "number",
+            "nullable": true,
+            "description": "Cost per outcome in USD cents, null if no outcomes"
+          },
+          "completedRuns": {
+            "type": "number",
+            "description": "Number of completed runs"
+          }
+        },
+        "required": [
+          "totalCostInUsdCents",
+          "totalOutcomes",
+          "costPerOutcome",
+          "completedRuns"
+        ]
+      },
+      "PublicRankedWorkflowItem": {
+        "type": "object",
+        "properties": {
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowMetadata"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/PublicWorkflowStats"
+          }
+        },
+        "required": [
+          "workflow",
+          "stats"
+        ]
+      },
+      "PublicRankedWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicRankedWorkflowItem"
+            },
+            "description": "Workflows ranked by performance, best first"
+          }
+        },
+        "required": [
+          "results"
+        ]
+      },
+      "PublicBestWorkflowRecord": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "workflowSlug": {
+            "type": "string",
+            "description": "Slug of the workflow"
+          },
+          "workflowName": {
+            "type": "string",
+            "description": "Display name of the workflow"
+          },
+          "createdForBrandId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Brand ID that created this workflow"
+          },
+          "value": {
+            "type": "number",
+            "description": "The record value (cost per outcome in USD cents)"
+          }
+        },
+        "required": [
+          "workflowSlug",
+          "workflowName",
+          "createdForBrandId",
+          "value"
+        ]
+      },
+      "PublicBestWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "best": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PublicBestWorkflowRecord"
+            },
+            "description": "Map of metric key to the workflow holding the best cost-per-outcome record. Null if no data."
+          }
+        },
+        "required": [
+          "best"
+        ],
+        "example": {
+          "best": {
+            "replied": {
+              "workflowSlug": "sales-email-cold-outreach-sienna-v3",
+              "workflowName": "Sales Cold Outreach (Sienna)",
+              "createdForBrandId": "brand-uuid-456",
+              "value": 42
+            },
+            "clicked": null
+          }
+        }
+      },
       "WorkflowEmailStats": {
         "type": "object",
         "properties": {
@@ -308,11 +421,35 @@
           "completedRuns"
         ]
       },
-      "PublicRankedWorkflowItem": {
+      "RankedWorkflowItem": {
         "type": "object",
         "properties": {
           "workflow": {
             "$ref": "#/components/schemas/WorkflowMetadata"
+          },
+          "dag": {
+            "type": "object",
+            "properties": {
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "nullable": true
+                },
+                "description": "DAG nodes"
+              },
+              "edges": {
+                "type": "array",
+                "items": {
+                  "nullable": true
+                },
+                "description": "DAG edges"
+              }
+            },
+            "required": [
+              "nodes",
+              "edges"
+            ],
+            "description": "The DAG definition"
           },
           "stats": {
             "$ref": "#/components/schemas/WorkflowStats"
@@ -320,16 +457,17 @@
         },
         "required": [
           "workflow",
+          "dag",
           "stats"
         ]
       },
-      "PublicRankedWorkflowResponse": {
+      "RankedWorkflowResponse": {
         "type": "object",
         "properties": {
           "results": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PublicRankedWorkflowItem"
+              "$ref": "#/components/schemas/RankedWorkflowItem"
             },
             "description": "Workflows ranked by performance, best first"
           }
@@ -398,61 +536,6 @@
             "clicked": null
           }
         }
-      },
-      "RankedWorkflowItem": {
-        "type": "object",
-        "properties": {
-          "workflow": {
-            "$ref": "#/components/schemas/WorkflowMetadata"
-          },
-          "dag": {
-            "type": "object",
-            "properties": {
-              "nodes": {
-                "type": "array",
-                "items": {
-                  "nullable": true
-                },
-                "description": "DAG nodes"
-              },
-              "edges": {
-                "type": "array",
-                "items": {
-                  "nullable": true
-                },
-                "description": "DAG edges"
-              }
-            },
-            "required": [
-              "nodes",
-              "edges"
-            ],
-            "description": "The DAG definition"
-          },
-          "stats": {
-            "$ref": "#/components/schemas/WorkflowStats"
-          }
-        },
-        "required": [
-          "workflow",
-          "dag",
-          "stats"
-        ]
-      },
-      "RankedWorkflowResponse": {
-        "type": "object",
-        "properties": {
-          "results": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RankedWorkflowItem"
-            },
-            "description": "Workflows ranked by performance, best first"
-          }
-        },
-        "required": [
-          "results"
-        ]
       },
       "MeResponse": {
         "type": "object",
@@ -7792,16 +7875,27 @@
           "Workflows"
         ],
         "summary": "Ranked workflows (public)",
-        "description": "Public ranked workflows by performance. Ranking metrics are dynamically resolved from the feature's declared outputs. Supports groupBy=feature and groupBy=brand. No authentication required.",
+        "description": "Public ranked workflows by performance. Proxied to features-service. featureDynastySlug and objective are required. Only groupBy=brand is supported. No authentication required.",
         "parameters": [
           {
             "schema": {
               "type": "string",
-              "description": "Stats key to rank by (e.g. 'replied', 'clicked', 'leads_found', 'outlets_found'). Dynamically resolved from the feature's declared outputs. If omitted, featureSlug or featureDynastySlug is required to auto-resolve the ranking metric.",
+              "description": "Feature dynasty slug (required). Resolves to all versioned slugs in the lineage.",
+              "example": "pr-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature dynasty slug (required). Resolves to all versioned slugs in the lineage.",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Stats key to rank by (required). e.g. 'replied', 'clicked', 'leads_found', 'outlets_found'.",
               "example": "replied"
             },
-            "required": false,
-            "description": "Stats key to rank by (e.g. 'replied', 'clicked', 'leads_found', 'outlets_found'). Dynamically resolved from the feature's declared outputs. If omitted, featureSlug or featureDynastySlug is required to auto-resolve the ranking metric.",
+            "required": true,
+            "description": "Stats key to rank by (required). e.g. 'replied', 'clicked', 'leads_found', 'outlets_found'.",
             "name": "objective",
             "in": "query"
           },
@@ -7819,11 +7913,14 @@
           {
             "schema": {
               "type": "string",
-              "description": "'feature' to group by featureSlug, 'brand' to group by brand",
-              "example": "feature"
+              "enum": [
+                "brand"
+              ],
+              "description": "'brand' to group by brand. groupBy=feature is no longer supported.",
+              "example": "brand"
             },
             "required": false,
-            "description": "'feature' to group by featureSlug, 'brand' to group by brand",
+            "description": "'brand' to group by brand. groupBy=feature is no longer supported.",
             "name": "groupBy",
             "in": "query"
           },
@@ -7836,28 +7933,6 @@
             "required": false,
             "description": "Filter by brand ID",
             "name": "brandId",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by exact versioned feature slug",
-              "example": "pr-cold-email-outreach-v3"
-            },
-            "required": false,
-            "description": "Filter by exact versioned feature slug",
-            "name": "featureSlug",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by feature dynasty slug (resolves to all versioned slugs in the lineage)",
-              "example": "pr-cold-email-outreach"
-            },
-            "required": false,
-            "description": "Filter by feature dynasty slug (resolves to all versioned slugs in the lineage)",
-            "name": "featureDynastySlug",
             "in": "query"
           }
         ],
@@ -7891,8 +7966,19 @@
           "Workflows"
         ],
         "summary": "Hero records (public)",
-        "description": "Public hero records — best cost-per-outcome for dynamic metrics resolved from the feature's outputs. Use ?by=brand for brand-level heroes. Requires objective or featureSlug/featureDynastySlug. No authentication required.",
+        "description": "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug is required. Response does not include workflowId. No authentication required.",
         "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature dynasty slug (required). Resolves to all versioned slugs in the lineage.",
+              "example": "pr-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature dynasty slug (required). Resolves to all versioned slugs in the lineage.",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
           {
             "schema": {
               "type": "string",
@@ -7903,54 +7989,21 @@
             "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
             "name": "by",
             "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Stats key to optimize for (e.g. 'replied', 'clicked', 'leads_found'). Dynamically resolved from the feature's declared outputs if omitted.",
-              "example": "replied"
-            },
-            "required": false,
-            "description": "Stats key to optimize for (e.g. 'replied', 'clicked', 'leads_found'). Dynamically resolved from the feature's declared outputs if omitted.",
-            "name": "objective",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by exact versioned feature slug. Required if objective is not provided.",
-              "example": "pr-cold-email-outreach-v3"
-            },
-            "required": false,
-            "description": "Filter by exact versioned feature slug. Required if objective is not provided.",
-            "name": "featureSlug",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by feature dynasty slug (resolves to all versioned slugs in the lineage). Required if objective is not provided.",
-              "example": "pr-cold-email-outreach"
-            },
-            "required": false,
-            "description": "Filter by feature dynasty slug (resolves to all versioned slugs in the lineage). Required if objective is not provided.",
-            "name": "featureDynastySlug",
-            "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Hero records — best cost-per-outcome for each dynamic metric. Metrics are resolved from the feature's declared outputs.",
+            "description": "Hero records — best cost-per-outcome (public). No workflowId in response.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BestWorkflowResponse"
+                  "$ref": "#/components/schemas/PublicBestWorkflowResponse"
                 }
               }
             }
           },
           "400": {
-            "description": "Bad request — neither objective nor featureSlug/featureDynastySlug provided",
+            "description": "Bad request — featureDynastySlug is required",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -101,6 +101,10 @@ function buildWorkflowParams(query: Record<string, unknown>, keys: string[]): UR
 const RANKED_PARAMS = ["objective", "limit", "groupBy", "brandId", "featureSlug", "featureDynastySlug"];
 const BEST_PARAMS = ["by", "orgId", "objective", "featureSlug", "featureDynastySlug"];
 
+// Public endpoints migrated to features-service — stricter contract
+const PUBLIC_RANKED_PARAMS = ["featureDynastySlug", "objective", "limit", "groupBy", "brandId"];
+const PUBLIC_BEST_PARAMS = ["featureDynastySlug", "by"];
+
 // ---------------------------------------------------------------------------
 // Public routes (no auth — proxied from workflow-service /public/*)
 // ---------------------------------------------------------------------------
@@ -111,15 +115,15 @@ const BEST_PARAMS = ["by", "orgId", "objective", "featureSlug", "featureDynastyS
  */
 router.get("/public/workflows/ranked", async (_req, res) => {
   try {
-    const params = buildWorkflowParams(_req.query as Record<string, unknown>, RANKED_PARAMS);
+    const params = buildWorkflowParams(_req.query as Record<string, unknown>, PUBLIC_RANKED_PARAMS);
     const result = await callExternalService(
-      externalServices.workflow,
-      `/public/workflows/ranked?${params}`,
+      externalServices.features,
+      `/public/stats/ranked?${params}`,
       {},
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Public ranked workflows error:", error.message);
+    console.error("[api-service] Public ranked workflows error:", error.message);
     res.status(502).json({ error: error.message || "Failed to get public ranked workflows" });
   }
 });
@@ -130,15 +134,15 @@ router.get("/public/workflows/ranked", async (_req, res) => {
  */
 router.get("/public/workflows/best", async (_req, res) => {
   try {
-    const params = buildWorkflowParams(_req.query as Record<string, unknown>, BEST_PARAMS);
+    const params = buildWorkflowParams(_req.query as Record<string, unknown>, PUBLIC_BEST_PARAMS);
     const result = await callExternalService(
-      externalServices.workflow,
-      `/public/workflows/best?${params}`,
+      externalServices.features,
+      `/public/stats/best?${params}`,
       {},
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Public best workflows error:", error.message);
+    console.error("[api-service] Public best workflows error:", error.message);
     res.status(502).json({ error: error.message || "Failed to get public best workflows" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -148,6 +148,20 @@ const bestQueryParams = z.object({
   featureDynastySlug: z.string().optional().openapi({ example: "pr-cold-email-outreach" }).describe("Filter by feature dynasty slug (resolves to all versioned slugs in the lineage). Required if objective is not provided."),
 });
 
+// Public endpoints — migrated to features-service with stricter contract
+const publicRankedQueryParams = z.object({
+  featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
+  objective: z.string().openapi({ example: "replied" }).describe("Stats key to rank by (required). e.g. 'replied', 'clicked', 'leads_found', 'outlets_found'."),
+  limit: z.string().optional().openapi({ example: "10" }).describe("Max results (default 10, max 100)"),
+  groupBy: z.enum(["brand"]).optional().openapi({ example: "brand" }).describe("'brand' to group by brand. groupBy=feature is no longer supported."),
+  brandId: z.string().optional().openapi({ example: "brand-uuid-123" }).describe("Filter by brand ID"),
+});
+
+const publicBestQueryParams = z.object({
+  featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
+  by: z.string().optional().openapi({ example: "workflow" }).describe("'workflow' (default) or 'brand' — hero records by workflow or by brand"),
+});
+
 // -- Workflow response schemas (mirroring workflow-service) --
 
 const WorkflowEmailStatsSchema = z
@@ -206,10 +220,19 @@ const RankedWorkflowItemSchema = z
   })
   .openapi("RankedWorkflowItem");
 
+const PublicWorkflowStatsSchema = z
+  .object({
+    totalCostInUsdCents: z.number().describe("Total cost across all completed runs"),
+    totalOutcomes: z.number().describe("Total outcome count for the ranked metric"),
+    costPerOutcome: z.number().nullable().describe("Cost per outcome in USD cents, null if no outcomes"),
+    completedRuns: z.number().describe("Number of completed runs"),
+  })
+  .openapi("PublicWorkflowStats");
+
 const PublicRankedWorkflowItemSchema = z
   .object({
     workflow: WorkflowMetadataSchema,
-    stats: WorkflowStatsSchema,
+    stats: PublicWorkflowStatsSchema,
   })
   .openapi("PublicRankedWorkflowItem");
 
@@ -222,6 +245,15 @@ const BestWorkflowRecordSchema = z
     value: z.number().describe("The record value (cost per outcome in USD cents)"),
   })
   .openapi("BestWorkflowRecord");
+
+const PublicBestWorkflowRecordSchema = z
+  .object({
+    workflowSlug: z.string().describe("Slug of the workflow"),
+    workflowName: z.string().describe("Display name of the workflow"),
+    createdForBrandId: z.string().nullable().describe("Brand ID that created this workflow"),
+    value: z.number().describe("The record value (cost per outcome in USD cents)"),
+  })
+  .openapi("PublicBestWorkflowRecord");
 
 const rankedResponse = {
   200: {
@@ -273,14 +305,36 @@ const bestResponse = {
   502: { description: "Upstream service error", content: errorContent },
 };
 
+const publicBestResponse = {
+  200: {
+    description: "Hero records — best cost-per-outcome (public). No workflowId in response.",
+    content: {
+      "application/json": {
+        schema: z.object({
+          best: z.record(z.string(), PublicBestWorkflowRecordSchema.nullable()).describe("Map of metric key to the workflow holding the best cost-per-outcome record. Null if no data."),
+        }).openapi("PublicBestWorkflowResponse", {
+          example: {
+            best: {
+              replied: { workflowSlug: "sales-email-cold-outreach-sienna-v3", workflowName: "Sales Cold Outreach (Sienna)", createdForBrandId: "brand-uuid-456", value: 42 },
+              clicked: null,
+            },
+          },
+        }),
+      },
+    },
+  },
+  400: { description: "Bad request — featureDynastySlug is required", content: errorContent },
+  502: { description: "Upstream service error", content: errorContent },
+};
+
 // Public endpoints (no auth)
 registry.registerPath({
   method: "get",
   path: "/v1/public/workflows/ranked",
   tags: ["Workflows"],
   summary: "Ranked workflows (public)",
-  description: "Public ranked workflows by performance. Ranking metrics are dynamically resolved from the feature's declared outputs. Supports groupBy=feature and groupBy=brand. No authentication required.",
-  request: { query: rankedQueryParams },
+  description: "Public ranked workflows by performance. Proxied to features-service. featureDynastySlug and objective are required. Only groupBy=brand is supported. No authentication required.",
+  request: { query: publicRankedQueryParams },
   responses: publicRankedResponse,
 });
 
@@ -289,9 +343,9 @@ registry.registerPath({
   path: "/v1/public/workflows/best",
   tags: ["Workflows"],
   summary: "Hero records (public)",
-  description: "Public hero records — best cost-per-outcome for dynamic metrics resolved from the feature's outputs. Use ?by=brand for brand-level heroes. Requires objective or featureSlug/featureDynastySlug. No authentication required.",
-  request: { query: bestQueryParams },
-  responses: bestResponse,
+  description: "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug is required. Response does not include workflowId. No authentication required.",
+  request: { query: publicBestQueryParams },
+  responses: publicBestResponse,
 });
 
 // Authenticated endpoints

--- a/tests/unit/workflow-dynasty-slugs.test.ts
+++ b/tests/unit/workflow-dynasty-slugs.test.ts
@@ -127,28 +127,28 @@ describe("Workflow dynasty slug forwarding", () => {
   // GET /v1/public/workflows/ranked
   // -----------------------------------------------------------------------
 
-  it("should forward featureDynastySlug on GET /public/workflows/ranked", async () => {
+  it("should forward featureDynastySlug to features-service on GET /public/workflows/ranked", async () => {
     const app = createApp();
     await request(app)
       .get("/v1/public/workflows/ranked")
       .query({ featureDynastySlug: "pr-cold-email-outreach" });
 
-    const call = fetchCalls.find((c) => c.url.includes("/public/workflows/ranked"));
+    const call = fetchCalls.find((c) => c.url.includes("/public/stats/ranked"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("featureDynastySlug=pr-cold-email-outreach");
   });
 
   // -----------------------------------------------------------------------
-  // GET /v1/public/workflows/best
+  // GET /v1/public/workflows/best (proxied to features-service /public/stats/best)
   // -----------------------------------------------------------------------
 
-  it("should forward featureDynastySlug on GET /public/workflows/best", async () => {
+  it("should forward featureDynastySlug to features-service on GET /public/workflows/best", async () => {
     const app = createApp();
     await request(app)
       .get("/v1/public/workflows/best")
       .query({ featureDynastySlug: "pr-cold-email-outreach" });
 
-    const call = fetchCalls.find((c) => c.url.includes("/public/workflows/best"));
+    const call = fetchCalls.find((c) => c.url.includes("/public/stats/best"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("featureDynastySlug=pr-cold-email-outreach");
   });

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -61,6 +61,29 @@ describe("Workflow proxy routes", () => {
     expect(content).toContain('"/public/workflows/best"');
   });
 
+  it("should proxy public ranked/best to features-service, not workflow-service", () => {
+    // Extract public ranked block
+    const pubRankedStart = content.indexOf('"/public/workflows/ranked"');
+    const pubRankedEnd = content.indexOf("});", pubRankedStart) + 3;
+    const pubRankedBlock = content.slice(pubRankedStart, pubRankedEnd);
+    expect(pubRankedBlock).toContain("externalServices.features");
+    expect(pubRankedBlock).toContain("/public/stats/ranked");
+    expect(pubRankedBlock).not.toContain("externalServices.workflow");
+
+    // Extract public best block
+    const pubBestStart = content.indexOf('"/public/workflows/best"');
+    const pubBestEnd = content.indexOf("});", pubBestStart) + 3;
+    const pubBestBlock = content.slice(pubBestStart, pubBestEnd);
+    expect(pubBestBlock).toContain("externalServices.features");
+    expect(pubBestBlock).toContain("/public/stats/best");
+    expect(pubBestBlock).not.toContain("externalServices.workflow");
+  });
+
+  it("should use PUBLIC_RANKED_PARAMS and PUBLIC_BEST_PARAMS for public routes", () => {
+    expect(content).toContain("PUBLIC_RANKED_PARAMS");
+    expect(content).toContain("PUBLIC_BEST_PARAMS");
+  });
+
   it("should forward featureSlug query param on ranked endpoints", () => {
     expect(content).toContain('"featureSlug"');
   });
@@ -228,12 +251,30 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     expect(audienceLine).toContain(".optional()");
   });
 
-  it("should use groupBy=feature instead of groupBy=section in ranked query params", () => {
+  it("should use groupBy=feature in authenticated ranked query params", () => {
     const start = content.indexOf("const rankedQueryParams");
     const end = content.indexOf("});", start) + 3;
     const rankedSection = content.slice(start, end);
     expect(rankedSection).toContain("feature");
     expect(rankedSection).not.toContain("'section'");
+  });
+
+  it("should define publicRankedQueryParams with required featureDynastySlug and objective", () => {
+    const start = content.indexOf("const publicRankedQueryParams");
+    const end = content.indexOf("});", start) + 3;
+    const section = content.slice(start, end);
+    expect(section).toContain("featureDynastySlug: z.string()");
+    expect(section).toContain("objective: z.string()");
+    expect(section).not.toContain("featureSlug");
+  });
+
+  it("should define publicBestQueryParams with required featureDynastySlug and no featureSlug/objective", () => {
+    const start = content.indexOf("const publicBestQueryParams");
+    const end = content.indexOf("});", start) + 3;
+    const section = content.slice(start, end);
+    expect(section).toContain("featureDynastySlug: z.string()");
+    expect(section).not.toContain("featureSlug");
+    expect(section).not.toContain("objective");
   });
 
   it("should not include category/channel/audienceType in rankedQueryParams", () => {

--- a/tests/unit/workflows-stats.test.ts
+++ b/tests/unit/workflows-stats.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../src/lib/service-client.js", () => ({
     instantly: { url: "http://mock-instantly", apiKey: "k" },
     billing: { url: "http://mock-billing", apiKey: "k" },
     chat: { url: "http://mock-chat", apiKey: "k" },
+    features: { url: "http://mock-features", apiKey: "k" },
   },
 }));
 
@@ -117,46 +118,84 @@ describe("GET /v1/workflows/best", () => {
 describe("GET /v1/public/workflows/ranked", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("proxies to workflow-service /public/workflows/ranked without auth", async () => {
+  it("proxies to features-service /public/stats/ranked without auth", async () => {
     const app = createApp();
     mockCallExternalService.mockImplementation((service: any, path: string) => {
-      if (service.url === "http://mock-workflow" && path.startsWith("/public/workflows/ranked")) {
+      if (service.url === "http://mock-features" && path.startsWith("/public/stats/ranked")) {
         return Promise.resolve(MOCK_RANKED);
       }
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/public/workflows/ranked?objective=sales&groupBy=brand");
+    const res = await request(app).get("/v1/public/workflows/ranked?featureDynastySlug=pr-cold-email&objective=replied&groupBy=brand");
 
     expect(res.status).toBe(200);
     expect(res.body.results).toEqual(MOCK_RANKED.results);
 
     const call = mockCallExternalService.mock.calls.find(
-      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/workflows/ranked"),
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/stats/ranked"),
     );
     expect(call).toBeDefined();
     const url = call![1] as string;
-    expect(url).toContain("objective=sales");
+    expect(url).toContain("featureDynastySlug=pr-cold-email");
+    expect(url).toContain("objective=replied");
     expect(url).toContain("groupBy=brand");
+  });
+
+  it("does not forward featureSlug to features-service", async () => {
+    const app = createApp();
+    mockCallExternalService.mockResolvedValue(MOCK_RANKED);
+
+    await request(app).get("/v1/public/workflows/ranked?featureSlug=pr-cold-email-v3&featureDynastySlug=pr-cold-email&objective=replied");
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/stats/ranked"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).not.toContain("featureSlug=");
   });
 });
 
 describe("GET /v1/public/workflows/best", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("proxies to workflow-service /public/workflows/best without auth", async () => {
+  it("proxies to features-service /public/stats/best without auth", async () => {
     const app = createApp();
     mockCallExternalService.mockImplementation((service: any, path: string) => {
-      if (service.url === "http://mock-workflow" && path.startsWith("/public/workflows/best")) {
+      if (service.url === "http://mock-features" && path.startsWith("/public/stats/best")) {
         return Promise.resolve(MOCK_HERO);
       }
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/public/workflows/best?by=workflow");
+    const res = await request(app).get("/v1/public/workflows/best?featureDynastySlug=pr-cold-email&by=workflow");
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(MOCK_HERO);
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/stats/best"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).toContain("featureDynastySlug=pr-cold-email");
+    expect(url).toContain("by=workflow");
+  });
+
+  it("does not forward featureSlug or objective to features-service", async () => {
+    const app = createApp();
+    mockCallExternalService.mockResolvedValue(MOCK_HERO);
+
+    await request(app).get("/v1/public/workflows/best?featureDynastySlug=pr-cold-email&featureSlug=pr-cold-email-v3&objective=replied");
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/stats/best"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).not.toContain("featureSlug=");
+    expect(url).not.toContain("objective=");
   });
 });
 


### PR DESCRIPTION
## Summary
- Public `GET /v1/public/workflows/ranked` and `GET /v1/public/workflows/best` now proxy to **features-service** (`/public/stats/ranked` and `/public/stats/best`) instead of workflow-service
- Stricter contract for public endpoints: `featureDynastySlug` required on both, `objective` required on ranked, `featureSlug` no longer accepted, `groupBy=feature` removed
- Public response schemas updated: no `email` stats breakdown on ranked, no `workflowId` on best
- Authenticated endpoints unchanged (still on workflow-service)

## Test plan
- [x] All 53 workflow tests pass (stats, proxy, dynasty-slugs)
- [x] OpenAPI spec regenerated
- [ ] Verify front/landing page passes `featureDynastySlug` (not `featureSlug`) before switching traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)