### PR TITLE
fix: correct OpenAPI examples and groupBy enum

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -304,7 +304,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/BestWorkflowRecord"
             },
-            "description": "Map of metric key (e.g. 'replied', 'leads_found') to the workflow holding the best cost-per-outcome record for that metric. Null if no data."
+            "description": "Map of metric key (e.g. 'emailsReplied', 'leadsServed') to the workflow holding the best cost-per-outcome record for that metric. Null if no data."
           }
         },
         "required": [
@@ -312,13 +312,13 @@
         ],
         "example": {
           "best": {
-            "replied": {
+            "emailsReplied": {
               "workflowSlug": "sales-email-cold-outreach-sienna-v3",
               "workflowName": "Sales Cold Outreach (Sienna)",
               "createdForBrandId": "brand-uuid-456",
               "value": 42
             },
-            "clicked": null
+            "leadsServed": null
           }
         }
       },
@@ -7699,14 +7699,13 @@
             "schema": {
               "type": "string",
               "enum": [
-                "workflow",
                 "brand"
               ],
-              "description": "'workflow' or 'brand' — group results by workflow or brand.",
+              "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
               "example": "brand"
             },
             "required": false,
-            "description": "'workflow' or 'brand' — group results by workflow or brand.",
+            "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
             "name": "groupBy",
             "in": "query"
           },
@@ -7872,14 +7871,13 @@
             "schema": {
               "type": "string",
               "enum": [
-                "workflow",
                 "brand"
               ],
-              "description": "'workflow' or 'brand' — group results by workflow or brand.",
+              "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
               "example": "brand"
             },
             "required": false,
-            "description": "'workflow' or 'brand' — group results by workflow or brand.",
+            "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
             "name": "groupBy",
             "in": "query"
           },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -137,7 +137,7 @@ const rankedQueryParams = z.object({
   featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
   objective: z.string().openapi({ example: "emailsReplied" }).describe("Stats key to rank by (required). e.g. 'emailsReplied', 'leadsServed'."),
   limit: z.string().optional().openapi({ example: "10" }).describe("Max results (default 10, max 100)"),
-  groupBy: z.enum(["workflow", "brand"]).optional().openapi({ example: "brand" }).describe("'workflow' or 'brand' — group results by workflow or brand."),
+  groupBy: z.enum(["brand"]).optional().openapi({ example: "brand" }).describe("'brand' to aggregate by brand. Omit for default per-workflow ranking."),
   brandId: z.string().optional().openapi({ example: "brand-uuid-123" }).describe("Filter by brand ID"),
 });
 
@@ -213,12 +213,12 @@ const bestResponse = {
     content: {
       "application/json": {
         schema: z.object({
-          best: z.record(z.string(), BestWorkflowRecordSchema.nullable()).describe("Map of metric key (e.g. 'replied', 'leads_found') to the workflow holding the best cost-per-outcome record for that metric. Null if no data."),
+          best: z.record(z.string(), BestWorkflowRecordSchema.nullable()).describe("Map of metric key (e.g. 'emailsReplied', 'leadsServed') to the workflow holding the best cost-per-outcome record for that metric. Null if no data."),
         }).openapi("BestWorkflowResponse", {
           example: {
             best: {
-              replied: { workflowSlug: "sales-email-cold-outreach-sienna-v3", workflowName: "Sales Cold Outreach (Sienna)", createdForBrandId: "brand-uuid-456", value: 42 },
-              clicked: null,
+              emailsReplied: { workflowSlug: "sales-email-cold-outreach-sienna-v3", workflowName: "Sales Cold Outreach (Sienna)", createdForBrandId: "brand-uuid-456", value: 42 },
+              leadsServed: null,
             },
           },
         }),

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -255,8 +255,7 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     expect(rankedSection).toContain("featureDynastySlug: z.string()");
     expect(rankedSection).toContain("objective: z.string()");
     expect(rankedSection).not.toContain("featureSlug");
-    // groupBy supports "workflow" and "brand"
-    expect(rankedSection).toContain('"workflow"');
+    // groupBy only supports "brand" (omit for per-workflow ranking)
     expect(rankedSection).toContain('"brand"');
   });
 


### PR DESCRIPTION
## Summary
- `groupBy` enum narrowed to `["brand"]` only — omit for default per-workflow ranking
- `BestWorkflowResponse` example keys updated to `emailsReplied`/`leadsServed` (not `replied`/`clicked`)

Follow-up to #276.

## Test plan
- [x] 53/53 tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)