### PR TITLE
fix: make groupBy and by required on ranked/best endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7660,7 +7660,7 @@
           "Features"
         ],
         "summary": "Ranked features (public)",
-        "description": "Public ranked workflows by performance. Proxied to features-service. featureDynastySlug and objective are required. No authentication required.",
+        "description": "Public ranked workflows by performance. Proxied to features-service. featureDynastySlug, objective, and groupBy are required. No authentication required.",
         "parameters": [
           {
             "schema": {
@@ -7687,25 +7687,15 @@
           {
             "schema": {
               "type": "string",
-              "description": "Max results (default 10, max 100)",
-              "example": "10"
-            },
-            "required": false,
-            "description": "Max results (default 10, max 100)",
-            "name": "limit",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
               "enum": [
+                "workflow",
                 "brand"
               ],
-              "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
-              "example": "brand"
+              "description": "'workflow' or 'brand' — group results by workflow or by brand.",
+              "example": "workflow"
             },
-            "required": false,
-            "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
+            "required": true,
+            "description": "'workflow' or 'brand' — group results by workflow or by brand.",
             "name": "groupBy",
             "in": "query"
           },
@@ -7718,6 +7708,17 @@
             "required": false,
             "description": "Filter by brand ID",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Max results (default 10, max 100)",
+              "example": "10"
+            },
+            "required": false,
+            "description": "Max results (default 10, max 100)",
+            "name": "limit",
             "in": "query"
           }
         ],
@@ -7751,7 +7752,7 @@
           "Features"
         ],
         "summary": "Hero records (public)",
-        "description": "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug is required. No authentication required.",
+        "description": "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug and by are required. No authentication required.",
         "parameters": [
           {
             "schema": {
@@ -7767,23 +7768,27 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "workflow",
+                "brand"
+              ],
+              "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
+              "example": "workflow"
+            },
+            "required": true,
+            "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
+            "name": "by",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "description": "Filter by brand ID",
               "example": "brand-uuid-123"
             },
             "required": false,
             "description": "Filter by brand ID",
             "name": "brandId",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
-              "example": "workflow"
-            },
-            "required": false,
-            "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
-            "name": "by",
             "in": "query"
           }
         ],
@@ -7827,7 +7832,7 @@
           "Workflows"
         ],
         "summary": "Ranked workflows",
-        "description": "Workflows ranked by performance, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and objective are required. Only groupBy=brand is supported.",
+        "description": "Workflows ranked by performance, scoped to the authenticated org. Proxied to features-service. featureDynastySlug, objective, and groupBy are required.",
         "security": [
           {
             "bearerAuth": []
@@ -7859,25 +7864,15 @@
           {
             "schema": {
               "type": "string",
-              "description": "Max results (default 10, max 100)",
-              "example": "10"
-            },
-            "required": false,
-            "description": "Max results (default 10, max 100)",
-            "name": "limit",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
               "enum": [
+                "workflow",
                 "brand"
               ],
-              "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
-              "example": "brand"
+              "description": "'workflow' or 'brand' — group results by workflow or by brand.",
+              "example": "workflow"
             },
-            "required": false,
-            "description": "'brand' to aggregate by brand. Omit for default per-workflow ranking.",
+            "required": true,
+            "description": "'workflow' or 'brand' — group results by workflow or by brand.",
             "name": "groupBy",
             "in": "query"
           },
@@ -7890,6 +7885,17 @@
             "required": false,
             "description": "Filter by brand ID",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Max results (default 10, max 100)",
+              "example": "10"
+            },
+            "required": false,
+            "description": "Max results (default 10, max 100)",
+            "name": "limit",
             "in": "query"
           },
           {
@@ -7988,7 +7994,7 @@
           "Workflows"
         ],
         "summary": "Hero records",
-        "description": "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug is required. Use ?by=brand for brand-level heroes.",
+        "description": "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and by are required.",
         "security": [
           {
             "bearerAuth": []
@@ -8009,23 +8015,27 @@
           {
             "schema": {
               "type": "string",
+              "enum": [
+                "workflow",
+                "brand"
+              ],
+              "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
+              "example": "workflow"
+            },
+            "required": true,
+            "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
+            "name": "by",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "description": "Filter by brand ID",
               "example": "brand-uuid-123"
             },
             "required": false,
             "description": "Filter by brand ID",
             "name": "brandId",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
-              "example": "workflow"
-            },
-            "required": false,
-            "description": "'workflow' (default) or 'brand' — hero records by workflow or by brand",
-            "name": "by",
             "in": "query"
           },
           {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -136,15 +136,15 @@ registry.registerPath({
 const rankedQueryParams = z.object({
   featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
   objective: z.string().openapi({ example: "emailsReplied" }).describe("Stats key to rank by (required). e.g. 'emailsReplied', 'leadsServed'."),
-  limit: z.string().optional().openapi({ example: "10" }).describe("Max results (default 10, max 100)"),
-  groupBy: z.enum(["brand"]).optional().openapi({ example: "brand" }).describe("'brand' to aggregate by brand. Omit for default per-workflow ranking."),
+  groupBy: z.enum(["workflow", "brand"]).openapi({ example: "workflow" }).describe("'workflow' or 'brand' — group results by workflow or by brand."),
   brandId: z.string().optional().openapi({ example: "brand-uuid-123" }).describe("Filter by brand ID"),
+  limit: z.string().optional().openapi({ example: "10" }).describe("Max results (default 10, max 100)"),
 });
 
 const bestQueryParams = z.object({
   featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
+  by: z.enum(["workflow", "brand"]).openapi({ example: "workflow" }).describe("'workflow' or 'brand' — hero records by workflow or by brand."),
   brandId: z.string().optional().openapi({ example: "brand-uuid-123" }).describe("Filter by brand ID"),
-  by: z.string().optional().openapi({ example: "workflow" }).describe("'workflow' (default) or 'brand' — hero records by workflow or by brand"),
 });
 
 // -- Workflow response schemas (mirroring workflow-service) --
@@ -235,7 +235,7 @@ registry.registerPath({
   path: "/v1/public/features/ranked",
   tags: ["Features"],
   summary: "Ranked features (public)",
-  description: "Public ranked workflows by performance. Proxied to features-service. featureDynastySlug and objective are required. No authentication required.",
+  description: "Public ranked workflows by performance. Proxied to features-service. featureDynastySlug, objective, and groupBy are required. No authentication required.",
   request: { query: rankedQueryParams },
   responses: rankedResponse,
 });
@@ -245,7 +245,7 @@ registry.registerPath({
   path: "/v1/public/features/best",
   tags: ["Features"],
   summary: "Hero records (public)",
-  description: "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug is required. No authentication required.",
+  description: "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug and by are required. No authentication required.",
   request: { query: bestQueryParams },
   responses: bestResponse,
 });
@@ -256,7 +256,7 @@ registry.registerPath({
   path: "/v1/workflows/ranked",
   tags: ["Workflows"],
   summary: "Ranked workflows",
-  description: "Workflows ranked by performance, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and objective are required. Only groupBy=brand is supported.",
+  description: "Workflows ranked by performance, scoped to the authenticated org. Proxied to features-service. featureDynastySlug, objective, and groupBy are required.",
   security: authed,
   request: { query: rankedQueryParams },
   responses: { ...rankedResponse, 401: { description: "Unauthorized", content: errorContent } },
@@ -267,7 +267,7 @@ registry.registerPath({
   path: "/v1/workflows/best",
   tags: ["Workflows"],
   summary: "Hero records",
-  description: "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug is required. Use ?by=brand for brand-level heroes.",
+  description: "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and by are required.",
   security: authed,
   request: { query: bestQueryParams },
   responses: { ...bestResponse, 401: { description: "Unauthorized", content: errorContent } },

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -248,22 +248,22 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     expect(audienceLine).toContain(".optional()");
   });
 
-  it("should require featureDynastySlug and objective in rankedQueryParams (features-service contract)", () => {
+  it("should require featureDynastySlug, objective, and groupBy in rankedQueryParams", () => {
     const start = content.indexOf("const rankedQueryParams");
     const end = content.indexOf("});", start) + 3;
     const rankedSection = content.slice(start, end);
     expect(rankedSection).toContain("featureDynastySlug: z.string()");
     expect(rankedSection).toContain("objective: z.string()");
+    expect(rankedSection).toContain('z.enum(["workflow", "brand"])');
     expect(rankedSection).not.toContain("featureSlug");
-    // groupBy only supports "brand" (omit for per-workflow ranking)
-    expect(rankedSection).toContain('"brand"');
   });
 
-  it("should require featureDynastySlug in bestQueryParams and not accept featureSlug/objective", () => {
+  it("should require featureDynastySlug and by in bestQueryParams, not accept featureSlug/objective", () => {
     const start = content.indexOf("const bestQueryParams");
     const end = content.indexOf("});", start) + 3;
     const section = content.slice(start, end);
     expect(section).toContain("featureDynastySlug: z.string()");
+    expect(section).toContain('z.enum(["workflow", "brand"])');
     expect(section).not.toContain("featureSlug");
     expect(section).not.toContain("objective");
   });


### PR DESCRIPTION
## Summary
- `groupBy` is now **required** (`workflow` | `brand`) on `/v1/public/features/ranked` and `/v1/workflows/ranked`
- `by` is now **required** (`workflow` | `brand`) on `/v1/public/features/best` and `/v1/workflows/best`
- Updates Zod schemas, OpenAPI spec, and proxy tests to match features-service upstream contract

## Test plan
- [x] `npx vitest run tests/unit/workflows-stats.test.ts` — 4 passed
- [x] `npx vitest run tests/unit/workflows-proxy.test.ts` — 38 passed
- [x] `npx vitest run tests/unit/features` — 61 passed
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)