### PR TITLE
fix: align ranked/best params — drop brandId/by, use groupBy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7702,17 +7702,6 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by brand ID",
-              "example": "brand-uuid-123"
-            },
-            "required": false,
-            "description": "Filter by brand ID",
-            "name": "brandId",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
               "description": "Max results (default 10, max 100)",
               "example": "10"
             },
@@ -7752,7 +7741,7 @@
           "Features"
         ],
         "summary": "Hero records (public)",
-        "description": "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug and by are required. No authentication required.",
+        "description": "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug and groupBy are required. No authentication required.",
         "parameters": [
           {
             "schema": {
@@ -7772,23 +7761,12 @@
                 "workflow",
                 "brand"
               ],
-              "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
+              "description": "'workflow' or 'brand' — group results by workflow or by brand.",
               "example": "workflow"
             },
             "required": true,
-            "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
-            "name": "by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by brand ID",
-              "example": "brand-uuid-123"
-            },
-            "required": false,
-            "description": "Filter by brand ID",
-            "name": "brandId",
+            "description": "'workflow' or 'brand' — group results by workflow or by brand.",
+            "name": "groupBy",
             "in": "query"
           }
         ],
@@ -7874,17 +7852,6 @@
             "required": true,
             "description": "'workflow' or 'brand' — group results by workflow or by brand.",
             "name": "groupBy",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by brand ID",
-              "example": "brand-uuid-123"
-            },
-            "required": false,
-            "description": "Filter by brand ID",
-            "name": "brandId",
             "in": "query"
           },
           {
@@ -7994,7 +7961,7 @@
           "Workflows"
         ],
         "summary": "Hero records",
-        "description": "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and by are required.",
+        "description": "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and groupBy are required.",
         "security": [
           {
             "bearerAuth": []
@@ -8019,23 +7986,12 @@
                 "workflow",
                 "brand"
               ],
-              "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
+              "description": "'workflow' or 'brand' — group results by workflow or by brand.",
               "example": "workflow"
             },
             "required": true,
-            "description": "'workflow' or 'brand' — hero records by workflow or by brand.",
-            "name": "by",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by brand ID",
-              "example": "brand-uuid-123"
-            },
-            "required": false,
-            "description": "Filter by brand ID",
-            "name": "brandId",
+            "description": "'workflow' or 'brand' — group results by workflow or by brand.",
+            "name": "groupBy",
             "in": "query"
           },
           {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -15,8 +15,8 @@ function buildParams(query: Record<string, unknown>, keys: string[]): URLSearchP
   return params;
 }
 
-const PUBLIC_RANKED_PARAMS = ["featureDynastySlug", "objective", "limit", "groupBy", "brandId"];
-const PUBLIC_BEST_PARAMS = ["featureDynastySlug", "brandId", "by"];
+const PUBLIC_RANKED_PARAMS = ["featureDynastySlug", "objective", "groupBy", "limit"];
+const PUBLIC_BEST_PARAMS = ["featureDynastySlug", "groupBy"];
 
 // ── Public routes (no auth) ─────────────────────────────────────────────────
 

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -99,8 +99,8 @@ function buildWorkflowParams(query: Record<string, unknown>, keys: string[]): UR
 }
 
 // Authenticated endpoints — migrated to features-service
-const RANKED_PARAMS = ["featureDynastySlug", "objective", "limit", "groupBy", "brandId"];
-const BEST_PARAMS = ["featureDynastySlug", "brandId", "by"];
+const RANKED_PARAMS = ["featureDynastySlug", "objective", "groupBy", "limit"];
+const BEST_PARAMS = ["featureDynastySlug", "groupBy"];
 
 // ---------------------------------------------------------------------------
 // Authenticated routes

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -137,14 +137,12 @@ const rankedQueryParams = z.object({
   featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
   objective: z.string().openapi({ example: "emailsReplied" }).describe("Stats key to rank by (required). e.g. 'emailsReplied', 'leadsServed'."),
   groupBy: z.enum(["workflow", "brand"]).openapi({ example: "workflow" }).describe("'workflow' or 'brand' — group results by workflow or by brand."),
-  brandId: z.string().optional().openapi({ example: "brand-uuid-123" }).describe("Filter by brand ID"),
   limit: z.string().optional().openapi({ example: "10" }).describe("Max results (default 10, max 100)"),
 });
 
 const bestQueryParams = z.object({
   featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
-  by: z.enum(["workflow", "brand"]).openapi({ example: "workflow" }).describe("'workflow' or 'brand' — hero records by workflow or by brand."),
-  brandId: z.string().optional().openapi({ example: "brand-uuid-123" }).describe("Filter by brand ID"),
+  groupBy: z.enum(["workflow", "brand"]).openapi({ example: "workflow" }).describe("'workflow' or 'brand' — group results by workflow or by brand."),
 });
 
 // -- Workflow response schemas (mirroring workflow-service) --
@@ -245,7 +243,7 @@ registry.registerPath({
   path: "/v1/public/features/best",
   tags: ["Features"],
   summary: "Hero records (public)",
-  description: "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug and by are required. No authentication required.",
+  description: "Public hero records — best cost-per-outcome. Proxied to features-service. featureDynastySlug and groupBy are required. No authentication required.",
   request: { query: bestQueryParams },
   responses: bestResponse,
 });
@@ -267,7 +265,7 @@ registry.registerPath({
   path: "/v1/workflows/best",
   tags: ["Workflows"],
   summary: "Hero records",
-  description: "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and by are required.",
+  description: "Best cost-per-outcome records, scoped to the authenticated org. Proxied to features-service. featureDynastySlug and groupBy are required.",
   security: authed,
   request: { query: bestQueryParams },
   responses: { ...bestResponse, 401: { description: "Unauthorized", content: errorContent } },

--- a/tests/unit/features-stats.test.ts
+++ b/tests/unit/features-stats.test.ts
@@ -75,7 +75,7 @@ describe("GET /v1/public/features/ranked", () => {
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/public/features/ranked?featureDynastySlug=pr-cold-email&objective=emailsReplied&groupBy=brand&brandId=b-1");
+    const res = await request(app).get("/v1/public/features/ranked?featureDynastySlug=pr-cold-email&objective=emailsReplied&groupBy=brand");
 
     expect(res.status).toBe(200);
     expect(res.body.results).toEqual(MOCK_RANKED.results);
@@ -88,7 +88,6 @@ describe("GET /v1/public/features/ranked", () => {
     expect(url).toContain("featureDynastySlug=pr-cold-email");
     expect(url).toContain("objective=emailsReplied");
     expect(url).toContain("groupBy=brand");
-    expect(url).toContain("brandId=b-1");
   });
 
   it("does not forward featureSlug to features-service", async () => {
@@ -118,7 +117,7 @@ describe("GET /v1/public/features/best", () => {
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/public/features/best?featureDynastySlug=pr-cold-email&by=workflow&brandId=b-1");
+    const res = await request(app).get("/v1/public/features/best?featureDynastySlug=pr-cold-email&groupBy=workflow");
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(MOCK_HERO);
@@ -129,15 +128,14 @@ describe("GET /v1/public/features/best", () => {
     expect(call).toBeDefined();
     const url = call![1] as string;
     expect(url).toContain("featureDynastySlug=pr-cold-email");
-    expect(url).toContain("by=workflow");
-    expect(url).toContain("brandId=b-1");
+    expect(url).toContain("groupBy=workflow");
   });
 
-  it("does not forward featureSlug or objective to features-service", async () => {
+  it("does not forward featureSlug, objective, brandId, or by to features-service", async () => {
     const app = createApp();
     mockCallExternalService.mockResolvedValue(MOCK_HERO);
 
-    await request(app).get("/v1/public/features/best?featureDynastySlug=pr-cold-email&featureSlug=pr-cold-email-v3&objective=replied");
+    await request(app).get("/v1/public/features/best?featureDynastySlug=pr-cold-email&featureSlug=pr-cold-email-v3&objective=replied&brandId=b-1&by=brand");
 
     const call = mockCallExternalService.mock.calls.find(
       (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/stats/best"),
@@ -146,5 +144,7 @@ describe("GET /v1/public/features/best", () => {
     const url = call![1] as string;
     expect(url).not.toContain("featureSlug=");
     expect(url).not.toContain("objective=");
+    expect(url).not.toContain("brandId=");
+    expect(url).not.toContain("by=");
   });
 });

--- a/tests/unit/workflows-proxy.test.ts
+++ b/tests/unit/workflows-proxy.test.ts
@@ -248,7 +248,7 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     expect(audienceLine).toContain(".optional()");
   });
 
-  it("should require featureDynastySlug, objective, and groupBy in rankedQueryParams", () => {
+  it("should require featureDynastySlug, objective, and groupBy in rankedQueryParams — no brandId", () => {
     const start = content.indexOf("const rankedQueryParams");
     const end = content.indexOf("});", start) + 3;
     const rankedSection = content.slice(start, end);
@@ -256,9 +256,10 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     expect(rankedSection).toContain("objective: z.string()");
     expect(rankedSection).toContain('z.enum(["workflow", "brand"])');
     expect(rankedSection).not.toContain("featureSlug");
+    expect(rankedSection).not.toContain("brandId");
   });
 
-  it("should require featureDynastySlug and by in bestQueryParams, not accept featureSlug/objective", () => {
+  it("should require featureDynastySlug and groupBy in bestQueryParams — no by, brandId, featureSlug, or objective", () => {
     const start = content.indexOf("const bestQueryParams");
     const end = content.indexOf("});", start) + 3;
     const section = content.slice(start, end);
@@ -266,6 +267,8 @@ describe("Workflow schemas — ranked and best endpoints", () => {
     expect(section).toContain('z.enum(["workflow", "brand"])');
     expect(section).not.toContain("featureSlug");
     expect(section).not.toContain("objective");
+    expect(section).not.toContain("brandId");
+    expect(section).not.toContain('"by"');
   });
 
   it("should not include category/channel/audienceType in rankedQueryParams", () => {

--- a/tests/unit/workflows-stats.test.ts
+++ b/tests/unit/workflows-stats.test.ts
@@ -72,7 +72,7 @@ describe("GET /v1/workflows/ranked", () => {
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/workflows/ranked?featureDynastySlug=pr-cold-email&objective=replied&groupBy=brand&limit=20&brandId=b-1");
+    const res = await request(app).get("/v1/workflows/ranked?featureDynastySlug=pr-cold-email&objective=replied&groupBy=brand&limit=20");
 
     expect(res.status).toBe(200);
     expect(res.body.results).toEqual(MOCK_RANKED.results);
@@ -86,7 +86,6 @@ describe("GET /v1/workflows/ranked", () => {
     expect(url).toContain("objective=replied");
     expect(url).toContain("groupBy=brand");
     expect(url).toContain("limit=20");
-    expect(url).toContain("brandId=b-1");
   });
 
   it("does not forward featureSlug to features-service", async () => {
@@ -116,7 +115,7 @@ describe("GET /v1/workflows/best", () => {
       return Promise.resolve({});
     });
 
-    const res = await request(app).get("/v1/workflows/best?featureDynastySlug=pr-cold-email&by=brand");
+    const res = await request(app).get("/v1/workflows/best?featureDynastySlug=pr-cold-email&groupBy=brand");
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(MOCK_HERO);
@@ -127,14 +126,14 @@ describe("GET /v1/workflows/best", () => {
     expect(call).toBeDefined();
     const url = call![1] as string;
     expect(url).toContain("featureDynastySlug=pr-cold-email");
-    expect(url).toContain("by=brand");
+    expect(url).toContain("groupBy=brand");
   });
 
-  it("does not forward featureSlug or objective to features-service", async () => {
+  it("does not forward featureSlug, objective, brandId, or by to features-service", async () => {
     const app = createApp();
     mockCallExternalService.mockResolvedValue(MOCK_HERO);
 
-    await request(app).get("/v1/workflows/best?featureDynastySlug=pr-cold-email&featureSlug=pr-cold-email-v3&objective=replied");
+    await request(app).get("/v1/workflows/best?featureDynastySlug=pr-cold-email&featureSlug=pr-cold-email-v3&objective=replied&brandId=b-1&by=brand");
 
     const call = mockCallExternalService.mock.calls.find(
       (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/stats/best"),
@@ -143,6 +142,8 @@ describe("GET /v1/workflows/best", () => {
     const url = call![1] as string;
     expect(url).not.toContain("featureSlug=");
     expect(url).not.toContain("objective=");
+    expect(url).not.toContain("brandId=");
+    expect(url).not.toContain("by=");
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove `brandId` from both ranked and best query params (not accepted by features-service)
- Remove `by` from best — replaced by `groupBy` (same enum as ranked: `workflow` | `brand`)
- Both `/stats/ranked` and `/stats/best` now use identical `groupBy` param
- Updates schemas, route handlers, OpenAPI spec, and tests

## Test plan
- [x] `npx vitest run` — 103 tests passed across 4 test files
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)