### PR TITLE
fix: use plural slug params for email-gateway stats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -16875,7 +16875,7 @@
           "Email Gateway"
         ],
         "summary": "Get email delivery stats",
-        "description": "Get broadcast delivery statistics from email-gateway. Filter by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
+        "description": "Get broadcast delivery statistics from email-gateway. Filter by brandId, campaignId, workflowSlugs, featureSlugs, workflowDynastySlug, or featureDynastySlug.",
         "security": [
           {
             "bearerAuth": []
@@ -16905,21 +16905,21 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by exact workflow slug"
+              "description": "Filter by workflow slugs (comma-separated, e.g. 'slug-v1,slug-v2')"
             },
             "required": false,
-            "description": "Filter by exact workflow slug",
-            "name": "workflowSlug",
+            "description": "Filter by workflow slugs (comma-separated, e.g. 'slug-v1,slug-v2')",
+            "name": "workflowSlugs",
             "in": "query"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Filter by exact feature slug"
+              "description": "Filter by feature slugs (comma-separated, e.g. 'feature-v1,feature-v2')"
             },
             "required": false,
-            "description": "Filter by exact feature slug",
-            "name": "featureSlug",
+            "description": "Filter by feature slugs (comma-separated, e.g. 'feature-v1,feature-v2')",
+            "name": "featureSlugs",
             "in": "query"
           },
           {

--- a/src/lib/delivery-stats.ts
+++ b/src/lib/delivery-stats.ts
@@ -11,12 +11,12 @@ interface EmailGatewayStats {
 
 /** Fetch delivery stats from email-gateway (aggregates transactional + broadcast). */
 export async function fetchDeliveryStats(
-  filters: { campaignId?: string; brandId?: string; workflowSlug?: string; featureSlug?: string; workflowDynastySlug?: string; featureDynastySlug?: string },
+  filters: { campaignId?: string; brandId?: string; workflowSlugs?: string; featureSlugs?: string; workflowDynastySlug?: string; featureDynastySlug?: string },
   req: AuthenticatedRequest,
 ): Promise<Record<string, number> | null> {
   const orgId = req.orgId!;
   const params = new URLSearchParams({ orgId });
-  for (const key of ["campaignId", "brandId", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"] as const) {
+  for (const key of ["campaignId", "brandId", "workflowSlugs", "featureSlugs", "workflowDynastySlug", "featureDynastySlug"] as const) {
     if (filters[key]) params.set(key, filters[key]!);
   }
   const deliveryResult = await callExternalService<{ transactional: EmailGatewayStats; broadcast: EmailGatewayStats }>(

--- a/src/routes/email-gateway.ts
+++ b/src/routes/email-gateway.ts
@@ -12,7 +12,7 @@ const router = Router();
 router.get("/email-gateway/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const filters: Record<string, string | undefined> = {};
-    for (const key of ["brandId", "campaignId", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"]) {
+    for (const key of ["brandId", "campaignId", "workflowSlugs", "featureSlugs", "workflowDynastySlug", "featureDynastySlug"]) {
       if (req.query[key]) filters[key] = req.query[key] as string;
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3327,14 +3327,14 @@ registry.registerPath({
   tags: ["Email Gateway"],
   summary: "Get email delivery stats",
   description:
-    "Get broadcast delivery statistics from email-gateway. Filter by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, or featureDynastySlug.",
+    "Get broadcast delivery statistics from email-gateway. Filter by brandId, campaignId, workflowSlugs, featureSlugs, workflowDynastySlug, or featureDynastySlug.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().optional().describe("Filter by brand ID"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),
-      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
-      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      workflowSlugs: z.string().optional().describe("Filter by workflow slugs (comma-separated, e.g. 'slug-v1,slug-v2')"),
+      featureSlugs: z.string().optional().describe("Filter by feature slugs (comma-separated, e.g. 'feature-v1,feature-v2')"),
       workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
       featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
     }),

--- a/tests/unit/dynasty-slug-forwarding.test.ts
+++ b/tests/unit/dynasty-slug-forwarding.test.ts
@@ -57,14 +57,16 @@ describe("Dynasty slug forwarding — runs/stats/costs", () => {
 });
 
 describe("Dynasty slug forwarding — email-gateway/stats", () => {
-  it("should forward dynasty slug filters on GET /email-gateway/stats", () => {
-    for (const param of allSlugParams) {
+  const emailGatewaySlugParams = ["workflowSlugs", "featureSlugs", "workflowDynastySlug", "featureDynastySlug"];
+
+  it("should forward slug filters on GET /email-gateway/stats (plural workflowSlugs/featureSlugs)", () => {
+    for (const param of emailGatewaySlugParams) {
       expect(emailGatewayRoute).toContain(`"${param}"`);
     }
   });
 
-  it("should accept dynasty slug filters in fetchDeliveryStats", () => {
-    for (const param of allSlugParams) {
+  it("should accept slug filters in fetchDeliveryStats (plural workflowSlugs/featureSlugs)", () => {
+    for (const param of emailGatewaySlugParams) {
       expect(deliveryStatsLib).toContain(param);
     }
   });
@@ -228,10 +230,10 @@ describe("Dynasty slug params in generated openapi.json", () => {
     expect(paramNames).toContain("featureSlug");
   });
 
-  it("should have dynasty query params on /v1/email-gateway/stats", () => {
+  it("should have dynasty query params on /v1/email-gateway/stats (plural workflowSlugs/featureSlugs)", () => {
     const params = openapiSpec.paths["/v1/email-gateway/stats"]?.get?.parameters ?? [];
     const paramNames = params.map((p: { name: string }) => p.name);
-    for (const param of allSlugParams) {
+    for (const param of ["workflowSlugs", "featureSlugs", "workflowDynastySlug", "featureDynastySlug"]) {
       expect(paramNames).toContain(param);
     }
   });

--- a/tests/unit/email-gateway-plural-slugs.regression.test.ts
+++ b/tests/unit/email-gateway-plural-slugs.regression.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Regression: email-gateway /stats removed singular featureSlug/workflowSlug params.
+ * Only plural forms (featureSlugs, workflowSlugs) are accepted.
+ * See: email-gateway breaking change 2026-04-02.
+ */
+describe("Regression: email-gateway stats must use plural slug params", () => {
+  const deliveryStats = fs.readFileSync(
+    path.join(__dirname, "../../src/lib/delivery-stats.ts"),
+    "utf-8",
+  );
+  const emailGatewayRoute = fs.readFileSync(
+    path.join(__dirname, "../../src/routes/email-gateway.ts"),
+    "utf-8",
+  );
+
+  it("delivery-stats.ts must NOT send singular featureSlug/workflowSlug to email-gateway", () => {
+    // The for-loop that builds query params must use plural forms
+    const paramsSection = deliveryStats.slice(
+      deliveryStats.indexOf("URLSearchParams"),
+      deliveryStats.indexOf("params.set(key"),
+    );
+    expect(paramsSection).toContain("featureSlugs");
+    expect(paramsSection).toContain("workflowSlugs");
+    expect(paramsSection).not.toMatch(/["']featureSlug["']/);
+    expect(paramsSection).not.toMatch(/["']workflowSlug["']/);
+  });
+
+  it("email-gateway route must accept plural featureSlugs/workflowSlugs from callers", () => {
+    const statsSection = emailGatewayRoute.slice(
+      emailGatewayRoute.indexOf('"/email-gateway/stats"'),
+    );
+    expect(statsSection).toContain("featureSlugs");
+    expect(statsSection).toContain("workflowSlugs");
+    expect(statsSection).not.toMatch(/["']featureSlug["']/);
+    expect(statsSection).not.toMatch(/["']workflowSlug["']/);
+  });
+});


### PR DESCRIPTION
## Summary
- Email-gateway removed singular `featureSlug`/`workflowSlug` query params from `/stats` — only plural `featureSlugs`/`workflowSlugs` (comma-separated) are accepted now
- Updated `fetchDeliveryStats` in `delivery-stats.ts` and the `/email-gateway/stats` proxy route to use plural forms
- Updated Zod schemas and regenerated `openapi.json`
- Added regression test to prevent reintroduction of singular params

## Test plan
- [x] All existing tests pass (93/94 files — 1 pre-existing failure unrelated to this change)
- [x] New regression test `email-gateway-plural-slugs.regression.test.ts` passes
- [x] Updated `dynasty-slug-forwarding.test.ts` passes with plural param expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)