### PR TITLE
fix: align llm-context proxy schema with api-registry format

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7225,6 +7225,65 @@
           "outputBlobToken"
         ]
       },
+      "LlmServiceOverview": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string",
+            "description": "Service name"
+          },
+          "title": {
+            "type": "string",
+            "description": "Service title"
+          },
+          "description": {
+            "type": "string",
+            "description": "Service description"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message if service metadata could not be loaded"
+          },
+          "endpointCount": {
+            "type": "number",
+            "description": "Number of endpoints exposed by this service"
+          }
+        },
+        "required": [
+          "service",
+          "endpointCount"
+        ]
+      },
+      "LlmContextResponse": {
+        "type": "object",
+        "properties": {
+          "_description": {
+            "type": "string",
+            "description": "Description of this context payload"
+          },
+          "_workflow": {
+            "type": "string",
+            "description": "Progressive-disclosure workflow: overview first, then drill into a service"
+          },
+          "serviceCount": {
+            "type": "number",
+            "description": "Total number of registered services"
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LlmServiceOverview"
+            },
+            "description": "Lightweight service list (use /llm-context/{service} for endpoints)"
+          }
+        },
+        "required": [
+          "_description",
+          "_workflow",
+          "serviceCount",
+          "services"
+        ]
+      },
       "LlmEndpointSummary": {
         "type": "object",
         "properties": {
@@ -7239,36 +7298,6 @@
           "summary": {
             "type": "string",
             "description": "Endpoint summary"
-          },
-          "params": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "in": {
-                  "type": "string"
-                },
-                "required": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "name",
-                "in",
-                "required"
-              ]
-            },
-            "description": "Endpoint parameters"
-          },
-          "bodyFields": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Request body field names"
           }
         },
         "required": [
@@ -7277,16 +7306,37 @@
           "summary"
         ]
       },
-      "LlmServiceSummary": {
+      "LlmEndpointGroup": {
+        "type": "object",
+        "properties": {
+          "group": {
+            "type": "string",
+            "description": "Path group prefix"
+          },
+          "endpointCount": {
+            "type": "number",
+            "description": "Number of endpoints in this group"
+          },
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LlmEndpointSummary"
+            },
+            "description": "Endpoints in this group"
+          }
+        },
+        "required": [
+          "group",
+          "endpointCount",
+          "endpoints"
+        ]
+      },
+      "LlmServiceDetailResponse": {
         "type": "object",
         "properties": {
           "service": {
             "type": "string",
             "description": "Service name"
-          },
-          "baseUrl": {
-            "type": "string",
-            "description": "Service base URL"
           },
           "title": {
             "type": "string",
@@ -7296,43 +7346,35 @@
             "type": "string",
             "description": "Service description"
           },
+          "endpointCount": {
+            "type": "number",
+            "description": "Number of endpoints returned"
+          },
           "endpoints": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/LlmEndpointSummary"
             },
-            "description": "Available endpoints"
-          }
-        },
-        "required": [
-          "service",
-          "baseUrl",
-          "endpoints"
-        ]
-      },
-      "LlmContextResponse": {
-        "type": "object",
-        "properties": {
-          "_description": {
-            "type": "string",
-            "description": "Description of this context payload"
+            "description": "Flat endpoint list (for small services)"
           },
-          "_usage": {
-            "type": "string",
-            "description": "Usage instructions for LLMs"
+          "totalEndpoints": {
+            "type": "number",
+            "description": "Total endpoints (when grouped)"
           },
-          "services": {
+          "groupCount": {
+            "type": "number",
+            "description": "Number of groups (when grouped)"
+          },
+          "groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/LlmServiceSummary"
+              "$ref": "#/components/schemas/LlmEndpointGroup"
             },
-            "description": "All platform services with their endpoints"
+            "description": "Grouped endpoints (for large services with 30+ endpoints)"
           }
         },
         "required": [
-          "_description",
-          "_usage",
-          "services"
+          "service"
         ]
       },
       "FeaturesListResponse": {
@@ -24910,8 +24952,8 @@
         "tags": [
           "Platform"
         ],
-        "summary": "Get LLM-friendly platform context",
-        "description": "Returns a compact summary of all platform services and their endpoints, optimized for LLM consumption. Proxied from api-registry. Ideal for giving an LLM full platform awareness to answer questions like 'what services exist?' or 'can the platform do X?'.",
+        "summary": "Get LLM-friendly platform overview",
+        "description": "Returns a lightweight overview of all platform services (name, description, endpoint count). Proxied from api-registry. Use GET /v1/platform/llm-context/{service} to drill into a specific service's endpoints.",
         "security": [
           {
             "bearerAuth": []
@@ -24919,7 +24961,7 @@
         ],
         "responses": {
           "200": {
-            "description": "LLM context with all services and endpoints",
+            "description": "Lightweight service overview for LLM consumption",
             "content": {
               "application/json": {
                 "schema": {
@@ -25006,6 +25048,159 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/platform/llm-context/{service}": {
+      "get": {
+        "tags": [
+          "Platform"
+        ],
+        "summary": "Get LLM-friendly endpoint details for a service",
+        "description": "Returns endpoint details for a specific service. Supports filtering by method, path group, or path prefix. Large services (30+ endpoints) auto-group by path prefix. Proxied from api-registry.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Service name"
+            },
+            "required": true,
+            "description": "Service name",
+            "name": "service",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by HTTP method (e.g. 'POST')"
+            },
+            "required": false,
+            "description": "Filter by HTTP method (e.g. 'POST')",
+            "name": "method",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by path group (e.g. 'campaigns')"
+            },
+            "required": false,
+            "description": "Filter by path group (e.g. 'campaigns')",
+            "name": "group",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by path prefix (e.g. '/v1/campaigns')"
+            },
+            "required": false,
+            "description": "Filter by path prefix (e.g. '/v1/campaigns')",
+            "name": "pathPrefix",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Endpoint list for the service (flat or grouped depending on size)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmServiceDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Service not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/features": {

--- a/src/routes/platform.ts
+++ b/src/routes/platform.ts
@@ -44,7 +44,7 @@ router.get("/platform/services/:service", authenticate, requireOrg, requireUser,
 
 /**
  * GET /v1/platform/llm-context
- * Get LLM context from api-registry (service descriptions + endpoint summaries for chat)
+ * Get lightweight LLM context overview from api-registry (service names + endpoint counts)
  */
 router.get("/platform/llm-context", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
@@ -55,8 +55,29 @@ router.get("/platform/llm-context", authenticate, requireOrg, requireUser, async
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Get platform LLM context error:", error.message);
+    console.error("[api-service] Get platform LLM context error:", error.message);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get LLM context" });
+  }
+});
+
+/**
+ * GET /v1/platform/llm-context/:service
+ * Get LLM-friendly endpoint details for a specific service from api-registry
+ */
+router.get("/platform/llm-context/:service", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { service } = req.params;
+    const queryString = new URLSearchParams(req.query as Record<string, string>).toString();
+    const path = `/llm-context/${service}${queryString ? `?${queryString}` : ""}`;
+    const result = await callExternalService(
+      externalServices.apiRegistry,
+      path,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Get platform LLM context for service error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get LLM context for service" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5496,37 +5496,57 @@ registry.registerPath({
   },
 });
 
+// -- /v1/platform/llm-context (overview — lightweight, no inline endpoints) --
+
+const LlmServiceOverviewSchema = z
+  .object({
+    service: z.string().describe("Service name"),
+    title: z.string().optional().describe("Service title"),
+    description: z.string().optional().describe("Service description"),
+    error: z.string().optional().describe("Error message if service metadata could not be loaded"),
+    endpointCount: z.number().describe("Number of endpoints exposed by this service"),
+  })
+  .openapi("LlmServiceOverview");
+
+const LlmContextResponseSchema = z
+  .object({
+    _description: z.string().describe("Description of this context payload"),
+    _workflow: z.string().describe("Progressive-disclosure workflow: overview first, then drill into a service"),
+    serviceCount: z.number().describe("Total number of registered services"),
+    services: z.array(LlmServiceOverviewSchema).describe("Lightweight service list (use /llm-context/{service} for endpoints)"),
+  })
+  .openapi("LlmContextResponse");
+
+// -- /v1/platform/llm-context/{service} (drill-down — endpoint details) --
+
 const LlmEndpointSummarySchema = z
   .object({
     method: z.string().describe("HTTP method"),
     path: z.string().describe("Endpoint path"),
     summary: z.string().describe("Endpoint summary"),
-    params: z.array(z.object({
-      name: z.string(),
-      in: z.string(),
-      required: z.boolean(),
-    })).optional().describe("Endpoint parameters"),
-    bodyFields: z.array(z.string()).optional().describe("Request body field names"),
   })
   .openapi("LlmEndpointSummary");
 
-const LlmServiceSummarySchema = z
+const LlmEndpointGroupSchema = z
+  .object({
+    group: z.string().describe("Path group prefix"),
+    endpointCount: z.number().describe("Number of endpoints in this group"),
+    endpoints: z.array(LlmEndpointSummarySchema).describe("Endpoints in this group"),
+  })
+  .openapi("LlmEndpointGroup");
+
+const LlmServiceDetailResponseSchema = z
   .object({
     service: z.string().describe("Service name"),
-    baseUrl: z.string().describe("Service base URL"),
     title: z.string().optional().describe("Service title"),
     description: z.string().optional().describe("Service description"),
-    endpoints: z.array(LlmEndpointSummarySchema).describe("Available endpoints"),
+    endpointCount: z.number().optional().describe("Number of endpoints returned"),
+    endpoints: z.array(LlmEndpointSummarySchema).optional().describe("Flat endpoint list (for small services)"),
+    totalEndpoints: z.number().optional().describe("Total endpoints (when grouped)"),
+    groupCount: z.number().optional().describe("Number of groups (when grouped)"),
+    groups: z.array(LlmEndpointGroupSchema).optional().describe("Grouped endpoints (for large services with 30+ endpoints)"),
   })
-  .openapi("LlmServiceSummary");
-
-const LlmContextResponseSchema = z
-  .object({
-    _description: z.string().describe("Description of this context payload"),
-    _usage: z.string().describe("Usage instructions for LLMs"),
-    services: z.array(LlmServiceSummarySchema).describe("All platform services with their endpoints"),
-  })
-  .openapi("LlmContextResponse");
+  .openapi("LlmServiceDetailResponse");
 
 // ---------------------------------------------------------------------------
 // ===================================================================
@@ -5873,18 +5893,47 @@ registry.registerPath({
   method: "get",
   path: "/v1/platform/llm-context",
   tags: ["Platform"],
-  summary: "Get LLM-friendly platform context",
+  summary: "Get LLM-friendly platform overview",
   description:
-    "Returns a compact summary of all platform services and their endpoints, optimized for LLM consumption. " +
-    "Proxied from api-registry. Ideal for giving an LLM full platform awareness to answer questions " +
-    "like 'what services exist?' or 'can the platform do X?'.",
+    "Returns a lightweight overview of all platform services (name, description, endpoint count). " +
+    "Proxied from api-registry. Use GET /v1/platform/llm-context/{service} to drill into a specific service's endpoints.",
   security: authed,
   responses: {
     200: {
-      description: "LLM context with all services and endpoints",
+      description: "Lightweight service overview for LLM consumption",
       content: { "application/json": { schema: LlmContextResponseSchema } },
     },
     401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/platform/llm-context/{service}",
+  tags: ["Platform"],
+  summary: "Get LLM-friendly endpoint details for a service",
+  description:
+    "Returns endpoint details for a specific service. Supports filtering by method, path group, or path prefix. " +
+    "Large services (30+ endpoints) auto-group by path prefix. Proxied from api-registry.",
+  security: authed,
+  request: {
+    params: z.object({
+      service: z.string().describe("Service name"),
+    }),
+    query: z.object({
+      method: z.string().optional().describe("Filter by HTTP method (e.g. 'POST')"),
+      group: z.string().optional().describe("Filter by path group (e.g. 'campaigns')"),
+      pathPrefix: z.string().optional().describe("Filter by path prefix (e.g. '/v1/campaigns')"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Endpoint list for the service (flat or grouped depending on size)",
+      content: { "application/json": { schema: LlmServiceDetailResponseSchema } },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Service not found", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },
 });

--- a/tests/unit/platform-proxy.test.ts
+++ b/tests/unit/platform-proxy.test.ts
@@ -73,9 +73,13 @@ describe("Platform proxy routes", () => {
     expect(platformContent).toContain('"/platform/llm-context"');
   });
 
+  it("should have GET /platform/llm-context/:service endpoint", () => {
+    expect(platformContent).toContain('"/platform/llm-context/:service"');
+  });
+
   it("should use authenticate, requireOrg, requireUser on all endpoints", () => {
     const routeLines = platformContent.split("\n").filter((l) => l.includes("router.get"));
-    expect(routeLines.length).toBe(3);
+    expect(routeLines.length).toBe(4);
     for (const line of routeLines) {
       expect(line).toContain("authenticate");
       expect(line).toContain("requireOrg");
@@ -100,7 +104,7 @@ describe("Platform proxy routes", () => {
     expect(platformContent).toContain("buildInternalHeaders");
     const headerMatches = platformContent.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(3);
+    expect(headerMatches!.length).toBe(4);
   });
 
   it("should forward upstream status codes on error", () => {
@@ -135,9 +139,11 @@ describe("Platform OpenAPI schemas", () => {
     expect(schemaContent).toContain('path: "/v1/platform/services"');
     expect(schemaContent).toContain('path: "/v1/platform/services/{service}"');
     expect(schemaContent).toContain('path: "/v1/platform/llm-context"');
+    expect(schemaContent).toContain('path: "/v1/platform/llm-context/{service}"');
     expect(schemaContent).toContain('tags: ["Platform"]');
     expect(schemaContent).toContain('"PlatformServicesResponse"');
     expect(schemaContent).toContain('"LlmContextResponse"');
+    expect(schemaContent).toContain('"LlmServiceDetailResponse"');
   });
 });
 
@@ -255,16 +261,14 @@ describe("GET /v1/platform/llm-context — integration", () => {
 
   const mockLlmContext = {
     _description: "Compact summary of all platform services",
-    _usage: "Use this to discover services and endpoints",
+    _workflow: "1. Read this overview  2. GET /llm-context/{service} for endpoint details",
+    serviceCount: 1,
     services: [
       {
         service: "lead",
-        baseUrl: "https://lead.distribute.you",
         title: "Lead Service",
         description: "Find and manage leads",
-        endpoints: [
-          { method: "POST", path: "/search", summary: "Search leads by ICP criteria", params: [], bodyFields: ["query", "limit"] },
-        ],
+        endpointCount: 3,
       },
     ],
   };
@@ -285,14 +289,19 @@ describe("GET /v1/platform/llm-context — integration", () => {
     app = createApp();
   });
 
-  it("should proxy to api-registry /llm-context", async () => {
+  it("should proxy to api-registry /llm-context with lightweight format", async () => {
     const res = await request(app).get("/v1/platform/llm-context");
 
     expect(res.status).toBe(200);
     expect(res.body._description).toBeDefined();
+    expect(res.body._workflow).toBeDefined();
+    expect(res.body.serviceCount).toBe(1);
     expect(res.body.services).toHaveLength(1);
     expect(res.body.services[0].service).toBe("lead");
-    expect(res.body.services[0].endpoints[0].method).toBe("POST");
+    expect(res.body.services[0].endpointCount).toBe(3);
+    // Should NOT have inline endpoints (progressive disclosure)
+    expect(res.body.services[0].endpoints).toBeUndefined();
+    expect(res.body.services[0].baseUrl).toBeUndefined();
   });
 
   it("should handle upstream failure gracefully", async () => {
@@ -303,5 +312,66 @@ describe("GET /v1/platform/llm-context — integration", () => {
 
     const res = await request(app).get("/v1/platform/llm-context");
     expect(res.status).toBe(502);
+  });
+});
+
+describe("GET /v1/platform/llm-context/:service — integration", () => {
+  let app: express.Express;
+
+  const mockServiceDetail = {
+    service: "lead",
+    title: "Lead Service",
+    description: "Find and manage leads",
+    endpointCount: 2,
+    endpoints: [
+      { method: "POST", path: "/search", summary: "Search leads by ICP criteria" },
+      { method: "GET", path: "/search/:id", summary: "Get lead by ID" },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      fetchCalls.push({ url, method: init?.method });
+
+      if (url.includes("/llm-context/lead")) {
+        return { ok: true, json: () => Promise.resolve(mockServiceDetail) };
+      }
+      if (url.includes("/llm-context/nonexistent")) {
+        return {
+          ok: false,
+          status: 404,
+          text: () => Promise.resolve('{"error":"Service \\"nonexistent\\" not found"}'),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    app = createApp();
+  });
+
+  it("should proxy to api-registry /llm-context/:service with endpoint details", async () => {
+    const res = await request(app).get("/v1/platform/llm-context/lead");
+
+    expect(res.status).toBe(200);
+    expect(res.body.service).toBe("lead");
+    expect(res.body.endpointCount).toBe(2);
+    expect(res.body.endpoints).toHaveLength(2);
+    expect(res.body.endpoints[0].method).toBe("POST");
+  });
+
+  it("should forward query parameters to api-registry", async () => {
+    await request(app).get("/v1/platform/llm-context/lead?method=POST&group=search");
+
+    const registryCall = fetchCalls.find((c) => c.url.includes("/llm-context/lead"));
+    expect(registryCall?.url).toContain("method=POST");
+    expect(registryCall?.url).toContain("group=search");
+  });
+
+  it("should return 404 for unknown service", async () => {
+    const res = await request(app).get("/v1/platform/llm-context/nonexistent");
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- **Fixed OpenAPI schema** for `GET /v1/platform/llm-context` to match api-registry's actual response format: `_workflow` (not `_usage`), `serviceCount`, lightweight services with `endpointCount` (no inline endpoints/baseUrl)
- **Added missing `GET /v1/platform/llm-context/{service}`** proxy endpoint with query param forwarding (`method`, `group`, `pathPrefix`) to preserve api-registry's progressive disclosure pattern
- **Updated tests** with correct mock shapes and added integration tests for the new drill-down endpoint

## Context
The route handler was a correct passthrough (`res.json(result)`), so no runtime transformation was happening. But the OpenAPI schema described a completely different response shape, which misled consumers generating types from the spec. The missing `/{service}` endpoint also forced consumers to call api-registry directly for drill-down.

## Test plan
- [x] All 24 platform-proxy tests pass
- [x] Full test suite passes (1 pre-existing failure in `openapi-response-schemas.test.ts` unrelated to this change)
- [x] `openapi.json` regenerated with correct schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)