### PR TITLE
feat: add campaign pipeline proxy endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1493,6 +1493,110 @@
           "journalists"
         ]
       },
+      "GateCheckResponse": {
+        "type": "object",
+        "properties": {
+          "allowed": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "autoStopped": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "allowed"
+        ]
+      },
+      "StartRunResponse": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string"
+          },
+          "brandIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "workflowSlug": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "featureInputs": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
+          "searchParams": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "nullable": true
+            }
+          }
+        },
+        "required": [
+          "runId",
+          "campaignId",
+          "orgId",
+          "brandIds",
+          "workflowSlug",
+          "userId",
+          "featureSlug",
+          "featureInputs",
+          "searchParams"
+        ]
+      },
+      "EndRunResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "EndRunRequest": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the run succeeded"
+          },
+          "stopCampaign": {
+            "type": "boolean",
+            "description": "If true, campaign-service auto-stops the campaign instead of re-triggering"
+          }
+        },
+        "required": [
+          "success",
+          "stopCampaign"
+        ]
+      },
       "CreateOutletRequest": {
         "type": "object",
         "properties": {
@@ -9817,6 +9921,374 @@
             }
           }
         }
+      }
+    },
+    "/v1/campaigns/pipeline/gate-check": {
+      "post": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Gate-check a campaign iteration",
+        "description": "Check if a campaign can run a new iteration. Validates budget limits, volume limits, campaign status, and consecutive failures. All contextual headers (x-org-id, x-campaign-id, x-user-id, x-run-id, x-workflow-slug, x-feature-slug) are required.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gate check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GateCheckResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required headers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Campaign not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/campaigns/pipeline/start-run": {
+      "post": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Start a campaign run",
+        "description": "Create a run in runs-service and return all campaign data needed by downstream DAG nodes. All contextual headers (x-org-id, x-campaign-id, x-user-id, x-run-id, x-workflow-slug, x-feature-slug) are required.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run created, campaign data returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required headers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Campaign not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/campaigns/pipeline/end-run": {
+      "post": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Finalize a campaign run",
+        "description": "Marks running runs as completed or failed. If stopCampaign=true, auto-stops the campaign. Otherwise re-triggers the workflow for the next iteration. All contextual headers (x-org-id, x-campaign-id, x-user-id, x-run-id, x-workflow-slug, x-feature-slug) are required.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Run finalized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required headers or body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/outlets": {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -6,6 +6,7 @@ import { fetchDeliveryStats } from "../lib/delivery-stats.js";
 import { getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 import {
   CreateCampaignRequestSchema,
+  EndRunRequestSchema,
   deriveCampaignType,
 } from "../schemas.js";
 
@@ -933,6 +934,86 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
   } catch (error: any) {
     console.error("Get campaign journalists error:", error);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get campaign journalists" });
+  }
+});
+
+// ===================================================================
+// Pipeline endpoints (proxied to campaign-service)
+// All require contextual headers: x-org-id, x-campaign-id, x-user-id,
+// x-run-id, x-workflow-slug, x-feature-slug.
+// ===================================================================
+
+/**
+ * POST /v1/campaigns/pipeline/gate-check
+ * Check if a campaign can run a new iteration
+ */
+router.post("/campaigns/pipeline/gate-check", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.campaign,
+      "/gate-check",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] POST /v1/campaigns/pipeline/gate-check — FAILED:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to gate-check campaign" });
+  }
+});
+
+/**
+ * POST /v1/campaigns/pipeline/start-run
+ * Create a run and return campaign data for downstream nodes
+ */
+router.post("/campaigns/pipeline/start-run", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.campaign,
+      "/start-run",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] POST /v1/campaigns/pipeline/start-run — FAILED:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to start campaign run" });
+  }
+});
+
+/**
+ * POST /v1/campaigns/pipeline/end-run
+ * Finalize run and optionally stop or re-trigger campaign
+ */
+router.post("/campaigns/pipeline/end-run", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const parsed = EndRunRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      const flat = parsed.error.flatten();
+      return res.status(400).json({
+        error: `Invalid request body: ${Object.keys(flat.fieldErrors).join(", ")}`,
+        details: flat.fieldErrors,
+        hint: "Body requires { success: boolean, stopCampaign: boolean }.",
+      });
+    }
+
+    const result = await callExternalService(
+      externalServices.campaign,
+      "/end-run",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: parsed.data,
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] POST /v1/campaigns/pipeline/end-run — FAILED:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to end campaign run" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -932,6 +932,115 @@ registry.registerPath({
   },
 });
 
+// -- Pipeline endpoints (proxied to campaign-service) --
+
+export const EndRunRequestSchema = z
+  .object({
+    success: z.boolean().describe("Whether the run succeeded"),
+    stopCampaign: z.boolean().describe("If true, campaign-service auto-stops the campaign instead of re-triggering"),
+  })
+  .openapi("EndRunRequest");
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/campaigns/pipeline/gate-check",
+  tags: ["Campaigns"],
+  summary: "Gate-check a campaign iteration",
+  description:
+    "Check if a campaign can run a new iteration. Validates budget limits, volume limits, campaign status, and consecutive failures. " +
+    "All contextual headers (x-org-id, x-campaign-id, x-user-id, x-run-id, x-workflow-slug, x-feature-slug) are required.",
+  security: authed,
+  responses: {
+    200: {
+      description: "Gate check result",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              allowed: z.boolean(),
+              reason: z.string().optional(),
+              autoStopped: z.boolean().optional(),
+            })
+            .openapi("GateCheckResponse"),
+        },
+      },
+    },
+    400: { description: "Missing required headers", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Campaign not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/campaigns/pipeline/start-run",
+  tags: ["Campaigns"],
+  summary: "Start a campaign run",
+  description:
+    "Create a run in runs-service and return all campaign data needed by downstream DAG nodes. " +
+    "All contextual headers (x-org-id, x-campaign-id, x-user-id, x-run-id, x-workflow-slug, x-feature-slug) are required.",
+  security: authed,
+  responses: {
+    200: {
+      description: "Run created, campaign data returned",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              runId: z.string().uuid(),
+              campaignId: z.string().uuid(),
+              orgId: z.string(),
+              brandIds: z.array(z.string().uuid()),
+              workflowSlug: z.string(),
+              userId: z.string().nullable(),
+              featureSlug: z.string().nullable(),
+              featureInputs: z.record(z.unknown()).nullable(),
+              searchParams: z.record(z.unknown()).nullable(),
+            })
+            .openapi("StartRunResponse"),
+        },
+      },
+    },
+    400: { description: "Missing required headers", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Campaign not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/campaigns/pipeline/end-run",
+  tags: ["Campaigns"],
+  summary: "Finalize a campaign run",
+  description:
+    "Marks running runs as completed or failed. If stopCampaign=true, auto-stops the campaign. " +
+    "Otherwise re-triggers the workflow for the next iteration. " +
+    "All contextual headers (x-org-id, x-campaign-id, x-user-id, x-run-id, x-workflow-slug, x-feature-slug) are required.",
+  security: authed,
+  request: {
+    body: {
+      content: { "application/json": { schema: EndRunRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Run finalized",
+      content: {
+        "application/json": {
+          schema: z
+            .object({ status: z.string() })
+            .openapi("EndRunResponse"),
+        },
+      },
+    },
+    400: { description: "Missing required headers or body", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // OUTLETS
 // ===================================================================

--- a/tests/unit/campaign-pipeline-proxy.test.ts
+++ b/tests/unit/campaign-pipeline-proxy.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/campaigns.ts");
+const routeContent = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const openapiPath = path.join(__dirname, "../../openapi.json");
+const openapiContent = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+describe("Campaign pipeline proxy routes", () => {
+  it("should have POST /campaigns/pipeline/gate-check endpoint", () => {
+    expect(routeContent).toContain('"/campaigns/pipeline/gate-check"');
+    expect(routeContent).toContain("router.post");
+  });
+
+  it("should have POST /campaigns/pipeline/start-run endpoint", () => {
+    expect(routeContent).toContain('"/campaigns/pipeline/start-run"');
+  });
+
+  it("should have POST /campaigns/pipeline/end-run endpoint", () => {
+    expect(routeContent).toContain('"/campaigns/pipeline/end-run"');
+  });
+
+  it("should proxy gate-check to campaign-service /gate-check", () => {
+    expect(routeContent).toContain('"/gate-check"');
+  });
+
+  it("should proxy start-run to campaign-service /start-run", () => {
+    expect(routeContent).toContain('"/start-run"');
+  });
+
+  it("should proxy end-run to campaign-service /end-run", () => {
+    expect(routeContent).toContain('"/end-run"');
+  });
+
+  it("should use authenticate, requireOrg, requireUser on all pipeline endpoints", () => {
+    // All 3 pipeline routes use the full auth chain
+    const pipelineBlock = routeContent.slice(routeContent.indexOf("Pipeline endpoints"));
+    const authMatches = pipelineBlock.match(/authenticate, requireOrg, requireUser/g);
+    expect(authMatches).not.toBeNull();
+    expect(authMatches!.length).toBe(3);
+  });
+
+  it("should use buildInternalHeaders on all pipeline endpoints", () => {
+    const pipelineBlock = routeContent.slice(routeContent.indexOf("Pipeline endpoints"));
+    const headerMatches = pipelineBlock.match(/buildInternalHeaders\(req\)/g);
+    expect(headerMatches).not.toBeNull();
+    expect(headerMatches!.length).toBe(3);
+  });
+
+  it("should proxy to externalServices.campaign", () => {
+    const pipelineBlock = routeContent.slice(routeContent.indexOf("Pipeline endpoints"));
+    const serviceMatches = pipelineBlock.match(/externalServices\.campaign/g);
+    expect(serviceMatches).not.toBeNull();
+    expect(serviceMatches!.length).toBe(3);
+  });
+});
+
+describe("End-run request body validation", () => {
+  it("should validate end-run body with EndRunRequestSchema", () => {
+    expect(routeContent).toContain("EndRunRequestSchema.safeParse(req.body)");
+  });
+
+  it("should return 400 on invalid end-run body", () => {
+    expect(routeContent).toContain("res.status(400)");
+    expect(routeContent).toContain("success: boolean, stopCampaign: boolean");
+  });
+
+  it("should import EndRunRequestSchema from schemas", () => {
+    expect(routeContent).toContain("EndRunRequestSchema");
+  });
+
+  it("should NOT accept leadFound in EndRunRequestSchema", () => {
+    expect(schemaContent).not.toContain("leadFound");
+  });
+
+  it("EndRunRequestSchema requires both success and stopCampaign", () => {
+    expect(schemaContent).toContain('success: z.boolean()');
+    expect(schemaContent).toContain('stopCampaign: z.boolean()');
+  });
+});
+
+describe("Campaign pipeline OpenAPI schemas", () => {
+  it("should register gate-check path", () => {
+    expect(schemaContent).toContain('path: "/v1/campaigns/pipeline/gate-check"');
+  });
+
+  it("should register start-run path", () => {
+    expect(schemaContent).toContain('path: "/v1/campaigns/pipeline/start-run"');
+  });
+
+  it("should register end-run path", () => {
+    expect(schemaContent).toContain('path: "/v1/campaigns/pipeline/end-run"');
+  });
+
+  it("should have all three pipeline paths in openapi.json", () => {
+    expect(openapiContent.paths["/v1/campaigns/pipeline/gate-check"]).toBeDefined();
+    expect(openapiContent.paths["/v1/campaigns/pipeline/gate-check"].post).toBeDefined();
+
+    expect(openapiContent.paths["/v1/campaigns/pipeline/start-run"]).toBeDefined();
+    expect(openapiContent.paths["/v1/campaigns/pipeline/start-run"].post).toBeDefined();
+
+    expect(openapiContent.paths["/v1/campaigns/pipeline/end-run"]).toBeDefined();
+    expect(openapiContent.paths["/v1/campaigns/pipeline/end-run"].post).toBeDefined();
+  });
+
+  it("end-run openapi should have EndRunRequest body schema with success and stopCampaign", () => {
+    const endRunPost = openapiContent.paths["/v1/campaigns/pipeline/end-run"].post;
+    const ref = endRunPost.requestBody?.content?.["application/json"]?.schema?.$ref;
+    expect(ref).toBe("#/components/schemas/EndRunRequest");
+    const resolved = openapiContent.components.schemas.EndRunRequest;
+    expect(resolved.required).toContain("success");
+    expect(resolved.required).toContain("stopCampaign");
+    expect(resolved.properties.success.type).toBe("boolean");
+    expect(resolved.properties.stopCampaign.type).toBe("boolean");
+  });
+
+  it("end-run openapi should NOT reference leadFound", () => {
+    const endRunPost = openapiContent.paths["/v1/campaigns/pipeline/end-run"].post;
+    const bodyStr = JSON.stringify(endRunPost);
+    expect(bodyStr).not.toContain("leadFound");
+  });
+
+  it("gate-check response should reference GateCheckResponse schema with allowed boolean", () => {
+    const gateCheckPost = openapiContent.paths["/v1/campaigns/pipeline/gate-check"].post;
+    const ref = gateCheckPost.responses["200"]?.content?.["application/json"]?.schema?.$ref;
+    expect(ref).toBe("#/components/schemas/GateCheckResponse");
+    const resolved = openapiContent.components.schemas.GateCheckResponse;
+    expect(resolved.properties.allowed.type).toBe("boolean");
+  });
+
+  it("start-run response should reference StartRunResponse schema with runId and campaignId", () => {
+    const startRunPost = openapiContent.paths["/v1/campaigns/pipeline/start-run"].post;
+    const ref = startRunPost.responses["200"]?.content?.["application/json"]?.schema?.$ref;
+    expect(ref).toBe("#/components/schemas/StartRunResponse");
+    const resolved = openapiContent.components.schemas.StartRunResponse;
+    expect(resolved.properties.runId).toBeDefined();
+    expect(resolved.properties.campaignId).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds three new proxy endpoints for campaign-service pipeline operations: `POST /v1/campaigns/pipeline/gate-check`, `POST /v1/campaigns/pipeline/start-run`, `POST /v1/campaigns/pipeline/end-run`
- Reflects the breaking change from campaign-service PR #104: `leadFound` → `stopCampaign` (both `success` and `stopCampaign` are now required on end-run)
- All pipeline endpoints forward full contextual headers (x-org-id, x-campaign-id, x-user-id, x-run-id, x-workflow-slug, x-feature-slug) via `buildInternalHeaders`
- Includes Zod schemas, OpenAPI spec registration, and regenerated `openapi.json`

## Test plan
- [x] 22 new unit tests covering route structure, body validation, header forwarding, and OpenAPI schema correctness
- [x] Full test suite passes (pre-existing failure in `openapi-response-schemas.test.ts` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)