### PR TITLE
docs: declare required workflow headers on outlet endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10297,6 +10297,7 @@
           "Outlets"
         ],
         "summary": "List outlets with filters",
+        "description": "List outlets with optional filters. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -10363,6 +10364,47 @@
             "required": false,
             "name": "offset",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
           },
           {
             "name": "x-org-id",
@@ -10441,46 +10483,54 @@
           "Outlets"
         ],
         "summary": "Create outlet (upsert by outlet_url)",
+        "description": "Create or upsert an outlet. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateOutletRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Outlet created"
-          },
-          "400": {
-            "description": "Validation error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
         "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
           {
             "name": "x-org-id",
             "in": "header",
@@ -10536,7 +10586,41 @@
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
-        ]
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOutletRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Outlet created"
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/outlets/stats": {
@@ -10545,7 +10629,7 @@
           "Outlets"
         ],
         "summary": "Aggregated outlet discovery metrics",
-        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy.",
+        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -10645,6 +10729,47 @@
             "in": "query"
           },
           {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
             "name": "x-org-id",
             "in": "header",
             "required": false,
@@ -10723,7 +10848,7 @@
           "Outlets"
         ],
         "summary": "Get outlet discovery cost stats",
-        "description": "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, and runCount per run. Without groupBy, returns flat totals across all discovery runs. All costs are org-scoped — each org only sees costs from their own discovery runs.",
+        "description": "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, and runCount per run. Without groupBy, returns flat totals across all discovery runs. All costs are org-scoped — each org only sees costs from their own discovery runs. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -10765,6 +10890,47 @@
             "description": "Group results by outletId or runId",
             "name": "groupBy",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
           },
           {
             "name": "x-org-id",
@@ -10852,9 +11018,108 @@
           "Outlets"
         ],
         "summary": "Bulk upsert outlets",
+        "description": "Bulk create or upsert outlets. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ],
         "requestBody": {
@@ -10880,8 +11145,63 @@
               }
             }
           }
-        },
+        }
+      }
+    },
+    "/v1/outlets/search": {
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Search outlets by name/url",
+        "description": "Search outlets by name or URL. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
           {
             "name": "x-org-id",
             "in": "header",
@@ -10936,19 +11256,6 @@
               "type": "string"
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
-      }
-    },
-    "/v1/outlets/search": {
-      "post": {
-        "tags": [
-          "Outlets"
-        ],
-        "summary": "Search outlets by name/url",
-        "security": [
-          {
-            "bearerAuth": []
           }
         ],
         "requestBody": {
@@ -10974,8 +11281,63 @@
               }
             }
           }
-        },
+        }
+      }
+    },
+    "/v1/outlets/discover": {
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Discover relevant outlets via Google search + LLM scoring",
+        "description": "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
           {
             "name": "x-org-id",
             "in": "header",
@@ -11030,20 +11392,6 @@
               "type": "string"
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
-      }
-    },
-    "/v1/outlets/discover": {
-      "post": {
-        "tags": [
-          "Outlets"
-        ],
-        "summary": "Discover relevant outlets via Google search + LLM scoring",
-        "description": "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. Requires x-campaign-id and x-brand-id headers.",
-        "security": [
-          {
-            "bearerAuth": []
           }
         ],
         "requestBody": {
@@ -11096,8 +11444,63 @@
               }
             }
           }
-        },
+        }
+      }
+    },
+    "/v1/outlets/buffer/next": {
+      "post": {
+        "tags": [
+          "Outlets"
+        ],
+        "summary": "Get next buffered outlet",
+        "description": "Returns the next buffered outlet from the queue. Response includes the runId of the discovery run that originally found the outlet. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
           {
             "name": "x-org-id",
             "in": "header",
@@ -11152,20 +11555,6 @@
               "type": "string"
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
-      }
-    },
-    "/v1/outlets/buffer/next": {
-      "post": {
-        "tags": [
-          "Outlets"
-        ],
-        "summary": "Get next buffered outlet",
-        "description": "Returns the next buffered outlet from the queue. Response includes the runId of the discovery run that originally found the outlet.",
-        "security": [
-          {
-            "bearerAuth": []
           }
         ],
         "responses": {
@@ -11192,64 +11581,7 @@
               }
             }
           }
-        },
-        "parameters": [
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "example": "uuid1,uuid2,uuid3"
-            },
-            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
+        }
       }
     },
     "/v1/outlets/{id}": {
@@ -11258,6 +11590,7 @@
           "Outlets"
         ],
         "summary": "Get outlet by ID",
+        "description": "Get a single outlet by ID. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -11273,6 +11606,47 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
           },
           {
             "name": "x-org-id",
@@ -11361,6 +11735,7 @@
           "Outlets"
         ],
         "summary": "Update outlet",
+        "description": "Update an outlet's fields. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -11376,6 +11751,47 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
           },
           {
             "name": "x-org-id",
@@ -11475,6 +11891,7 @@
           "Outlets"
         ],
         "summary": "Update outlet status",
+        "description": "Update an outlet's status. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -11501,6 +11918,47 @@
             "description": "Campaign ID (required)",
             "name": "campaignId",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — required by outlets-service"
+            },
+            "required": true,
+            "description": "Campaign ID — required by outlets-service",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service"
+            },
+            "required": true,
+            "description": "Brand ID (may be comma-separated for multi-brand) — required by outlets-service",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Feature slug — required by outlets-service",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — required by outlets-service"
+            },
+            "required": true,
+            "description": "Workflow slug — required by outlets-service",
+            "name": "x-workflow-slug",
+            "in": "header"
           },
           {
             "name": "x-org-id",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1045,6 +1045,18 @@ registry.registerPath({
 // OUTLETS
 // ===================================================================
 
+/**
+ * outlets-service requires all 7 identity headers on every request.
+ * x-org-id, x-user-id, x-run-id are set by auth middleware.
+ * These 4 must be provided by the caller.
+ */
+const outletsRequiredHeaders = z.object({
+  "x-campaign-id": z.string().uuid().describe("Campaign ID — required by outlets-service"),
+  "x-brand-id": z.string().describe("Brand ID (may be comma-separated for multi-brand) — required by outlets-service"),
+  "x-feature-slug": z.string().describe("Feature slug — required by outlets-service"),
+  "x-workflow-slug": z.string().describe("Workflow slug — required by outlets-service"),
+});
+
 const OutletIdParam = z.object({
   id: z.string().uuid().openapi({ description: "Outlet ID" }),
 });
@@ -1054,8 +1066,10 @@ registry.registerPath({
   path: "/v1/outlets",
   tags: ["Outlets"],
   summary: "List outlets with filters",
+  description: "List outlets with optional filters. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     query: z.object({
       campaignId: z.string().uuid().optional(),
       brandId: z.string().uuid().optional(),
@@ -1076,8 +1090,10 @@ registry.registerPath({
   path: "/v1/outlets",
   tags: ["Outlets"],
   summary: "Create outlet (upsert by outlet_url)",
+  description: "Create or upsert an outlet. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     body: {
       content: {
         "application/json": {
@@ -1113,9 +1129,10 @@ registry.registerPath({
   path: "/v1/outlets/stats",
   tags: ["Outlets"],
   summary: "Aggregated outlet discovery metrics",
-  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy.",
+  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     query: z.object({
       brandId: z.string().uuid().optional(),
       campaignId: z.string().uuid().optional(),
@@ -1144,9 +1161,11 @@ registry.registerPath({
     "and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets " +
     "in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, " +
     "and runCount per run. Without groupBy, returns flat totals across all discovery runs. " +
-    "All costs are org-scoped — each org only sees costs from their own discovery runs.",
+    "All costs are org-scoped — each org only sees costs from their own discovery runs. " +
+    "All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     query: z.object({
       brandId: z.string().uuid().optional().describe("Filter by brand ID"),
       campaignId: z.string().uuid().optional().describe("Filter by campaign ID"),
@@ -1183,8 +1202,10 @@ registry.registerPath({
   path: "/v1/outlets/bulk",
   tags: ["Outlets"],
   summary: "Bulk upsert outlets",
+  description: "Bulk create or upsert outlets. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     body: {
       content: {
         "application/json": {
@@ -1223,8 +1244,10 @@ registry.registerPath({
   path: "/v1/outlets/search",
   tags: ["Outlets"],
   summary: "Search outlets by name/url",
+  description: "Search outlets by name or URL. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     body: {
       content: {
         "application/json": {
@@ -1252,9 +1275,10 @@ registry.registerPath({
   summary: "Discover relevant outlets via Google search + LLM scoring",
   description: "Generates search queries via LLM, searches Google, scores results, and stores discovered outlets as buffered. " +
     "Creates a child run — use the returned runId to query outlets from this specific discovery run via GET /v1/outlets?runId={runId}. " +
-    "Requires x-campaign-id and x-brand-id headers.",
+    "All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     body: {
       content: {
         "application/json": {
@@ -1292,9 +1316,9 @@ registry.registerPath({
   path: "/v1/outlets/buffer/next",
   tags: ["Outlets"],
   summary: "Get next buffered outlet",
-  description: "Returns the next buffered outlet from the queue. Response includes the runId of the discovery run that originally found the outlet.",
+  description: "Returns the next buffered outlet from the queue. Response includes the runId of the discovery run that originally found the outlet. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
-  request: {},
+  request: { headers: outletsRequiredHeaders },
   responses: {
     200: {
       description: "Next buffered outlet",
@@ -1319,8 +1343,9 @@ registry.registerPath({
   path: "/v1/outlets/{id}",
   tags: ["Outlets"],
   summary: "Get outlet by ID",
+  description: "Get a single outlet by ID. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
-  request: { params: OutletIdParam },
+  request: { headers: outletsRequiredHeaders, params: OutletIdParam },
   responses: {
     200: { description: "Outlet found" },
     401: { description: "Unauthorized", content: errorContent },
@@ -1333,8 +1358,10 @@ registry.registerPath({
   path: "/v1/outlets/{id}",
   tags: ["Outlets"],
   summary: "Update outlet",
+  description: "Update an outlet's fields. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     params: OutletIdParam,
     body: {
       content: {
@@ -1367,8 +1394,10 @@ registry.registerPath({
   path: "/v1/outlets/{id}/status",
   tags: ["Outlets"],
   summary: "Update outlet status",
+  description: "Update an outlet's status. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
+    headers: outletsRequiredHeaders,
     params: OutletIdParam,
     query: z.object({
       campaignId: z.string().uuid().describe("Campaign ID (required)"),

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -215,7 +215,7 @@ describe("Outlets OpenAPI schemas", () => {
   it("should include runId filter on GET /v1/outlets query params", () => {
     const getOutletsSection = schemaContent.slice(
       schemaContent.indexOf('path: "/v1/outlets"'),
-      schemaContent.indexOf('path: "/v1/outlets"') + 400
+      schemaContent.indexOf('path: "/v1/outlets"') + 600
     );
     expect(getOutletsSection).toContain("runId:");
   });
@@ -259,6 +259,50 @@ describe("Outlets OpenAPI schemas", () => {
     expect(blockBefore).not.toContain("targetGeo:");
     expect(blockBefore).not.toContain("targetAudience:");
     expect(blockBefore).not.toContain("angles:");
+  });
+});
+
+describe("Outlets OpenAPI — required workflow headers", () => {
+  const openapiPath = path.join(__dirname, "../../openapi.json");
+  const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+  const outletPaths = [
+    ["/v1/outlets", "get"],
+    ["/v1/outlets", "post"],
+    ["/v1/outlets/stats", "get"],
+    ["/v1/outlets/stats/costs", "get"],
+    ["/v1/outlets/bulk", "post"],
+    ["/v1/outlets/search", "post"],
+    ["/v1/outlets/discover", "post"],
+    ["/v1/outlets/buffer/next", "post"],
+    ["/v1/outlets/{id}", "get"],
+    ["/v1/outlets/{id}", "patch"],
+    ["/v1/outlets/{id}/status", "patch"],
+  ] as const;
+
+  const requiredHeaders = ["x-campaign-id", "x-brand-id", "x-feature-slug", "x-workflow-slug"];
+
+  for (const [pathKey, method] of outletPaths) {
+    it(`${method.toUpperCase()} ${pathKey} should declare all 4 workflow headers as required`, () => {
+      const pathEntry = openapi.paths[pathKey];
+      expect(pathEntry).toBeDefined();
+
+      const operation = pathEntry[method];
+      expect(operation).toBeDefined();
+
+      const params: Array<{ name: string; in: string; required?: boolean }> = operation.parameters || [];
+      const headerParams = params.filter((p) => p.in === "header");
+
+      for (const header of requiredHeaders) {
+        const param = headerParams.find((p) => p.name === header);
+        expect(param, `Missing header parameter: ${header} on ${method.toUpperCase()} ${pathKey}`).toBeDefined();
+        expect(param!.required, `${header} should be required on ${method.toUpperCase()} ${pathKey}`).toBe(true);
+      }
+    });
+  }
+
+  it("schemas.ts should define outletsRequiredHeaders with all 4 headers", () => {
+    expect(schemaContent).toContain("outletsRequiredHeaders");
   });
 });
 


### PR DESCRIPTION
## Summary
- outlets-service now requires all 7 identity headers on every request
- Added `x-campaign-id`, `x-brand-id`, `x-feature-slug`, `x-workflow-slug` as required header parameters on all 11 `/v1/outlets/*` OpenAPI endpoints
- `x-org-id`, `x-user-id`, `x-run-id` are already guaranteed by auth middleware
- Regenerated `openapi.json`
- Added 12 tests verifying headers appear as required in the generated spec

## Test plan
- [x] All 50 outlet proxy tests pass
- [x] New tests verify all 4 headers are declared as required on each outlet path/method in openapi.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)