### PR TITLE
fix: update internal outlets endpoint to consolidated path

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -885,7 +885,7 @@ router.get("/campaigns/:id/journalists", authenticate, requireOrg, requireUser, 
     // First get the campaign's outlets, then resolve journalists for each
     const outletsResult = await callExternalService<{ outlets: Array<{ id: string; outletName?: string; outletDomain?: string | null }> }>(
       externalServices.outlet,
-      `/internal/outlets/by-campaign/${encodeURIComponent(id)}`,
+      `/internal/outlets?campaignId=${encodeURIComponent(id)}`,
       { headers: baseHeaders }
     );
 

--- a/tests/unit/campaign-discovery-proxy.test.ts
+++ b/tests/unit/campaign-discovery-proxy.test.ts
@@ -168,6 +168,16 @@ describe("OpenAPI schemas: campaign discovery endpoints", () => {
   });
 });
 
+describe("Campaign journalists: consolidated internal outlets endpoint", () => {
+  it("should call GET /internal/outlets?campaignId= (not the old /internal/outlets/by-campaign/ path)", () => {
+    const journalistsSection = content.slice(
+      content.indexOf('"/campaigns/:id/journalists"'),
+    );
+    expect(journalistsSection).toContain("/internal/outlets?campaignId=");
+    expect(journalistsSection).not.toContain("/internal/outlets/by-campaign/");
+  });
+});
+
 describe("Campaign journalists: outlet name/domain enrichment", () => {
   it("should build an outlet lookup map from the fetched outlets", () => {
     const journalistsSection = content.slice(


### PR DESCRIPTION
## Summary
- Updates `GET /campaigns/:id/journalists` to call the new consolidated `GET /internal/outlets?campaignId=...` endpoint instead of the removed `GET /internal/outlets/by-campaign/:id` (outlets-service PR #49)
- Adds regression test verifying the new path and absence of the old path

## Context
outlets-service PR #49 consolidated two internal endpoints (`/internal/outlets/by-ids` and `/internal/outlets/by-campaign/:id`) into a single `GET /internal/outlets?ids=...&campaignId=...`. The old paths now 404.

Header relaxation (read/stats/internal endpoints only require `x-org-id`, `x-user-id`, `x-run-id`) is backwards-compatible — no code changes needed since we already send all available headers.

## Test plan
- [x] Regression test confirms new endpoint path used
- [x] Regression test confirms old path absent from source
- [x] Full test suite passes (24/24 in affected file, 1022/1024 overall — 2 pre-existing failures in openapi-response-schemas.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)