### PR TITLE
docs: make workflow headers optional on journalist stats endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12972,40 +12972,40 @@
             "schema": {
               "type": "string",
               "format": "uuid",
-              "description": "Campaign ID — required by journalists-service"
+              "description": "Campaign ID — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Campaign ID — required by journalists-service",
+            "required": false,
+            "description": "Campaign ID — optional for stats endpoints",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID (may be comma-separated for multi-brand) — required by journalists-service"
+              "description": "Brand ID (may be comma-separated for multi-brand) — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Brand ID (may be comma-separated for multi-brand) — required by journalists-service",
+            "required": false,
+            "description": "Brand ID (may be comma-separated for multi-brand) — optional for stats endpoints",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug — required by journalists-service"
+              "description": "Feature slug — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Feature slug — required by journalists-service",
+            "required": false,
+            "description": "Feature slug — optional for stats endpoints",
             "name": "x-feature-slug",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow slug — required by journalists-service"
+              "description": "Workflow slug — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Workflow slug — required by journalists-service",
+            "required": false,
+            "description": "Workflow slug — optional for stats endpoints",
             "name": "x-workflow-slug",
             "in": "header"
           },
@@ -13105,7 +13105,7 @@
           "Journalists"
         ],
         "summary": "Get journalist discovery cost stats",
-        "description": "Returns cost statistics for journalist discovery runs. Requires brandId. Supports optional campaignId filter and groupBy=journalistId to get per-journalist breakdowns. Costs are fetched from runs-service via POST /v1/runs/costs/batch. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "description": "Returns cost statistics for journalist discovery runs. Requires brandId. Supports optional campaignId filter and groupBy=journalistId to get per-journalist breakdowns. Costs are fetched from runs-service via POST /v1/runs/costs/batch. Workflow-context headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are optional — send them if available.",
         "security": [
           {
             "bearerAuth": []
@@ -13149,40 +13149,40 @@
             "schema": {
               "type": "string",
               "format": "uuid",
-              "description": "Campaign ID — required by journalists-service"
+              "description": "Campaign ID — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Campaign ID — required by journalists-service",
+            "required": false,
+            "description": "Campaign ID — optional for stats endpoints",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID (may be comma-separated for multi-brand) — required by journalists-service"
+              "description": "Brand ID (may be comma-separated for multi-brand) — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Brand ID (may be comma-separated for multi-brand) — required by journalists-service",
+            "required": false,
+            "description": "Brand ID (may be comma-separated for multi-brand) — optional for stats endpoints",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug — required by journalists-service"
+              "description": "Feature slug — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Feature slug — required by journalists-service",
+            "required": false,
+            "description": "Feature slug — optional for stats endpoints",
             "name": "x-feature-slug",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow slug — required by journalists-service"
+              "description": "Workflow slug — optional for stats endpoints"
             },
-            "required": true,
-            "description": "Workflow slug — required by journalists-service",
+            "required": false,
+            "description": "Workflow slug — optional for stats endpoints",
             "name": "x-workflow-slug",
             "in": "header"
           },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1438,6 +1438,15 @@ const journalistsRequiredHeaders = z.object({
   "x-workflow-slug": z.string().describe("Workflow slug — required by journalists-service"),
 });
 
+// Stats endpoints on journalists-service accept just the base 3 auth headers;
+// workflow-context headers are optional (forwarded when available).
+const journalistsStatsOptionalHeaders = z.object({
+  "x-campaign-id": z.string().uuid().optional().describe("Campaign ID — optional for stats endpoints"),
+  "x-brand-id": z.string().optional().describe("Brand ID (may be comma-separated for multi-brand) — optional for stats endpoints"),
+  "x-feature-slug": z.string().optional().describe("Feature slug — optional for stats endpoints"),
+  "x-workflow-slug": z.string().optional().describe("Workflow slug — optional for stats endpoints"),
+});
+
 registry.registerPath({
   method: "get",
   path: "/v1/journalists",
@@ -1688,7 +1697,7 @@ registry.registerPath({
     "Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. " +
     "Optional groupBy returns per-slug breakdowns.",
   security: authed,
-  request: { headers: journalistsRequiredHeaders, query: journalistStatsQueryParams },
+  request: { headers: journalistsStatsOptionalHeaders, query: journalistStatsQueryParams },
   responses: {
     200: {
       description: "Journalist stats (flat or grouped)",
@@ -1719,10 +1728,10 @@ registry.registerPath({
     "Returns cost statistics for journalist discovery runs. Requires brandId. " +
     "Supports optional campaignId filter and groupBy=journalistId to get per-journalist breakdowns. " +
     "Costs are fetched from runs-service via POST /v1/runs/costs/batch. " +
-    "All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+    "Workflow-context headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are optional — send them if available.",
   security: authed,
   request: {
-    headers: journalistsRequiredHeaders,
+    headers: journalistsStatsOptionalHeaders,
     query: z.object({
       brandId: z.string().describe("Filter by brand ID (required)"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -306,24 +306,22 @@ describe("Journalists OpenAPI — required workflow headers", () => {
   const openapiPath = path.join(__dirname, "../../openapi.json");
   const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
 
-  const journalistPaths = [
+  const workflowHeaders = ["x-campaign-id", "x-brand-id", "x-feature-slug", "x-workflow-slug"];
+
+  // Non-stats endpoints require all 4 workflow headers
+  const requiredHeaderPaths = [
     "/v1/journalists",
     "/v1/journalists/discover",
     "/v1/journalists/discover-emails",
     "/v1/journalists/buffer/next",
     "/v1/journalists/resolve",
-    "/v1/journalists/stats",
-    "/v1/journalists/stats/costs",
   ];
 
-  const requiredHeaders = ["x-campaign-id", "x-brand-id", "x-feature-slug", "x-workflow-slug"];
-
-  for (const pathKey of journalistPaths) {
+  for (const pathKey of requiredHeaderPaths) {
     it(`${pathKey} should declare all 4 workflow headers as required parameters`, () => {
       const pathEntry = openapi.paths[pathKey];
       expect(pathEntry).toBeDefined();
 
-      // Get the first method (get or post)
       const method = Object.keys(pathEntry).find((k) => ["get", "post"].includes(k));
       expect(method).toBeDefined();
 
@@ -331,7 +329,7 @@ describe("Journalists OpenAPI — required workflow headers", () => {
       const params: Array<{ name: string; in: string; required?: boolean }> = operation.parameters || [];
       const headerParams = params.filter((p) => p.in === "header");
 
-      for (const header of requiredHeaders) {
+      for (const header of workflowHeaders) {
         const param = headerParams.find((p) => p.name === header);
         expect(param, `Missing header parameter: ${header} on ${pathKey}`).toBeDefined();
         expect(param!.required, `${header} should be required on ${pathKey}`).toBe(true);
@@ -339,11 +337,41 @@ describe("Journalists OpenAPI — required workflow headers", () => {
     });
   }
 
+  // Stats endpoints accept workflow headers as optional (dashboard queries have no workflow context)
+  const optionalHeaderPaths = [
+    "/v1/journalists/stats",
+    "/v1/journalists/stats/costs",
+  ];
+
+  for (const pathKey of optionalHeaderPaths) {
+    it(`${pathKey} should declare all 4 workflow headers as optional parameters`, () => {
+      const pathEntry = openapi.paths[pathKey];
+      expect(pathEntry).toBeDefined();
+
+      const method = Object.keys(pathEntry).find((k) => ["get", "post"].includes(k));
+      expect(method).toBeDefined();
+
+      const operation = pathEntry[method!];
+      const params: Array<{ name: string; in: string; required?: boolean }> = operation.parameters || [];
+      const headerParams = params.filter((p) => p.in === "header");
+
+      for (const header of workflowHeaders) {
+        const param = headerParams.find((p) => p.name === header);
+        expect(param, `Missing header parameter: ${header} on ${pathKey}`).toBeDefined();
+        expect(param!.required, `${header} should NOT be required on ${pathKey}`).toBeFalsy();
+      }
+    });
+  }
+
   it("schemas.ts should define journalistsRequiredHeaders with all 4 headers", () => {
-    for (const header of requiredHeaders) {
+    for (const header of workflowHeaders) {
       expect(schemaContent).toContain(`"${header}"`);
     }
     expect(schemaContent).toContain("journalistsRequiredHeaders");
+  });
+
+  it("schemas.ts should define journalistsStatsOptionalHeaders with all 4 headers as optional", () => {
+    expect(schemaContent).toContain("journalistsStatsOptionalHeaders");
   });
 });
 


### PR DESCRIPTION
## Summary
- Updated OpenAPI spec for `GET /v1/journalists/stats` and `GET /v1/journalists/stats/costs` to declare workflow-context headers (`x-campaign-id`, `x-brand-id`, `x-feature-slug`, `x-workflow-slug`) as **optional** instead of required
- Matches upstream change in journalists-service (shamanic-technologies/journalists-service#57) where these stats endpoints now accept just the base 3 auth headers
- Updated tests to assert optional headers on stats endpoints while keeping them required on write/workflow endpoints

## Test plan
- [x] Existing journalist proxy tests pass with updated assertions
- [x] OpenAPI spec regenerated and committed
- [x] Pre-existing test failures in `openapi-response-schemas.test.ts` are unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)