### PR TITLE
fix: enrich workflow headers on GET /journalists proxy

### DIFF
--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -18,10 +18,24 @@ router.get("/journalists", authenticate, requireOrg, requireUser, async (req: Au
     if (runId) params.set("run_id", runId);
     if (campaignId) params.set("campaign_id", campaignId);
 
+    // Build headers, enriching with campaign metadata when workflow headers are missing
+    const headers = buildInternalHeaders(req);
+    if (campaignId && (!req.campaignId || !req.brandId || !req.featureSlug || !req.workflowSlug)) {
+      const campaignResult = await callExternalService<{
+        campaign: { brandIds?: string[]; featureSlug?: string; workflowSlug?: string };
+      }>(externalServices.campaign, `/campaigns/${encodeURIComponent(campaignId)}`, { headers });
+
+      const campaign = campaignResult.campaign;
+      if (!headers["x-campaign-id"]) headers["x-campaign-id"] = campaignId;
+      if (!headers["x-brand-id"] && campaign.brandIds?.length) headers["x-brand-id"] = campaign.brandIds.join(",");
+      if (!headers["x-feature-slug"] && campaign.featureSlug) headers["x-feature-slug"] = campaign.featureSlug;
+      if (!headers["x-workflow-slug"] && campaign.workflowSlug) headers["x-workflow-slug"] = campaign.workflowSlug;
+    }
+
     const result = await callExternalService(
       externalServices.journalist,
       `/campaign-outlet-journalists?${params}`,
-      { headers: buildInternalHeaders(req) }
+      { headers }
     );
     res.json(result);
   } catch (error: any) {

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -98,6 +98,19 @@ describe("Journalists proxy routes", () => {
     expect(content).toContain('params.set("campaign_id", campaignId)');
   });
 
+  it("should enrich workflow headers from campaign-service when campaignId query param is present but headers are missing", () => {
+    // The GET /journalists handler fetches campaign metadata to populate x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug
+    expect(content).toContain("externalServices.campaign");
+    expect(content).toContain("/campaigns/");
+    // Should only enrich when workflow headers are missing
+    expect(content).toContain("!req.campaignId || !req.brandId || !req.featureSlug || !req.workflowSlug");
+    // Should set missing headers from campaign data
+    expect(content).toContain('headers["x-campaign-id"] = campaignId');
+    expect(content).toContain('headers["x-brand-id"]');
+    expect(content).toContain('headers["x-feature-slug"]');
+    expect(content).toContain('headers["x-workflow-slug"]');
+  });
+
   it("should proxy POST /journalists/buffer/next to /buffer/next on journalist-service", () => {
     expect(content).toContain('"/buffer/next"');
   });


### PR DESCRIPTION
## Summary
- **Bug**: `GET /v1/journalists?brandId=X&campaignId=Y` called from the dashboard (without workflow headers) fails with `Missing required headers: x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug` on journalists-service
- **Fix**: When `campaignId` query param is present but workflow headers are missing, fetch campaign metadata from campaign-service and populate the missing headers before forwarding to journalists-service
- Same pattern already used by `GET /v1/campaigns/:id/journalists`

## Test plan
- [x] Regression test verifying enrichment logic is present in route
- [x] All 53 existing journalists-proxy tests pass
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)