### PR TITLE
fix: resolve brandUrls from brandIds on GET /campaigns

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -371,11 +371,10 @@
           },
           "brandUrls": {
             "type": "array",
-            "nullable": true,
             "items": {
               "type": "string"
             },
-            "description": "Brand website URLs"
+            "description": "Brand website URLs (resolved from brandIds via brand-service)"
           },
           "brandIds": {
             "type": "array",

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -13,6 +13,40 @@ import {
 const router = Router();
 
 /**
+ * Resolve brandIds → brandUrls via brand-service.
+ * Calls GET /brands/:id for each brand in parallel and extracts the URL.
+ */
+async function resolveBrandUrls(
+  brandIds: string[],
+  headers: Record<string, string>,
+): Promise<string[]> {
+  if (brandIds.length === 0) return [];
+  const results = await Promise.all(
+    brandIds.map((id) =>
+      callExternalService<{ brand: { brandUrl: string | null } }>(
+        externalServices.brand,
+        `/brands/${encodeURIComponent(id)}`,
+        { headers },
+      ),
+    ),
+  );
+  return results.map((r) => r.brand.brandUrl).filter((url): url is string => url != null);
+}
+
+/**
+ * Enrich a campaign object by resolving brandUrls from brandIds.
+ */
+async function enrichCampaignBrandUrls(
+  campaign: Record<string, unknown>,
+  headers: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const brandIds = campaign.brandIds as string[] | undefined;
+  if (!brandIds || brandIds.length === 0) return { ...campaign, brandUrls: [] };
+  const brandUrls = await resolveBrandUrls(brandIds, headers);
+  return { ...campaign, brandUrls };
+}
+
+/**
  * GET /v1/campaigns
  * List campaigns for the organization
  * Query params:
@@ -26,16 +60,19 @@ router.get("/campaigns", authenticate, requireOrg, requireUser, async (req: Auth
     }
     const queryString = params.toString() ? `?${params.toString()}` : "";
 
-    const result = await callExternalService(
+    const internalHeaders = buildInternalHeaders(req);
+    const result = await callExternalService<{ campaigns: Record<string, unknown>[] }>(
       externalServices.campaign,
       `/campaigns${queryString}`,
-      {
-        headers: buildInternalHeaders(req),
-      }
+      { headers: internalHeaders },
     );
-    res.json(result);
+
+    const enriched = await Promise.all(
+      result.campaigns.map((c) => enrichCampaignBrandUrls(c, internalHeaders)),
+    );
+    res.json({ ...result, campaigns: enriched });
   } catch (error: any) {
-    console.error("List campaigns error:", error);
+    console.error("[api-service] List campaigns error:", error);
     res.status(500).json({ error: error.message || "Failed to list campaigns" });
   }
 });
@@ -335,17 +372,18 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
 router.get("/campaigns/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    const internalHeaders = buildInternalHeaders(req);
 
-    const result = await callExternalService(
+    const result = await callExternalService<{ campaign: Record<string, unknown> }>(
       externalServices.campaign,
       `/campaigns/${id}`,
-      {
-        headers: buildInternalHeaders(req),
-      }
+      { headers: internalHeaders },
     );
-    res.json(result);
+
+    const enriched = await enrichCampaignBrandUrls(result.campaign, internalHeaders);
+    res.json({ ...result, campaign: enriched });
   } catch (error: any) {
-    console.error("Get campaign error:", error);
+    console.error("[api-service] Get campaign error:", error);
     res.status(500).json({ error: error.message || "Failed to get campaign" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -405,7 +405,7 @@ const CampaignSchema = z
     name: z.string().describe("Campaign name"),
     workflowSlug: z.string().describe("Exact versioned workflow slug used for execution"),
     workflowDynastySlug: z.string().nullable().describe("Stable dynasty slug for the workflow lineage (unversioned)"),
-    brandUrls: z.array(z.string()).nullable().describe("Brand website URLs"),
+    brandUrls: z.array(z.string()).describe("Brand website URLs (resolved from brandIds via brand-service)"),
     brandIds: z.array(z.string()).describe("Brand IDs"),
     featureSlug: z.string().nullable().describe("Exact versioned feature slug for tracking"),
     featureDynastySlug: z.string().nullable().describe("Stable dynasty slug for the feature lineage (unversioned)"),

--- a/tests/unit/campaign-brand-urls-resolution.test.ts
+++ b/tests/unit/campaign-brand-urls-resolution.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * Regression tests for brandUrls resolution on GET /v1/campaigns and GET /v1/campaigns/:id.
+ * api-service resolves brandIds → brandUrls via brand-service so clients always get brandUrls.
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import campaignRouter from "../../src/routes/campaigns.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignRouter);
+  return app;
+}
+
+const BRAND_LOOKUP: Record<string, string> = {
+  "brand-1": "https://acme.com",
+  "brand-2": "https://foo.io",
+  "brand-3": "https://bar.dev",
+};
+
+describe("Campaign brandUrls resolution", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      // GET /brands/:id — return brand with brandUrl
+      for (const [brandId, brandUrl] of Object.entries(BRAND_LOOKUP)) {
+        if (url.includes(`/brands/${brandId}`) && !url.includes("/campaigns")) {
+          return {
+            ok: true,
+            json: () => Promise.resolve({ brand: { id: brandId, brandUrl, domain: brandUrl.replace(/https?:\/\//, "") } }),
+          };
+        }
+      }
+
+      // GET /campaigns/:id — return campaign with brandIds but null brandUrls (simulates campaign-service)
+      if (url.match(/\/campaigns\/camp-[a-z0-9]+$/) && !url.includes("?")) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              campaign: {
+                id: "camp-abc",
+                orgId: "org_test456",
+                name: "Test Campaign",
+                brandIds: ["brand-1", "brand-2"],
+                brandUrls: null,
+                status: "ongoing",
+                workflowSlug: "workflow-v1",
+              },
+            }),
+        };
+      }
+
+      // GET /campaigns — return list with brandIds but null brandUrls
+      if (url.includes("/campaigns") && !url.includes("/campaigns/")) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              campaigns: [
+                {
+                  id: "camp-1",
+                  orgId: "org_test456",
+                  name: "Campaign One",
+                  brandIds: ["brand-1"],
+                  brandUrls: null,
+                  status: "ongoing",
+                },
+                {
+                  id: "camp-2",
+                  orgId: "org_test456",
+                  name: "Campaign Two",
+                  brandIds: ["brand-2", "brand-3"],
+                  brandUrls: null,
+                  status: "stopped",
+                },
+              ],
+            }),
+        };
+      }
+
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+  });
+
+  it("GET /v1/campaigns/:id resolves brandUrls from brandIds", async () => {
+    const app = createApp();
+    const res = await request(app).get("/v1/campaigns/camp-abc");
+
+    expect(res.status).toBe(200);
+    expect(res.body.campaign.brandUrls).toEqual(["https://acme.com", "https://foo.io"]);
+    expect(res.body.campaign.brandIds).toEqual(["brand-1", "brand-2"]);
+  });
+
+  it("GET /v1/campaigns resolves brandUrls for each campaign in the list", async () => {
+    const app = createApp();
+    const res = await request(app).get("/v1/campaigns");
+
+    expect(res.status).toBe(200);
+    expect(res.body.campaigns).toHaveLength(2);
+    expect(res.body.campaigns[0].brandUrls).toEqual(["https://acme.com"]);
+    expect(res.body.campaigns[1].brandUrls).toEqual(["https://foo.io", "https://bar.dev"]);
+  });
+
+  it("GET /v1/campaigns/:id returns empty brandUrls when brandIds is empty", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) => {
+      if (url.match(/\/campaigns\/camp-empty$/)) {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              campaign: {
+                id: "camp-empty",
+                orgId: "org_test456",
+                name: "Empty Brands",
+                brandIds: [],
+                brandUrls: null,
+                status: "ongoing",
+                workflowSlug: "workflow-v1",
+              },
+            }),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/v1/campaigns/camp-empty");
+
+    expect(res.status).toBe(200);
+    expect(res.body.campaign.brandUrls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- GET /v1/campaigns and GET /v1/campaigns/:id now resolve `brandUrls` from `brandIds` via brand-service (`GET /brands/:id`) in parallel
- `brandUrls` is now non-nullable in the OpenAPI spec — clients always get the array
- Unblocks dashboard "Relaunch" feature for stopped campaigns that have brandIds but were missing brandUrls

## Test plan
- [x] New test: `campaign-brand-urls-resolution.test.ts` — covers single campaign, list, and empty brandIds cases
- [x] All existing tests pass (2 pre-existing failures in `openapi-response-schemas.test.ts` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)