### PR TITLE
feat: proxy GET /entities/registry from features-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7607,6 +7607,10 @@
           "brandIds"
         ]
       },
+      "EntitiesRegistryResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "StatsRegistryResponse": {
         "type": "object",
         "properties": {}
@@ -27622,6 +27626,109 @@
             }
           }
         }
+      }
+    },
+    "/v1/features/entities/registry": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Entity type registry",
+        "description": "Complete entity type registry — label, icon, pathSuffix, and description for each entity type. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Entity type registry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntitiesRegistryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/features/stats/registry": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -123,6 +123,24 @@ router.get("/features", authenticate, requireOrg, requireUser, async (req: Authe
 });
 
 /**
+ * GET /v1/features/entities/registry
+ * Entity type registry — label, icon, pathSuffix, description per type.
+ */
+router.get("/features/entities/registry", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      "/entities/registry",
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Entities registry error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get entities registry" });
+  }
+});
+
+/**
  * GET /v1/features/stats/registry
  * Public dictionary of stats keys (label + type per key)
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6318,6 +6318,20 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/features/entities/registry",
+  tags: ["Features"],
+  summary: "Entity type registry",
+  description: "Complete entity type registry — label, icon, pathSuffix, and description for each entity type. Proxied from features-service.",
+  security: authed,
+  responses: {
+    200: { description: "Entity type registry", content: { "application/json": { schema: z.object({}).passthrough().openapi("EntitiesRegistryResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/features/stats/registry",
   tags: ["Features"],
   summary: "Stats key registry",

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -139,11 +139,21 @@ describe("Features proxy routes", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(12);
+    expect(headerMatches!.length).toBe(13);
   });
 
   it("should proxy to externalServices.features", () => {
     expect(content).toContain("externalServices.features");
+  });
+
+  it("should have GET /features/entities/registry with auth + requireOrg + requireUser", () => {
+    expect(content).toContain('"/features/entities/registry"');
+    const line = content.split("\n").find((l) =>
+      l.includes('"/features/entities/registry"')
+    );
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
   it("should have GET /features/stats/registry with auth + requireOrg + requireUser", () => {
@@ -210,10 +220,12 @@ describe("Features proxy routes", () => {
   });
 
   it("should register static routes before parameterized :slug route", () => {
+    const entitiesRegistryIdx = content.indexOf('"/features/entities/registry"');
     const registryIdx = content.indexOf('"/features/stats/registry"');
     const globalStatsIdx = content.indexOf('"/features/stats"');
     const dynastyIdx = content.indexOf('"/features/dynasty"');
     const slugIdx = content.indexOf('"/features/:slug"');
+    expect(entitiesRegistryIdx).toBeLessThan(slugIdx);
     expect(registryIdx).toBeLessThan(slugIdx);
     expect(globalStatsIdx).toBeLessThan(slugIdx);
     expect(dynastyIdx).toBeLessThan(slugIdx);
@@ -296,6 +308,10 @@ describe("Features OpenAPI schemas", () => {
   it("should define FeaturePrefillRequest schema with brandIds", () => {
     expect(schemaContent).toContain("FeaturePrefillRequest");
     expect(schemaContent).toContain("brandIds");
+  });
+
+  it("should register GET /v1/features/entities/registry", () => {
+    expect(schemaContent).toContain('path: "/v1/features/entities/registry"');
   });
 
   it("should register GET /v1/features/stats/registry", () => {


### PR DESCRIPTION
## Summary
- Adds proxy route `GET /v1/features/entities/registry` → features-service `/entities/registry`
- Registers OpenAPI schema for the new endpoint
- Tests: route auth guards, buildInternalHeaders count, static-before-parameterized ordering, schema registration

## Context
Dashboard needs the entity type registry (label, icon, pathSuffix, description per type) to dynamically render campaign sidebar tabs instead of hardcoding `ENTITY_CONFIG`.

## Test plan
- [x] All 59 features-proxy tests pass
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)