### PR TITLE
feat: add brand-level GET /leads and GET /emails endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3840,6 +3840,152 @@
           "person_titles"
         ]
       },
+      "BrandLeadsResponse": {
+        "type": "object",
+        "properties": {
+          "leads": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "leadId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "email": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "apolloPersonId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "journalistId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "outletId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "firstName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "lastName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "emailStatus": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "title": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationDomain": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationLogoUrl": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationIndustry": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationSize": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "linkedinUrl": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "contacted",
+                    "served"
+                  ]
+                },
+                "contacted": {
+                  "type": "boolean"
+                },
+                "delivered": {
+                  "type": "boolean"
+                },
+                "bounced": {
+                  "type": "boolean"
+                },
+                "replied": {
+                  "type": "boolean"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "enrichmentRunId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "enrichmentRun": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/RunCostData"
+                    },
+                    {
+                      "nullable": true
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "leadId",
+                "email",
+                "namespace",
+                "apolloPersonId",
+                "journalistId",
+                "outletId",
+                "firstName",
+                "lastName",
+                "emailStatus",
+                "title",
+                "organizationName",
+                "organizationDomain",
+                "organizationLogoUrl",
+                "organizationIndustry",
+                "organizationSize",
+                "linkedinUrl",
+                "status",
+                "contacted",
+                "delivered",
+                "bounced",
+                "replied",
+                "createdAt",
+                "enrichmentRunId",
+                "enrichmentRun"
+              ]
+            }
+          }
+        },
+        "required": [
+          "leads"
+        ]
+      },
       "QualifyResponse": {
         "type": "object",
         "properties": {
@@ -6313,6 +6459,108 @@
         },
         "required": [
           "return_url"
+        ]
+      },
+      "BrandEmailsResponse": {
+        "type": "object",
+        "properties": {
+          "emails": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Generation ID"
+                },
+                "campaignId": {
+                  "type": "string"
+                },
+                "subject": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "bodyHtml": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "bodyText": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "sequence": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "leadFirstName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadLastName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadCompany": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadOrganizationDomain": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadTitle": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "leadIndustry": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "clientCompanyName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "generationRunId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "generationRun": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/RunCostData"
+                    },
+                    {
+                      "nullable": true
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "campaignId",
+                "subject",
+                "bodyHtml",
+                "bodyText",
+                "sequence",
+                "leadFirstName",
+                "leadLastName",
+                "leadCompany",
+                "leadOrganizationDomain",
+                "leadTitle",
+                "leadIndustry",
+                "clientCompanyName",
+                "generationRunId",
+                "createdAt",
+                "generationRun"
+              ]
+            }
+          }
+        },
+        "required": [
+          "emails"
         ]
       },
       "SendEmailResponse": {
@@ -16430,6 +16678,159 @@
         ]
       }
     },
+    "/v1/leads": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "List leads by brand",
+        "description": "List all leads across campaigns for a brand. Returns the same enriched shape as GET /campaigns/{id}/leads. Proxies to lead-service GET /leads with brandId filter.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID (required)"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Optional campaign ID filter"
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Max results to return"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Offset for pagination"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leads with enrichment and delivery status data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandLeadsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing brandId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/qualify": {
       "post": {
         "tags": [
@@ -22194,6 +22595,159 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/emails": {
+      "get": {
+        "tags": [
+          "Emails"
+        ],
+        "summary": "List generated emails by brand",
+        "description": "List all generated emails across campaigns for a brand. Returns the same enriched shape as GET /campaigns/{id}/emails. Proxies to content-generation-service GET /generations with brandId filter.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID (required)"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Optional campaign ID filter"
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Max results to return"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Offset for pagination"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated emails with run cost data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandEmailsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing brandId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/emails/send": {

--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -1,10 +1,89 @@
 import { Router } from "express";
-import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { SendEmailRequestSchema, DeployEmailTemplatesRequestSchema } from "../schemas.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
+import { getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 
 const router = Router();
+
+/**
+ * GET /v1/emails — list generated emails with filters (brand-level)
+ * Proxies to content-generation-service GET /generations with brandId query param.
+ * Returns the same enriched shape as GET /campaigns/:id/emails.
+ */
+router.get("/emails", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId, campaignId, limit, offset } = req.query as {
+      brandId?: string;
+      campaignId?: string;
+      limit?: string;
+      offset?: string;
+    };
+    if (!brandId) {
+      return res.status(400).json({ error: "Missing required query parameter: brandId" });
+    }
+
+    const headers = buildInternalHeaders(req);
+
+    const params = new URLSearchParams();
+    params.set("brandId", brandId);
+    if (campaignId) params.set("campaignId", campaignId);
+    if (limit) params.set("limit", limit);
+    if (offset) params.set("offset", offset);
+
+    const emailsResult = await callExternalService(
+      externalServices.emailgen,
+      `/generations?${params}`,
+      { headers }
+    ) as { generations: Array<Record<string, unknown>> };
+
+    const allEmails = emailsResult.generations || [];
+
+    if (allEmails.length === 0) {
+      return res.json({ emails: [] });
+    }
+
+    // Batch-fetch generation run costs from runs-service
+    const generationRunIds = allEmails
+      .map((e) => e.generationRunId as string | undefined)
+      .filter((id): id is string => !!id);
+
+    let runMap = new Map<string, RunWithCosts>();
+    if (generationRunIds.length > 0) {
+      try {
+        runMap = await getRunsBatch(generationRunIds, req.orgId, buildInternalHeaders(req));
+      } catch (err) {
+        console.warn("[api-service] Failed to fetch email generation run costs:", err);
+      }
+    }
+
+    // Attach run data to each email
+    const emailsWithRuns = allEmails.map((email) => {
+      const run = email.generationRunId ? runMap.get(email.generationRunId as string) : undefined;
+      return {
+        ...email,
+        generationRun: run
+          ? {
+              status: run.status,
+              startedAt: run.startedAt,
+              completedAt: run.completedAt,
+              totalCostInUsdCents: run.totalCostInUsdCents,
+              costs: run.costs,
+              serviceName: run.serviceName,
+              taskName: run.taskName,
+              descendantRuns: run.descendantRuns ?? [],
+            }
+          : null,
+      };
+    });
+
+    res.json({ emails: emailsWithRuns });
+  } catch (error: any) {
+    console.error("[api-service] Get brand emails error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get emails" });
+  }
+});
 
 /**
  * POST /v1/emails/send

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -3,8 +3,130 @@ import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { LeadSearchRequestSchema } from "../schemas.js";
+import { getRunsBatch, type RunWithCosts } from "@distribute/runs-client";
 
 const router = Router();
+
+/**
+ * GET /v1/leads — list leads with filters (brand-level)
+ * Proxies to lead-service GET /leads with brandId query param.
+ * Returns the same enriched shape as GET /campaigns/:id/leads.
+ */
+router.get("/leads", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId, campaignId, limit, offset } = req.query as {
+      brandId?: string;
+      campaignId?: string;
+      limit?: string;
+      offset?: string;
+    };
+    if (!brandId) {
+      return res.status(400).json({ error: "Missing required query parameter: brandId" });
+    }
+
+    const headers = buildInternalHeaders(req);
+
+    const params = new URLSearchParams();
+    params.set("brandId", brandId);
+    if (campaignId) params.set("campaignId", campaignId);
+    if (limit) params.set("limit", limit);
+    if (offset) params.set("offset", offset);
+
+    // Fetch leads and their delivery statuses in parallel
+    const [leadsResult, statusResult] = await Promise.all([
+      callExternalService(
+        externalServices.lead,
+        `/leads?${params}`,
+        { headers }
+      ) as Promise<{ leads: Array<Record<string, unknown>> }>,
+      callExternalService<{ statuses: Array<{ leadId: string; email: string; contacted: boolean; delivered: boolean; bounced: boolean; replied: boolean; lastDeliveredAt: string | null }> }>(
+        externalServices.lead,
+        `/leads/status?${params}`,
+        { headers }
+      ),
+    ]);
+
+    const rawLeads = leadsResult.leads || [];
+
+    // Build a lookup of email → delivery status from lead-service
+    const statusByEmail = new Map<string, { contacted: boolean; delivered: boolean; bounced: boolean; replied: boolean }>();
+    for (const s of statusResult.statuses || []) {
+      statusByEmail.set(s.email, { contacted: s.contacted, delivered: s.delivered, bounced: s.bounced, replied: s.replied });
+    }
+
+    // Flatten enrichment data into each lead to match dashboard expectations.
+    const leads = rawLeads.map((raw) => {
+      const enrichment = (raw.enrichment as Record<string, unknown>) || {};
+      const email = raw.email as string;
+      const delivery = statusByEmail.get(email);
+      return {
+        id: raw.id,
+        leadId: raw.leadId ?? null,
+        email,
+        namespace: raw.namespace ?? null,
+        apolloPersonId: raw.apolloPersonId ?? null,
+        journalistId: raw.journalistId ?? null,
+        outletId: raw.outletId ?? null,
+        firstName: enrichment.firstName ?? null,
+        lastName: enrichment.lastName ?? null,
+        emailStatus: enrichment.emailStatus ?? null,
+        title: enrichment.title ?? null,
+        organizationName: enrichment.organizationName ?? null,
+        organizationDomain: enrichment.organizationDomain ?? null,
+        organizationLogoUrl: enrichment.organizationLogoUrl ?? null,
+        organizationIndustry: enrichment.organizationIndustry ?? null,
+        organizationSize: enrichment.organizationSize ?? null,
+        linkedinUrl: enrichment.linkedinUrl ?? null,
+        status: delivery?.contacted ? "contacted" : "served",
+        contacted: delivery?.contacted ?? false,
+        delivered: delivery?.delivered ?? false,
+        bounced: delivery?.bounced ?? false,
+        replied: delivery?.replied ?? false,
+        createdAt: raw.servedAt ?? null,
+        enrichmentRunId: raw.runId ?? null,
+      };
+    });
+
+    // Batch-fetch enrichment run costs from runs-service
+    const enrichmentRunIds = leads
+      .map((l) => l.enrichmentRunId as string | undefined)
+      .filter((id): id is string => !!id);
+
+    let runMap = new Map<string, RunWithCosts>();
+    if (enrichmentRunIds.length > 0) {
+      try {
+        runMap = await getRunsBatch(enrichmentRunIds, req.orgId, buildInternalHeaders(req));
+      } catch (err) {
+        console.warn("[api-service] Failed to fetch lead enrichment run costs:", err);
+      }
+    }
+
+    // Attach run data to each lead
+    const leadsWithRuns = leads.map((lead) => {
+      const run = lead.enrichmentRunId ? runMap.get(lead.enrichmentRunId as string) : undefined;
+      return {
+        ...lead,
+        enrichmentRun: run
+          ? {
+              status: run.status,
+              startedAt: run.startedAt,
+              completedAt: run.completedAt,
+              totalCostInUsdCents: run.totalCostInUsdCents,
+              costs: run.costs,
+              serviceName: run.serviceName,
+              taskName: run.taskName,
+              descendantRuns: run.descendantRuns ?? [],
+            }
+          : null,
+      };
+    });
+
+    res.json({ leads: leadsWithRuns });
+  } catch (error: any) {
+    console.error("[api-service] Get brand leads error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get leads" });
+  }
+});
 
 /**
  * POST /v1/leads/search

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2881,6 +2881,70 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/leads",
+  tags: ["Leads"],
+  summary: "List leads by brand",
+  description:
+    "List all leads across campaigns for a brand. Returns the same enriched shape as GET /campaigns/{id}/leads. " +
+    "Proxies to lead-service GET /leads with brandId filter.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().openapi({ description: "Brand ID (required)" }),
+      campaignId: z.string().uuid().optional().openapi({ description: "Optional campaign ID filter" }),
+      limit: z.coerce.number().int().optional().openapi({ description: "Max results to return" }),
+      offset: z.coerce.number().int().optional().openapi({ description: "Offset for pagination" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Leads with enrichment and delivery status data",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              leads: z.array(
+                z.object({
+                  id: z.string(),
+                  leadId: z.string().nullable(),
+                  email: z.string(),
+                  namespace: z.string().nullable(),
+                  apolloPersonId: z.string().nullable(),
+                  journalistId: z.string().nullable(),
+                  outletId: z.string().nullable(),
+                  firstName: z.string().nullable(),
+                  lastName: z.string().nullable(),
+                  emailStatus: z.string().nullable(),
+                  title: z.string().nullable(),
+                  organizationName: z.string().nullable(),
+                  organizationDomain: z.string().nullable(),
+                  organizationLogoUrl: z.string().nullable(),
+                  organizationIndustry: z.string().nullable(),
+                  organizationSize: z.string().nullable(),
+                  linkedinUrl: z.string().nullable(),
+                  status: z.enum(["contacted", "served"]),
+                  contacted: z.boolean(),
+                  delivered: z.boolean(),
+                  bounced: z.boolean(),
+                  replied: z.boolean(),
+                  createdAt: z.string().nullable(),
+                  enrichmentRunId: z.string().nullable(),
+                  enrichmentRun: RunCostDataSchema.nullable(),
+                }),
+              ),
+            })
+            .openapi("BrandLeadsResponse"),
+        },
+      },
+    },
+    400: { description: "Missing brandId", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // QUALIFY
 // ===================================================================
@@ -5024,6 +5088,61 @@ export const DeployEmailTemplatesRequestSchema = z
     templates: z.array(TemplateItemSchema).min(1).describe("Templates to deploy"),
   })
   .openapi("DeployEmailTemplatesRequest");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/emails",
+  tags: ["Emails"],
+  summary: "List generated emails by brand",
+  description:
+    "List all generated emails across campaigns for a brand. Returns the same enriched shape as GET /campaigns/{id}/emails. " +
+    "Proxies to content-generation-service GET /generations with brandId filter.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().openapi({ description: "Brand ID (required)" }),
+      campaignId: z.string().uuid().optional().openapi({ description: "Optional campaign ID filter" }),
+      limit: z.coerce.number().int().optional().openapi({ description: "Max results to return" }),
+      offset: z.coerce.number().int().optional().openapi({ description: "Offset for pagination" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Generated emails with run cost data",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              emails: z.array(
+                z.object({
+                  id: z.string().describe("Generation ID"),
+                  campaignId: z.string(),
+                  subject: z.string().nullable(),
+                  bodyHtml: z.string().nullable(),
+                  bodyText: z.string().nullable(),
+                  sequence: z.number().nullable(),
+                  leadFirstName: z.string().nullable(),
+                  leadLastName: z.string().nullable(),
+                  leadCompany: z.string().nullable(),
+                  leadOrganizationDomain: z.string().nullable(),
+                  leadTitle: z.string().nullable(),
+                  leadIndustry: z.string().nullable(),
+                  clientCompanyName: z.string().nullable(),
+                  generationRunId: z.string().nullable(),
+                  createdAt: z.string(),
+                  generationRun: RunCostDataSchema.nullable(),
+                }),
+              ),
+            })
+            .openapi("BrandEmailsResponse"),
+        },
+      },
+    },
+    400: { description: "Missing brandId", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
 
 registry.registerPath({
   method: "post",

--- a/tests/unit/brand-emails-proxy.test.ts
+++ b/tests/unit/brand-emails-proxy.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/emails.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const openapiPath = path.join(__dirname, "../../openapi.json");
+const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+describe("Brand-level GET /emails route", () => {
+  it("should have GET /emails with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/emails"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should require brandId query param", () => {
+    expect(content).toContain('"Missing required query parameter: brandId"');
+  });
+
+  it("should forward brandId and optional campaignId to emailgen service", () => {
+    expect(content).toContain('params.set("brandId", brandId)');
+    expect(content).toContain('params.set("campaignId", campaignId)');
+  });
+
+  it("should call content-generation-service /generations endpoint", () => {
+    expect(content).toContain("externalServices.emailgen");
+    expect(content).toContain("`/generations?${params}`");
+  });
+
+  it("should batch-fetch run costs via getRunsBatch", () => {
+    expect(content).toContain("getRunsBatch");
+  });
+
+  it("should use buildInternalHeaders", () => {
+    expect(content).toContain("buildInternalHeaders(req)");
+  });
+
+  it("should return 400 when brandId is missing", () => {
+    const emailGetSection = content.slice(
+      content.indexOf('router.get("/emails"'),
+      content.indexOf('router.post("/emails/send"')
+    );
+    expect(emailGetSection).toContain("res.status(400)");
+  });
+
+  it("should return empty array when no emails found", () => {
+    expect(content).toContain('res.json({ emails: [] })');
+  });
+
+  it("should GET /emails route be registered before POST /emails/send", () => {
+    const getIdx = content.indexOf('router.get("/emails"');
+    const postIdx = content.indexOf('router.post("/emails/send"');
+    expect(getIdx).toBeLessThan(postIdx);
+  });
+});
+
+describe("Brand-level GET /emails OpenAPI schema", () => {
+  it("should register GET /v1/emails in schemas.ts", () => {
+    expect(schemaContent).toContain('path: "/v1/emails"');
+  });
+
+  it("should have brandId query param in OpenAPI spec", () => {
+    const emailsPath = openapi.paths["/v1/emails"];
+    expect(emailsPath).toBeDefined();
+    expect(emailsPath.get).toBeDefined();
+    const params = emailsPath.get.parameters || [];
+    const brandIdParam = params.find(
+      (p: { name: string; in: string }) => p.name === "brandId" && p.in === "query"
+    );
+    expect(brandIdParam).toBeDefined();
+    expect(brandIdParam.required).toBe(true);
+  });
+
+  it("should use BrandEmailsResponse schema name", () => {
+    expect(schemaContent).toContain("BrandEmailsResponse");
+  });
+
+  it("should have 200, 400, 401, 500 responses", () => {
+    const emailsOp = openapi.paths["/v1/emails"]?.get;
+    expect(emailsOp).toBeDefined();
+    expect(emailsOp.responses["200"]).toBeDefined();
+    expect(emailsOp.responses["400"]).toBeDefined();
+    expect(emailsOp.responses["401"]).toBeDefined();
+    expect(emailsOp.responses["500"]).toBeDefined();
+  });
+});
+
+describe("Discoveries already supports brandId (no changes needed)", () => {
+  it("should have brandId in discoveries OpenAPI query params", () => {
+    const discoveriesPath = openapi.paths["/v1/discoveries"];
+    expect(discoveriesPath).toBeDefined();
+    expect(discoveriesPath.get).toBeDefined();
+    const params = discoveriesPath.get.parameters || [];
+    const brandIdParam = params.find(
+      (p: { name: string; in: string }) => p.name === "brandId" && p.in === "query"
+    );
+    expect(brandIdParam).toBeDefined();
+  });
+});

--- a/tests/unit/brand-leads-proxy.test.ts
+++ b/tests/unit/brand-leads-proxy.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/leads.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const openapiPath = path.join(__dirname, "../../openapi.json");
+const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+describe("Brand-level GET /leads route", () => {
+  it("should have GET /leads with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/leads"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should require brandId query param", () => {
+    expect(content).toContain('"Missing required query parameter: brandId"');
+  });
+
+  it("should forward brandId and optional campaignId to lead-service", () => {
+    expect(content).toContain('params.set("brandId", brandId)');
+    expect(content).toContain('params.set("campaignId", campaignId)');
+  });
+
+  it("should call lead-service /leads endpoint", () => {
+    expect(content).toContain("externalServices.lead");
+    expect(content).toContain("`/leads?${params}`");
+  });
+
+  it("should call lead-service /leads/status endpoint in parallel", () => {
+    expect(content).toContain("`/leads/status?${params}`");
+  });
+
+  it("should flatten enrichment data into each lead", () => {
+    expect(content).toContain("enrichment.firstName");
+    expect(content).toContain("enrichment.lastName");
+    expect(content).toContain("enrichment.title");
+  });
+
+  it("should compute contacted status from delivery data", () => {
+    expect(content).toContain('delivery?.contacted ? "contacted" : "served"');
+  });
+
+  it("should batch-fetch run costs via getRunsBatch", () => {
+    expect(content).toContain("getRunsBatch");
+  });
+
+  it("should use buildInternalHeaders", () => {
+    expect(content).toContain("buildInternalHeaders(req)");
+  });
+
+  it("should return 400 when brandId is missing", () => {
+    const brandIdCheckSection = content.slice(
+      content.indexOf('router.get("/leads"'),
+      content.indexOf('router.post("/leads/search"')
+    );
+    expect(brandIdCheckSection).toContain("res.status(400)");
+  });
+});
+
+describe("Brand-level GET /leads OpenAPI schema", () => {
+  it("should register GET /v1/leads in schemas.ts", () => {
+    expect(schemaContent).toContain('path: "/v1/leads"');
+  });
+
+  it("should have brandId query param in OpenAPI spec", () => {
+    const leadsPath = openapi.paths["/v1/leads"];
+    expect(leadsPath).toBeDefined();
+    expect(leadsPath.get).toBeDefined();
+    const params = leadsPath.get.parameters || [];
+    const brandIdParam = params.find(
+      (p: { name: string; in: string }) => p.name === "brandId" && p.in === "query"
+    );
+    expect(brandIdParam).toBeDefined();
+    expect(brandIdParam.required).toBe(true);
+  });
+
+  it("should use BrandLeadsResponse schema name", () => {
+    expect(schemaContent).toContain("BrandLeadsResponse");
+  });
+
+  it("should have 200, 400, 401, 500 responses", () => {
+    const leadsOp = openapi.paths["/v1/leads"]?.get;
+    expect(leadsOp).toBeDefined();
+    expect(leadsOp.responses["200"]).toBeDefined();
+    expect(leadsOp.responses["400"]).toBeDefined();
+    expect(leadsOp.responses["401"]).toBeDefined();
+    expect(leadsOp.responses["500"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Added `GET /v1/leads?brandId=` — proxies to lead-service with same enrichment (delivery status, run costs) as campaign-scoped `GET /campaigns/:id/leads`
- Added `GET /v1/emails?brandId=` — proxies to content-generation-service with same run cost enrichment as `GET /campaigns/:id/emails`
- `GET /v1/discoveries?brandId=` already existed — no changes needed
- All three downstream services (lead, content-generation, articles) confirmed to support `brandId` filtering via API Registry

## Test plan
- [x] 28 new tests across `brand-leads-proxy.test.ts` and `brand-emails-proxy.test.ts`
- [x] Full test suite passes (3 pre-existing failures unrelated to this PR)
- [ ] Verify dashboard entity tabs load at feature level with real brand data

🤖 Generated with [Claude Code](https://claude.com/claude-code)