### PR TITLE
feat: add GET /v1/journalists/list proxy endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1989,6 +1989,527 @@
           "campaignJournalists"
         ]
       },
+      "JournalistListResponse": {
+        "type": "object",
+        "properties": {
+          "journalists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "journalistId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "campaignId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "outletId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "orgId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "brandIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "featureSlug": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "workflowSlug": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "relevanceScore": {
+                  "type": "string"
+                },
+                "whyRelevant": {
+                  "type": "string"
+                },
+                "whyNotRelevant": {
+                  "type": "string"
+                },
+                "articleUrls": {
+                  "type": "array",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "buffered",
+                    "claimed",
+                    "served",
+                    "contacted",
+                    "skipped"
+                  ]
+                },
+                "email": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "runId": {
+                  "type": "string",
+                  "nullable": true,
+                  "format": "uuid"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "journalistName": {
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "lastName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "entityType": {
+                  "type": "string",
+                  "enum": [
+                    "individual",
+                    "organization"
+                  ]
+                },
+                "emailStatus": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "broadcast": {
+                      "type": "object",
+                      "properties": {
+                        "campaign": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "lead": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "replied": {
+                                  "type": "boolean"
+                                },
+                                "replyClassification": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "enum": [
+                                    "positive",
+                                    "negative",
+                                    "neutral"
+                                  ]
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "replied",
+                                "replyClassification",
+                                "lastDeliveredAt"
+                              ]
+                            },
+                            "email": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "bounced": {
+                                  "type": "boolean"
+                                },
+                                "unsubscribed": {
+                                  "type": "boolean"
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "bounced",
+                                "unsubscribed",
+                                "lastDeliveredAt"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lead",
+                            "email"
+                          ]
+                        },
+                        "brand": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "lead": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "replied": {
+                                  "type": "boolean"
+                                },
+                                "replyClassification": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "enum": [
+                                    "positive",
+                                    "negative",
+                                    "neutral"
+                                  ]
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "replied",
+                                "replyClassification",
+                                "lastDeliveredAt"
+                              ]
+                            },
+                            "email": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "bounced": {
+                                  "type": "boolean"
+                                },
+                                "unsubscribed": {
+                                  "type": "boolean"
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "bounced",
+                                "unsubscribed",
+                                "lastDeliveredAt"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lead",
+                            "email"
+                          ]
+                        },
+                        "global": {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "type": "object",
+                              "properties": {
+                                "bounced": {
+                                  "type": "boolean"
+                                },
+                                "unsubscribed": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "bounced",
+                                "unsubscribed"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "email"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "campaign",
+                        "brand",
+                        "global"
+                      ]
+                    },
+                    "transactional": {
+                      "type": "object",
+                      "properties": {
+                        "campaign": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "lead": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "replied": {
+                                  "type": "boolean"
+                                },
+                                "replyClassification": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "enum": [
+                                    "positive",
+                                    "negative",
+                                    "neutral"
+                                  ]
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "replied",
+                                "replyClassification",
+                                "lastDeliveredAt"
+                              ]
+                            },
+                            "email": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "bounced": {
+                                  "type": "boolean"
+                                },
+                                "unsubscribed": {
+                                  "type": "boolean"
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "bounced",
+                                "unsubscribed",
+                                "lastDeliveredAt"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lead",
+                            "email"
+                          ]
+                        },
+                        "brand": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "lead": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "replied": {
+                                  "type": "boolean"
+                                },
+                                "replyClassification": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "enum": [
+                                    "positive",
+                                    "negative",
+                                    "neutral"
+                                  ]
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "replied",
+                                "replyClassification",
+                                "lastDeliveredAt"
+                              ]
+                            },
+                            "email": {
+                              "type": "object",
+                              "properties": {
+                                "contacted": {
+                                  "type": "boolean"
+                                },
+                                "delivered": {
+                                  "type": "boolean"
+                                },
+                                "bounced": {
+                                  "type": "boolean"
+                                },
+                                "unsubscribed": {
+                                  "type": "boolean"
+                                },
+                                "lastDeliveredAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "contacted",
+                                "delivered",
+                                "bounced",
+                                "unsubscribed",
+                                "lastDeliveredAt"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "lead",
+                            "email"
+                          ]
+                        },
+                        "global": {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "type": "object",
+                              "properties": {
+                                "bounced": {
+                                  "type": "boolean"
+                                },
+                                "unsubscribed": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "bounced",
+                                "unsubscribed"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "email"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "campaign",
+                        "brand",
+                        "global"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "broadcast",
+                    "transactional"
+                  ],
+                  "description": "Email delivery statuses from email-gateway. Null if journalist has no email."
+                },
+                "cost": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "totalCostInUsdCents": {
+                      "type": "number"
+                    },
+                    "actualCostInUsdCents": {
+                      "type": "number"
+                    },
+                    "provisionedCostInUsdCents": {
+                      "type": "number"
+                    },
+                    "runCount": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "totalCostInUsdCents",
+                    "actualCostInUsdCents",
+                    "provisionedCostInUsdCents",
+                    "runCount"
+                  ],
+                  "description": "Per-journalist cost from runs-service. Null if no runs."
+                }
+              },
+              "required": [
+                "id",
+                "journalistId",
+                "campaignId",
+                "outletId",
+                "orgId",
+                "brandIds",
+                "featureSlug",
+                "workflowSlug",
+                "relevanceScore",
+                "whyRelevant",
+                "whyNotRelevant",
+                "articleUrls",
+                "status",
+                "email",
+                "runId",
+                "createdAt",
+                "journalistName",
+                "firstName",
+                "lastName",
+                "entityType",
+                "emailStatus",
+                "cost"
+              ]
+            }
+          }
+        },
+        "required": [
+          "journalists"
+        ]
+      },
       "DiscoverJournalistsResponse": {
         "type": "object",
         "properties": {
@@ -12453,6 +12974,172 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListJournalistsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing brandId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/journalists/list": {
+      "get": {
+        "tags": [
+          "Journalists"
+        ],
+        "summary": "List journalists with email statuses and costs",
+        "description": "Returns all journalists for a brand, each enriched with per-journalist email delivery statuses (broadcast + transactional, at campaign/brand/global scope) and cost breakdown from runs-service. Replaces the need to aggregate contacted status from lead-service — delivery details come directly. Proxies to journalists-service GET /journalists/list.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID (required)"
+            },
+            "required": true,
+            "description": "Brand ID (required)",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Optionally narrow to a single campaign"
+            },
+            "required": false,
+            "description": "Optionally narrow to a single campaign",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign ID — optional for stats endpoints"
+            },
+            "required": false,
+            "description": "Campaign ID — optional for stats endpoints",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID (may be comma-separated for multi-brand) — optional for stats endpoints"
+            },
+            "required": false,
+            "description": "Brand ID (may be comma-separated for multi-brand) — optional for stats endpoints",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug — optional for stats endpoints"
+            },
+            "required": false,
+            "description": "Feature slug — optional for stats endpoints",
+            "name": "x-feature-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug — optional for stats endpoints"
+            },
+            "required": false,
+            "description": "Workflow slug — optional for stats endpoints",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Enriched journalist list with email statuses and costs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JournalistListResponse"
                 }
               }
             }

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -43,6 +43,29 @@ router.get("/journalists", authenticate, requireOrg, requireUser, async (req: Au
   }
 });
 
+// ── GET /v1/journalists/list — enriched journalist list with email statuses + costs ──
+router.get("/journalists/list", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId, campaignId } = req.query as { brandId?: string; campaignId?: string };
+    if (!brandId) {
+      return res.status(400).json({ error: "Missing required query parameter: brandId" });
+    }
+
+    const params = new URLSearchParams();
+    params.set("brandId", brandId);
+    if (campaignId) params.set("campaignId", campaignId);
+
+    const result = await callExternalService(
+      externalServices.journalist,
+      `/journalists/list?${params}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list journalists" });
+  }
+});
+
 // ── POST /v1/journalists/discover — discover journalists for brand+outlet ───
 router.post("/journalists/discover", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1496,6 +1496,111 @@ registry.registerPath({
   },
 });
 
+// Shared sub-schemas for journalist email delivery statuses
+const JournalistLeadDeliverySchema = z.object({
+  contacted: z.boolean(),
+  delivered: z.boolean(),
+  replied: z.boolean(),
+  replyClassification: z.enum(["positive", "negative", "neutral"]).nullable(),
+  lastDeliveredAt: z.string().nullable(),
+});
+
+const JournalistEmailDeliverySchema = z.object({
+  contacted: z.boolean(),
+  delivered: z.boolean(),
+  bounced: z.boolean(),
+  unsubscribed: z.boolean(),
+  lastDeliveredAt: z.string().nullable(),
+});
+
+const JournalistScopeDeliverySchema = z.object({
+  lead: JournalistLeadDeliverySchema,
+  email: JournalistEmailDeliverySchema,
+}).nullable();
+
+const JournalistGlobalDeliverySchema = z.object({
+  email: z.object({ bounced: z.boolean(), unsubscribed: z.boolean() }),
+});
+
+const JournalistChannelStatusSchema = z.object({
+  campaign: JournalistScopeDeliverySchema,
+  brand: JournalistScopeDeliverySchema,
+  global: JournalistGlobalDeliverySchema,
+});
+
+const JournalistEmailStatusSchema = z.object({
+  broadcast: JournalistChannelStatusSchema,
+  transactional: JournalistChannelStatusSchema,
+}).nullable().describe("Email delivery statuses from email-gateway. Null if journalist has no email.");
+
+const JournalistCostSchema = z.object({
+  totalCostInUsdCents: z.number(),
+  actualCostInUsdCents: z.number(),
+  provisionedCostInUsdCents: z.number(),
+  runCount: z.number(),
+}).nullable().describe("Per-journalist cost from runs-service. Null if no runs.");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/journalists/list",
+  tags: ["Journalists"],
+  summary: "List journalists with email statuses and costs",
+  description:
+    "Returns all journalists for a brand, each enriched with per-journalist email delivery statuses " +
+    "(broadcast + transactional, at campaign/brand/global scope) and cost breakdown from runs-service. " +
+    "Replaces the need to aggregate contacted status from lead-service — delivery details come directly. " +
+    "Proxies to journalists-service GET /journalists/list.",
+  security: authed,
+  request: {
+    headers: journalistsStatsOptionalHeaders,
+    query: z.object({
+      brandId: z.string().uuid().describe("Brand ID (required)"),
+      campaignId: z.string().uuid().optional().describe("Optionally narrow to a single campaign"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Enriched journalist list with email statuses and costs",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              journalists: z.array(
+                z.object({
+                  id: z.string().uuid(),
+                  journalistId: z.string().uuid(),
+                  campaignId: z.string().uuid(),
+                  outletId: z.string().uuid(),
+                  orgId: z.string().uuid(),
+                  brandIds: z.array(z.string().uuid()),
+                  featureSlug: z.string().nullable(),
+                  workflowSlug: z.string().nullable(),
+                  relevanceScore: z.string(),
+                  whyRelevant: z.string(),
+                  whyNotRelevant: z.string(),
+                  articleUrls: z.array(z.string()).nullable(),
+                  status: z.enum(["buffered", "claimed", "served", "contacted", "skipped"]),
+                  email: z.string().nullable(),
+                  runId: z.string().uuid().nullable(),
+                  createdAt: z.string(),
+                  journalistName: z.string(),
+                  firstName: z.string().nullable(),
+                  lastName: z.string().nullable(),
+                  entityType: z.enum(["individual", "organization"]),
+                  emailStatus: JournalistEmailStatusSchema,
+                  cost: JournalistCostSchema,
+                }),
+              ),
+            })
+            .openapi("JournalistListResponse"),
+        },
+      },
+    },
+    400: { description: "Missing brandId", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
 registry.registerPath({
   method: "post",
   path: "/v1/journalists/discover",

--- a/tests/unit/journalists-list-proxy.test.ts
+++ b/tests/unit/journalists-list-proxy.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/journalists.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const openapiPath = path.join(__dirname, "../../openapi.json");
+const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+describe("GET /journalists/list route", () => {
+  it("should have GET /journalists/list with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/journalists/list"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should require brandId query param", () => {
+    const listSection = content.slice(
+      content.indexOf('"/journalists/list"'),
+      content.indexOf("// ── POST /v1/journalists/discover")
+    );
+    expect(listSection).toContain('"Missing required query parameter: brandId"');
+  });
+
+  it("should forward brandId and optional campaignId", () => {
+    const listSection = content.slice(
+      content.indexOf('"/journalists/list"'),
+      content.indexOf("// ── POST /v1/journalists/discover")
+    );
+    expect(listSection).toContain('params.set("brandId", brandId)');
+    expect(listSection).toContain('params.set("campaignId", campaignId)');
+  });
+
+  it("should proxy to journalists-service /journalists/list", () => {
+    expect(content).toContain("`/journalists/list?${params}`");
+  });
+
+  it("should use buildInternalHeaders", () => {
+    const listSection = content.slice(
+      content.indexOf('"/journalists/list"'),
+      content.indexOf("// ── POST /v1/journalists/discover")
+    );
+    expect(listSection).toContain("buildInternalHeaders(req)");
+  });
+
+  it("should be registered before /journalists/discover to avoid route conflict", () => {
+    const listIdx = content.indexOf('"/journalists/list"');
+    const discoverIdx = content.indexOf('"/journalists/discover"');
+    expect(listIdx).toBeLessThan(discoverIdx);
+  });
+
+  it("should be registered before /journalists/stats to avoid route conflict", () => {
+    const listIdx = content.indexOf('"/journalists/list"');
+    const statsIdx = content.indexOf('"/journalists/stats"');
+    expect(listIdx).toBeLessThan(statsIdx);
+  });
+});
+
+describe("GET /journalists/list OpenAPI schema", () => {
+  it("should register GET /v1/journalists/list in schemas.ts", () => {
+    expect(schemaContent).toContain('path: "/v1/journalists/list"');
+  });
+
+  it("should use JournalistListResponse schema name", () => {
+    expect(schemaContent).toContain("JournalistListResponse");
+  });
+
+  it("should define JournalistEmailStatusSchema", () => {
+    expect(schemaContent).toContain("JournalistEmailStatusSchema");
+  });
+
+  it("should define JournalistCostSchema", () => {
+    expect(schemaContent).toContain("JournalistCostSchema");
+  });
+
+  it("should have brandId in OpenAPI spec as required query param", () => {
+    const listPath = openapi.paths["/v1/journalists/list"];
+    expect(listPath).toBeDefined();
+    expect(listPath.get).toBeDefined();
+    const params = listPath.get.parameters || [];
+    const brandIdParam = params.find(
+      (p: { name: string; in: string }) => p.name === "brandId" && p.in === "query"
+    );
+    expect(brandIdParam).toBeDefined();
+    expect(brandIdParam.required).toBe(true);
+  });
+
+  it("should have optional campaignId in OpenAPI spec", () => {
+    const listPath = openapi.paths["/v1/journalists/list"];
+    const params = listPath.get.parameters || [];
+    const campaignIdParam = params.find(
+      (p: { name: string; in: string }) => p.name === "campaignId" && p.in === "query"
+    );
+    expect(campaignIdParam).toBeDefined();
+    expect(campaignIdParam.required).toBeFalsy();
+  });
+
+  it("should have 200, 400, 401 responses", () => {
+    const op = openapi.paths["/v1/journalists/list"]?.get;
+    expect(op).toBeDefined();
+    expect(op.responses["200"]).toBeDefined();
+    expect(op.responses["400"]).toBeDefined();
+    expect(op.responses["401"]).toBeDefined();
+  });
+
+  it("should include emailStatus and cost in response schema", () => {
+    const ref =
+      openapi.paths["/v1/journalists/list"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema?.$ref;
+    expect(ref).toBe("#/components/schemas/JournalistListResponse");
+    const schema = openapi.components?.schemas?.JournalistListResponse;
+    expect(schema).toBeDefined();
+    const journalistProps = schema.properties?.journalists?.items?.properties;
+    expect(journalistProps).toBeDefined();
+    expect(journalistProps.emailStatus).toBeDefined();
+    expect(journalistProps.cost).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Added `GET /v1/journalists/list?brandId=&campaignId=` — proxies to journalists-service's new enriched endpoint
- Returns per-journalist email delivery statuses (broadcast + transactional, at campaign/brand/global scope) and cost breakdowns
- Replaces the need to aggregate contacted status from lead-service or call `/journalists/stats/costs` separately
- Full OpenAPI schema with `JournalistListResponse`, `JournalistEmailStatusSchema`, `JournalistCostSchema`

## Test plan
- [x] 15 new tests in `journalists-list-proxy.test.ts`
- [x] Route registration, auth middleware, param forwarding, OpenAPI schema all verified
- [ ] Manual verification with real brand data

🤖 Generated with [Claude Code](https://claude.com/claude-code)