### PR TITLE
feat: update GET /outlets proxy for new deduplicated response

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1596,6 +1596,85 @@
           "stopCampaign"
         ]
       },
+      "OutletCampaignEntry": {
+        "type": "object",
+        "properties": {
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "relevanceScore": {
+            "type": "number",
+            "nullable": true
+          }
+        },
+        "required": [
+          "campaignId",
+          "status",
+          "relevanceScore"
+        ]
+      },
+      "OutletWithCampaigns": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "outletName": {
+            "type": "string"
+          },
+          "outletUrl": {
+            "type": "string"
+          },
+          "latestStatus": {
+            "type": "string",
+            "description": "Most recent status across all campaigns"
+          },
+          "latestRelevanceScore": {
+            "type": "number",
+            "nullable": true,
+            "description": "Most recent relevance score across all campaigns"
+          },
+          "campaigns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutletCampaignEntry"
+            },
+            "description": "Per-campaign data for this outlet"
+          }
+        },
+        "required": [
+          "id",
+          "outletName",
+          "outletUrl",
+          "latestStatus",
+          "latestRelevanceScore",
+          "campaigns"
+        ]
+      },
+      "ListOutletsResponse": {
+        "type": "object",
+        "properties": {
+          "outlets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutletWithCampaigns"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total number of deduplicated outlets matching the filters"
+          }
+        },
+        "required": [
+          "outlets",
+          "total"
+        ]
+      },
       "CreateOutletRequest": {
         "type": "object",
         "properties": {
@@ -11069,7 +11148,7 @@
           "Outlets"
         ],
         "summary": "List outlets with filters",
-        "description": "List outlets with optional filters. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "description": "List deduplicated outlets with optional filters. Each outlet appears once with a nested campaigns[] array containing per-campaign data (status, relevance score, etc.). Top-level latestStatus and latestRelevanceScore fields provide a quick summary. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -11115,6 +11194,36 @@
             },
             "required": false,
             "name": "runId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact feature slug"
+            },
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by multiple feature slugs (comma-separated)"
+            },
+            "required": false,
+            "description": "Filter by multiple feature slugs (comma-separated)",
+            "name": "featureSlugs",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -11236,7 +11345,14 @@
         ],
         "responses": {
           "200": {
-            "description": "List of outlets"
+            "description": "Deduplicated list of outlets, each with a nested campaigns[] array",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOutletsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -9,12 +9,9 @@ const router = Router();
 router.get("/outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
-    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
-    if (req.query.status) params.set("status", req.query.status as string);
-    if (req.query.runId) params.set("runId", req.query.runId as string);
-    if (req.query.limit) params.set("limit", req.query.limit as string);
-    if (req.query.offset) params.set("offset", req.query.offset as string);
+    for (const key of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlug", "featureSlugs", "featureDynastySlug"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
     const qs = params.toString() ? `?${params.toString()}` : "";
 
     const result = await callExternalService(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1066,7 +1066,9 @@ registry.registerPath({
   path: "/v1/outlets",
   tags: ["Outlets"],
   summary: "List outlets with filters",
-  description: "List outlets with optional filters. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+  description: "List deduplicated outlets with optional filters. Each outlet appears once with a nested campaigns[] array containing per-campaign data (status, relevance score, etc.). " +
+    "Top-level latestStatus and latestRelevanceScore fields provide a quick summary. " +
+    "All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
     headers: outletsRequiredHeaders,
@@ -1075,12 +1077,42 @@ registry.registerPath({
       brandId: z.string().uuid().optional(),
       status: z.enum(["open", "ended", "denied"]).optional(),
       runId: z.string().uuid().optional().openapi({ description: "Filter outlets by discovery run ID" }),
+      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
+      featureSlugs: z.string().optional().describe("Filter by multiple feature slugs (comma-separated)"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
       limit: z.coerce.number().int().optional().default(100),
       offset: z.coerce.number().int().optional().default(0),
     }),
   },
   responses: {
-    200: { description: "List of outlets" },
+    200: {
+      description: "Deduplicated list of outlets, each with a nested campaigns[] array",
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              outlets: z.array(
+                z.object({
+                  id: z.string().uuid(),
+                  outletName: z.string(),
+                  outletUrl: z.string(),
+                  latestStatus: z.string().describe("Most recent status across all campaigns"),
+                  latestRelevanceScore: z.number().nullable().describe("Most recent relevance score across all campaigns"),
+                  campaigns: z.array(
+                    z.object({
+                      campaignId: z.string().uuid(),
+                      status: z.string(),
+                      relevanceScore: z.number().nullable(),
+                    }).openapi("OutletCampaignEntry"),
+                  ).describe("Per-campaign data for this outlet"),
+                }).openapi("OutletWithCampaigns"),
+              ),
+              total: z.number().int().describe("Total number of deduplicated outlets matching the filters"),
+            })
+            .openapi("ListOutletsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
   },
 });

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -26,7 +26,7 @@ describe("Outlets proxy routes", () => {
   });
 
   it("should forward query params on GET /outlets", () => {
-    for (const param of ["campaignId", "brandId", "status", "runId", "limit", "offset"]) {
+    for (const param of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlug", "featureSlugs", "featureDynastySlug"]) {
       expect(content).toContain(`"${param}"`);
     }
   });
@@ -215,9 +215,27 @@ describe("Outlets OpenAPI schemas", () => {
   it("should include runId filter on GET /v1/outlets query params", () => {
     const getOutletsSection = schemaContent.slice(
       schemaContent.indexOf('path: "/v1/outlets"'),
-      schemaContent.indexOf('path: "/v1/outlets"') + 600
+      schemaContent.indexOf('path: "/v1/outlets"') + 1200
     );
     expect(getOutletsSection).toContain("runId:");
+  });
+
+  it("should include featureSlug, featureSlugs, and featureDynastySlug filters on GET /v1/outlets", () => {
+    const getOutletsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/outlets"'),
+      schemaContent.indexOf('path: "/v1/outlets"') + 1200
+    );
+    expect(getOutletsSection).toContain("featureSlug:");
+    expect(getOutletsSection).toContain("featureSlugs:");
+    expect(getOutletsSection).toContain("featureDynastySlug:");
+  });
+
+  it("should document deduplicated response with campaigns[] array on GET /v1/outlets", () => {
+    expect(schemaContent).toContain("ListOutletsResponse");
+    expect(schemaContent).toContain("OutletWithCampaigns");
+    expect(schemaContent).toContain("OutletCampaignEntry");
+    expect(schemaContent).toContain("latestStatus");
+    expect(schemaContent).toContain("latestRelevanceScore");
   });
 
   it("should register GET /v1/outlets/{id}", () => {


### PR DESCRIPTION
## Summary
- Forward 3 new query params (`featureSlug`, `featureSlugs`, `featureDynastySlug`) on `GET /v1/outlets` proxy
- Update OpenAPI docs to reflect outlets-service PR #53: deduplicated response with nested `campaigns[]` array, `latestStatus`, and `latestRelevanceScore` fields
- Add test coverage for new filters and response schema

## Context
outlets-service [PR #53](https://github.com/shamanic-technologies/outlets-service/pull/53) changed `GET /outlets` to return one row per outlet (instead of one per campaign_outlet), with campaign data nested in a `campaigns[]` array.

## Test plan
- [x] All 52 outlets proxy tests pass
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)