### PR TITLE
fix: align GET /outlets proxy with upstream breaking changes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1603,18 +1603,59 @@
             "type": "string",
             "format": "uuid"
           },
-          "status": {
+          "featureSlug": {
+            "type": "string"
+          },
+          "brandIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "whyRelevant": {
+            "type": "string"
+          },
+          "whyNotRelevant": {
             "type": "string"
           },
           "relevanceScore": {
-            "type": "number",
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "ended",
+              "denied",
+              "served",
+              "skipped"
+            ]
+          },
+          "overallRelevance": {
+            "type": "string",
             "nullable": true
+          },
+          "relevanceRationale": {
+            "type": "string",
+            "nullable": true
+          },
+          "runId": {
+            "type": "string",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "required": [
           "campaignId",
+          "featureSlug",
+          "brandIds",
+          "relevanceScore",
           "status",
-          "relevanceScore"
+          "updatedAt"
         ]
       },
       "OutletWithCampaigns": {
@@ -1630,14 +1671,25 @@
           "outletUrl": {
             "type": "string"
           },
+          "outletDomain": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
           "latestStatus": {
             "type": "string",
-            "description": "Most recent status across all campaigns"
+            "enum": [
+              "open",
+              "ended",
+              "denied",
+              "served",
+              "skipped"
+            ]
           },
           "latestRelevanceScore": {
-            "type": "number",
-            "nullable": true,
-            "description": "Most recent relevance score across all campaigns"
+            "type": "number"
           },
           "campaigns": {
             "type": "array",
@@ -1651,6 +1703,8 @@
           "id",
           "outletName",
           "outletUrl",
+          "outletDomain",
+          "createdAt",
           "latestStatus",
           "latestRelevanceScore",
           "campaigns"
@@ -1667,7 +1721,7 @@
           },
           "total": {
             "type": "integer",
-            "description": "Total number of deduplicated outlets matching the filters"
+            "description": "Total number of distinct outlets matching filters"
           }
         },
         "required": [
@@ -11147,8 +11201,8 @@
         "tags": [
           "Outlets"
         ],
-        "summary": "List outlets with filters",
-        "description": "List deduplicated outlets with optional filters. Each outlet appears once with a nested campaigns[] array containing per-campaign data (status, relevance score, etc.). Top-level latestStatus and latestRelevanceScore fields provide a quick summary. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "summary": "List outlets with filters (deduplicated)",
+        "description": "Returns outlets deduplicated by outlet_id with nested campaign data. Each outlet appears once with a campaigns[] array containing per-campaign details. Filter by campaignId, brandId, status, featureSlugs (comma-separated), or featureDynastySlug. Supports pagination on distinct outlets. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -11179,7 +11233,9 @@
               "enum": [
                 "open",
                 "ended",
-                "denied"
+                "denied",
+                "served",
+                "skipped"
               ]
             },
             "required": false,
@@ -11189,8 +11245,7 @@
           {
             "schema": {
               "type": "string",
-              "format": "uuid",
-              "description": "Filter outlets by discovery run ID"
+              "description": "Filter by run ID (from discover endpoint)"
             },
             "required": false,
             "name": "runId",
@@ -11199,30 +11254,20 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by exact feature slug"
+              "description": "Filter by feature slugs (comma-separated). Use a single slug or multiple."
             },
             "required": false,
-            "description": "Filter by exact feature slug",
-            "name": "featureSlug",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by multiple feature slugs (comma-separated)"
-            },
-            "required": false,
-            "description": "Filter by multiple feature slugs (comma-separated)",
+            "description": "Filter by feature slugs (comma-separated). Use a single slug or multiple.",
             "name": "featureSlugs",
             "in": "query"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs."
             },
             "required": false,
-            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs.",
             "name": "featureDynastySlug",
             "in": "query"
           },
@@ -11345,7 +11390,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Deduplicated list of outlets, each with a nested campaigns[] array",
+            "description": "List of deduplicated outlets with nested campaigns",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -9,7 +9,7 @@ const router = Router();
 router.get("/outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlug", "featureSlugs", "featureDynastySlug"]) {
+    for (const key of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlugs", "featureDynastySlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1065,9 +1065,9 @@ registry.registerPath({
   method: "get",
   path: "/v1/outlets",
   tags: ["Outlets"],
-  summary: "List outlets with filters",
-  description: "List deduplicated outlets with optional filters. Each outlet appears once with a nested campaigns[] array containing per-campaign data (status, relevance score, etc.). " +
-    "Top-level latestStatus and latestRelevanceScore fields provide a quick summary. " +
+  summary: "List outlets with filters (deduplicated)",
+  description: "Returns outlets deduplicated by outlet_id with nested campaign data. Each outlet appears once with a campaigns[] array containing per-campaign details. " +
+    "Filter by campaignId, brandId, status, featureSlugs (comma-separated), or featureDynastySlug. Supports pagination on distinct outlets. " +
     "All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
@@ -1075,18 +1075,17 @@ registry.registerPath({
     query: z.object({
       campaignId: z.string().uuid().optional(),
       brandId: z.string().uuid().optional(),
-      status: z.enum(["open", "ended", "denied"]).optional(),
-      runId: z.string().uuid().optional().openapi({ description: "Filter outlets by discovery run ID" }),
-      featureSlug: z.string().optional().describe("Filter by exact feature slug"),
-      featureSlugs: z.string().optional().describe("Filter by multiple feature slugs (comma-separated)"),
-      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
+      status: z.enum(["open", "ended", "denied", "served", "skipped"]).optional(),
+      runId: z.string().optional().openapi({ description: "Filter by run ID (from discover endpoint)" }),
+      featureSlugs: z.string().optional().describe("Filter by feature slugs (comma-separated). Use a single slug or multiple."),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs."),
       limit: z.coerce.number().int().optional().default(100),
       offset: z.coerce.number().int().optional().default(0),
     }),
   },
   responses: {
     200: {
-      description: "Deduplicated list of outlets, each with a nested campaigns[] array",
+      description: "List of deduplicated outlets with nested campaigns",
       content: {
         "application/json": {
           schema: z
@@ -1096,18 +1095,28 @@ registry.registerPath({
                   id: z.string().uuid(),
                   outletName: z.string(),
                   outletUrl: z.string(),
-                  latestStatus: z.string().describe("Most recent status across all campaigns"),
-                  latestRelevanceScore: z.number().nullable().describe("Most recent relevance score across all campaigns"),
+                  outletDomain: z.string(),
+                  createdAt: z.string().datetime(),
+                  latestStatus: z.enum(["open", "ended", "denied", "served", "skipped"]),
+                  latestRelevanceScore: z.number(),
                   campaigns: z.array(
                     z.object({
                       campaignId: z.string().uuid(),
-                      status: z.string(),
-                      relevanceScore: z.number().nullable(),
+                      featureSlug: z.string(),
+                      brandIds: z.array(z.string().uuid()),
+                      whyRelevant: z.string().optional(),
+                      whyNotRelevant: z.string().optional(),
+                      relevanceScore: z.number(),
+                      status: z.enum(["open", "ended", "denied", "served", "skipped"]),
+                      overallRelevance: z.string().nullable().optional(),
+                      relevanceRationale: z.string().nullable().optional(),
+                      runId: z.string().nullable().optional(),
+                      updatedAt: z.string().datetime(),
                     }).openapi("OutletCampaignEntry"),
                   ).describe("Per-campaign data for this outlet"),
                 }).openapi("OutletWithCampaigns"),
               ),
-              total: z.number().int().describe("Total number of deduplicated outlets matching the filters"),
+              total: z.number().int().describe("Total number of distinct outlets matching filters"),
             })
             .openapi("ListOutletsResponse"),
         },

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -26,9 +26,20 @@ describe("Outlets proxy routes", () => {
   });
 
   it("should forward query params on GET /outlets", () => {
-    for (const param of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlug", "featureSlugs", "featureDynastySlug"]) {
+    for (const param of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlugs", "featureDynastySlug"]) {
       expect(content).toContain(`"${param}"`);
     }
+  });
+
+  it("should NOT forward removed featureSlug (singular) on GET /outlets", () => {
+    // featureSlug was removed in outlets-service PR #54, replaced by featureSlugs
+    const getOutletsSection = content.slice(
+      content.indexOf('"/outlets"'),
+      content.indexOf('"/outlets/stats"')
+    );
+    // featureSlugs is present, but featureSlug as a standalone key should not be
+    const keys = getOutletsSection.match(/"(\w+)"/g)?.map((k) => k.replace(/"/g, "")) || [];
+    expect(keys).not.toContain("featureSlug");
   });
 
   it("should have GET /outlets/stats with auth", () => {
@@ -220,14 +231,19 @@ describe("Outlets OpenAPI schemas", () => {
     expect(getOutletsSection).toContain("runId:");
   });
 
-  it("should include featureSlug, featureSlugs, and featureDynastySlug filters on GET /v1/outlets", () => {
+  it("should include featureSlugs and featureDynastySlug filters on GET /v1/outlets (no singular featureSlug)", () => {
     const getOutletsSection = schemaContent.slice(
       schemaContent.indexOf('path: "/v1/outlets"'),
-      schemaContent.indexOf('path: "/v1/outlets"') + 1200
+      schemaContent.indexOf('path: "/v1/outlets"') + 1500
     );
-    expect(getOutletsSection).toContain("featureSlug:");
     expect(getOutletsSection).toContain("featureSlugs:");
     expect(getOutletsSection).toContain("featureDynastySlug:");
+    // featureSlug (singular) was removed in outlets-service PR #54
+    const queryBlock = getOutletsSection.slice(
+      getOutletsSection.indexOf("query: z.object"),
+      getOutletsSection.indexOf("responses:")
+    );
+    expect(queryBlock).not.toMatch(/\bfeatureSlug\b(?!s)/);
   });
 
   it("should document deduplicated response with campaigns[] array on GET /v1/outlets", () => {
@@ -236,6 +252,24 @@ describe("Outlets OpenAPI schemas", () => {
     expect(schemaContent).toContain("OutletCampaignEntry");
     expect(schemaContent).toContain("latestStatus");
     expect(schemaContent).toContain("latestRelevanceScore");
+    expect(schemaContent).toContain("outletDomain");
+  });
+
+  it("should include full campaign entry fields in OutletCampaignEntry", () => {
+    const idx = schemaContent.indexOf("OutletCampaignEntry");
+    const entrySection = schemaContent.slice(Math.max(0, idx - 800), idx + 100);
+    for (const field of ["campaignId", "featureSlug", "brandIds", "whyRelevant", "relevanceScore", "updatedAt"]) {
+      expect(entrySection).toContain(field);
+    }
+  });
+
+  it("should include served and skipped in status enum on GET /v1/outlets", () => {
+    const getOutletsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/outlets"'),
+      schemaContent.indexOf('path: "/v1/outlets"') + 1500
+    );
+    expect(getOutletsSection).toContain('"served"');
+    expect(getOutletsSection).toContain('"skipped"');
   });
 
   it("should register GET /v1/outlets/{id}", () => {


### PR DESCRIPTION
## Summary
- Remove `featureSlug` (singular) query param — replaced by `featureSlugs` (comma-separated) per outlets-service PR #54
- Add `served` and `skipped` to status enum
- Enrich OpenAPI response schema to match actual upstream: `outletDomain`, `createdAt`, and full `OutletCampaignEntry` fields (`featureSlug`, `brandIds`, `whyRelevant`, `whyNotRelevant`, `overallRelevance`, `relevanceRationale`, `runId`, `updatedAt`)
- Regenerate `openapi.json`

## Context
Follows up on PR #292. outlets-service PRs #53 + #54 introduced breaking changes to `GET /outlets`: deduplicated response format, new status values, and `featureSlug` → `featureSlugs` rename.

## Test plan
- [x] 55 outlets proxy tests pass (including new tests for removed param, status enum, campaign entry fields)
- [x] openapi.json regenerated from schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)