### PR TITLE
feat: forward featureDynastySlug on journalist endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -13054,6 +13054,16 @@
           {
             "schema": {
               "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs via features-service)"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs via features-service)",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "format": "uuid",
               "description": "Campaign ID — required by journalists-service"
             },
@@ -13225,6 +13235,16 @@
             "required": false,
             "description": "Comma-separated feature slugs to filter campaign rows",
             "name": "featureSlugs",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs."
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs.",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {

--- a/src/routes/journalists.ts
+++ b/src/routes/journalists.ts
@@ -17,6 +17,7 @@ router.get("/journalists", authenticate, requireOrg, requireUser, async (req: Au
     params.set("brand_id", brandId);
     if (runId) params.set("run_id", runId);
     if (campaignId) params.set("campaign_id", campaignId);
+    if (req.query.featureDynastySlug) params.set("feature_dynasty_slug", req.query.featureDynastySlug as string);
 
     // Build headers, enriching with campaign metadata when workflow headers are missing
     const headers = buildInternalHeaders(req);
@@ -53,7 +54,7 @@ router.get("/journalists/list", authenticate, requireOrg, requireUser, async (re
 
     const params = new URLSearchParams();
     params.set("brandId", brandId);
-    for (const key of ["campaignId", "featureSlugs", "workflowSlug"]) {
+    for (const key of ["campaignId", "featureSlugs", "featureDynastySlug", "workflowSlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1501,6 +1501,7 @@ registry.registerPath({
       brandId: z.string().uuid().describe("Brand ID to filter journalists by"),
       runId: z.string().uuid().optional().describe("Filter journalists by discovery run ID"),
       campaignId: z.string().uuid().optional().describe("Filter journalists by campaign ID"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs via features-service)"),
     }).openapi("ListJournalistsQuery"),
   },
   responses: {
@@ -1598,6 +1599,7 @@ registry.registerPath({
       brandId: z.string().uuid().describe("Brand ID (required). Returns journalists whose brand_ids array contains this brand."),
       campaignId: z.string().uuid().optional().describe("Optionally narrow to a single campaign"),
       featureSlugs: z.string().optional().describe("Comma-separated feature slugs to filter campaign rows"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs."),
       workflowSlug: z.string().optional().describe("Optionally filter campaign rows by workflow slug"),
     }),
   },

--- a/tests/unit/journalists-list-proxy.test.ts
+++ b/tests/unit/journalists-list-proxy.test.ts
@@ -30,7 +30,7 @@ describe("GET /journalists/list route", () => {
     expect(listSection).toContain('"Missing required query parameter: brandId"');
   });
 
-  it("should forward brandId, campaignId, featureSlugs, and workflowSlug", () => {
+  it("should forward brandId, campaignId, featureSlugs, featureDynastySlug, and workflowSlug", () => {
     const listSection = content.slice(
       content.indexOf('"/journalists/list"'),
       content.indexOf("// ── POST /v1/journalists/discover")
@@ -38,6 +38,7 @@ describe("GET /journalists/list route", () => {
     expect(listSection).toContain('params.set("brandId", brandId)');
     expect(listSection).toContain('"campaignId"');
     expect(listSection).toContain('"featureSlugs"');
+    expect(listSection).toContain('"featureDynastySlug"');
     expect(listSection).toContain('"workflowSlug"');
   });
 
@@ -123,6 +124,16 @@ describe("GET /journalists/list OpenAPI schema", () => {
     const params = listPath.get.parameters || [];
     const param = params.find(
       (p: { name: string; in: string }) => p.name === "featureSlugs" && p.in === "query"
+    );
+    expect(param).toBeDefined();
+    expect(param.required).toBeFalsy();
+  });
+
+  it("should have optional featureDynastySlug in OpenAPI spec", () => {
+    const listPath = openapi.paths["/v1/journalists/list"];
+    const params = listPath.get.parameters || [];
+    const param = params.find(
+      (p: { name: string; in: string }) => p.name === "featureDynastySlug" && p.in === "query"
     );
     expect(param).toBeDefined();
     expect(param.required).toBeFalsy();

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -34,6 +34,15 @@ describe("Journalists proxy routes", () => {
     expect(content).toContain("Missing required query parameter: brandId");
   });
 
+  it("should forward featureDynastySlug as feature_dynasty_slug on GET /journalists", () => {
+    const getSection = content.slice(
+      content.indexOf('"/journalists"'),
+      content.indexOf('"/journalists/list"')
+    );
+    expect(getSection).toContain("feature_dynasty_slug");
+    expect(getSection).toContain("featureDynastySlug");
+  });
+
   it("should have POST /journalists/discover with auth + requireOrg + requireUser", () => {
     const line = content.split("\n").find((l) =>
       l.includes("router.post") && l.includes('"/journalists/discover"') && !l.includes("emails")


### PR DESCRIPTION
## Summary
- Forward `featureDynastySlug` on `GET /v1/journalists/list` (camelCase, journalists-service PR #66)
- Forward `featureDynastySlug` on `GET /v1/journalists` as `feature_dynasty_slug` (snake_case per upstream convention)
- Update OpenAPI schemas for both endpoints
- Regenerate `openapi.json`

## Context
journalists-service PR #66 added dynasty slug support. The dashboard needs this to filter journalists by feature on feature-level pages.

## Test plan
- [x] 75 journalist tests pass
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)