### PR TITLE
feat: forward feature/workflow filters on GET /discoveries

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -15418,6 +15418,7 @@
           "Articles"
         ],
         "summary": "List article discoveries with filters",
+        "description": "List discoveries with optional filters. Supports filtering by featureDynastySlug (resolves to all versioned slugs via features-service), featureSlugs (comma-separated), and equivalent workflow filters. Dynasty slug takes priority over slugs list.",
         "security": [
           {
             "bearerAuth": []
@@ -15472,6 +15473,42 @@
             },
             "required": false,
             "name": "topicId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slugs (comma-separated or single value)"
+            },
+            "required": false,
+            "name": "featureSlugs",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug (resolves to all versioned slugs via features-service)"
+            },
+            "required": false,
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow slugs (comma-separated or single value)"
+            },
+            "required": false,
+            "name": "workflowSlugs",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug (resolves to all versioned slugs via workflow-service)"
+            },
+            "required": false,
+            "name": "workflowDynastySlug",
             "in": "query"
           },
           {

--- a/src/routes/articles.ts
+++ b/src/routes/articles.ts
@@ -172,13 +172,9 @@ router.post("/topics/bulk", authenticate, requireOrg, requireUser, async (req: A
 router.get("/discoveries", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    if (req.query.brandId) params.set("brandId", req.query.brandId as string);
-    if (req.query.campaignId) params.set("campaignId", req.query.campaignId as string);
-    if (req.query.outletId) params.set("outletId", req.query.outletId as string);
-    if (req.query.journalistId) params.set("journalistId", req.query.journalistId as string);
-    if (req.query.topicId) params.set("topicId", req.query.topicId as string);
-    if (req.query.limit) params.set("limit", req.query.limit as string);
-    if (req.query.offset) params.set("offset", req.query.offset as string);
+    for (const key of ["brandId", "campaignId", "outletId", "journalistId", "topicId", "featureSlugs", "featureDynastySlug", "workflowSlugs", "workflowDynastySlug", "limit", "offset"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
     const qs = params.toString() ? `?${params.toString()}` : "";
 
     const result = await callExternalService(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2305,6 +2305,8 @@ registry.registerPath({
   path: "/v1/discoveries",
   tags: ["Articles"],
   summary: "List article discoveries with filters",
+  description: "List discoveries with optional filters. Supports filtering by featureDynastySlug (resolves to all versioned slugs via features-service), " +
+    "featureSlugs (comma-separated), and equivalent workflow filters. Dynasty slug takes priority over slugs list.",
   security: authed,
   request: {
     query: z.object({
@@ -2313,6 +2315,10 @@ registry.registerPath({
       outletId: z.string().uuid().optional().openapi({ description: "Filter by outlet ID" }),
       journalistId: z.string().uuid().optional().openapi({ description: "Filter by journalist ID" }),
       topicId: z.string().uuid().optional().openapi({ description: "Filter by topic ID" }),
+      featureSlugs: z.string().optional().openapi({ description: "Filter by feature slugs (comma-separated or single value)" }),
+      featureDynastySlug: z.string().optional().openapi({ description: "Filter by feature dynasty slug (resolves to all versioned slugs via features-service)" }),
+      workflowSlugs: z.string().optional().openapi({ description: "Filter by workflow slugs (comma-separated or single value)" }),
+      workflowDynastySlug: z.string().optional().openapi({ description: "Filter by workflow dynasty slug (resolves to all versioned slugs via workflow-service)" }),
       limit: z.coerce.number().int().optional(),
       offset: z.coerce.number().int().optional(),
     }),

--- a/tests/unit/articles-proxy.test.ts
+++ b/tests/unit/articles-proxy.test.ts
@@ -134,6 +134,17 @@ describe("Articles proxy routes", () => {
     expect(section).toContain('"topicId"');
   });
 
+  it("should forward feature and workflow dynasty/slug filters on GET /discoveries", () => {
+    const section = content.slice(
+      content.indexOf('router.get("/discoveries"'),
+      content.indexOf('router.post("/discoveries"')
+    );
+    expect(section).toContain('"featureSlugs"');
+    expect(section).toContain('"featureDynastySlug"');
+    expect(section).toContain('"workflowSlugs"');
+    expect(section).toContain('"workflowDynastySlug"');
+  });
+
   it("should have POST /discoveries with auth", () => {
     const line = content.split("\n").find((l) =>
       l.includes("router.post") && l.includes('"/discoveries"') && !l.includes("/bulk")
@@ -236,6 +247,17 @@ describe("Articles OpenAPI schemas", () => {
 
   it("should register GET /v1/discoveries", () => {
     expect(schemaContent).toContain('path: "/v1/discoveries"');
+  });
+
+  it("should include featureDynastySlug and featureSlugs in GET /v1/discoveries schema", () => {
+    const discoveriesSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/discoveries"'),
+      schemaContent.indexOf('path: "/v1/discoveries"') + 1500
+    );
+    expect(discoveriesSection).toContain("featureSlugs:");
+    expect(discoveriesSection).toContain("featureDynastySlug:");
+    expect(discoveriesSection).toContain("workflowSlugs:");
+    expect(discoveriesSection).toContain("workflowDynastySlug:");
   });
 
   it("should register POST /v1/discoveries", () => {


### PR DESCRIPTION
## Summary
- Forward `featureSlugs`, `featureDynastySlug`, `workflowSlugs`, `workflowDynastySlug` query params on `GET /v1/discoveries`
- Update OpenAPI schema with new query params and description
- Regenerate `openapi.json`

## Context
articles-service now supports feature/workflow filtering on `GET /v1/discoveries`. This was the last missing piece for the dashboard to filter entities by feature dynasty slug on all entity pages.

## Test plan
- [x] 44 articles proxy tests pass
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)