### PR TITLE
feat: add featureDynastySlug filter on GET /outlets/stats/costs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11801,7 +11801,7 @@
           "Outlets"
         ],
         "summary": "Get outlet discovery cost stats",
-        "description": "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, and runCount per run. Without groupBy, returns flat totals across all discovery runs. All costs are org-scoped — each org only sees costs from their own discovery runs. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "description": "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, featureDynastySlug, and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, and runCount per run. Without groupBy, returns flat totals across all discovery runs. All costs are org-scoped — each org only sees costs from their own discovery runs. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -11828,6 +11828,16 @@
             "required": false,
             "description": "Filter by campaign ID",
             "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug"
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -119,7 +119,7 @@ router.post("/outlets/buffer/next", authenticate, requireOrg, requireUser, async
 router.get("/outlets/stats/costs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "campaignId", "groupBy"]) {
+    for (const key of ["brandId", "campaignId", "groupBy", "featureDynastySlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1198,7 +1198,7 @@ registry.registerPath({
   tags: ["Outlets"],
   summary: "Get outlet discovery cost stats",
   description:
-    "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, " +
+    "Returns cost statistics for outlet discovery runs. Supports filtering by brandId, campaignId, featureDynastySlug, " +
     "and grouping by outletId or runId. When grouped by outletId, cost = discovery run cost / number of outlets " +
     "in that run (summed across multiple runs). When grouped by runId, returns totalCostInUsdCents, outletCount, " +
     "and runCount per run. Without groupBy, returns flat totals across all discovery runs. " +
@@ -1210,6 +1210,7 @@ registry.registerPath({
     query: z.object({
       brandId: z.string().uuid().optional().describe("Filter by brand ID"),
       campaignId: z.string().uuid().optional().describe("Filter by campaign ID"),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug"),
       groupBy: z.enum(["outletId", "runId"]).optional().describe("Group results by outletId or runId"),
     }),
   },

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -148,6 +148,7 @@ describe("Outlets proxy routes", () => {
     expect(costSection).toContain('"brandId"');
     expect(costSection).toContain('"campaignId"');
     expect(costSection).toContain('"groupBy"');
+    expect(costSection).toContain('"featureDynastySlug"');
   });
 
   it("should register static routes before parameterized :id route", () => {


### PR DESCRIPTION
## Summary
- Adds optional `featureDynastySlug` query parameter to `GET /v1/outlets/stats/costs` proxy
- Forwards it to upstream outlets-service so feature-level dashboard pages can scope cost stats to a single feature dynasty
- Updates OpenAPI spec and proxy tests

## Test plan
- [x] `pnpm vitest run tests/unit/outlets-proxy.test.ts` — 55/55 passing
- [ ] Dashboard team confirms feature-level outlets page now shows scoped costs

🤖 Generated with [Claude Code](https://claude.com/claude-code)