### PR TITLE
feat: replace status with consolidatedStatus/localStatus/emailGatewayStatus on journalist endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2083,7 +2083,21 @@
                     "type": "string"
                   }
                 },
-                "status": {
+                "consolidatedStatus": {
+                  "type": "string",
+                  "enum": [
+                    "buffered",
+                    "claimed",
+                    "served",
+                    "contacted",
+                    "delivered",
+                    "replied",
+                    "bounced",
+                    "skipped"
+                  ],
+                  "description": "Consolidated status: email-gateway status when available, otherwise local DB status"
+                },
+                "localStatus": {
                   "type": "string",
                   "enum": [
                     "buffered",
@@ -2092,7 +2106,18 @@
                     "contacted",
                     "skipped"
                   ],
-                  "description": "Current status of this journalist in the campaign pipeline"
+                  "description": "Status from the local database"
+                },
+                "emailGatewayStatus": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    "contacted",
+                    "delivered",
+                    "replied",
+                    "bounced"
+                  ],
+                  "description": "Status derived from email-gateway. Null if no email-gateway data."
                 },
                 "runId": {
                   "type": "string",
@@ -2112,7 +2137,9 @@
                 "whyRelevant",
                 "whyNotRelevant",
                 "articleUrls",
-                "status",
+                "consolidatedStatus",
+                "localStatus",
+                "emailGatewayStatus",
                 "runId"
               ]
             }
@@ -2142,7 +2169,21 @@
             "type": "string",
             "nullable": true
           },
-          "status": {
+          "consolidatedStatus": {
+            "type": "string",
+            "enum": [
+              "buffered",
+              "claimed",
+              "served",
+              "contacted",
+              "delivered",
+              "replied",
+              "bounced",
+              "skipped"
+            ],
+            "description": "Consolidated status: email-gateway status when available, otherwise local DB status"
+          },
+          "localStatus": {
             "type": "string",
             "enum": [
               "buffered",
@@ -2150,7 +2191,19 @@
               "served",
               "contacted",
               "skipped"
-            ]
+            ],
+            "description": "Status from the local database"
+          },
+          "emailGatewayStatus": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "contacted",
+              "delivered",
+              "replied",
+              "bounced"
+            ],
+            "description": "Status derived from email-gateway. Null if no email-gateway data."
           },
           "relevanceScore": {
             "type": "string"
@@ -2191,7 +2244,9 @@
           "campaignId",
           "featureSlug",
           "workflowSlug",
-          "status",
+          "consolidatedStatus",
+          "localStatus",
+          "emailGatewayStatus",
           "relevanceScore",
           "whyRelevant",
           "whyNotRelevant",
@@ -2902,7 +2957,7 @@
             "additionalProperties": {
               "type": "number"
             },
-            "description": "Map of status to count (buffered, claimed, served, contacted, skipped)"
+            "description": "Map of status to count. Local: buffered, claimed, served, skipped. Email-gateway enriched: contacted, delivered, replied, bounced."
           },
           "groupedBy": {
             "type": "object",
@@ -14020,7 +14075,7 @@
           "Journalists"
         ],
         "summary": "Get journalist stats with dynasty-aware filtering and grouping",
-        "description": "Returns journalist counts by status (buffered, claimed, served, contacted, skipped). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
+        "description": "Returns journalist counts by status. Local statuses: buffered, claimed, served, skipped. Email-gateway enriched statuses: contacted, delivered, replied, bounced. Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
         "security": [
           {
             "bearerAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1524,7 +1524,9 @@ registry.registerPath({
                   whyRelevant: z.string().nullable(),
                   whyNotRelevant: z.string().nullable(),
                   articleUrls: z.array(z.string()).nullable(),
-                  status: z.enum(["buffered", "claimed", "served", "contacted", "skipped"]).describe("Current status of this journalist in the campaign pipeline"),
+                  consolidatedStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).describe("Consolidated status: email-gateway status when available, otherwise local DB status"),
+                  localStatus: z.enum(["buffered", "claimed", "served", "contacted", "skipped"]).describe("Status from the local database"),
+                  emailGatewayStatus: z.enum(["contacted", "delivered", "replied", "bounced"]).nullable().describe("Status derived from email-gateway. Null if no email-gateway data."),
                   runId: z.string().uuid().nullable().describe("The discovery run that created this journalist entry"),
                 }).passthrough(),
               ),
@@ -1629,7 +1631,9 @@ registry.registerPath({
                       campaignId: z.string().uuid(),
                       featureSlug: z.string().nullable(),
                       workflowSlug: z.string().nullable(),
-                      status: z.enum(["buffered", "claimed", "served", "contacted", "skipped"]),
+                      consolidatedStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).describe("Consolidated status: email-gateway status when available, otherwise local DB status"),
+                      localStatus: z.enum(["buffered", "claimed", "served", "contacted", "skipped"]).describe("Status from the local database"),
+                      emailGatewayStatus: z.enum(["contacted", "delivered", "replied", "bounced"]).nullable().describe("Status derived from email-gateway. Null if no email-gateway data."),
                       relevanceScore: z.string(),
                       whyRelevant: z.string(),
                       whyNotRelevant: z.string(),
@@ -1849,7 +1853,8 @@ registry.registerPath({
   tags: ["Journalists"],
   summary: "Get journalist stats with dynasty-aware filtering and grouping",
   description:
-    "Returns journalist counts by status (buffered, claimed, served, contacted, skipped). " +
+    "Returns journalist counts by status. Local statuses: buffered, claimed, served, skipped. " +
+    "Email-gateway enriched statuses: contacted, delivered, replied, bounced. " +
     "Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. " +
     "Optional groupBy returns per-slug breakdowns.",
   security: authed,
@@ -1861,7 +1866,7 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             totalJournalists: z.number(),
-            byStatus: z.record(z.number()).describe("Map of status to count (buffered, claimed, served, contacted, skipped)"),
+            byStatus: z.record(z.number()).describe("Map of status to count. Local: buffered, claimed, served, skipped. Email-gateway enriched: contacted, delivered, replied, bounced."),
             groupedBy: z.record(z.object({
               totalJournalists: z.number(),
               byStatus: z.record(z.number()),

--- a/tests/unit/journalists-list-proxy.test.ts
+++ b/tests/unit/journalists-list-proxy.test.ts
@@ -173,9 +173,16 @@ describe("GET /journalists/list OpenAPI schema", () => {
     expect(campaignEntryRef).toBe("#/components/schemas/JournalistCampaignEntry");
     const campaignEntry = openapi.components?.schemas?.JournalistCampaignEntry;
     expect(campaignEntry).toBeDefined();
-    expect(campaignEntry.properties.status).toBeDefined();
+    expect(campaignEntry.properties.consolidatedStatus).toBeDefined();
+    expect(campaignEntry.properties.localStatus).toBeDefined();
+    expect(campaignEntry.properties.emailGatewayStatus).toBeDefined();
     expect(campaignEntry.properties.relevanceScore).toBeDefined();
     expect(campaignEntry.properties.campaignId).toBeDefined();
+  });
+
+  it("campaign entries should NOT have old 'status' field (replaced by consolidatedStatus/localStatus/emailGatewayStatus)", () => {
+    const campaignEntry = openapi.components?.schemas?.JournalistCampaignEntry;
+    expect(campaignEntry.properties.status).toBeUndefined();
   });
 
   it("should NOT have flat campaign fields at journalist top level", () => {

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -299,13 +299,24 @@ describe("Journalists OpenAPI schemas", () => {
     expect(block).toContain("campaignId:");
   });
 
-  it("should have status enum in ListJournalistsResponse", () => {
+  it("should have consolidatedStatus/localStatus/emailGatewayStatus in ListJournalistsResponse", () => {
     const start = schemaContent.indexOf("ListJournalistsResponse");
     const block = schemaContent.slice(Math.max(0, start - 800), start);
-    expect(block).toContain("status:");
+    expect(block).toContain("consolidatedStatus:");
+    expect(block).toContain("localStatus:");
+    expect(block).toContain("emailGatewayStatus:");
     expect(block).toContain('"buffered"');
-    expect(block).toContain('"contacted"');
-    expect(block).toContain('"skipped"');
+    expect(block).toContain('"delivered"');
+    expect(block).toContain('"replied"');
+    expect(block).toContain('"bounced"');
+  });
+
+  it("should NOT have old 'status' field in ListJournalistsResponse", () => {
+    const start = schemaContent.indexOf("ListJournalistsResponse");
+    const block = schemaContent.slice(Math.max(0, start - 800), start);
+    // consolidatedStatus contains "Status" but standalone "status:" should not exist
+    const lines = block.split("\n").filter((l: string) => l.trim().startsWith("status:"));
+    expect(lines.length).toBe(0);
   });
 
   it("should register GET /v1/journalists/stats", () => {


### PR DESCRIPTION
## Summary
- Aligns api-service OpenAPI schemas with journalists-service breaking change (PR #71)
- Replaces single `status` field with `consolidatedStatus`, `localStatus`, `emailGatewayStatus` on both `GET /v1/journalists` and `GET /v1/journalists/list` response schemas
- Updates `JournalistStatsResponse` description to reflect new `byStatus` values (delivered, replied, bounced)
- Tests verify new fields are present and old `status` field is absent

## Test plan
- [x] journalists-proxy.test.ts — 55 tests pass (includes new status field assertions)
- [x] journalists-list-proxy.test.ts — 22 tests pass (includes campaign entry status field checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)