### PR TITLE
fix: enrich campaign outlets proxy with campaign metadata headers

### DIFF
--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -888,17 +888,31 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
 router.get("/campaigns/:id/outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    const baseHeaders = buildInternalHeaders(req);
+
+    // Fetch campaign to enrich headers with campaign metadata for downstream calls
+    const campaignResult = await callExternalService<{
+      campaign: { brandIds?: string[]; featureSlug?: string; workflowSlug?: string };
+    }>(externalServices.campaign, `/campaigns/${encodeURIComponent(id)}`, { headers: baseHeaders });
+
+    const campaign = campaignResult.campaign;
+
+    const headers: Record<string, string> = {
+      ...baseHeaders,
+      "x-campaign-id": id,
+    };
+    if (campaign.brandIds?.length) headers["x-brand-id"] = campaign.brandIds.join(",");
+    if (campaign.featureSlug) headers["x-feature-slug"] = campaign.featureSlug;
+    if (campaign.workflowSlug) headers["x-workflow-slug"] = campaign.workflowSlug;
 
     const result = await callExternalService(
       externalServices.outlet,
       `/outlets?campaignId=${encodeURIComponent(id)}`,
-      {
-        headers: buildInternalHeaders(req),
-      }
+      { headers }
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Get campaign outlets error:", error);
+    console.error("[api-service] Get campaign outlets error:", error);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get campaign outlets" });
   }
 });

--- a/tests/unit/campaign-outlets-headers.regression.test.ts
+++ b/tests/unit/campaign-outlets-headers.regression.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const campaignsRoutePath = path.join(__dirname, "../../src/routes/campaigns.ts");
+const content = fs.readFileSync(campaignsRoutePath, "utf-8");
+
+describe("Campaign outlets: header enrichment from campaign data (regression)", () => {
+  const outletsSection = content.slice(
+    content.indexOf('"/campaigns/:id/outlets"'),
+    content.indexOf('"/campaigns/:id/journalists"'),
+  );
+
+  it("should fetch campaign from campaign-service to resolve metadata", () => {
+    expect(outletsSection).toContain("externalServices.campaign");
+    expect(outletsSection).toContain("/campaigns/");
+  });
+
+  it("should explicitly set x-campaign-id from path param", () => {
+    expect(outletsSection).toContain('"x-campaign-id"');
+  });
+
+  it("should forward x-brand-id resolved from campaign data to outlet-service", () => {
+    expect(outletsSection).toContain('"x-brand-id"');
+    expect(outletsSection).toContain("campaign.brandIds");
+  });
+
+  it("should forward x-feature-slug and x-workflow-slug from campaign data", () => {
+    expect(outletsSection).toContain('"x-feature-slug"');
+    expect(outletsSection).toContain("campaign.featureSlug");
+    expect(outletsSection).toContain('"x-workflow-slug"');
+    expect(outletsSection).toContain("campaign.workflowSlug");
+  });
+
+  it("should spread enriched headers into the outlet-service call (not just baseHeaders)", () => {
+    // The call to outlet-service should use the enriched `headers` object, not `buildInternalHeaders(req)` directly
+    const outletCallIdx = outletsSection.indexOf("externalServices.outlet");
+    const outletCallBlock = outletsSection.slice(outletCallIdx, outletCallIdx + 200);
+    expect(outletCallBlock).toContain("{ headers }");
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /campaigns/:id/outlets` was forwarding only incoming request headers to outlets-service, missing `x-campaign-id`, `x-brand-id`, `x-feature-slug`, and `x-workflow-slug`
- This caused outlets-service's downstream call to journalists-service (`POST /internal/outlets/status`) to fail with 400, bubbling up as 500s
- Now fetches campaign data first and enriches headers before calling outlets-service — matching the pattern already used by the `/campaigns/:id/journalists` route

## Test plan
- [x] Added regression test `campaign-outlets-headers.regression.test.ts` verifying header enrichment
- [x] All existing tests pass (3 pre-existing failures unrelated to this change)

> **Note:** There is also a Layer 2 issue in **outlets-service** — it should forward these headers when calling journalists-service at `POST /internal/outlets/status`. This PR fixes the api-service side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)