### PR TITLE
feat: expand outlet status enums with journalist statuses

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1629,8 +1629,15 @@
               "ended",
               "denied",
               "served",
-              "skipped"
-            ]
+              "skipped",
+              "buffered",
+              "claimed",
+              "contacted",
+              "delivered",
+              "replied",
+              "bounced"
+            ],
+            "description": "Consolidated status: most advanced journalist status for this campaign"
           },
           "overallRelevance": {
             "type": "string",
@@ -1685,8 +1692,15 @@
               "ended",
               "denied",
               "served",
-              "skipped"
-            ]
+              "skipped",
+              "buffered",
+              "claimed",
+              "contacted",
+              "delivered",
+              "replied",
+              "bounced"
+            ],
+            "description": "Consolidated status: most advanced status across all journalists in this outlet"
           },
           "latestRelevanceScore": {
             "type": "number"

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1097,7 +1097,7 @@ registry.registerPath({
                   outletUrl: z.string(),
                   outletDomain: z.string(),
                   createdAt: z.string().datetime(),
-                  latestStatus: z.enum(["open", "ended", "denied", "served", "skipped"]),
+                  latestStatus: z.enum(["open", "ended", "denied", "served", "skipped", "buffered", "claimed", "contacted", "delivered", "replied", "bounced"]).describe("Consolidated status: most advanced status across all journalists in this outlet"),
                   latestRelevanceScore: z.number(),
                   campaigns: z.array(
                     z.object({
@@ -1107,7 +1107,7 @@ registry.registerPath({
                       whyRelevant: z.string().optional(),
                       whyNotRelevant: z.string().optional(),
                       relevanceScore: z.number(),
-                      status: z.enum(["open", "ended", "denied", "served", "skipped"]),
+                      status: z.enum(["open", "ended", "denied", "served", "skipped", "buffered", "claimed", "contacted", "delivered", "replied", "bounced"]).describe("Consolidated status: most advanced journalist status for this campaign"),
                       overallRelevance: z.string().nullable().optional(),
                       relevanceRationale: z.string().nullable().optional(),
                       runId: z.string().nullable().optional(),

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -258,7 +258,7 @@ describe("Outlets OpenAPI schemas", () => {
 
   it("should include full campaign entry fields in OutletCampaignEntry", () => {
     const idx = schemaContent.indexOf("OutletCampaignEntry");
-    const entrySection = schemaContent.slice(Math.max(0, idx - 800), idx + 100);
+    const entrySection = schemaContent.slice(Math.max(0, idx - 1200), idx + 100);
     for (const field of ["campaignId", "featureSlug", "brandIds", "whyRelevant", "relevanceScore", "updatedAt"]) {
       expect(entrySection).toContain(field);
     }
@@ -271,6 +271,24 @@ describe("Outlets OpenAPI schemas", () => {
     );
     expect(getOutletsSection).toContain('"served"');
     expect(getOutletsSection).toContain('"skipped"');
+  });
+
+  it("latestStatus enum should include journalist-level statuses (contacted, delivered, replied, bounced)", () => {
+    const getOutletsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/outlets"'),
+      schemaContent.indexOf('path: "/v1/outlets"') + 2000
+    );
+    for (const status of ["contacted", "delivered", "replied", "bounced", "buffered", "claimed"]) {
+      expect(getOutletsSection).toContain(`"${status}"`);
+    }
+  });
+
+  it("per-campaign status enum should include journalist-level statuses (contacted, delivered, replied, bounced)", () => {
+    const idx = schemaContent.indexOf("OutletCampaignEntry");
+    const entrySection = schemaContent.slice(Math.max(0, idx - 1200), idx + 100);
+    for (const status of ["contacted", "delivered", "replied", "bounced", "buffered", "claimed"]) {
+      expect(entrySection).toContain(`"${status}"`);
+    }
   });
 
   it("should register GET /v1/outlets/{id}", () => {


### PR DESCRIPTION
## Summary
- Expanded `latestStatus` enum on `GET /v1/outlets` response to include journalist-level statuses: `buffered`, `claimed`, `contacted`, `delivered`, `replied`, `bounced`
- Expanded per-campaign `status` enum in the `campaigns[]` array with the same statuses
- Added regression tests ensuring journalist statuses are present in both enums
- Regenerated `openapi.json`

**Context:** Outlets with journalists at `delivered` or `contacted` still showed `open` because the enum only allowed outlet-level values. This makes the dashboard status tabs meaningless. The enum expansion on the api-service side unblocks outlet-service from returning consolidated statuses.

## Test plan
- [x] Existing outlet proxy tests pass (57/57)
- [x] New regression tests verify journalist statuses in both enums
- [ ] Verify outlet-service returns the expanded statuses (separate outlet-service change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)