### PR TITLE
fix: update emailStatus schema to flat format

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2325,144 +2325,94 @@
                           "type": "object",
                           "nullable": true,
                           "properties": {
-                            "lead": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "replied": {
-                                  "type": "boolean"
-                                },
-                                "replyClassification": {
-                                  "type": "string",
-                                  "nullable": true,
-                                  "enum": [
-                                    "positive",
-                                    "negative",
-                                    "neutral"
-                                  ]
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "replied",
-                                "replyClassification",
-                                "lastDeliveredAt"
+                            "contacted": {
+                              "type": "boolean"
+                            },
+                            "delivered": {
+                              "type": "boolean"
+                            },
+                            "opened": {
+                              "type": "boolean"
+                            },
+                            "replied": {
+                              "type": "boolean"
+                            },
+                            "replyClassification": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "positive",
+                                "negative",
+                                "neutral"
                               ]
                             },
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "bounced": {
-                                  "type": "boolean"
-                                },
-                                "unsubscribed": {
-                                  "type": "boolean"
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "bounced",
-                                "unsubscribed",
-                                "lastDeliveredAt"
-                              ]
+                            "bounced": {
+                              "type": "boolean"
+                            },
+                            "unsubscribed": {
+                              "type": "boolean"
+                            },
+                            "lastDeliveredAt": {
+                              "type": "string",
+                              "nullable": true
                             }
                           },
                           "required": [
-                            "lead",
-                            "email"
+                            "contacted",
+                            "delivered",
+                            "opened",
+                            "replied",
+                            "replyClassification",
+                            "bounced",
+                            "unsubscribed",
+                            "lastDeliveredAt"
                           ]
                         },
                         "brand": {
                           "type": "object",
                           "nullable": true,
                           "properties": {
-                            "lead": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "replied": {
-                                  "type": "boolean"
-                                },
-                                "replyClassification": {
-                                  "type": "string",
-                                  "nullable": true,
-                                  "enum": [
-                                    "positive",
-                                    "negative",
-                                    "neutral"
-                                  ]
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "replied",
-                                "replyClassification",
-                                "lastDeliveredAt"
+                            "contacted": {
+                              "type": "boolean"
+                            },
+                            "delivered": {
+                              "type": "boolean"
+                            },
+                            "opened": {
+                              "type": "boolean"
+                            },
+                            "replied": {
+                              "type": "boolean"
+                            },
+                            "replyClassification": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "positive",
+                                "negative",
+                                "neutral"
                               ]
                             },
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "bounced": {
-                                  "type": "boolean"
-                                },
-                                "unsubscribed": {
-                                  "type": "boolean"
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "bounced",
-                                "unsubscribed",
-                                "lastDeliveredAt"
-                              ]
+                            "bounced": {
+                              "type": "boolean"
+                            },
+                            "unsubscribed": {
+                              "type": "boolean"
+                            },
+                            "lastDeliveredAt": {
+                              "type": "string",
+                              "nullable": true
                             }
                           },
                           "required": [
-                            "lead",
-                            "email"
+                            "contacted",
+                            "delivered",
+                            "opened",
+                            "replied",
+                            "replyClassification",
+                            "bounced",
+                            "unsubscribed",
+                            "lastDeliveredAt"
                           ]
                         },
                         "global": {
@@ -2502,144 +2452,94 @@
                           "type": "object",
                           "nullable": true,
                           "properties": {
-                            "lead": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "replied": {
-                                  "type": "boolean"
-                                },
-                                "replyClassification": {
-                                  "type": "string",
-                                  "nullable": true,
-                                  "enum": [
-                                    "positive",
-                                    "negative",
-                                    "neutral"
-                                  ]
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "replied",
-                                "replyClassification",
-                                "lastDeliveredAt"
+                            "contacted": {
+                              "type": "boolean"
+                            },
+                            "delivered": {
+                              "type": "boolean"
+                            },
+                            "opened": {
+                              "type": "boolean"
+                            },
+                            "replied": {
+                              "type": "boolean"
+                            },
+                            "replyClassification": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "positive",
+                                "negative",
+                                "neutral"
                               ]
                             },
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "bounced": {
-                                  "type": "boolean"
-                                },
-                                "unsubscribed": {
-                                  "type": "boolean"
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "bounced",
-                                "unsubscribed",
-                                "lastDeliveredAt"
-                              ]
+                            "bounced": {
+                              "type": "boolean"
+                            },
+                            "unsubscribed": {
+                              "type": "boolean"
+                            },
+                            "lastDeliveredAt": {
+                              "type": "string",
+                              "nullable": true
                             }
                           },
                           "required": [
-                            "lead",
-                            "email"
+                            "contacted",
+                            "delivered",
+                            "opened",
+                            "replied",
+                            "replyClassification",
+                            "bounced",
+                            "unsubscribed",
+                            "lastDeliveredAt"
                           ]
                         },
                         "brand": {
                           "type": "object",
                           "nullable": true,
                           "properties": {
-                            "lead": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "replied": {
-                                  "type": "boolean"
-                                },
-                                "replyClassification": {
-                                  "type": "string",
-                                  "nullable": true,
-                                  "enum": [
-                                    "positive",
-                                    "negative",
-                                    "neutral"
-                                  ]
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "replied",
-                                "replyClassification",
-                                "lastDeliveredAt"
+                            "contacted": {
+                              "type": "boolean"
+                            },
+                            "delivered": {
+                              "type": "boolean"
+                            },
+                            "opened": {
+                              "type": "boolean"
+                            },
+                            "replied": {
+                              "type": "boolean"
+                            },
+                            "replyClassification": {
+                              "type": "string",
+                              "nullable": true,
+                              "enum": [
+                                "positive",
+                                "negative",
+                                "neutral"
                               ]
                             },
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "contacted": {
-                                  "type": "boolean"
-                                },
-                                "delivered": {
-                                  "type": "boolean"
-                                },
-                                "bounced": {
-                                  "type": "boolean"
-                                },
-                                "unsubscribed": {
-                                  "type": "boolean"
-                                },
-                                "lastDeliveredAt": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "contacted",
-                                "delivered",
-                                "bounced",
-                                "unsubscribed",
-                                "lastDeliveredAt"
-                              ]
+                            "bounced": {
+                              "type": "boolean"
+                            },
+                            "unsubscribed": {
+                              "type": "boolean"
+                            },
+                            "lastDeliveredAt": {
+                              "type": "string",
+                              "nullable": true
                             }
                           },
                           "required": [
-                            "lead",
-                            "email"
+                            "contacted",
+                            "delivered",
+                            "opened",
+                            "replied",
+                            "replyClassification",
+                            "bounced",
+                            "unsubscribed",
+                            "lastDeliveredAt"
                           ]
                         },
                         "global": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1541,26 +1541,16 @@ registry.registerPath({
   },
 });
 
-// Shared sub-schemas for journalist email delivery statuses
-const JournalistLeadDeliverySchema = z.object({
+// Shared sub-schemas for journalist email delivery statuses (flat format since journalists-service PR #76)
+const JournalistScopeDeliverySchema = z.object({
   contacted: z.boolean(),
   delivered: z.boolean(),
+  opened: z.boolean(),
   replied: z.boolean(),
   replyClassification: z.enum(["positive", "negative", "neutral"]).nullable(),
-  lastDeliveredAt: z.string().nullable(),
-});
-
-const JournalistEmailDeliverySchema = z.object({
-  contacted: z.boolean(),
-  delivered: z.boolean(),
   bounced: z.boolean(),
   unsubscribed: z.boolean(),
   lastDeliveredAt: z.string().nullable(),
-});
-
-const JournalistScopeDeliverySchema = z.object({
-  lead: JournalistLeadDeliverySchema,
-  email: JournalistEmailDeliverySchema,
 }).nullable();
 
 const JournalistGlobalDeliverySchema = z.object({


### PR DESCRIPTION
## Summary
- Updates `JournalistScopeDeliverySchema` to match the new flat format from journalists-service (PR #76)
- Removes nested `lead`/`email` objects at campaign/brand scope level
- Adds new `opened` boolean field
- Promotes `bounced` and `unsubscribed` to scope level
- Regenerates `openapi.json`

## Context
journalists-service now consumes email-gateway's flat response format. The `emailStatus` field shape changed from:
```
{ campaign: { lead: {...}, email: {...} } }
```
to:
```
{ campaign: { contacted, delivered, opened, replied, replyClassification, bounced, unsubscribed, lastDeliveredAt } }
```

`global` scope is unchanged.

## Test plan
- [x] All 22 journalists-list-proxy tests pass
- [x] Full test suite: 0 new failures (5 pre-existing failures confirmed on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)