### PR TITLE
fix: update lead-service proxy paths for /orgs/ prefix

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6302,7 +6302,7 @@
                 "config": {
                   "service": "lead",
                   "method": "POST",
-                  "path": "/buffer/next"
+                  "path": "/orgs/buffer/next"
                 },
                 "inputMapping": {
                   "body.campaignId": "$ref:flow_input.campaignId"
@@ -10274,7 +10274,7 @@
           "Campaigns"
         ],
         "summary": "Get per-lead delivery status",
-        "description": "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. Proxies to lead-service GET /leads/status.",
+        "description": "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. Proxies to lead-service GET /orgs/leads/status.",
         "security": [
           {
             "bearerAuth": []
@@ -17368,7 +17368,7 @@
           "Leads"
         ],
         "summary": "List leads by brand",
-        "description": "List all leads across campaigns for a brand. Returns the same enriched shape as GET /campaigns/{id}/leads. Proxies to lead-service GET /leads with brandId filter.",
+        "description": "List all leads across campaigns for a brand. Returns the same enriched shape as GET /campaigns/{id}/leads. Proxies to lead-service GET /orgs/leads with brandId filter.",
         "security": [
           {
             "bearerAuth": []

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -269,7 +269,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
       }),
       callExternalService<{ groups: Array<{ key: string; served: number; contacted?: number; buffered: number; skipped: number }> }>(
         externalServices.lead,
-        `/stats?${leadParams}`,
+        `/orgs/stats?${leadParams}`,
         { headers: internalHeaders },
       ).catch((err) => {
         console.warn("[campaigns/stats] lead-service groupBy failed:", (err as Error).message);
@@ -473,7 +473,7 @@ router.get("/campaigns/:id/stats", authenticate, requireOrg, requireUser, async 
     const [leadStats, emailgenStats, delivery, budgetUsage, costBreakdown] = await Promise.all([
       callExternalService(
         externalServices.lead,
-        `/stats?campaignId=${id}`,
+        `/orgs/stats?campaignId=${id}`,
         { headers: internalHeaders }
       ).catch((err) => {
         console.warn("[campaigns] Lead-service stats failed:", (err as Error).message);
@@ -588,12 +588,12 @@ router.get("/campaigns/:id/leads", authenticate, requireOrg, requireUser, async 
     const [leadsResult, statusResult] = await Promise.all([
       callExternalService(
         externalServices.lead,
-        `/leads?campaignId=${id}`,
+        `/orgs/leads?campaignId=${id}`,
         { headers }
       ) as Promise<{ leads: Array<Record<string, unknown>> }>,
       callExternalService<{ statuses: Array<{ leadId: string; email: string; contacted: boolean; delivered: boolean; bounced: boolean; replied: boolean; lastDeliveredAt: string | null }> }>(
         externalServices.lead,
-        `/leads/status?campaignId=${id}`,
+        `/orgs/leads/status?campaignId=${id}`,
         { headers }
       ),
     ]);
@@ -696,7 +696,7 @@ router.get("/campaigns/:id/leads/status", authenticate, requireOrg, requireUser,
 
     const result = await callExternalService(
       externalServices.lead,
-      `/leads/status?${params}`,
+      `/orgs/leads/status?${params}`,
       { headers: buildInternalHeaders(req) },
     );
 
@@ -811,7 +811,7 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
         ).catch(() => null),
         callExternalService<{ served: number; buffered: number; skipped: number }>(
           externalServices.lead,
-          `/stats?campaignId=${id}`,
+          `/orgs/stats?campaignId=${id}`,
           { headers: internalHeaders }
         ).catch(() => null),
         callExternalService<{ stats?: { emailsGenerated?: number } }>(

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -9,7 +9,7 @@ const router = Router();
 
 /**
  * GET /v1/leads — list leads with filters (brand-level)
- * Proxies to lead-service GET /leads with brandId query param.
+ * Proxies to lead-service GET /orgs/leads with brandId query param.
  * Returns the same enriched shape as GET /campaigns/:id/leads.
  */
 router.get("/leads", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
@@ -36,12 +36,12 @@ router.get("/leads", authenticate, requireOrg, requireUser, async (req: Authenti
     const [leadsResult, statusResult] = await Promise.all([
       callExternalService(
         externalServices.lead,
-        `/leads?${params}`,
+        `/orgs/leads?${params}`,
         { headers }
       ) as Promise<{ leads: Array<Record<string, unknown>> }>,
       callExternalService<{ statuses: Array<{ leadId: string; email: string; contacted: boolean; delivered: boolean; bounced: boolean; replied: boolean; lastDeliveredAt: string | null }> }>(
         externalServices.lead,
-        `/leads/status?${params}`,
+        `/orgs/leads/status?${params}`,
         { headers }
       ),
     ]);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -771,7 +771,7 @@ registry.registerPath({
   tags: ["Campaigns"],
   summary: "Get per-lead delivery status",
   description:
-    "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. Proxies to lead-service GET /leads/status.",
+    "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. Proxies to lead-service GET /orgs/leads/status.",
   security: authed,
   request: {
     params: CampaignIdParam,
@@ -2992,7 +2992,7 @@ registry.registerPath({
   summary: "List leads by brand",
   description:
     "List all leads across campaigns for a brand. Returns the same enriched shape as GET /campaigns/{id}/leads. " +
-    "Proxies to lead-service GET /leads with brandId filter.",
+    "Proxies to lead-service GET /orgs/leads with brandId filter.",
   security: authed,
   request: {
     query: z.object({
@@ -4160,7 +4160,7 @@ export const UpdateWorkflowRequestSchema = z
       tags: ["email", "outreach"],
       dag: {
         nodes: [
-          { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/buffer/next" }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+          { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/orgs/buffer/next" }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
           { id: "send-email", type: "http.call", config: { service: "email-gateway", method: "POST", path: "/send" }, inputMapping: { "body.to": "$ref:fetch-lead.output.lead.email" }, retries: 0 },
         ],
         edges: [{ from: "fetch-lead", to: "send-email" }],

--- a/tests/unit/brand-leads-proxy.test.ts
+++ b/tests/unit/brand-leads-proxy.test.ts
@@ -33,11 +33,11 @@ describe("Brand-level GET /leads route", () => {
 
   it("should call lead-service /leads endpoint", () => {
     expect(content).toContain("externalServices.lead");
-    expect(content).toContain("`/leads?${params}`");
+    expect(content).toContain("`/orgs/leads?${params}`");
   });
 
   it("should call lead-service /leads/status endpoint in parallel", () => {
-    expect(content).toContain("`/leads/status?${params}`");
+    expect(content).toContain("`/orgs/leads/status?${params}`");
   });
 
   it("should flatten enrichment data into each lead", () => {


### PR DESCRIPTION
## Summary
- Updates all lead-service call paths to use the new `/orgs/` prefix (lead-service PR #168)
- Affected paths: `/leads`, `/leads/status`, `/stats`, `/buffer/next` (DAG example)
- Updates test assertions to match new paths
- Regenerates `openapi.json`

## Test plan
- [x] brand-leads-proxy tests pass (14/14)
- [x] Full suite: 0 new failures (5 pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)