### PR TITLE
fix: promote all identity query params to downstream headers

### DIFF
--- a/src/lib/internal-headers.ts
+++ b/src/lib/internal-headers.ts
@@ -21,32 +21,37 @@ function resolveHeaderOrQuery(
 }
 
 /**
+ * Identity query params that map 1:1 to forwarded headers.
+ * Each entry: [header-name, req property on AuthenticatedRequest, query param name]
+ */
+const IDENTITY_QUERY_MAP: Array<[string, keyof AuthenticatedRequest, string]> = [
+  ["x-brand-id", "brandId", "brandId"],
+  ["x-campaign-id", "campaignId", "campaignId"],
+  ["x-feature-slug", "featureSlug", "featureSlug"],
+  ["x-workflow-slug", "workflowSlug", "workflowSlug"],
+];
+
+/**
  * Build headers for internal service-to-service calls.
  * Identity headers from the incoming request are forwarded.
- * brandId and campaignId are also read from query params and promoted
- * to headers so downstream services always receive them.
+ * brandId, campaignId, featureSlug, and workflowSlug are also read
+ * from query params and promoted to headers so downstream services
+ * always receive them. Throws 400 if header and query param conflict.
  */
 export function buildInternalHeaders(req: AuthenticatedRequest): Record<string, string> {
   const headers: Record<string, string> = {};
   if (req.orgId) headers["x-org-id"] = req.orgId;
   if (req.userId) headers["x-user-id"] = req.userId;
   if (req.runId) headers["x-run-id"] = req.runId;
-  if (req.workflowSlug) headers["x-workflow-slug"] = req.workflowSlug;
-  if (req.featureSlug) headers["x-feature-slug"] = req.featureSlug;
 
-  const brandId = resolveHeaderOrQuery(
-    req.brandId,
-    req.query?.brandId as string | undefined,
-    "x-brand-id",
-  );
-  if (brandId) headers["x-brand-id"] = brandId;
-
-  const campaignId = resolveHeaderOrQuery(
-    req.campaignId,
-    req.query?.campaignId as string | undefined,
-    "x-campaign-id",
-  );
-  if (campaignId) headers["x-campaign-id"] = campaignId;
+  for (const [headerName, reqProp, queryParam] of IDENTITY_QUERY_MAP) {
+    const resolved = resolveHeaderOrQuery(
+      req[reqProp] as string | undefined,
+      req.query?.[queryParam] as string | undefined,
+      headerName,
+    );
+    if (resolved) headers[headerName] = resolved;
+  }
 
   return headers;
 }

--- a/tests/unit/header-forwarding-audit.test.ts
+++ b/tests/unit/header-forwarding-audit.test.ts
@@ -86,7 +86,8 @@ describe("header forwarding audit", () => {
 
     for (const header of ["x-campaign-id", "x-brand-id", "x-workflow-slug", "x-feature-slug"]) {
       it(`should forward ${header} to downstream services`, () => {
-        expect(src).toContain(`headers["${header}"]`);
+        // Header name must appear in the source (either as literal assignment or in IDENTITY_QUERY_MAP)
+        expect(src).toContain(`"${header}"`);
       });
     }
   });

--- a/tests/unit/internal-headers.test.ts
+++ b/tests/unit/internal-headers.test.ts
@@ -82,6 +82,38 @@ describe("buildInternalHeaders", () => {
     ).toThrow(/Conflict/);
   });
 
+  it("promotes featureSlug from query param to x-feature-slug header", () => {
+    const headers = buildInternalHeaders(fakeReq({
+      query: { featureSlug: "ft-from-query" } as any,
+    }));
+    expect(headers["x-feature-slug"]).toBe("ft-from-query");
+  });
+
+  it("promotes workflowSlug from query param to x-workflow-slug header", () => {
+    const headers = buildInternalHeaders(fakeReq({
+      query: { workflowSlug: "wf-from-query" } as any,
+    }));
+    expect(headers["x-workflow-slug"]).toBe("wf-from-query");
+  });
+
+  it("throws 400 when featureSlug header and query param conflict", () => {
+    expect(() =>
+      buildInternalHeaders(fakeReq({
+        featureSlug: "ft-header",
+        query: { featureSlug: "ft-query" } as any,
+      })),
+    ).toThrow(/Conflict/);
+  });
+
+  it("throws 400 when workflowSlug header and query param conflict", () => {
+    expect(() =>
+      buildInternalHeaders(fakeReq({
+        workflowSlug: "wf-header",
+        query: { workflowSlug: "wf-query" } as any,
+      })),
+    ).toThrow(/Conflict/);
+  });
+
   it("omits optional headers when not present", () => {
     const headers = buildInternalHeaders(fakeReq());
     expect(headers).toEqual({


### PR DESCRIPTION
## Summary
- Extends PR #308 to also promote `featureSlug` and `workflowSlug` from query params to `x-feature-slug` / `x-workflow-slug` headers
- Uses a data-driven `IDENTITY_QUERY_MAP` — all 4 identity params (brandId, campaignId, featureSlug, workflowSlug) are now promoted from query params to headers when the header is absent
- All 4 throw 400 if the header and query param values conflict
- Affects every route that calls `buildInternalHeaders` (all proxy routes)

## Test plan
- [x] 12 unit tests for promotion and conflict scenarios (all 4 params)
- [x] 33 header-forwarding audit tests pass
- [x] Updated audit test to match new loop-based implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)