### PR TITLE
refactor: use single lead-service endpoint for leads + delivery status

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4489,6 +4489,15 @@
                 "replied": {
                   "type": "boolean"
                 },
+                "replyClassification": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    "positive",
+                    "negative",
+                    "neutral"
+                  ]
+                },
                 "createdAt": {
                   "type": "string",
                   "nullable": true
@@ -4531,6 +4540,7 @@
                 "delivered",
                 "bounced",
                 "replied",
+                "replyClassification",
                 "createdAt",
                 "enrichmentRunId",
                 "enrichmentRun"

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -32,33 +32,19 @@ router.get("/leads", authenticate, requireOrg, requireUser, async (req: Authenti
     if (limit) params.set("limit", limit);
     if (offset) params.set("offset", offset);
 
-    // Fetch leads and their delivery statuses in parallel
-    const [leadsResult, statusResult] = await Promise.all([
-      callExternalService(
-        externalServices.lead,
-        `/orgs/leads?${params}`,
-        { headers }
-      ) as Promise<{ leads: Array<Record<string, unknown>> }>,
-      callExternalService<{ statuses: Array<{ leadId: string; email: string; contacted: boolean; delivered: boolean; bounced: boolean; replied: boolean; lastDeliveredAt: string | null }> }>(
-        externalServices.lead,
-        `/orgs/leads/status?${params}`,
-        { headers }
-      ),
-    ]);
+    // Single call to lead-service — delivery status fields are included directly on each lead (PR #171)
+    const leadsResult = await callExternalService(
+      externalServices.lead,
+      `/orgs/leads?${params}`,
+      { headers }
+    ) as { leads: Array<Record<string, unknown>> };
 
     const rawLeads = leadsResult.leads || [];
-
-    // Build a lookup of email → delivery status from lead-service
-    const statusByEmail = new Map<string, { contacted: boolean; delivered: boolean; bounced: boolean; replied: boolean }>();
-    for (const s of statusResult.statuses || []) {
-      statusByEmail.set(s.email, { contacted: s.contacted, delivered: s.delivered, bounced: s.bounced, replied: s.replied });
-    }
 
     // Flatten enrichment data into each lead to match dashboard expectations.
     const leads = rawLeads.map((raw) => {
       const enrichment = (raw.enrichment as Record<string, unknown>) || {};
       const email = raw.email as string;
-      const delivery = statusByEmail.get(email);
       return {
         id: raw.id,
         leadId: raw.leadId ?? null,
@@ -77,11 +63,12 @@ router.get("/leads", authenticate, requireOrg, requireUser, async (req: Authenti
         organizationIndustry: enrichment.organizationIndustry ?? null,
         organizationSize: enrichment.organizationSize ?? null,
         linkedinUrl: enrichment.linkedinUrl ?? null,
-        status: delivery?.contacted ? "contacted" : "served",
-        contacted: delivery?.contacted ?? false,
-        delivered: delivery?.delivered ?? false,
-        bounced: delivery?.bounced ?? false,
-        replied: delivery?.replied ?? false,
+        status: raw.contacted ? "contacted" : "served",
+        contacted: raw.contacted as boolean,
+        delivered: raw.delivered as boolean,
+        bounced: raw.bounced as boolean,
+        replied: raw.replied as boolean,
+        replyClassification: (raw.replyClassification as string) ?? null,
         createdAt: raw.servedAt ?? null,
         enrichmentRunId: raw.runId ?? null,
       };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3033,6 +3033,7 @@ registry.registerPath({
                   delivered: z.boolean(),
                   bounced: z.boolean(),
                   replied: z.boolean(),
+                  replyClassification: z.enum(["positive", "negative", "neutral"]).nullable(),
                   createdAt: z.string().nullable(),
                   enrichmentRunId: z.string().nullable(),
                   enrichmentRun: RunCostDataSchema.nullable(),

--- a/tests/unit/brand-leads-proxy.test.ts
+++ b/tests/unit/brand-leads-proxy.test.ts
@@ -31,13 +31,28 @@ describe("Brand-level GET /leads route", () => {
     expect(content).toContain('params.set("campaignId", campaignId)');
   });
 
-  it("should call lead-service /leads endpoint", () => {
+  it("should call lead-service /orgs/leads endpoint (single call, no /status)", () => {
     expect(content).toContain("externalServices.lead");
     expect(content).toContain("`/orgs/leads?${params}`");
+    expect(content).not.toContain("/orgs/leads/status");
   });
 
-  it("should call lead-service /leads/status endpoint in parallel", () => {
-    expect(content).toContain("`/orgs/leads/status?${params}`");
+  it("should NOT use Promise.all to merge two endpoints", () => {
+    // After lead-service PR #171, status fields are on the lead object directly
+    const leadsRoute = content.slice(
+      content.indexOf('router.get("/leads"'),
+      content.indexOf('router.post("/leads/search"')
+    );
+    expect(leadsRoute).not.toContain("Promise.all");
+    expect(leadsRoute).not.toContain("statusByEmail");
+  });
+
+  it("should read status fields directly from each lead object", () => {
+    expect(content).toContain("raw.contacted");
+    expect(content).toContain("raw.delivered");
+    expect(content).toContain("raw.bounced");
+    expect(content).toContain("raw.replied");
+    expect(content).toContain("raw.replyClassification");
   });
 
   it("should flatten enrichment data into each lead", () => {
@@ -47,7 +62,7 @@ describe("Brand-level GET /leads route", () => {
   });
 
   it("should compute contacted status from delivery data", () => {
-    expect(content).toContain('delivery?.contacted ? "contacted" : "served"');
+    expect(content).toContain('raw.contacted ? "contacted" : "served"');
   });
 
   it("should batch-fetch run costs via getRunsBatch", () => {

--- a/tests/unit/lead-reply-classification.regression.test.ts
+++ b/tests/unit/lead-reply-classification.regression.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/leads.ts");
+const routeContent = fs.readFileSync(routePath, "utf-8");
+
+const openapiPath = path.join(__dirname, "../../openapi.json");
+const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+describe("replyClassification on GET /v1/leads", () => {
+  it("should read replyClassification directly from lead object (not from a status merge)", () => {
+    expect(routeContent).toContain("raw.replyClassification");
+    expect(routeContent).not.toContain("delivery?.replyClassification");
+  });
+
+  it("should include replyClassification in the OpenAPI response schema", () => {
+    const schema =
+      openapi.components?.schemas?.BrandLeadsResponse;
+    expect(schema).toBeDefined();
+
+    const leadProps = schema.properties.leads.items.properties;
+    expect(leadProps.replyClassification).toBeDefined();
+    expect(leadProps.replyClassification.nullable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Lead-service PR #171 merged delivery status fields directly into `GET /orgs/leads` and removed `/orgs/leads/status`
- Removed the second `callExternalService` call and the `Promise.all` + email-based status merge
- Status fields (`contacted`, `delivered`, `bounced`, `replied`, `replyClassification`) are now read directly from each lead object
- Added `replyClassification` to the OpenAPI schema (`BrandLeadsResponse`)

## Test plan
- [x] `brand-leads-proxy.test.ts` updated: verifies single endpoint call, no `Promise.all`, no `statusByEmail`, reads `raw.contacted` etc.
- [x] `lead-reply-classification.regression.test.ts` updated: verifies `replyClassification` read from lead object (not from status merge)
- [x] 17 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)