### PR TITLE
fix: correct brand-service paths, remove deprecated by-ID routes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4561,116 +4561,6 @@
           "brand"
         ]
       },
-      "ExtractFieldResult": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "nullable": true
-                }
-              },
-              {
-                "type": "object",
-                "additionalProperties": {
-                  "nullable": true
-                }
-              },
-              {
-                "nullable": true
-              },
-              {
-                "nullable": true
-              }
-            ],
-            "description": "Extracted value. Type depends on the field key: string (companyOverview, valueProposition, callToAction), array (targetAudience, keyFeatures, customerPainPoints, productDifferentiators), object (socialProof, funding, additionalContext, riskReversal, scarcity, urgency), or null when the field was not found on the site (e.g. competitors, leadership)."
-          },
-          "cached": {
-            "type": "boolean",
-            "description": "Whether this result was served from cache"
-          },
-          "extractedAt": {
-            "type": "string",
-            "description": "ISO timestamp of extraction"
-          },
-          "expiresAt": {
-            "type": "string",
-            "description": "ISO timestamp when cached result expires"
-          },
-          "sourceUrls": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "type": "string"
-            },
-            "description": "URLs scraped to extract this field. Null for pre-existing extractions."
-          }
-        },
-        "required": [
-          "value",
-          "cached",
-          "extractedAt",
-          "expiresAt",
-          "sourceUrls"
-        ]
-      },
-      "ExtractFieldsResponse": {
-        "type": "object",
-        "properties": {
-          "brandId": {
-            "type": "string",
-            "description": "Brand ID"
-          },
-          "results": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ExtractFieldResult"
-            },
-            "description": "Extraction results keyed by field name (e.g. results.biography.value)"
-          }
-        },
-        "required": [
-          "brandId",
-          "results"
-        ]
-      },
-      "ExtractFieldRequest": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "Field key (e.g. 'industry', 'valueProposition')"
-          },
-          "description": {
-            "type": "string",
-            "description": "Description of what to extract"
-          }
-        },
-        "required": [
-          "key",
-          "description"
-        ]
-      },
-      "ExtractFieldsRequest": {
-        "type": "object",
-        "properties": {
-          "fields": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtractFieldRequest"
-            },
-            "description": "Fields to extract"
-          }
-        },
-        "required": [
-          "fields"
-        ]
-      },
       "ExtractFieldsFromHeaderResponse": {
         "type": "object",
         "properties": {
@@ -4805,6 +4695,23 @@
         "required": [
           "brands",
           "fields"
+        ]
+      },
+      "ExtractFieldRequest": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Field key (e.g. 'industry', 'valueProposition')"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of what to extract"
+          }
+        },
+        "required": [
+          "key",
+          "description"
         ]
       },
       "ExtractFieldsFromHeaderRequest": {
@@ -5052,41 +4959,6 @@
         },
         "required": [
           "brandIds",
-          "categories"
-        ]
-      },
-      "ExtractImagesResponse": {
-        "type": "object",
-        "properties": {
-          "brandId": {
-            "type": "string",
-            "description": "Brand ID"
-          },
-          "images": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtractedImage"
-            },
-            "description": "Extracted images"
-          }
-        },
-        "required": [
-          "brandId",
-          "images"
-        ]
-      },
-      "ExtractImagesRequest": {
-        "type": "object",
-        "properties": {
-          "categories": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtractImageCategory"
-            },
-            "description": "Image categories to extract"
-          }
-        },
-        "required": [
           "categories"
         ]
       },
@@ -17777,145 +17649,13 @@
         }
       }
     },
-    "/v1/brands/{id}/extract-fields": {
-      "post": {
-        "tags": [
-          "Brand"
-        ],
-        "summary": "Extract fields from brand (single brand, deprecated)",
-        "description": "Deprecated — use POST /v1/brands/extract-fields instead (reads brand IDs from x-brand-id header). Generic field extraction: send fields you want with a key and description, and brand-service extracts them via AI. Results are cached 30 days per field.",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Brand ID"
-            },
-            "required": true,
-            "description": "Brand ID",
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "example": "uuid1,uuid2,uuid3"
-            },
-            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExtractFieldsRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Extracted field results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExtractFieldsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Anthropic API key not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/brands/extract-fields": {
       "post": {
         "tags": [
           "Brand"
         ],
         "summary": "Extract fields from brand(s)",
-        "description": "Multi-brand field extraction. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service. Send fields you want with a key and description, and brand-service extracts them via AI. Results are cached 30 days per field per brand. Replaces POST /v1/brands/{id}/extract-fields for multi-brand campaigns.",
+        "description": "Multi-brand field extraction. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service. Send fields you want with a key and description, and brand-service extracts them via AI. Results are cached 30 days per field per brand. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service.",
         "security": [
           {
             "bearerAuth": []
@@ -18160,7 +17900,7 @@
           "Brand"
         ],
         "summary": "Extract images from brand(s)",
-        "description": "Multi-brand image extraction. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service. Replaces POST /v1/brands/{id}/extract-images for multi-brand campaigns.",
+        "description": "Multi-brand image extraction. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service.",
         "security": [
           {
             "bearerAuth": []
@@ -18274,138 +18014,6 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
-      }
-    },
-    "/v1/brands/{id}/extract-images": {
-      "post": {
-        "tags": [
-          "Brand"
-        ],
-        "summary": "Extract images from brand (single brand, deprecated)",
-        "description": "Deprecated — use POST /v1/brands/extract-images instead. Extract brand images by category (logo, product shots, hero image, etc.) via scraping + vision AI. Returns permanent R2 URLs.",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Brand ID"
-            },
-            "required": true,
-            "description": "Brand ID",
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "example": "uuid1,uuid2,uuid3"
-            },
-            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExtractImagesRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Extracted image results",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExtractImagesResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Anthropic API key not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/v1/brands/{id}/extracted-images": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -178,36 +178,6 @@ router.post("/brands/extract-fields", authenticate, requireOrg, requireUser, asy
 });
 
 /**
- * POST /v1/brands/:id/extract-fields
- * Generic field extraction: send fields you want with key + description,
- * brand-service extracts them via AI. Results cached 30 days per field.
- * Deprecated — use POST /v1/brands/extract-fields instead.
- */
-router.post("/brands/:id/extract-fields", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const result = await callExternalService(
-      externalServices.brand,
-      `/orgs/brands/${req.params.id}/extract-fields`,
-      {
-        method: "POST",
-        headers: buildInternalHeaders(req),
-        body: req.body,
-      },
-    );
-    res.json(result);
-  } catch (error: any) {
-    console.error("Extract fields error:", error);
-    const msg = error.message || "Failed to extract fields";
-    if (msg.includes("No Anthropic API key found")) {
-      return res.status(400).json({
-        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
-      });
-    }
-    res.status(error.statusCode || 500).json({ error: msg });
-  }
-});
-
-/**
  * GET /v1/brands/:id/extracted-fields
  * List all previously extracted and cached fields for a brand.
  */
@@ -215,12 +185,12 @@ router.get("/brands/:id/extracted-fields", authenticate, requireOrg, requireUser
   try {
     const result = await callExternalService(
       externalServices.brand,
-      `/orgs/brands/${req.params.id}/extracted-fields`,
+      `/internal/brands/${req.params.id}/extracted-fields`,
       { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Get extracted fields error:", error);
+    console.error("[api-service] Get extracted fields error:", error);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get extracted fields" });
   }
 });
@@ -264,34 +234,6 @@ router.post("/brands/extract-images", authenticate, requireOrg, requireUser, asy
 });
 
 /**
- * POST /v1/brands/:id/extract-images
- * Deprecated — use POST /v1/brands/extract-images instead.
- */
-router.post("/brands/:id/extract-images", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const result = await callExternalService(
-      externalServices.brand,
-      `/orgs/brands/${req.params.id}/extract-images`,
-      {
-        method: "POST",
-        headers: buildInternalHeaders(req),
-        body: req.body,
-      },
-    );
-    res.json(result);
-  } catch (error: any) {
-    console.error("Extract images (deprecated) error:", error);
-    const msg = error.message || "Failed to extract images";
-    if (msg.includes("No Anthropic API key found")) {
-      return res.status(400).json({
-        error: "Anthropic API key not configured. Add your Anthropic key in the dashboard under Settings > API Keys.",
-      });
-    }
-    res.status(error.statusCode || 500).json({ error: msg });
-  }
-});
-
-/**
  * GET /v1/brands/:id/extracted-images
  * List extracted images in cache. Supports ?campaignId= query param.
  */
@@ -302,12 +244,12 @@ router.get("/brands/:id/extracted-images", authenticate, requireOrg, requireUser
     const qs = params.toString() ? `?${params.toString()}` : "";
     const result = await callExternalService(
       externalServices.brand,
-      `/orgs/brands/${req.params.id}/extracted-images${qs}`,
+      `/internal/brands/${req.params.id}/extracted-images${qs}`,
       { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Get extracted images error:", error);
+    console.error("[api-service] Get extracted images error:", error);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get extracted images" });
   }
 });
@@ -362,7 +304,7 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
     // 1. Get runs list from brand-service
     const data = await callExternalService<{ runs?: Array<{ id: string; taskName: string; status: string; startedAt: string; completedAt: string | null }> }>(
       externalServices.brand,
-      `/orgs/brands/${id}/runs`,
+      `/internal/brands/${id}/runs`,
       { headers: buildInternalHeaders(req) },
     );
     const runs: Array<{ id: string; taskName: string; status: string; startedAt: string; completedAt: string | null }> = data.runs || [];

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -14,7 +14,7 @@ const router = Router();
 
 /**
  * Resolve brandIds → brandUrls via brand-service.
- * Calls GET /orgs/brands/:id for each brand in parallel and extracts the URL.
+ * Calls GET /internal/brands/:id for each brand in parallel and extracts the URL.
  */
 async function resolveBrandUrls(
   brandIds: string[],
@@ -25,7 +25,7 @@ async function resolveBrandUrls(
     brandIds.map((id) =>
       callExternalService<{ brand: { brandUrl: string | null } }>(
         externalServices.brand,
-        `/orgs/brands/${encodeURIComponent(id)}`,
+        `/internal/brands/${encodeURIComponent(id)}`,
         { headers },
       ),
     ),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3199,45 +3199,6 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/brands/{id}/extract-fields",
-  tags: ["Brand"],
-  summary: "Extract fields from brand (single brand, deprecated)",
-  description:
-    "Deprecated — use POST /v1/brands/extract-fields instead (reads brand IDs from x-brand-id header). " +
-    "Generic field extraction: send fields you want with a key and description, and brand-service extracts them via AI. Results are cached 30 days per field.",
-  security: authed,
-  request: {
-    params: BrandIdParam,
-    body: {
-      content: {
-        "application/json": {
-          schema: z.object({
-            fields: z.array(ExtractFieldRequestSchema).describe("Fields to extract"),
-          }).openapi("ExtractFieldsRequest"),
-        },
-      },
-    },
-  },
-  responses: {
-    200: {
-      description: "Extracted field results",
-      content: {
-        "application/json": {
-          schema: z.object({
-            brandId: z.string().describe("Brand ID"),
-            results: z.record(z.string(), ExtractFieldResultSchema).describe("Extraction results keyed by field name (e.g. results.biography.value)"),
-          }).openapi("ExtractFieldsResponse"),
-        },
-      },
-    },
-    400: { description: "Anthropic API key not configured", content: errorContent },
-    401: { description: "Unauthorized", content: errorContent },
-    500: { description: "Internal error", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "post",
   path: "/v1/brands/extract-fields",
   tags: ["Brand"],
   summary: "Extract fields from brand(s)",
@@ -3245,7 +3206,7 @@ registry.registerPath({
     "Multi-brand field extraction. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service. " +
     "Send fields you want with a key and description, and brand-service extracts them via AI. " +
     "Results are cached 30 days per field per brand. " +
-    "Replaces POST /v1/brands/{id}/extract-fields for multi-brand campaigns.",
+    "Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service.",
   security: authed,
   request: {
     body: {
@@ -3349,7 +3310,7 @@ registry.registerPath({
   summary: "Extract images from brand(s)",
   description:
     "Multi-brand image extraction. Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service. " +
-    "Replaces POST /v1/brands/{id}/extract-images for multi-brand campaigns.",
+    "Pass brandIds in the request body — api-service sets x-brand-id header and proxies to brand-service.",
   security: authed,
   request: {
     body: {
@@ -3384,45 +3345,6 @@ registry.registerPath({
       },
     },
     400: { description: "Validation error or Anthropic API key not configured", content: errorContent },
-    401: { description: "Unauthorized", content: errorContent },
-    500: { description: "Internal error", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "post",
-  path: "/v1/brands/{id}/extract-images",
-  tags: ["Brand"],
-  summary: "Extract images from brand (single brand, deprecated)",
-  description:
-    "Deprecated — use POST /v1/brands/extract-images instead. " +
-    "Extract brand images by category (logo, product shots, hero image, etc.) via scraping + vision AI. Returns permanent R2 URLs.",
-  security: authed,
-  request: {
-    params: BrandIdParam,
-    body: {
-      content: {
-        "application/json": {
-          schema: z.object({
-            categories: z.array(ExtractImageCategorySchema).describe("Image categories to extract"),
-          }).openapi("ExtractImagesRequest"),
-        },
-      },
-    },
-  },
-  responses: {
-    200: {
-      description: "Extracted image results",
-      content: {
-        "application/json": {
-          schema: z.object({
-            brandId: z.string().describe("Brand ID"),
-            images: z.array(ExtractedImageSchema).describe("Extracted images"),
-          }).openapi("ExtractImagesResponse"),
-        },
-      },
-    },
-    400: { description: "Anthropic API key not configured", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },

--- a/tests/unit/brand-extracted-fields.test.ts
+++ b/tests/unit/brand-extracted-fields.test.ts
@@ -89,7 +89,7 @@ describe("GET /v1/brands/:id/extracted-fields", () => {
 
     await request(app).get("/v1/brands/brand-xyz/extracted-fields");
 
-    expect(capturedUrl).toContain("/brands/brand-xyz/extracted-fields");
+    expect(capturedUrl).toContain("/internal/brands/brand-xyz/extracted-fields");
   });
 
   it("should return 404 when brand-service returns 404", async () => {

--- a/tests/unit/brand-extracted-images.test.ts
+++ b/tests/unit/brand-extracted-images.test.ts
@@ -42,79 +42,6 @@ const mockImages = [
   },
 ];
 
-describe("POST /v1/brands/:id/extract-images", () => {
-  let app: express.Express;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    app = buildApp();
-  });
-
-  it("should proxy the request body to brand-service and return results", async () => {
-    let capturedBody: any;
-    global.fetch = vi.fn().mockImplementation(async (_url: string, opts: any) => {
-      capturedBody = JSON.parse(opts.body);
-      return {
-        ok: true,
-        json: () => Promise.resolve({ brandId: "brand-abc", images: mockImages }),
-      };
-    });
-
-    const body = {
-      categories: [
-        { key: "logo", description: "Company logo", maxCount: 1 },
-        { key: "hero_image", description: "Main hero/banner image", maxCount: 1 },
-      ],
-    };
-
-    const res = await request(app).post("/v1/brands/brand-abc/extract-images").send(body);
-
-    expect(res.status).toBe(200);
-    expect(res.body.brandId).toBe("brand-abc");
-    expect(res.body.images).toHaveLength(2);
-    expect(capturedBody.categories).toHaveLength(2);
-    expect(capturedBody.categories[0].key).toBe("logo");
-  });
-
-  it("should forward the brand ID in the URL", async () => {
-    let capturedUrl = "";
-    global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      capturedUrl = url;
-      return { ok: true, json: () => Promise.resolve({ brandId: "brand-xyz", images: [] }) };
-    });
-
-    await request(app).post("/v1/brands/brand-xyz/extract-images").send({ categories: [] });
-
-    expect(capturedUrl).toContain("/brands/brand-xyz/extract-images");
-  });
-
-  it("should return 400 when Anthropic key is not configured", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 400,
-      text: () => Promise.resolve('{"error":"No Anthropic API key found"}'),
-    }));
-
-    const res = await request(app).post("/v1/brands/brand-abc/extract-images").send({ categories: [] });
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain("Anthropic API key not configured");
-  });
-
-  it("should return 500 when brand-service fails", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 500,
-      text: () => Promise.resolve('{"error":"Internal error"}'),
-    }));
-
-    const res = await request(app).post("/v1/brands/brand-abc/extract-images").send({ categories: [] });
-
-    expect(res.status).toBe(500);
-    expect(res.body.error).toContain("Internal error");
-  });
-});
-
 describe("GET /v1/brands/:id/extracted-images", () => {
   let app: express.Express;
 
@@ -137,6 +64,18 @@ describe("GET /v1/brands/:id/extracted-images", () => {
     expect(res.body.images[0].category).toBe("logo");
   });
 
+  it("should call brand-service at /internal/brands/:id/extracted-images", async () => {
+    let capturedUrl = "";
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, json: () => Promise.resolve({ brandId: "brand-abc", images: [] }) };
+    });
+
+    await request(app).get("/v1/brands/brand-abc/extracted-images");
+
+    expect(capturedUrl).toContain("/internal/brands/brand-abc/extracted-images");
+  });
+
   it("should forward campaignId query param", async () => {
     let capturedUrl = "";
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
@@ -146,7 +85,7 @@ describe("GET /v1/brands/:id/extracted-images", () => {
 
     await request(app).get("/v1/brands/brand-abc/extracted-images?campaignId=camp-123");
 
-    expect(capturedUrl).toContain("/brands/brand-abc/extracted-images?campaignId=camp-123");
+    expect(capturedUrl).toContain("/internal/brands/brand-abc/extracted-images?campaignId=camp-123");
   });
 
   it("should not append query string when no campaignId", async () => {
@@ -158,7 +97,7 @@ describe("GET /v1/brands/:id/extracted-images", () => {
 
     await request(app).get("/v1/brands/brand-abc/extracted-images");
 
-    expect(capturedUrl).toContain("/brands/brand-abc/extracted-images");
+    expect(capturedUrl).toContain("/internal/brands/brand-abc/extracted-images");
     expect(capturedUrl).not.toContain("?");
   });
 

--- a/tests/unit/brand-sales-profile-404.regression.test.ts
+++ b/tests/unit/brand-sales-profile-404.regression.test.ts
@@ -3,9 +3,9 @@ import request from "supertest";
 import express from "express";
 
 /**
- * POST /v1/brands/:id/extract-fields
- * Generic field extraction proxy to brand-service.
- * Replaces the old GET/POST/PUT sales-profile endpoints.
+ * Regression: deprecated brand endpoints return 404.
+ * POST /v1/brands/:id/extract-fields was removed (use POST /v1/brands/extract-fields instead).
+ * Old sales-profile endpoints were removed long ago.
  */
 
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -33,7 +33,7 @@ function buildApp() {
   return app;
 }
 
-describe("POST /v1/brands/:id/extract-fields", () => {
+describe("deprecated brand endpoints return 404", () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -41,88 +41,21 @@ describe("POST /v1/brands/:id/extract-fields", () => {
     app = buildApp();
   });
 
-  it("should return 200 with extracted results", async () => {
-    const response = {
-      brandId: "b-1",
-      results: {
-        industry: { value: "SaaS", cached: true, extractedAt: "2026-03-01T00:00:00Z", expiresAt: "2026-03-31T00:00:00Z" },
-        valueProposition: { value: "All-in-one platform", cached: false, extractedAt: "2026-03-23T00:00:00Z", expiresAt: "2026-04-22T00:00:00Z" },
-      },
-    };
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: true,
-      json: () => Promise.resolve(response),
-    }));
-
-    const res = await request(app)
-      .post("/v1/brands/some-brand-id/extract-fields")
-      .send({
-        fields: [
-          { key: "industry", description: "Brand sector" },
-          { key: "valueProposition", description: "Core value proposition" },
-        ],
-      });
-
-    expect(res.status).toBe(200);
-    expect(res.body.brandId).toBe("b-1");
-    expect(Object.keys(res.body.results)).toHaveLength(2);
-    expect(res.body.results.industry.value).toBe("SaaS");
-    expect(res.body.results.industry.cached).toBe(true);
-  });
-
-  it("should forward the request body to brand-service", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: true,
-      json: () => Promise.resolve({ brandId: "b-1", results: {} }),
-    }));
-
-    const fields = [
-      { key: "industry", description: "Brand sector" },
-      { key: "suggestedAngles", description: "PR angles" },
-    ];
-
-    await request(app)
-      .post("/v1/brands/some-brand-id/extract-fields")
-      .send({ fields });
-
-    const fetchCall = (global.fetch as any).mock.calls[0];
-    const url = typeof fetchCall[0] === "string" ? fetchCall[0] : fetchCall[0].url;
-    expect(url).toContain("/brands/some-brand-id/extract-fields");
-
-    const body = JSON.parse(fetchCall[1].body);
-    expect(body.fields).toEqual(fields);
-  });
-
-  it("should return 400 when Anthropic key is missing", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 400,
-      text: () => Promise.resolve('{"error":"No Anthropic API key found"}'),
-    }));
-
+  it("POST /v1/brands/:id/extract-fields returns 404 (use POST /v1/brands/extract-fields)", async () => {
     const res = await request(app)
       .post("/v1/brands/some-brand-id/extract-fields")
       .send({ fields: [{ key: "industry", description: "Brand sector" }] });
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain("Anthropic API key not configured");
+    expect(res.status).toBe(404);
   });
 
-  it("should return 500 for genuine server errors", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 500,
-      text: () => Promise.resolve('{"error":"Internal server error"}'),
-    }));
-
+  it("POST /v1/brands/:id/extract-images returns 404 (use POST /v1/brands/extract-images)", async () => {
     const res = await request(app)
-      .post("/v1/brands/some-brand-id/extract-fields")
-      .send({ fields: [{ key: "industry", description: "Brand sector" }] });
-
-    expect(res.status).toBe(500);
+      .post("/v1/brands/some-brand-id/extract-images")
+      .send({ categories: [{ key: "logo", description: "Logo" }] });
+    expect(res.status).toBe(404);
   });
 
-  it("should return 404 for old sales-profile endpoints", async () => {
+  it("GET /v1/brands/:id/sales-profile returns 404", async () => {
     const res = await request(app).get("/v1/brands/some-brand-id/sales-profile");
     expect(res.status).toBe(404);
   });

--- a/tests/unit/brand-service-paths.regression.test.ts
+++ b/tests/unit/brand-service-paths.regression.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * Regression test: brand-service paths must match the actual brand-service API.
+ *
+ * /orgs/*   routes exist on brand-service for org-scoped operations (list, extract).
+ * /internal/* routes exist for by-ID lookups (get brand, extracted fields/images, runs).
+ *
+ * api-service must NEVER call /orgs/brands/:id — that path does not exist on brand-service.
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+import campaignRouter from "../../src/routes/campaigns.js";
+
+function buildBrandApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+function buildCampaignApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignRouter);
+  return app;
+}
+
+describe("brand-service path correctness", () => {
+  let capturedUrls: string[];
+
+  beforeEach(() => {
+    capturedUrls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrls.push(url);
+
+      // Return valid responses for all expected paths
+      if (url.includes("/internal/brands/") && url.includes("/runs")) {
+        return { ok: true, json: () => Promise.resolve({ runs: [] }) };
+      }
+      if (url.includes("/internal/brands/")) {
+        return { ok: true, json: () => Promise.resolve({ brand: { id: "brand-abc", brandUrl: "https://acme.com" } }) };
+      }
+      if (url.includes("/orgs/brands")) {
+        return { ok: true, json: () => Promise.resolve({ brands: [] }) };
+      }
+      if (url.includes("/campaigns")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({
+            campaign: { id: "camp-1", brandIds: ["brand-abc"], brandUrls: null, status: "ongoing", workflowSlug: "wf-1" },
+          }),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+  });
+
+  it("GET /v1/brands/:id calls /internal/brands/:id (not /orgs/brands/:id)", async () => {
+    const app = buildBrandApp();
+    await request(app).get("/v1/brands/brand-abc");
+
+    const brandCall = capturedUrls.find((u) => u.includes("/brands/brand-abc") && !u.includes("/extracted"));
+    expect(brandCall).toBeDefined();
+    expect(brandCall).toContain("/internal/brands/brand-abc");
+    expect(brandCall).not.toContain("/orgs/brands/brand-abc");
+  });
+
+  it("GET /v1/brands/:id/extracted-fields calls /internal/brands/:id/extracted-fields", async () => {
+    const app = buildBrandApp();
+    await request(app).get("/v1/brands/brand-abc/extracted-fields");
+
+    const call = capturedUrls.find((u) => u.includes("extracted-fields"));
+    expect(call).toBeDefined();
+    expect(call).toContain("/internal/brands/brand-abc/extracted-fields");
+  });
+
+  it("GET /v1/brands/:id/extracted-images calls /internal/brands/:id/extracted-images", async () => {
+    const app = buildBrandApp();
+    await request(app).get("/v1/brands/brand-abc/extracted-images");
+
+    const call = capturedUrls.find((u) => u.includes("extracted-images"));
+    expect(call).toBeDefined();
+    expect(call).toContain("/internal/brands/brand-abc/extracted-images");
+  });
+
+  it("GET /v1/brands/:id/runs calls /internal/brands/:id/runs", async () => {
+    const app = buildBrandApp();
+    await request(app).get("/v1/brands/brand-abc/runs");
+
+    const call = capturedUrls.find((u) => u.includes("/runs"));
+    expect(call).toBeDefined();
+    expect(call).toContain("/internal/brands/brand-abc/runs");
+  });
+
+  it("GET /v1/brands (list) calls /orgs/brands (org-scoped, no ID in path)", async () => {
+    const app = buildBrandApp();
+    await request(app).get("/v1/brands");
+
+    const call = capturedUrls.find((u) => u.includes("/orgs/brands"));
+    expect(call).toBeDefined();
+    expect(call).toContain("/orgs/brands");
+  });
+
+  it("campaign brandUrls resolution calls /internal/brands/:id (not /orgs/)", async () => {
+    const app = buildCampaignApp();
+    await request(app).get("/v1/campaigns/camp-1");
+
+    const brandCall = capturedUrls.find((u) => u.includes("/brands/brand-abc") && !u.includes("/campaigns"));
+    expect(brandCall).toBeDefined();
+    expect(brandCall).toContain("/internal/brands/brand-abc");
+    expect(brandCall).not.toContain("/orgs/brands/brand-abc");
+  });
+
+  it("deprecated POST /v1/brands/:id/extract-fields no longer exists", async () => {
+    const app = buildBrandApp();
+    const res = await request(app).post("/v1/brands/brand-abc/extract-fields").send({ fields: [] });
+    expect(res.status).toBe(404);
+  });
+
+  it("deprecated POST /v1/brands/:id/extract-images no longer exists", async () => {
+    const app = buildBrandApp();
+    const res = await request(app).post("/v1/brands/brand-abc/extract-images").send({ categories: [] });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix brand-service path mapping: by-ID lookups use `/internal/brands/{id}`, not `/orgs/brands/{id}` (which doesn't exist and was returning 404)
- Remove deprecated `POST /v1/brands/:id/extract-fields` and `POST /v1/brands/:id/extract-images` (already 404 on brand-service; use the multi-brand endpoints instead)
- Add regression test enforcing correct path prefixes for all brand-service calls

## Test plan
- [x] All 29 brand-related tests pass
- [x] New regression test verifies `/internal/` prefix for by-ID routes and `/orgs/` for org-scoped routes
- [x] Deprecated route tests updated to assert 404
- [x] Pre-existing test failures confirmed unrelated (same 5 failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)