### PR TITLE
docs: improve journalist stats OpenAPI descriptions

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2535,7 +2535,8 @@
                   "type": "object",
                   "additionalProperties": {
                     "type": "number"
-                  }
+                  },
+                  "description": "Map of outreach status to count for this group"
                 }
               },
               "required": [
@@ -2543,7 +2544,7 @@
                 "byOutreachStatus"
               ]
             },
-            "description": "Per-slug breakdown when groupBy is specified"
+            "description": "Per-slug breakdown when groupBy is specified. Keys are slug values (or dynasty slugs for dynasty grouping)."
           }
         },
         "required": [
@@ -13132,7 +13133,7 @@
           "Journalists"
         ],
         "summary": "Get journalist stats with dynasty-aware filtering and grouping",
-        "description": "Returns journalist counts by status. Local statuses: buffered, claimed, served, skipped. Email-gateway enriched statuses: contacted, delivered, replied, bounced. Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
+        "description": "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, replied, bounced). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
         "security": [
           {
             "bearerAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1689,8 +1689,7 @@ registry.registerPath({
   tags: ["Journalists"],
   summary: "Get journalist stats with dynasty-aware filtering and grouping",
   description:
-    "Returns journalist counts by status. Local statuses: buffered, claimed, served, skipped. " +
-    "Email-gateway enriched statuses: contacted, delivered, replied, bounced. " +
+    "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, replied, bounced). " +
     "Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. " +
     "Optional groupBy returns per-slug breakdowns.",
   security: authed,
@@ -1705,8 +1704,8 @@ registry.registerPath({
             byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count. Statuses: buffered, claimed, served, skipped, contacted, delivered, replied, bounced."),
             groupedBy: z.record(z.object({
               totalJournalists: z.number(),
-              byOutreachStatus: z.record(z.number()),
-            })).optional().describe("Per-slug breakdown when groupBy is specified"),
+              byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count for this group"),
+            })).optional().describe("Per-slug breakdown when groupBy is specified. Keys are slug values (or dynasty slugs for dynasty grouping)."),
           }).openapi("JournalistStatsResponse"),
         },
       },


### PR DESCRIPTION
## Summary
- Remove stale "Local statuses" / "Email-gateway enriched statuses" distinction from stats endpoint description — it's all `outreachStatus` now
- Add missing description on `byOutreachStatus` inside `groupedBy`
- Add clarification on `groupedBy` keys

Follow-up to PR #315.

## Test plan
- [x] 73 journalist tests pass
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)