### PR TITLE
fix: update outlet schemas for outlets-service v5.0.0

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1407,22 +1407,29 @@
           "relevanceScore": {
             "type": "number"
           },
-          "status": {
+          "outreachStatus": {
             "type": "string",
             "enum": [
               "open",
               "ended",
               "denied",
               "served",
-              "skipped",
-              "buffered",
-              "claimed",
               "contacted",
               "delivered",
               "replied",
-              "bounced"
+              "skipped"
             ],
-            "description": "Consolidated status: most advanced journalist status for this campaign"
+            "description": "Outreach status scoped to this specific campaign."
+          },
+          "replyClassification": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "positive",
+              "negative",
+              "neutral"
+            ],
+            "description": "Reply classification when outreachStatus is 'replied'. Null otherwise."
           },
           "overallRelevance": {
             "type": "string",
@@ -1446,7 +1453,8 @@
           "featureSlug",
           "brandIds",
           "relevanceScore",
-          "status",
+          "outreachStatus",
+          "replyClassification",
           "updatedAt"
         ]
       },
@@ -1470,25 +1478,29 @@
             "type": "string",
             "format": "date-time"
           },
-          "latestStatus": {
+          "outreachStatus": {
             "type": "string",
             "enum": [
               "open",
               "ended",
               "denied",
               "served",
-              "skipped",
-              "buffered",
-              "claimed",
               "contacted",
               "delivered",
               "replied",
-              "bounced"
+              "skipped"
             ],
-            "description": "Consolidated status: most advanced status across all journalists in this outlet"
+            "description": "High watermark outreach status from journalists-service at the query's scope (campaign or brand). Falls back to most advanced DB status when no journalist data exists."
           },
-          "latestRelevanceScore": {
-            "type": "number"
+          "replyClassification": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "positive",
+              "negative",
+              "neutral"
+            ],
+            "description": "Best reply classification when outreachStatus is 'replied'. Null otherwise."
           },
           "campaigns": {
             "type": "array",
@@ -1504,8 +1516,8 @@
           "outletUrl",
           "outletDomain",
           "createdAt",
-          "latestStatus",
-          "latestRelevanceScore",
+          "outreachStatus",
+          "replyClassification",
           "campaigns"
         ]
       },
@@ -1590,6 +1602,62 @@
           "whyRelevant",
           "whyNotRelevant",
           "relevanceScore"
+        ]
+      },
+      "OutletStatsResponse": {
+        "type": "object",
+        "properties": {
+          "outletsDiscovered": {
+            "type": "number",
+            "description": "Total outlets discovered matching the filters"
+          },
+          "avgRelevanceScore": {
+            "type": "number",
+            "description": "Average relevance score across matching outlets"
+          },
+          "searchQueriesUsed": {
+            "type": "number",
+            "description": "Number of distinct search queries used"
+          },
+          "byOutreachStatus": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "Map of outreach status to outlet count. Enriched from journalists-service with DB status fallback."
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "outletsDiscovered": {
+                  "type": "number"
+                },
+                "avgRelevanceScore": {
+                  "type": "number"
+                },
+                "searchQueriesUsed": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "key",
+                "outletsDiscovered",
+                "avgRelevanceScore",
+                "searchQueriesUsed"
+              ]
+            },
+            "description": "Per-dimension breakdown when groupBy is specified"
+          }
+        },
+        "required": [
+          "outletsDiscovered",
+          "avgRelevanceScore",
+          "searchQueriesUsed"
         ]
       },
       "OutletStatsCostsResponse": {
@@ -10488,7 +10556,7 @@
           "Outlets"
         ],
         "summary": "List outlets with filters (deduplicated)",
-        "description": "Returns outlets deduplicated by outlet_id with nested campaign data. Each outlet appears once with a campaigns[] array containing per-campaign details. Filter by campaignId, brandId, status, featureSlugs (comma-separated), or featureDynastySlug. Supports pagination on distinct outlets. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "description": "Returns outlets deduplicated by outlet_id with nested campaign data. Each outlet appears once with a campaigns[] array containing per-campaign details. At least one of brandId or campaignId is required (returns 400 otherwise). Outreach status is enriched from journalists-service at the query's scope. Filter by status, featureSlugs (comma-separated), or featureDynastySlug. Supports pagination on distinct outlets. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -10848,7 +10916,7 @@
           "Outlets"
         ],
         "summary": "Aggregated outlet discovery metrics",
-        "description": "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+        "description": "Returns outlet discovery stats with byOutreachStatus breakdown enriched from journalists-service. All outlets are enriched (not just served ones). Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
         "security": [
           {
             "bearerAuth": []
@@ -11046,7 +11114,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Stats (flat or grouped)"
+            "description": "Stats (flat when no groupBy, grouped when groupBy is set). Flat response includes byOutreachStatus — a map of outreach status to count, enriched from journalists-service.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutletStatsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -970,7 +970,9 @@ registry.registerPath({
   tags: ["Outlets"],
   summary: "List outlets with filters (deduplicated)",
   description: "Returns outlets deduplicated by outlet_id with nested campaign data. Each outlet appears once with a campaigns[] array containing per-campaign details. " +
-    "Filter by campaignId, brandId, status, featureSlugs (comma-separated), or featureDynastySlug. Supports pagination on distinct outlets. " +
+    "At least one of brandId or campaignId is required (returns 400 otherwise). " +
+    "Outreach status is enriched from journalists-service at the query's scope. " +
+    "Filter by status, featureSlugs (comma-separated), or featureDynastySlug. Supports pagination on distinct outlets. " +
     "All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
@@ -1000,8 +1002,8 @@ registry.registerPath({
                   outletUrl: z.string(),
                   outletDomain: z.string(),
                   createdAt: z.string().datetime(),
-                  latestStatus: z.enum(["open", "ended", "denied", "served", "skipped", "buffered", "claimed", "contacted", "delivered", "replied", "bounced"]).describe("Consolidated status: most advanced status across all journalists in this outlet"),
-                  latestRelevanceScore: z.number(),
+                  outreachStatus: z.enum(["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]).describe("High watermark outreach status from journalists-service at the query's scope (campaign or brand). Falls back to most advanced DB status when no journalist data exists."),
+                  replyClassification: z.enum(["positive", "negative", "neutral"]).nullable().describe("Best reply classification when outreachStatus is 'replied'. Null otherwise."),
                   campaigns: z.array(
                     z.object({
                       campaignId: z.string().uuid(),
@@ -1010,7 +1012,8 @@ registry.registerPath({
                       whyRelevant: z.string().optional(),
                       whyNotRelevant: z.string().optional(),
                       relevanceScore: z.number(),
-                      status: z.enum(["open", "ended", "denied", "served", "skipped", "buffered", "claimed", "contacted", "delivered", "replied", "bounced"]).describe("Consolidated status: most advanced journalist status for this campaign"),
+                      outreachStatus: z.enum(["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]).describe("Outreach status scoped to this specific campaign."),
+                      replyClassification: z.enum(["positive", "negative", "neutral"]).nullable().describe("Reply classification when outreachStatus is 'replied'. Null otherwise."),
                       overallRelevance: z.string().nullable().optional(),
                       relevanceRationale: z.string().nullable().optional(),
                       runId: z.string().nullable().optional(),
@@ -1073,7 +1076,10 @@ registry.registerPath({
   path: "/v1/outlets/stats",
   tags: ["Outlets"],
   summary: "Aggregated outlet discovery metrics",
-  description: "Returns outlet discovery stats. Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy. All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
+  description: "Returns outlet discovery stats with byOutreachStatus breakdown enriched from journalists-service. " +
+    "All outlets are enriched (not just served ones). " +
+    "Supports filtering by brandId, campaignId, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug and optional groupBy. " +
+    "All 4 workflow headers (x-campaign-id, x-brand-id, x-feature-slug, x-workflow-slug) are required.",
   security: authed,
   request: {
     headers: outletsRequiredHeaders,
@@ -1090,7 +1096,25 @@ registry.registerPath({
     }),
   },
   responses: {
-    200: { description: "Stats (flat or grouped)" },
+    200: {
+      description: "Stats (flat when no groupBy, grouped when groupBy is set). Flat response includes byOutreachStatus — a map of outreach status to count, enriched from journalists-service.",
+      content: {
+        "application/json": {
+          schema: z.object({
+            outletsDiscovered: z.number().describe("Total outlets discovered matching the filters"),
+            avgRelevanceScore: z.number().describe("Average relevance score across matching outlets"),
+            searchQueriesUsed: z.number().describe("Number of distinct search queries used"),
+            byOutreachStatus: z.record(z.number()).optional().describe("Map of outreach status to outlet count. Enriched from journalists-service with DB status fallback."),
+            groups: z.array(z.object({
+              key: z.string(),
+              outletsDiscovered: z.number(),
+              avgRelevanceScore: z.number(),
+              searchQueriesUsed: z.number(),
+            })).optional().describe("Per-dimension breakdown when groupBy is specified"),
+          }).openapi("OutletStatsResponse"),
+        },
+      },
+    },
     401: { description: "Unauthorized", content: errorContent },
   },
 });

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -251,9 +251,12 @@ describe("Outlets OpenAPI schemas", () => {
     expect(schemaContent).toContain("ListOutletsResponse");
     expect(schemaContent).toContain("OutletWithCampaigns");
     expect(schemaContent).toContain("OutletCampaignEntry");
-    expect(schemaContent).toContain("latestStatus");
-    expect(schemaContent).toContain("latestRelevanceScore");
+    expect(schemaContent).toContain("outreachStatus");
+    expect(schemaContent).toContain("replyClassification");
     expect(schemaContent).toContain("outletDomain");
+    // latestStatus was replaced by outreachStatus in outlets-service v5.0.0
+    expect(schemaContent).not.toContain("latestStatus");
+    expect(schemaContent).not.toContain("latestRelevanceScore");
   });
 
   it("should include full campaign entry fields in OutletCampaignEntry", () => {
@@ -273,22 +276,37 @@ describe("Outlets OpenAPI schemas", () => {
     expect(getOutletsSection).toContain('"skipped"');
   });
 
-  it("latestStatus enum should include journalist-level statuses (contacted, delivered, replied, bounced)", () => {
-    const getOutletsSection = schemaContent.slice(
-      schemaContent.indexOf('path: "/v1/outlets"'),
-      schemaContent.indexOf('path: "/v1/outlets"') + 2000
+  it("outreachStatus enum should include enriched statuses (contacted, delivered, replied, skipped)", () => {
+    // Use ListOutletsResponse block which contains both outlet-level and campaign-level schemas
+    const start = schemaContent.indexOf("ListOutletsResponse");
+    const responseBlock = schemaContent.slice(Math.max(0, start - 3000), start);
+    for (const status of ["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]) {
+      expect(responseBlock).toContain(`"${status}"`);
+    }
+    // buffered, claimed, bounced removed from outlet-level enum in outlets-service v5.0.0
+    const outreachEnumBlock = responseBlock.slice(
+      responseBlock.indexOf("outreachStatus"),
+      responseBlock.indexOf("outreachStatus") + 400
     );
-    for (const status of ["contacted", "delivered", "replied", "bounced", "buffered", "claimed"]) {
-      expect(getOutletsSection).toContain(`"${status}"`);
+    expect(outreachEnumBlock).not.toContain('"buffered"');
+    expect(outreachEnumBlock).not.toContain('"claimed"');
+    expect(outreachEnumBlock).not.toContain('"bounced"');
+  });
+
+  it("per-campaign outreachStatus enum should match outlet-level enum", () => {
+    const idx = schemaContent.indexOf("OutletCampaignEntry");
+    const entrySection = schemaContent.slice(Math.max(0, idx - 1200), idx + 100);
+    for (const status of ["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]) {
+      expect(entrySection).toContain(`"${status}"`);
     }
   });
 
-  it("per-campaign status enum should include journalist-level statuses (contacted, delivered, replied, bounced)", () => {
-    const idx = schemaContent.indexOf("OutletCampaignEntry");
-    const entrySection = schemaContent.slice(Math.max(0, idx - 1200), idx + 100);
-    for (const status of ["contacted", "delivered", "replied", "bounced", "buffered", "claimed"]) {
-      expect(entrySection).toContain(`"${status}"`);
-    }
+  it("should have replyClassification at both outlet and campaign level", () => {
+    const start = schemaContent.indexOf("ListOutletsResponse");
+    const responseBlock = schemaContent.slice(Math.max(0, start - 3000), start);
+    const matches = responseBlock.match(/replyClassification/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
   });
 
   it("should register GET /v1/outlets/{id}", () => {


### PR DESCRIPTION
## Summary
- `latestStatus` → `outreachStatus` with updated enum (removed `buffered`, `claimed`, `bounced` from outlet-level enum)
- Added `replyClassification` at both outlet and campaign level
- `campaigns[].status` → `campaigns[].outreachStatus`
- Added `byOutreachStatus` response schema for `GET /v1/outlets/stats` (was undocumented)
- Updated endpoint description: `brandId` or `campaignId` now required on `GET /v1/outlets`
- Removed stale `latestRelevanceScore` field (no longer in upstream contract)

Adapts api-service OpenAPI schemas to match outlets-service v5.0.0 (PRs #71 + #72).

## Test plan
- [x] `outlets-proxy.test.ts` passes (58 tests)
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)