### PR TITLE
fix: add outlet-level relevanceScore (outlets-service PR #73)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1502,6 +1502,10 @@
             ],
             "description": "Best reply classification when outreachStatus is 'replied'. Null otherwise."
           },
+          "relevanceScore": {
+            "type": "number",
+            "description": "Max relevance score across all per-campaign scores for this outlet (same high watermark logic as outreachStatus)."
+          },
           "campaigns": {
             "type": "array",
             "items": {
@@ -1518,6 +1522,7 @@
           "createdAt",
           "outreachStatus",
           "replyClassification",
+          "relevanceScore",
           "campaigns"
         ]
       },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1004,6 +1004,7 @@ registry.registerPath({
                   createdAt: z.string().datetime(),
                   outreachStatus: z.enum(["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]).describe("High watermark outreach status from journalists-service at the query's scope (campaign or brand). Falls back to most advanced DB status when no journalist data exists."),
                   replyClassification: z.enum(["positive", "negative", "neutral"]).nullable().describe("Best reply classification when outreachStatus is 'replied'. Null otherwise."),
+                  relevanceScore: z.number().describe("Max relevance score across all per-campaign scores for this outlet (same high watermark logic as outreachStatus)."),
                   campaigns: z.array(
                     z.object({
                       campaignId: z.string().uuid(),


### PR DESCRIPTION
## Summary
- Added `relevanceScore` at outlet level in `OutletWithCampaigns` schema
- Max across all per-campaign scores (same high watermark logic as `outreachStatus`)
- Per-campaign `relevanceScore` unchanged

## Test plan
- [x] `outlets-proxy.test.ts` passes (58 tests)
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)