### PR TITLE
fix: add outreachStatus at journalist level in list schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2115,6 +2115,20 @@
                   "type": "string",
                   "format": "uuid"
                 },
+                "outreachStatus": {
+                  "type": "string",
+                  "enum": [
+                    "buffered",
+                    "claimed",
+                    "served",
+                    "contacted",
+                    "delivered",
+                    "replied",
+                    "bounced",
+                    "skipped"
+                  ],
+                  "description": "High watermark outreach status across all campaigns for this journalist"
+                },
                 "email": {
                   "type": "string",
                   "nullable": true,
@@ -2429,6 +2443,7 @@
                 "lastName",
                 "entityType",
                 "outletId",
+                "outreachStatus",
                 "email",
                 "apolloPersonId",
                 "emailStatus",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1537,6 +1537,7 @@ registry.registerPath({
                   lastName: z.string().nullable(),
                   entityType: z.enum(["individual", "organization"]),
                   outletId: z.string().uuid(),
+                  outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).describe("High watermark outreach status across all campaigns for this journalist"),
                   email: z.string().nullable().describe("Global email (from journalists table apollo_email, fallback to best campaign email)"),
                   apolloPersonId: z.string().nullable(),
                   emailStatus: JournalistEmailStatusSchema,

--- a/tests/unit/journalists-list-proxy.test.ts
+++ b/tests/unit/journalists-list-proxy.test.ts
@@ -157,7 +157,7 @@ describe("GET /journalists/list OpenAPI schema", () => {
     expect(op.responses["401"]).toBeDefined();
   });
 
-  it("should include emailStatus, cost, and campaigns[] in response schema", () => {
+  it("should include outreachStatus, emailStatus, cost, and campaigns[] in response schema", () => {
     const ref =
       openapi.paths["/v1/journalists/list"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema?.$ref;
     expect(ref).toBe("#/components/schemas/JournalistListResponse");
@@ -165,6 +165,7 @@ describe("GET /journalists/list OpenAPI schema", () => {
     expect(schema).toBeDefined();
     const journalistProps = schema.properties?.journalists?.items?.properties;
     expect(journalistProps).toBeDefined();
+    expect(journalistProps.outreachStatus).toBeDefined();
     expect(journalistProps.emailStatus).toBeDefined();
     expect(journalistProps.cost).toBeDefined();
     expect(journalistProps.campaigns).toBeDefined();


### PR DESCRIPTION
## Summary
- Added `outreachStatus` field (same enum as per-campaign) at the journalist level in the `/v1/journalists/list` OpenAPI response schema
- Regenerated `openapi.json`
- Updated test to assert the new field exists in the spec

No runtime change needed — the proxy is transparent and already passes through the new field from journalists-service.

## Test plan
- [x] `journalists-list-proxy.test.ts` — 22/22 passing
- [x] `openapi.json` regenerated and includes `outreachStatus` in `JournalistListResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)