### PR TITLE
fix: align outreachStatus enum to 10-value spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1413,6 +1413,8 @@
               "open",
               "ended",
               "denied",
+              "buffered",
+              "claimed",
               "served",
               "contacted",
               "delivered",
@@ -1484,6 +1486,8 @@
               "open",
               "ended",
               "denied",
+              "buffered",
+              "claimed",
               "served",
               "contacted",
               "delivered",
@@ -1956,13 +1960,15 @@
                 "outreachStatus": {
                   "type": "string",
                   "enum": [
+                    "open",
+                    "ended",
+                    "denied",
                     "buffered",
                     "claimed",
                     "served",
                     "contacted",
                     "delivered",
                     "replied",
-                    "bounced",
                     "skipped"
                   ],
                   "description": "Outreach status: email-gateway status when available, otherwise local DB status"
@@ -2018,13 +2024,15 @@
           "outreachStatus": {
             "type": "string",
             "enum": [
+              "open",
+              "ended",
+              "denied",
               "buffered",
               "claimed",
               "served",
               "contacted",
               "delivered",
               "replied",
-              "bounced",
               "skipped"
             ],
             "description": "Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status.",
@@ -2124,13 +2132,15 @@
                 "outreachStatus": {
                   "type": "string",
                   "enum": [
+                    "open",
+                    "ended",
+                    "denied",
                     "buffered",
                     "claimed",
                     "served",
                     "contacted",
                     "delivered",
                     "replied",
-                    "bounced",
                     "skipped"
                   ],
                   "description": "High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied').",
@@ -2616,7 +2626,7 @@
             "additionalProperties": {
               "type": "number"
             },
-            "description": "Map of outreach status to count. Statuses: buffered, claimed, served, skipped, contacted, delivered, replied, bounced."
+            "description": "Map of outreach status to count. Statuses: open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied."
           },
           "groupedBy": {
             "type": "object",
@@ -13235,7 +13245,7 @@
           "Journalists"
         ],
         "summary": "Get journalist stats with dynasty-aware filtering and grouping",
-        "description": "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, replied, bounced). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
+        "description": "Returns journalist counts grouped by outreach status (open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
         "security": [
           {
             "bearerAuth": []

--- a/openapi.json
+++ b/openapi.json
@@ -1960,15 +1960,13 @@
                 "outreachStatus": {
                   "type": "string",
                   "enum": [
-                    "open",
-                    "ended",
-                    "denied",
                     "buffered",
                     "claimed",
                     "served",
                     "contacted",
                     "delivered",
                     "replied",
+                    "bounced",
                     "skipped"
                   ],
                   "description": "Outreach status: email-gateway status when available, otherwise local DB status"
@@ -2024,15 +2022,13 @@
           "outreachStatus": {
             "type": "string",
             "enum": [
-              "open",
-              "ended",
-              "denied",
               "buffered",
               "claimed",
               "served",
               "contacted",
               "delivered",
               "replied",
+              "bounced",
               "skipped"
             ],
             "description": "Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status.",
@@ -2132,15 +2128,13 @@
                 "outreachStatus": {
                   "type": "string",
                   "enum": [
-                    "open",
-                    "ended",
-                    "denied",
                     "buffered",
                     "claimed",
                     "served",
                     "contacted",
                     "delivered",
                     "replied",
+                    "bounced",
                     "skipped"
                   ],
                   "description": "High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied').",
@@ -2626,7 +2620,7 @@
             "additionalProperties": {
               "type": "number"
             },
-            "description": "Map of outreach status to count. Statuses: open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied."
+            "description": "Map of outreach status to count. Statuses: buffered, claimed, served, skipped, contacted, delivered, replied, bounced."
           },
           "groupedBy": {
             "type": "object",
@@ -13245,7 +13239,7 @@
           "Journalists"
         ],
         "summary": "Get journalist stats with dynasty-aware filtering and grouping",
-        "description": "Returns journalist counts grouped by outreach status (open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
+        "description": "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, replied, bounced). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
         "security": [
           {
             "bearerAuth": []

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1452,7 +1452,7 @@ registry.registerPath({
                   whyRelevant: z.string().nullable(),
                   whyNotRelevant: z.string().nullable(),
                   articleUrls: z.array(z.string()).nullable(),
-                  outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).describe("Outreach status: email-gateway status when available, otherwise local DB status"),
+                  outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).describe("Outreach status: email-gateway status when available, otherwise local DB status"),
                   runId: z.string().uuid().nullable().describe("The discovery run that created this journalist entry"),
                 }).passthrough(),
               ),
@@ -1537,7 +1537,7 @@ registry.registerPath({
                   lastName: z.string().nullable().openapi({ example: "Perez" }),
                   entityType: z.enum(["individual", "organization"]).openapi({ example: "individual" }),
                   outletId: z.string().uuid().openapi({ example: "f7e6d5c4-b3a2-4190-8877-665544332211" }),
-                  outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).openapi({ example: "contacted" }).describe("High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied')."),
+                  outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).openapi({ example: "contacted" }).describe("High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied')."),
                   email: z.string().nullable().describe("Global email (from journalists table apollo_email, fallback to best campaign email)"),
                   apolloPersonId: z.string().nullable(),
                   emailStatus: JournalistEmailStatusSchema,
@@ -1548,7 +1548,7 @@ registry.registerPath({
                       campaignId: z.string().uuid(),
                       featureSlug: z.string().nullable(),
                       workflowSlug: z.string().nullable(),
-                      outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).openapi({ example: "served" }).describe("Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status."),
+                      outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).openapi({ example: "served" }).describe("Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status."),
                       relevanceScore: z.string(),
                       whyRelevant: z.string(),
                       whyNotRelevant: z.string(),
@@ -1715,7 +1715,7 @@ registry.registerPath({
   tags: ["Journalists"],
   summary: "Get journalist stats with dynasty-aware filtering and grouping",
   description:
-    "Returns journalist counts grouped by outreach status (open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied). " +
+    "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, replied, bounced). " +
     "Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. " +
     "Optional groupBy returns per-slug breakdowns.",
   security: authed,
@@ -1727,7 +1727,7 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             totalJournalists: z.number(),
-            byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count. Statuses: open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied."),
+            byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count. Statuses: buffered, claimed, served, skipped, contacted, delivered, replied, bounced."),
             groupedBy: z.record(z.object({
               totalJournalists: z.number(),
               byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count for this group"),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1002,7 +1002,7 @@ registry.registerPath({
                   outletUrl: z.string(),
                   outletDomain: z.string(),
                   createdAt: z.string().datetime(),
-                  outreachStatus: z.enum(["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]).describe("High watermark outreach status from journalists-service at the query's scope (campaign or brand). Falls back to most advanced DB status when no journalist data exists."),
+                  outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).describe("High watermark outreach status from journalists-service at the query's scope (campaign or brand). Falls back to most advanced DB status when no journalist data exists."),
                   replyClassification: z.enum(["positive", "negative", "neutral"]).nullable().describe("Best reply classification when outreachStatus is 'replied'. Null otherwise."),
                   relevanceScore: z.number().describe("Max relevance score across all per-campaign scores for this outlet (same high watermark logic as outreachStatus)."),
                   campaigns: z.array(
@@ -1013,7 +1013,7 @@ registry.registerPath({
                       whyRelevant: z.string().optional(),
                       whyNotRelevant: z.string().optional(),
                       relevanceScore: z.number(),
-                      outreachStatus: z.enum(["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]).describe("Outreach status scoped to this specific campaign."),
+                      outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).describe("Outreach status scoped to this specific campaign."),
                       replyClassification: z.enum(["positive", "negative", "neutral"]).nullable().describe("Reply classification when outreachStatus is 'replied'. Null otherwise."),
                       overallRelevance: z.string().nullable().optional(),
                       relevanceRationale: z.string().nullable().optional(),
@@ -1452,7 +1452,7 @@ registry.registerPath({
                   whyRelevant: z.string().nullable(),
                   whyNotRelevant: z.string().nullable(),
                   articleUrls: z.array(z.string()).nullable(),
-                  outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).describe("Outreach status: email-gateway status when available, otherwise local DB status"),
+                  outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).describe("Outreach status: email-gateway status when available, otherwise local DB status"),
                   runId: z.string().uuid().nullable().describe("The discovery run that created this journalist entry"),
                 }).passthrough(),
               ),
@@ -1537,7 +1537,7 @@ registry.registerPath({
                   lastName: z.string().nullable().openapi({ example: "Perez" }),
                   entityType: z.enum(["individual", "organization"]).openapi({ example: "individual" }),
                   outletId: z.string().uuid().openapi({ example: "f7e6d5c4-b3a2-4190-8877-665544332211" }),
-                  outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).openapi({ example: "contacted" }).describe("High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied')."),
+                  outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).openapi({ example: "contacted" }).describe("High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied')."),
                   email: z.string().nullable().describe("Global email (from journalists table apollo_email, fallback to best campaign email)"),
                   apolloPersonId: z.string().nullable(),
                   emailStatus: JournalistEmailStatusSchema,
@@ -1548,7 +1548,7 @@ registry.registerPath({
                       campaignId: z.string().uuid(),
                       featureSlug: z.string().nullable(),
                       workflowSlug: z.string().nullable(),
-                      outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).openapi({ example: "served" }).describe("Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status."),
+                      outreachStatus: z.enum(["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]).openapi({ example: "served" }).describe("Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status."),
                       relevanceScore: z.string(),
                       whyRelevant: z.string(),
                       whyNotRelevant: z.string(),
@@ -1715,7 +1715,7 @@ registry.registerPath({
   tags: ["Journalists"],
   summary: "Get journalist stats with dynasty-aware filtering and grouping",
   description:
-    "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, replied, bounced). " +
+    "Returns journalist counts grouped by outreach status (open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied). " +
     "Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. " +
     "Optional groupBy returns per-slug breakdowns.",
   security: authed,
@@ -1727,7 +1727,7 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             totalJournalists: z.number(),
-            byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count. Statuses: buffered, claimed, served, skipped, contacted, delivered, replied, bounced."),
+            byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count. Statuses: open, ended, denied, buffered, claimed, served, skipped, contacted, delivered, replied."),
             groupedBy: z.record(z.object({
               totalJournalists: z.number(),
               byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count for this group"),

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -295,7 +295,7 @@ describe("Journalists OpenAPI schemas", () => {
     expect(block).toContain('"buffered"');
     expect(block).toContain('"delivered"');
     expect(block).toContain('"replied"');
-    expect(block).not.toContain('"bounced"');
+    expect(block).toContain('"bounced"');
   });
 
   it("should register GET /v1/journalists/stats", () => {

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -295,7 +295,7 @@ describe("Journalists OpenAPI schemas", () => {
     expect(block).toContain('"buffered"');
     expect(block).toContain('"delivered"');
     expect(block).toContain('"replied"');
-    expect(block).toContain('"bounced"');
+    expect(block).not.toContain('"bounced"');
   });
 
   it("should register GET /v1/journalists/stats", () => {

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -280,23 +280,21 @@ describe("Outlets OpenAPI schemas", () => {
     // Use ListOutletsResponse block which contains both outlet-level and campaign-level schemas
     const start = schemaContent.indexOf("ListOutletsResponse");
     const responseBlock = schemaContent.slice(Math.max(0, start - 3000), start);
-    for (const status of ["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]) {
+    for (const status of ["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]) {
       expect(responseBlock).toContain(`"${status}"`);
     }
-    // buffered, claimed, bounced removed from outlet-level enum in outlets-service v5.0.0
+    // bounced removed from outlet-level enum
     const outreachEnumBlock = responseBlock.slice(
       responseBlock.indexOf("outreachStatus"),
       responseBlock.indexOf("outreachStatus") + 400
     );
-    expect(outreachEnumBlock).not.toContain('"buffered"');
-    expect(outreachEnumBlock).not.toContain('"claimed"');
     expect(outreachEnumBlock).not.toContain('"bounced"');
   });
 
   it("per-campaign outreachStatus enum should match outlet-level enum", () => {
     const idx = schemaContent.indexOf("OutletCampaignEntry");
     const entrySection = schemaContent.slice(Math.max(0, idx - 1200), idx + 100);
-    for (const status of ["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]) {
+    for (const status of ["open", "ended", "denied", "buffered", "claimed", "served", "contacted", "delivered", "replied", "skipped"]) {
       expect(entrySection).toContain(`"${status}"`);
     }
   });


### PR DESCRIPTION
## Summary
- Aligned outlet-level `outreachStatus` enum: added `buffered` and `claimed` (previously excluded since outlets-service v5.0.0, now re-added)
- Aligned journalist-level `outreachStatus` enum: added `open`, `ended`, `denied`; removed `bounced`
- Both outlets and journalists now share the same unified 10-value enum: `open`, `ended`, `denied`, `buffered`, `claimed`, `served`, `contacted`, `delivered`, `replied`, `skipped`
- Updated OpenAPI spec and tests accordingly

## Test plan
- [x] All 1106 tests pass
- [ ] Verify frontend displays each of the 10 statuses distinctly (no more "Processing" bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)