### PR TITLE
hotfix: Replace /campaigns/:id/runs with transparent /runs proxy (fix 404)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -780,7 +780,7 @@
           "descendantRuns"
         ]
       },
-      "CampaignRunsResponse": {
+      "ListRunsResponse": {
         "type": "object",
         "properties": {
           "runs": {
@@ -788,10 +788,17 @@
             "items": {
               "$ref": "#/components/schemas/RunCostData"
             }
+          },
+          "offset": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
           }
         },
         "required": [
-          "runs"
+          "runs",
+          "offset"
         ]
       },
       "CampaignStatsResponse": {
@@ -9491,13 +9498,13 @@
         }
       }
     },
-    "/v1/campaigns/{id}/runs": {
+    "/v1/runs": {
       "get": {
         "tags": [
-          "Campaigns"
+          "Runs"
         ],
-        "summary": "Get campaign runs",
-        "description": "Get execution history/runs for a campaign",
+        "summary": "List runs",
+        "description": "Transparent proxy to runs-service GET /v1/runs. Supports all runs-service query params: campaignId, brandId, userId, workflowSlug, featureSlug, serviceName, taskName, status, parentRunId, startedAfter, startedBefore, limit, offset.",
         "security": [
           {
             "bearerAuth": []
@@ -9506,13 +9513,109 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "description": "Campaign ID"
+              "type": "string"
             },
-            "required": true,
-            "description": "Campaign ID",
-            "name": "id",
-            "in": "path"
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "userId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "serviceName",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "taskName",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "parentRunId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "startedAfter",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "startedBefore",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
           },
           {
             "name": "x-org-id",
@@ -9572,11 +9675,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Campaign runs list",
+            "description": "List of runs with cost totals",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CampaignRunsResponse"
+                  "$ref": "#/components/schemas/ListRunsResponse"
                 }
               }
             }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -444,17 +444,21 @@ router.post("/campaigns/:id/stop", authenticate, requireOrg, requireUser, async 
 router.get("/campaigns/:id/runs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
+    const qs = new URLSearchParams({ campaignId: id });
+    // Forward pagination params from the client
+    if (req.query.limit) qs.set("limit", String(req.query.limit));
+    if (req.query.offset) qs.set("offset", String(req.query.offset));
 
     const result = await callExternalService(
-      externalServices.campaign,
-      `/campaigns/${id}/runs`,
+      externalServices.runs,
+      `/v1/runs?${qs.toString()}`,
       {
         headers: buildInternalHeaders(req),
       }
     );
     res.json(result);
   } catch (error: any) {
-    console.error("Get campaign runs error:", error);
+    console.error("[api-service] Get campaign runs error:", error);
     res.status(500).json({ error: error.message || "Failed to get campaign runs" });
   }
 });

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -437,31 +437,6 @@ router.post("/campaigns/:id/stop", authenticate, requireOrg, requireUser, async 
   }
 });
 
-/**
- * GET /v1/campaigns/:id/runs
- * Get campaign runs/history
- */
-router.get("/campaigns/:id/runs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const { id } = req.params;
-    const qs = new URLSearchParams({ campaignId: id });
-    // Forward pagination params from the client
-    if (req.query.limit) qs.set("limit", String(req.query.limit));
-    if (req.query.offset) qs.set("offset", String(req.query.offset));
-
-    const result = await callExternalService(
-      externalServices.runs,
-      `/v1/runs?${qs.toString()}`,
-      {
-        headers: buildInternalHeaders(req),
-      }
-    );
-    res.json(result);
-  } catch (error: any) {
-    console.error("[api-service] Get campaign runs error:", error);
-    res.status(500).json({ error: error.message || "Failed to get campaign runs" });
-  }
-});
 
 /**
  * GET /v1/campaigns/:id/stats

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -6,6 +6,29 @@ import { buildInternalHeaders } from "../lib/internal-headers.js";
 const router = Router();
 
 /**
+ * GET /v1/runs
+ * List runs from runs-service. Transparent proxy — all query params forwarded as-is.
+ */
+router.get("/runs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const qs = new URLSearchParams();
+    for (const [key, val] of Object.entries(req.query)) {
+      if (val != null) qs.set(key, String(val));
+    }
+
+    const result = await callExternalService(
+      externalServices.runs,
+      `/v1/runs?${qs.toString()}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] List runs error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list runs" });
+  }
+});
+
+/**
  * GET /v1/runs/stats/costs
  * Get cost stats from runs-service.
  *

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -566,20 +566,42 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/v1/campaigns/{id}/runs",
-  tags: ["Campaigns"],
-  summary: "Get campaign runs",
-  description: "Get execution history/runs for a campaign",
+  path: "/v1/runs",
+  tags: ["Runs"],
+  summary: "List runs",
+  description:
+    "Transparent proxy to runs-service GET /v1/runs. " +
+    "Supports all runs-service query params: campaignId, brandId, userId, " +
+    "workflowSlug, featureSlug, serviceName, taskName, status, parentRunId, " +
+    "startedAfter, startedBefore, limit, offset.",
   security: authed,
-  request: { params: CampaignIdParam },
+  request: {
+    query: z.object({
+      campaignId: z.string().optional(),
+      brandId: z.string().optional(),
+      userId: z.string().uuid().optional(),
+      workflowSlug: z.string().optional(),
+      featureSlug: z.string().optional(),
+      serviceName: z.string().optional(),
+      taskName: z.string().optional(),
+      status: z.string().optional(),
+      parentRunId: z.string().uuid().optional(),
+      startedAfter: z.string().optional(),
+      startedBefore: z.string().optional(),
+      limit: z.string().optional(),
+      offset: z.string().optional(),
+    }).openapi("ListRunsQuery"),
+  },
   responses: {
     200: {
-      description: "Campaign runs list",
+      description: "List of runs with cost totals",
       content: {
         "application/json": {
           schema: z.object({
             runs: z.array(RunCostDataSchema),
-          }).openapi("CampaignRunsResponse"),
+            offset: z.number(),
+            limit: z.number().optional(),
+          }).openapi("ListRunsResponse"),
         },
       },
     },

--- a/tests/unit/campaign-runs-proxy.regression.test.ts
+++ b/tests/unit/campaign-runs-proxy.regression.test.ts
@@ -2,47 +2,33 @@ import { describe, it, expect } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 
-const routePath = path.join(__dirname, "../../src/routes/campaigns.ts");
-const routeContent = fs.readFileSync(routePath, "utf-8");
+const runsRoutePath = path.join(__dirname, "../../src/routes/runs.ts");
+const runsRouteContent = fs.readFileSync(runsRoutePath, "utf-8");
+
+const campaignsRoutePath = path.join(__dirname, "../../src/routes/campaigns.ts");
+const campaignsRouteContent = fs.readFileSync(campaignsRoutePath, "utf-8");
+
+const openapiPath = path.join(__dirname, "../../openapi.json");
+const openapiContent = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
 
 /**
- * Regression test: GET /v1/campaigns/:id/runs must proxy to runs-service
- * (NOT campaign-service). campaign-service has no /campaigns/{id}/runs endpoint;
- * the correct source is runs-service filtered by campaignId.
- *
- * Root cause: the original proxy called campaign-service at /campaigns/{id}/runs,
- * which returned 404 because that endpoint doesn't exist on campaign-service.
+ * Regression test: runs must be listed via GET /v1/runs (transparent proxy to
+ * runs-service), NOT via a fabricated /v1/campaigns/:id/runs path on campaign-service
+ * which doesn't exist (was returning 404).
  */
-describe("campaign runs proxy targets runs-service", () => {
-  it("should proxy to externalServices.runs, not externalServices.campaign", () => {
-    // Find the campaign runs route handler block
-    const runsRouteIdx = routeContent.indexOf('"/campaigns/:id/runs"');
-    expect(runsRouteIdx).toBeGreaterThan(-1);
-
-    // Get the block from the route declaration to the next router.* call
-    const afterRoute = routeContent.slice(runsRouteIdx);
-    const nextRouteMatch = afterRoute.indexOf("\nrouter.", 10);
-    const routeBlock = nextRouteMatch > 0 ? afterRoute.slice(0, nextRouteMatch) : afterRoute;
-
-    expect(routeBlock).toContain("externalServices.runs");
-    expect(routeBlock).not.toContain("externalServices.campaign");
+describe("runs list proxy targets runs-service", () => {
+  it("GET /runs route exists in runs.ts and proxies to externalServices.runs", () => {
+    expect(runsRouteContent).toContain('"/runs"');
+    expect(runsRouteContent).toContain("externalServices.runs");
+    expect(runsRouteContent).toContain("/v1/runs");
   });
 
-  it("should filter by campaignId query param", () => {
-    const runsRouteIdx = routeContent.indexOf('"/campaigns/:id/runs"');
-    const afterRoute = routeContent.slice(runsRouteIdx);
-    const nextRouteMatch = afterRoute.indexOf("\nrouter.", 10);
-    const routeBlock = nextRouteMatch > 0 ? afterRoute.slice(0, nextRouteMatch) : afterRoute;
-
-    expect(routeBlock).toContain("campaignId");
+  it("campaigns.ts does NOT have a /campaigns/:id/runs route", () => {
+    expect(campaignsRouteContent).not.toContain("/campaigns/:id/runs");
   });
 
-  it("should call runs-service /v1/runs path", () => {
-    const runsRouteIdx = routeContent.indexOf('"/campaigns/:id/runs"');
-    const afterRoute = routeContent.slice(runsRouteIdx);
-    const nextRouteMatch = afterRoute.indexOf("\nrouter.", 10);
-    const routeBlock = nextRouteMatch > 0 ? afterRoute.slice(0, nextRouteMatch) : afterRoute;
-
-    expect(routeBlock).toContain("/v1/runs");
+  it("OpenAPI spec has /v1/runs, not /v1/campaigns/{id}/runs", () => {
+    expect(openapiContent.paths).toHaveProperty("/v1/runs");
+    expect(openapiContent.paths).not.toHaveProperty("/v1/campaigns/{id}/runs");
   });
 });

--- a/tests/unit/campaign-runs-proxy.regression.test.ts
+++ b/tests/unit/campaign-runs-proxy.regression.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/campaigns.ts");
+const routeContent = fs.readFileSync(routePath, "utf-8");
+
+/**
+ * Regression test: GET /v1/campaigns/:id/runs must proxy to runs-service
+ * (NOT campaign-service). campaign-service has no /campaigns/{id}/runs endpoint;
+ * the correct source is runs-service filtered by campaignId.
+ *
+ * Root cause: the original proxy called campaign-service at /campaigns/{id}/runs,
+ * which returned 404 because that endpoint doesn't exist on campaign-service.
+ */
+describe("campaign runs proxy targets runs-service", () => {
+  it("should proxy to externalServices.runs, not externalServices.campaign", () => {
+    // Find the campaign runs route handler block
+    const runsRouteIdx = routeContent.indexOf('"/campaigns/:id/runs"');
+    expect(runsRouteIdx).toBeGreaterThan(-1);
+
+    // Get the block from the route declaration to the next router.* call
+    const afterRoute = routeContent.slice(runsRouteIdx);
+    const nextRouteMatch = afterRoute.indexOf("\nrouter.", 10);
+    const routeBlock = nextRouteMatch > 0 ? afterRoute.slice(0, nextRouteMatch) : afterRoute;
+
+    expect(routeBlock).toContain("externalServices.runs");
+    expect(routeBlock).not.toContain("externalServices.campaign");
+  });
+
+  it("should filter by campaignId query param", () => {
+    const runsRouteIdx = routeContent.indexOf('"/campaigns/:id/runs"');
+    const afterRoute = routeContent.slice(runsRouteIdx);
+    const nextRouteMatch = afterRoute.indexOf("\nrouter.", 10);
+    const routeBlock = nextRouteMatch > 0 ? afterRoute.slice(0, nextRouteMatch) : afterRoute;
+
+    expect(routeBlock).toContain("campaignId");
+  });
+
+  it("should call runs-service /v1/runs path", () => {
+    const runsRouteIdx = routeContent.indexOf('"/campaigns/:id/runs"');
+    const afterRoute = routeContent.slice(runsRouteIdx);
+    const nextRouteMatch = afterRoute.indexOf("\nrouter.", 10);
+    const routeBlock = nextRouteMatch > 0 ? afterRoute.slice(0, nextRouteMatch) : afterRoute;
+
+    expect(routeBlock).toContain("/v1/runs");
+  });
+});


### PR DESCRIPTION
Automated by release.sh