### PR TITLE
fix: add missing userId to POST /api-keys body

### DIFF
--- a/.github/workflows/neon-reset-staging.yml
+++ b/.github/workflows/neon-reset-staging.yml
@@ -1,0 +1,70 @@
+name: Reset Neon Staging Branches
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # Daily at 3am UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  reset-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install neonctl
+        run: npm i -g neonctl
+
+      - name: Reset all staging branches from production
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_ORG_ID: ${{ vars.NEON_ORG_ID }}
+        run: |
+          set -euo pipefail
+
+          # Fetch all projects once
+          PROJECTS_JSON=$(neonctl projects list --api-key "$NEON_API_KEY" --org-id "$NEON_ORG_ID" --output json)
+
+          TOTAL=0
+          RESET=0
+          SKIPPED=0
+          FAILED=0
+
+          echo "$PROJECTS_JSON" | jq -c '.[]' | while read -r project; do
+            PROJECT_ID=$(echo "$project" | jq -r '.id')
+            PROJECT_NAME=$(echo "$project" | jq -r '.name')
+            TOTAL=$((TOTAL + 1))
+
+            # Check if a staging branch exists in this project
+            STAGING_ID=$(neonctl branches list \
+              --project-id "$PROJECT_ID" \
+              --api-key "$NEON_API_KEY" \
+              --output json 2>/dev/null \
+              | jq -r '[.[] | select(.name == "staging")] | first | .id // empty')
+
+            if [ -z "$STAGING_ID" ]; then
+              echo "SKIP $PROJECT_NAME — no staging branch"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            echo "RESET $PROJECT_NAME (project=$PROJECT_ID, branch=$STAGING_ID)..."
+            if neonctl branches reset staging \
+              --project-id "$PROJECT_ID" \
+              --parent \
+              --api-key "$NEON_API_KEY" 2>&1; then
+              RESET=$((RESET + 1))
+              echo "  OK"
+            else
+              FAILED=$((FAILED + 1))
+              echo "  FAILED"
+            fi
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Total projects: $TOTAL"
+          echo "Reset:          $RESET"
+          echo "Skipped:        $SKIPPED"
+          echo "Failed:         $FAILED"
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::warning::$FAILED project(s) failed to reset staging branch"
+          fi

--- a/openapi.json
+++ b/openapi.json
@@ -4455,9 +4455,13 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
             "description": "Human-readable name for the API key"
           }
-        }
+        },
+        "required": [
+          "name"
+        ]
       },
       "RevokeApiKeyResponse": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -213,118 +213,75 @@
           "signatureName"
         ]
       },
-      "WorkflowStats": {
+      "RankedResponse": {
         "type": "object",
         "properties": {
-          "totalCostInUsdCents": {
-            "type": "number",
-            "description": "Total cost across all completed runs"
+          "objective": {
+            "type": "string",
+            "description": "The stats key used for sorting"
           },
-          "totalOutcomes": {
-            "type": "number",
-            "description": "Total outcome count for the ranked metric (dynamic per feature — e.g. replies, leads found, outlets found)"
+          "sortDirection": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "description": "Sort direction applied"
           },
-          "costPerOutcome": {
-            "type": "number",
-            "nullable": true,
-            "description": "Cost per outcome in USD cents, null if no outcomes"
-          },
-          "completedRuns": {
-            "type": "number",
-            "description": "Number of completed runs"
-          }
-        },
-        "required": [
-          "totalCostInUsdCents",
-          "totalOutcomes",
-          "costPerOutcome",
-          "completedRuns"
-        ]
-      },
-      "RankedWorkflowItem": {
-        "type": "object",
-        "properties": {
-          "workflow": {
-            "$ref": "#/components/schemas/WorkflowMetadata"
-          },
-          "stats": {
-            "$ref": "#/components/schemas/WorkflowStats"
-          }
-        },
-        "required": [
-          "workflow",
-          "stats"
-        ]
-      },
-      "RankedWorkflowResponse": {
-        "type": "object",
-        "properties": {
           "results": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RankedWorkflowItem"
+              "type": "object",
+              "properties": {
+                "workflow": {
+                  "$ref": "#/components/schemas/WorkflowMetadata"
+                },
+                "brand": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "domain": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "domain"
+                  ]
+                },
+                "stats": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "description": "All output stats for the feature (raw counts + derived rates). Keys are dynamic per feature. Always includes totalCostInUsdCents and completedRuns."
+                }
+              },
+              "required": [
+                "stats"
+              ]
             },
-            "description": "Workflows ranked by performance, best first"
+            "description": "Results ranked by the objective metric"
           }
         },
         "required": [
+          "objective",
+          "sortDirection",
           "results"
         ]
       },
-      "BestWorkflowRecord": {
+      "BestResponse": {
         "type": "object",
-        "nullable": true,
-        "properties": {
-          "workflowSlug": {
-            "type": "string",
-            "description": "Slug of the workflow"
-          },
-          "workflowName": {
-            "type": "string",
-            "description": "Display name of the workflow"
-          },
-          "createdForBrandId": {
-            "type": "string",
-            "nullable": true,
-            "description": "Brand ID that created this workflow"
-          },
-          "value": {
-            "type": "number",
-            "description": "The record value (cost per outcome in USD cents)"
-          }
-        },
-        "required": [
-          "workflowSlug",
-          "workflowName",
-          "createdForBrandId",
-          "value"
-        ]
-      },
-      "BestWorkflowResponse": {
-        "type": "object",
-        "properties": {
-          "best": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/BestWorkflowRecord"
-            },
-            "description": "Map of metric key (e.g. 'repliesInterested', 'leadsServed') to the workflow holding the best cost-per-outcome record for that metric. Null if no data."
-          }
-        },
-        "required": [
-          "best"
-        ],
-        "example": {
-          "best": {
-            "repliesInterested": {
-              "workflowSlug": "sales-email-cold-outreach-sienna-v3",
-              "workflowName": "Sales Cold Outreach (Sienna)",
-              "createdForBrandId": "brand-uuid-456",
-              "value": 42
-            },
-            "leadsServed": null
-          }
-        }
+        "properties": {}
       },
       "MeResponse": {
         "type": "object",
@@ -805,6 +762,49 @@
           "offset"
         ]
       },
+      "RepliesDetail": {
+        "type": "object",
+        "properties": {
+          "interested": {
+            "type": "number"
+          },
+          "meetingBooked": {
+            "type": "number"
+          },
+          "closed": {
+            "type": "number"
+          },
+          "notInterested": {
+            "type": "number"
+          },
+          "wrongPerson": {
+            "type": "number"
+          },
+          "unsubscribe": {
+            "type": "number"
+          },
+          "neutral": {
+            "type": "number"
+          },
+          "autoReply": {
+            "type": "number"
+          },
+          "outOfOffice": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "interested",
+          "meetingBooked",
+          "closed",
+          "notInterested",
+          "wrongPerson",
+          "unsubscribe",
+          "neutral",
+          "autoReply",
+          "outOfOffice"
+        ]
+      },
       "CampaignStatsResponse": {
         "type": "object",
         "properties": {
@@ -874,29 +874,20 @@
           "emailsBounced": {
             "type": "number"
           },
-          "emailsReplied": {
+          "repliesPositive": {
             "type": "number"
           },
-          "repliesInterested": {
-            "type": "number"
-          },
-          "repliesMeetingBooked": {
-            "type": "number"
-          },
-          "repliesClosed": {
-            "type": "number"
-          },
-          "repliesNotInterested": {
+          "repliesNegative": {
             "type": "number"
           },
           "repliesNeutral": {
             "type": "number"
           },
-          "repliesOutOfOffice": {
+          "repliesAutoReply": {
             "type": "number"
           },
-          "repliesUnsubscribe": {
-            "type": "number"
+          "repliesDetail": {
+            "$ref": "#/components/schemas/RepliesDetail"
           },
           "totalCostInUsdCents": {
             "type": "string",
@@ -997,29 +988,20 @@
                 "emailsBounced": {
                   "type": "number"
                 },
-                "emailsReplied": {
+                "repliesPositive": {
                   "type": "number"
                 },
-                "repliesInterested": {
-                  "type": "number"
-                },
-                "repliesMeetingBooked": {
-                  "type": "number"
-                },
-                "repliesClosed": {
-                  "type": "number"
-                },
-                "repliesNotInterested": {
+                "repliesNegative": {
                   "type": "number"
                 },
                 "repliesNeutral": {
                   "type": "number"
                 },
-                "repliesOutOfOffice": {
+                "repliesAutoReply": {
                   "type": "number"
                 },
-                "repliesUnsubscribe": {
-                  "type": "number"
+                "repliesDetail": {
+                  "$ref": "#/components/schemas/RepliesDetail"
                 },
                 "totalCostInUsdCents": {
                   "type": "string",
@@ -1042,14 +1024,11 @@
                 "emailsOpened",
                 "emailsClicked",
                 "emailsBounced",
-                "emailsReplied",
-                "repliesInterested",
-                "repliesMeetingBooked",
-                "repliesClosed",
-                "repliesNotInterested",
+                "repliesPositive",
+                "repliesNegative",
                 "repliesNeutral",
-                "repliesOutOfOffice",
-                "repliesUnsubscribe",
+                "repliesAutoReply",
+                "repliesDetail",
                 "totalCostInUsdCents",
                 "runCount"
               ]
@@ -1431,30 +1410,6 @@
           "relevanceScore": {
             "type": "number"
           },
-          "outreachStatus": {
-            "type": "string",
-            "enum": [
-              "open",
-              "ended",
-              "denied",
-              "served",
-              "contacted",
-              "delivered",
-              "replied",
-              "skipped"
-            ],
-            "description": "Outreach status scoped to this specific campaign."
-          },
-          "replyClassification": {
-            "type": "string",
-            "nullable": true,
-            "enum": [
-              "positive",
-              "negative",
-              "neutral"
-            ],
-            "description": "Reply classification when outreachStatus is 'replied'. Null otherwise."
-          },
           "overallRelevance": {
             "type": "string",
             "nullable": true
@@ -1477,8 +1432,6 @@
           "featureSlug",
           "brandIds",
           "relevanceScore",
-          "outreachStatus",
-          "replyClassification",
           "updatedAt"
         ]
       },
@@ -1502,33 +1455,253 @@
             "type": "string",
             "format": "date-time"
           },
-          "outreachStatus": {
-            "type": "string",
-            "enum": [
-              "open",
-              "ended",
-              "denied",
-              "served",
-              "contacted",
-              "delivered",
-              "replied",
-              "skipped"
-            ],
-            "description": "High watermark outreach status from journalists-service at the query's scope (campaign or brand). Falls back to most advanced DB status when no journalist data exists."
-          },
-          "replyClassification": {
-            "type": "string",
+          "status": {
+            "type": "object",
             "nullable": true,
-            "enum": [
-              "positive",
-              "negative",
-              "neutral"
+            "properties": {
+              "totalJournalists": {
+                "type": "number"
+              },
+              "brand": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "buffered": {
+                    "type": "number"
+                  },
+                  "claimed": {
+                    "type": "number"
+                  },
+                  "served": {
+                    "type": "number"
+                  },
+                  "skipped": {
+                    "type": "number"
+                  },
+                  "contacted": {
+                    "type": "number"
+                  },
+                  "sent": {
+                    "type": "number"
+                  },
+                  "delivered": {
+                    "type": "number"
+                  },
+                  "opened": {
+                    "type": "number"
+                  },
+                  "clicked": {
+                    "type": "number"
+                  },
+                  "replied": {
+                    "type": "number"
+                  },
+                  "repliesPositive": {
+                    "type": "number"
+                  },
+                  "repliesNegative": {
+                    "type": "number"
+                  },
+                  "repliesNeutral": {
+                    "type": "number"
+                  },
+                  "bounced": {
+                    "type": "number"
+                  },
+                  "unsubscribed": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "buffered",
+                  "claimed",
+                  "served",
+                  "skipped",
+                  "contacted",
+                  "sent",
+                  "delivered",
+                  "opened",
+                  "clicked",
+                  "replied",
+                  "repliesPositive",
+                  "repliesNegative",
+                  "repliesNeutral",
+                  "bounced",
+                  "unsubscribed"
+                ],
+                "description": "Cumulative counts at brand scope. Present in brand mode, null in campaign mode."
+              },
+              "byCampaign": {
+                "type": "object",
+                "nullable": true,
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "buffered": {
+                      "type": "number"
+                    },
+                    "claimed": {
+                      "type": "number"
+                    },
+                    "served": {
+                      "type": "number"
+                    },
+                    "skipped": {
+                      "type": "number"
+                    },
+                    "contacted": {
+                      "type": "number"
+                    },
+                    "sent": {
+                      "type": "number"
+                    },
+                    "delivered": {
+                      "type": "number"
+                    },
+                    "opened": {
+                      "type": "number"
+                    },
+                    "clicked": {
+                      "type": "number"
+                    },
+                    "replied": {
+                      "type": "number"
+                    },
+                    "repliesPositive": {
+                      "type": "number"
+                    },
+                    "repliesNegative": {
+                      "type": "number"
+                    },
+                    "repliesNeutral": {
+                      "type": "number"
+                    },
+                    "bounced": {
+                      "type": "number"
+                    },
+                    "unsubscribed": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "buffered",
+                    "claimed",
+                    "served",
+                    "skipped",
+                    "contacted",
+                    "sent",
+                    "delivered",
+                    "opened",
+                    "clicked",
+                    "replied",
+                    "repliesPositive",
+                    "repliesNegative",
+                    "repliesNeutral",
+                    "bounced",
+                    "unsubscribed"
+                  ],
+                  "description": "Cumulative status counts across ALL journalists matching filters."
+                },
+                "description": "Per-campaign counts. Present in brand mode, null in campaign mode."
+              },
+              "campaign": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "buffered": {
+                    "type": "number"
+                  },
+                  "claimed": {
+                    "type": "number"
+                  },
+                  "served": {
+                    "type": "number"
+                  },
+                  "skipped": {
+                    "type": "number"
+                  },
+                  "contacted": {
+                    "type": "number"
+                  },
+                  "sent": {
+                    "type": "number"
+                  },
+                  "delivered": {
+                    "type": "number"
+                  },
+                  "opened": {
+                    "type": "number"
+                  },
+                  "clicked": {
+                    "type": "number"
+                  },
+                  "replied": {
+                    "type": "number"
+                  },
+                  "repliesPositive": {
+                    "type": "number"
+                  },
+                  "repliesNegative": {
+                    "type": "number"
+                  },
+                  "repliesNeutral": {
+                    "type": "number"
+                  },
+                  "bounced": {
+                    "type": "number"
+                  },
+                  "unsubscribed": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "buffered",
+                  "claimed",
+                  "served",
+                  "skipped",
+                  "contacted",
+                  "sent",
+                  "delivered",
+                  "opened",
+                  "clicked",
+                  "replied",
+                  "repliesPositive",
+                  "repliesNegative",
+                  "repliesNeutral",
+                  "bounced",
+                  "unsubscribed"
+                ],
+                "description": "Cumulative counts at campaign scope. Present in campaign mode, null in brand mode."
+              },
+              "global": {
+                "type": "object",
+                "properties": {
+                  "bounced": {
+                    "type": "number"
+                  },
+                  "unsubscribed": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "bounced",
+                  "unsubscribed"
+                ],
+                "description": "Global email signals (bounced/unsubscribed counts)."
+              }
+            },
+            "required": [
+              "totalJournalists",
+              "brand",
+              "byCampaign",
+              "campaign",
+              "global"
             ],
-            "description": "Best reply classification when outreachStatus is 'replied'. Null otherwise."
+            "description": "Structured status from journalists-service. Null when no journalist data exists for this outlet."
           },
           "relevanceScore": {
             "type": "number",
-            "description": "Max relevance score across all per-campaign scores for this outlet (same high watermark logic as outreachStatus)."
+            "description": "Max relevance score across all per-campaign scores for this outlet."
           },
           "campaigns": {
             "type": "array",
@@ -1544,8 +1717,7 @@
           "outletUrl",
           "outletDomain",
           "createdAt",
-          "outreachStatus",
-          "replyClassification",
+          "status",
           "relevanceScore",
           "campaigns"
         ]
@@ -1565,10 +1737,71 @@
           },
           "byOutreachStatus": {
             "type": "object",
-            "additionalProperties": {
-              "type": "number"
+            "properties": {
+              "buffered": {
+                "type": "number"
+              },
+              "claimed": {
+                "type": "number"
+              },
+              "served": {
+                "type": "number"
+              },
+              "skipped": {
+                "type": "number"
+              },
+              "contacted": {
+                "type": "number"
+              },
+              "sent": {
+                "type": "number"
+              },
+              "delivered": {
+                "type": "number"
+              },
+              "opened": {
+                "type": "number"
+              },
+              "clicked": {
+                "type": "number"
+              },
+              "replied": {
+                "type": "number"
+              },
+              "repliesPositive": {
+                "type": "number"
+              },
+              "repliesNegative": {
+                "type": "number"
+              },
+              "repliesNeutral": {
+                "type": "number"
+              },
+              "bounced": {
+                "type": "number"
+              },
+              "unsubscribed": {
+                "type": "number"
+              }
             },
-            "description": "Map of outreach status to outlet count across ALL outlets (not affected by pagination). Statuses: open, ended, denied, served, contacted, delivered, replied, skipped."
+            "required": [
+              "buffered",
+              "claimed",
+              "served",
+              "skipped",
+              "contacted",
+              "sent",
+              "delivered",
+              "opened",
+              "clicked",
+              "replied",
+              "repliesPositive",
+              "repliesNegative",
+              "repliesNeutral",
+              "bounced",
+              "unsubscribed"
+            ],
+            "description": "Cumulative status counts across ALL outlets (not affected by pagination)."
           }
         },
         "required": [
@@ -1658,10 +1891,71 @@
           },
           "byOutreachStatus": {
             "type": "object",
-            "additionalProperties": {
-              "type": "number"
+            "properties": {
+              "buffered": {
+                "type": "number"
+              },
+              "claimed": {
+                "type": "number"
+              },
+              "served": {
+                "type": "number"
+              },
+              "skipped": {
+                "type": "number"
+              },
+              "contacted": {
+                "type": "number"
+              },
+              "sent": {
+                "type": "number"
+              },
+              "delivered": {
+                "type": "number"
+              },
+              "opened": {
+                "type": "number"
+              },
+              "clicked": {
+                "type": "number"
+              },
+              "replied": {
+                "type": "number"
+              },
+              "repliesPositive": {
+                "type": "number"
+              },
+              "repliesNegative": {
+                "type": "number"
+              },
+              "repliesNeutral": {
+                "type": "number"
+              },
+              "bounced": {
+                "type": "number"
+              },
+              "unsubscribed": {
+                "type": "number"
+              }
             },
-            "description": "Map of outreach status to outlet count. Enriched from journalists-service with DB status fallback."
+            "required": [
+              "buffered",
+              "claimed",
+              "served",
+              "skipped",
+              "contacted",
+              "sent",
+              "delivered",
+              "opened",
+              "clicked",
+              "replied",
+              "repliesPositive",
+              "repliesNegative",
+              "repliesNeutral",
+              "bounced",
+              "unsubscribed"
+            ],
+            "description": "Cumulative status counts across matching outlets. Enriched from journalists-service."
           },
           "groups": {
             "type": "array",
@@ -1922,8 +2216,8 @@
             "type": "string",
             "enum": [
               "open",
-              "ended",
-              "denied"
+              "served",
+              "skipped"
             ]
           },
           "reason": {
@@ -1985,19 +2279,76 @@
                     "type": "string"
                   }
                 },
-                "outreachStatus": {
-                  "type": "string",
-                  "enum": [
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "buffered": {
+                      "type": "boolean"
+                    },
+                    "claimed": {
+                      "type": "boolean"
+                    },
+                    "served": {
+                      "type": "boolean"
+                    },
+                    "skipped": {
+                      "type": "boolean"
+                    },
+                    "contacted": {
+                      "type": "boolean"
+                    },
+                    "sent": {
+                      "type": "boolean"
+                    },
+                    "delivered": {
+                      "type": "boolean"
+                    },
+                    "opened": {
+                      "type": "boolean"
+                    },
+                    "clicked": {
+                      "type": "boolean"
+                    },
+                    "replied": {
+                      "type": "boolean"
+                    },
+                    "replyClassification": {
+                      "type": "string",
+                      "nullable": true,
+                      "enum": [
+                        "positive",
+                        "negative",
+                        "neutral"
+                      ]
+                    },
+                    "bounced": {
+                      "type": "boolean"
+                    },
+                    "unsubscribed": {
+                      "type": "boolean"
+                    },
+                    "lastDeliveredAt": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
                     "buffered",
                     "claimed",
                     "served",
+                    "skipped",
                     "contacted",
+                    "sent",
                     "delivered",
+                    "opened",
+                    "clicked",
                     "replied",
+                    "replyClassification",
                     "bounced",
-                    "skipped"
+                    "unsubscribed",
+                    "lastDeliveredAt"
                   ],
-                  "description": "Outreach status: email-gateway status when available, otherwise local DB status"
+                  "description": "Cumulative status booleans merging DB statuses and email-gateway data."
                 },
                 "runId": {
                   "type": "string",
@@ -2017,7 +2368,7 @@
                 "whyRelevant",
                 "whyNotRelevant",
                 "articleUrls",
-                "outreachStatus",
+                "status",
                 "runId"
               ]
             }
@@ -2046,21 +2397,6 @@
           "workflowSlug": {
             "type": "string",
             "nullable": true
-          },
-          "outreachStatus": {
-            "type": "string",
-            "enum": [
-              "buffered",
-              "claimed",
-              "served",
-              "contacted",
-              "delivered",
-              "replied",
-              "bounced",
-              "skipped"
-            ],
-            "description": "Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status.",
-            "example": "served"
           },
           "relevanceScore": {
             "type": "string"
@@ -2101,7 +2437,6 @@
           "campaignId",
           "featureSlug",
           "workflowSlug",
-          "outreachStatus",
           "relevanceScore",
           "whyRelevant",
           "whyNotRelevant",
@@ -2153,21 +2488,6 @@
                   "format": "uuid",
                   "example": "f7e6d5c4-b3a2-4190-8877-665544332211"
                 },
-                "outreachStatus": {
-                  "type": "string",
-                  "enum": [
-                    "buffered",
-                    "claimed",
-                    "served",
-                    "contacted",
-                    "delivered",
-                    "replied",
-                    "bounced",
-                    "skipped"
-                  ],
-                  "description": "High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied').",
-                  "example": "contacted"
-                },
                 "email": {
                   "type": "string",
                   "nullable": true,
@@ -2177,270 +2497,244 @@
                   "type": "string",
                   "nullable": true
                 },
-                "emailStatus": {
+                "brand": {
                   "type": "object",
                   "nullable": true,
                   "properties": {
-                    "broadcast": {
-                      "type": "object",
-                      "properties": {
-                        "campaign": {
-                          "type": "object",
-                          "nullable": true,
-                          "properties": {
-                            "contacted": {
-                              "type": "boolean"
-                            },
-                            "delivered": {
-                              "type": "boolean"
-                            },
-                            "opened": {
-                              "type": "boolean"
-                            },
-                            "replied": {
-                              "type": "boolean"
-                            },
-                            "replyClassification": {
-                              "type": "string",
-                              "nullable": true,
-                              "enum": [
-                                "positive",
-                                "negative",
-                                "neutral"
-                              ]
-                            },
-                            "bounced": {
-                              "type": "boolean"
-                            },
-                            "unsubscribed": {
-                              "type": "boolean"
-                            },
-                            "lastDeliveredAt": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          },
-                          "required": [
-                            "contacted",
-                            "delivered",
-                            "opened",
-                            "replied",
-                            "replyClassification",
-                            "bounced",
-                            "unsubscribed",
-                            "lastDeliveredAt"
-                          ]
-                        },
-                        "brand": {
-                          "type": "object",
-                          "nullable": true,
-                          "properties": {
-                            "contacted": {
-                              "type": "boolean"
-                            },
-                            "delivered": {
-                              "type": "boolean"
-                            },
-                            "opened": {
-                              "type": "boolean"
-                            },
-                            "replied": {
-                              "type": "boolean"
-                            },
-                            "replyClassification": {
-                              "type": "string",
-                              "nullable": true,
-                              "enum": [
-                                "positive",
-                                "negative",
-                                "neutral"
-                              ]
-                            },
-                            "bounced": {
-                              "type": "boolean"
-                            },
-                            "unsubscribed": {
-                              "type": "boolean"
-                            },
-                            "lastDeliveredAt": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          },
-                          "required": [
-                            "contacted",
-                            "delivered",
-                            "opened",
-                            "replied",
-                            "replyClassification",
-                            "bounced",
-                            "unsubscribed",
-                            "lastDeliveredAt"
-                          ]
-                        },
-                        "global": {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "bounced": {
-                                  "type": "boolean"
-                                },
-                                "unsubscribed": {
-                                  "type": "boolean"
-                                }
-                              },
-                              "required": [
-                                "bounced",
-                                "unsubscribed"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "email"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "campaign",
-                        "brand",
-                        "global"
+                    "buffered": {
+                      "type": "boolean"
+                    },
+                    "claimed": {
+                      "type": "boolean"
+                    },
+                    "served": {
+                      "type": "boolean"
+                    },
+                    "skipped": {
+                      "type": "boolean"
+                    },
+                    "contacted": {
+                      "type": "boolean"
+                    },
+                    "sent": {
+                      "type": "boolean"
+                    },
+                    "delivered": {
+                      "type": "boolean"
+                    },
+                    "opened": {
+                      "type": "boolean"
+                    },
+                    "clicked": {
+                      "type": "boolean"
+                    },
+                    "replied": {
+                      "type": "boolean"
+                    },
+                    "replyClassification": {
+                      "type": "string",
+                      "nullable": true,
+                      "enum": [
+                        "positive",
+                        "negative",
+                        "neutral"
                       ]
                     },
-                    "transactional": {
-                      "type": "object",
-                      "properties": {
-                        "campaign": {
-                          "type": "object",
-                          "nullable": true,
-                          "properties": {
-                            "contacted": {
-                              "type": "boolean"
-                            },
-                            "delivered": {
-                              "type": "boolean"
-                            },
-                            "opened": {
-                              "type": "boolean"
-                            },
-                            "replied": {
-                              "type": "boolean"
-                            },
-                            "replyClassification": {
-                              "type": "string",
-                              "nullable": true,
-                              "enum": [
-                                "positive",
-                                "negative",
-                                "neutral"
-                              ]
-                            },
-                            "bounced": {
-                              "type": "boolean"
-                            },
-                            "unsubscribed": {
-                              "type": "boolean"
-                            },
-                            "lastDeliveredAt": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          },
-                          "required": [
-                            "contacted",
-                            "delivered",
-                            "opened",
-                            "replied",
-                            "replyClassification",
-                            "bounced",
-                            "unsubscribed",
-                            "lastDeliveredAt"
-                          ]
-                        },
-                        "brand": {
-                          "type": "object",
-                          "nullable": true,
-                          "properties": {
-                            "contacted": {
-                              "type": "boolean"
-                            },
-                            "delivered": {
-                              "type": "boolean"
-                            },
-                            "opened": {
-                              "type": "boolean"
-                            },
-                            "replied": {
-                              "type": "boolean"
-                            },
-                            "replyClassification": {
-                              "type": "string",
-                              "nullable": true,
-                              "enum": [
-                                "positive",
-                                "negative",
-                                "neutral"
-                              ]
-                            },
-                            "bounced": {
-                              "type": "boolean"
-                            },
-                            "unsubscribed": {
-                              "type": "boolean"
-                            },
-                            "lastDeliveredAt": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          },
-                          "required": [
-                            "contacted",
-                            "delivered",
-                            "opened",
-                            "replied",
-                            "replyClassification",
-                            "bounced",
-                            "unsubscribed",
-                            "lastDeliveredAt"
-                          ]
-                        },
-                        "global": {
-                          "type": "object",
-                          "properties": {
-                            "email": {
-                              "type": "object",
-                              "properties": {
-                                "bounced": {
-                                  "type": "boolean"
-                                },
-                                "unsubscribed": {
-                                  "type": "boolean"
-                                }
-                              },
-                              "required": [
-                                "bounced",
-                                "unsubscribed"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "email"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "campaign",
-                        "brand",
-                        "global"
-                      ]
+                    "bounced": {
+                      "type": "boolean"
+                    },
+                    "unsubscribed": {
+                      "type": "boolean"
+                    },
+                    "lastDeliveredAt": {
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "required": [
-                    "broadcast",
-                    "transactional"
+                    "buffered",
+                    "claimed",
+                    "served",
+                    "skipped",
+                    "contacted",
+                    "sent",
+                    "delivered",
+                    "opened",
+                    "clicked",
+                    "replied",
+                    "replyClassification",
+                    "bounced",
+                    "unsubscribed",
+                    "lastDeliveredAt"
                   ],
-                  "description": "Email delivery statuses from email-gateway. Null if journalist has no email."
+                  "description": "Cumulative status at brand scope (aggregate across campaigns). Present in brand mode, null in campaign mode."
+                },
+                "byCampaign": {
+                  "type": "object",
+                  "nullable": true,
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "buffered": {
+                        "type": "boolean"
+                      },
+                      "claimed": {
+                        "type": "boolean"
+                      },
+                      "served": {
+                        "type": "boolean"
+                      },
+                      "skipped": {
+                        "type": "boolean"
+                      },
+                      "contacted": {
+                        "type": "boolean"
+                      },
+                      "sent": {
+                        "type": "boolean"
+                      },
+                      "delivered": {
+                        "type": "boolean"
+                      },
+                      "opened": {
+                        "type": "boolean"
+                      },
+                      "clicked": {
+                        "type": "boolean"
+                      },
+                      "replied": {
+                        "type": "boolean"
+                      },
+                      "replyClassification": {
+                        "type": "string",
+                        "nullable": true,
+                        "enum": [
+                          "positive",
+                          "negative",
+                          "neutral"
+                        ]
+                      },
+                      "bounced": {
+                        "type": "boolean"
+                      },
+                      "unsubscribed": {
+                        "type": "boolean"
+                      },
+                      "lastDeliveredAt": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    },
+                    "required": [
+                      "buffered",
+                      "claimed",
+                      "served",
+                      "skipped",
+                      "contacted",
+                      "sent",
+                      "delivered",
+                      "opened",
+                      "clicked",
+                      "replied",
+                      "replyClassification",
+                      "bounced",
+                      "unsubscribed",
+                      "lastDeliveredAt"
+                    ],
+                    "description": "Cumulative status booleans merging DB statuses and email-gateway data."
+                  },
+                  "description": "Per-campaign status breakdown. Present in brand mode, null in campaign mode."
+                },
+                "campaign": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "buffered": {
+                      "type": "boolean"
+                    },
+                    "claimed": {
+                      "type": "boolean"
+                    },
+                    "served": {
+                      "type": "boolean"
+                    },
+                    "skipped": {
+                      "type": "boolean"
+                    },
+                    "contacted": {
+                      "type": "boolean"
+                    },
+                    "sent": {
+                      "type": "boolean"
+                    },
+                    "delivered": {
+                      "type": "boolean"
+                    },
+                    "opened": {
+                      "type": "boolean"
+                    },
+                    "clicked": {
+                      "type": "boolean"
+                    },
+                    "replied": {
+                      "type": "boolean"
+                    },
+                    "replyClassification": {
+                      "type": "string",
+                      "nullable": true,
+                      "enum": [
+                        "positive",
+                        "negative",
+                        "neutral"
+                      ]
+                    },
+                    "bounced": {
+                      "type": "boolean"
+                    },
+                    "unsubscribed": {
+                      "type": "boolean"
+                    },
+                    "lastDeliveredAt": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "buffered",
+                    "claimed",
+                    "served",
+                    "skipped",
+                    "contacted",
+                    "sent",
+                    "delivered",
+                    "opened",
+                    "clicked",
+                    "replied",
+                    "replyClassification",
+                    "bounced",
+                    "unsubscribed",
+                    "lastDeliveredAt"
+                  ],
+                  "description": "Cumulative status at campaign scope. Present in campaign mode, null in brand mode."
+                },
+                "global": {
+                  "type": "object",
+                  "nullable": true,
+                  "properties": {
+                    "bounced": {
+                      "type": "boolean",
+                      "description": "Whether this email has bounced anywhere"
+                    },
+                    "unsubscribed": {
+                      "type": "boolean",
+                      "description": "Whether this email has unsubscribed anywhere"
+                    }
+                  },
+                  "required": [
+                    "bounced",
+                    "unsubscribed"
+                  ],
+                  "description": "Global email signals (bounced/unsubscribed). Null if no email-gateway data."
                 },
                 "cost": {
                   "type": "object",
@@ -2482,18 +2776,94 @@
                 "lastName",
                 "entityType",
                 "outletId",
-                "outreachStatus",
                 "email",
                 "apolloPersonId",
-                "emailStatus",
+                "brand",
+                "byCampaign",
+                "campaign",
+                "global",
                 "cost",
                 "campaigns"
               ]
             }
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total journalists matching filters (not affected by pagination)"
+          },
+          "byOutreachStatus": {
+            "type": "object",
+            "properties": {
+              "buffered": {
+                "type": "number"
+              },
+              "claimed": {
+                "type": "number"
+              },
+              "served": {
+                "type": "number"
+              },
+              "skipped": {
+                "type": "number"
+              },
+              "contacted": {
+                "type": "number"
+              },
+              "sent": {
+                "type": "number"
+              },
+              "delivered": {
+                "type": "number"
+              },
+              "opened": {
+                "type": "number"
+              },
+              "clicked": {
+                "type": "number"
+              },
+              "replied": {
+                "type": "number"
+              },
+              "repliesPositive": {
+                "type": "number"
+              },
+              "repliesNegative": {
+                "type": "number"
+              },
+              "repliesNeutral": {
+                "type": "number"
+              },
+              "bounced": {
+                "type": "number"
+              },
+              "unsubscribed": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "buffered",
+              "claimed",
+              "served",
+              "skipped",
+              "contacted",
+              "sent",
+              "delivered",
+              "opened",
+              "clicked",
+              "replied",
+              "repliesPositive",
+              "repliesNegative",
+              "repliesNeutral",
+              "bounced",
+              "unsubscribed"
+            ],
+            "description": "Cumulative status counts across ALL journalists matching filters."
           }
         },
         "required": [
-          "journalists"
+          "journalists",
+          "total",
+          "byOutreachStatus"
         ]
       },
       "DiscoverJournalistsResponse": {
@@ -2648,7 +3018,17 @@
             "additionalProperties": {
               "type": "number"
             },
-            "description": "Map of outreach status to count. Statuses: buffered, claimed, served, skipped, contacted, delivered, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply."
+            "description": "Cumulative status counts. DB statuses (buffered, claimed, served, skipped) are cumulative. Email-gateway fields (contacted, sent, delivered, opened, clicked, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply, recipients) are passed through."
+          },
+          "repliesDetail": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RepliesDetail"
+              },
+              {
+                "description": "Granular reply breakdown from email-gateway. Present when reply data exists."
+              }
+            ]
           },
           "groupedBy": {
             "type": "object",
@@ -2663,7 +3043,17 @@
                   "additionalProperties": {
                     "type": "number"
                   },
-                  "description": "Map of outreach status to count for this group"
+                  "description": "Cumulative status counts for this group"
+                },
+                "repliesDetail": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/RepliesDetail"
+                    },
+                    {
+                      "description": "Granular reply breakdown for this group"
+                    }
+                  ]
                 }
               },
               "required": [
@@ -5197,29 +5587,20 @@
           "emailsBounced": {
             "type": "number"
           },
-          "emailsReplied": {
+          "repliesPositive": {
             "type": "number"
           },
-          "repliesInterested": {
-            "type": "number"
-          },
-          "repliesMeetingBooked": {
-            "type": "number"
-          },
-          "repliesClosed": {
-            "type": "number"
-          },
-          "repliesNotInterested": {
+          "repliesNegative": {
             "type": "number"
           },
           "repliesNeutral": {
             "type": "number"
           },
-          "repliesOutOfOffice": {
+          "repliesAutoReply": {
             "type": "number"
           },
-          "repliesUnsubscribe": {
-            "type": "number"
+          "repliesDetail": {
+            "$ref": "#/components/schemas/RepliesDetail"
           }
         },
         "required": [
@@ -5229,14 +5610,11 @@
           "emailsOpened",
           "emailsClicked",
           "emailsBounced",
-          "emailsReplied",
-          "repliesInterested",
-          "repliesMeetingBooked",
-          "repliesClosed",
-          "repliesNotInterested",
+          "repliesPositive",
+          "repliesNegative",
           "repliesNeutral",
-          "repliesOutOfOffice",
-          "repliesUnsubscribe"
+          "repliesAutoReply",
+          "repliesDetail"
         ]
       },
       "RunsCostStatsResponse": {
@@ -8383,11 +8761,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Stats key to rank by (required). e.g. 'repliesInterested', 'leadsServed'.",
-              "example": "repliesInterested"
+              "description": "Stats key to rank by (required). e.g. 'repliesPositive', 'leadsServed'.",
+              "example": "repliesPositive"
             },
             "required": true,
-            "description": "Stats key to rank by (required). e.g. 'repliesInterested', 'leadsServed'.",
+            "description": "Stats key to rank by (required). e.g. 'repliesPositive', 'leadsServed'.",
             "name": "objective",
             "in": "query"
           },
@@ -8420,11 +8798,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Ranked workflows with stats (from features-service)",
+            "description": "Pass-through from features-service. Each result has a stats object with dynamic keys matching the feature's outputs (e.g. emailsSent, repliesPositive, positiveReplyRate). Always includes totalCostInUsdCents and completedRuns.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RankedWorkflowResponse"
+                  "$ref": "#/components/schemas/RankedResponse"
                 }
               }
             }
@@ -8479,11 +8857,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Hero records — best cost-per-outcome for each dynamic metric. Metrics are resolved from the feature's declared outputs.",
+            "description": "Pass-through from features-service. Best cost-per-outcome records per metric.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BestWorkflowResponse"
+                  "$ref": "#/components/schemas/BestResponse"
                 }
               }
             }
@@ -8538,11 +8916,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Stats key to rank by (required). e.g. 'repliesInterested', 'leadsServed'.",
-              "example": "repliesInterested"
+              "description": "Stats key to rank by (required). e.g. 'repliesPositive', 'leadsServed'.",
+              "example": "repliesPositive"
             },
             "required": true,
-            "description": "Stats key to rank by (required). e.g. 'repliesInterested', 'leadsServed'.",
+            "description": "Stats key to rank by (required). e.g. 'repliesPositive', 'leadsServed'.",
             "name": "objective",
             "in": "query"
           },
@@ -8630,11 +9008,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Ranked workflows with stats (from features-service)",
+            "description": "Pass-through from features-service. Each result has a stats object with dynamic keys matching the feature's outputs (e.g. emailsSent, repliesPositive, positiveReplyRate). Always includes totalCostInUsdCents and completedRuns.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RankedWorkflowResponse"
+                  "$ref": "#/components/schemas/RankedResponse"
                 }
               }
             }
@@ -8759,11 +9137,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Hero records — best cost-per-outcome for each dynamic metric. Metrics are resolved from the feature's declared outputs.",
+            "description": "Pass-through from features-service. Best cost-per-outcome records per metric.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BestWorkflowResponse"
+                  "$ref": "#/components/schemas/BestResponse"
                 }
               }
             }
@@ -9745,7 +10123,7 @@
           "Campaigns"
         ],
         "summary": "Get campaign stats",
-        "description": "Get campaign statistics (leads served/buffered/skipped, apollo metrics, emails sent/opened/clicked/replied, etc.)",
+        "description": "Get campaign statistics (leads served/buffered/skipped, apollo metrics, emails sent/opened/clicked, reply aggregates, etc.)",
         "security": [
           {
             "bearerAuth": []
@@ -10748,8 +11126,6 @@
               "type": "string",
               "enum": [
                 "open",
-                "ended",
-                "denied",
                 "served",
                 "skipped"
               ]
@@ -13370,7 +13746,7 @@
           "Journalists"
         ],
         "summary": "Get journalist stats with dynasty-aware filtering and grouping",
-        "description": "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
+        "description": "Returns journalist counts with cumulative DB statuses (buffered, claimed, served, skipped) and full email-gateway passthrough (contacted, sent, delivered, opened, clicked, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply, recipients). Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. Optional groupBy returns per-slug breakdowns.",
         "security": [
           {
             "bearerAuth": []

--- a/src/lib/delivery-stats.ts
+++ b/src/lib/delivery-stats.ts
@@ -2,12 +2,18 @@ import { AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "./service-client.js";
 import { buildInternalHeaders } from "./internal-headers.js";
 
+interface RepliesDetail {
+  interested: number; meetingBooked: number; closed: number;
+  notInterested: number; wrongPerson: number; unsubscribe: number;
+  neutral: number; autoReply: number; outOfOffice: number;
+}
+
 interface EmailGatewayStats {
   emailsContacted: number; emailsSent: number; emailsDelivered: number; emailsOpened: number;
-  emailsClicked: number; emailsReplied: number; emailsBounced: number;
-  repliesInterested: number; repliesMeetingBooked: number; repliesClosed: number;
-  repliesNotInterested: number; repliesNeutral: number; repliesOutOfOffice: number;
-  repliesUnsubscribe: number; recipients: number;
+  emailsClicked: number; emailsBounced: number;
+  repliesPositive: number; repliesNegative: number; repliesNeutral: number; repliesAutoReply: number;
+  repliesDetail: RepliesDetail;
+  recipients: number;
 }
 
 /** Fetch delivery stats from email-gateway (aggregates transactional + broadcast). */
@@ -42,14 +48,15 @@ export async function fetchDeliveryStats(
     emailsDelivered: b.emailsDelivered || 0,
     emailsOpened: b.emailsOpened || 0,
     emailsClicked: b.emailsClicked || 0,
-    emailsReplied: b.emailsReplied || 0,
     emailsBounced: b.emailsBounced || 0,
-    repliesInterested: b.repliesInterested || 0,
-    repliesMeetingBooked: b.repliesMeetingBooked || 0,
-    repliesClosed: b.repliesClosed || 0,
-    repliesNotInterested: b.repliesNotInterested || 0,
+    repliesPositive: b.repliesPositive || 0,
+    repliesNegative: b.repliesNegative || 0,
     repliesNeutral: b.repliesNeutral || 0,
-    repliesOutOfOffice: b.repliesOutOfOffice || 0,
-    repliesUnsubscribe: b.repliesUnsubscribe || 0,
+    repliesAutoReply: b.repliesAutoReply || 0,
+    repliesDetail: b.repliesDetail ?? {
+      interested: 0, meetingBooked: 0, closed: 0,
+      notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+      neutral: 0, autoReply: 0, outOfOffice: 0,
+    },
   };
 }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -261,10 +261,10 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
     const [deliveryGroups, leadGroups, emailgenGroups, costGroups] = await Promise.all([
       callExternalService<{ groups: Array<{ key: string; broadcast: {
         emailsContacted: number; emailsSent: number; emailsDelivered: number;
-        emailsOpened: number; emailsClicked: number; emailsReplied: number; emailsBounced: number;
-        repliesInterested: number; repliesMeetingBooked: number; repliesClosed: number;
-        repliesNotInterested: number; repliesNeutral: number; repliesOutOfOffice: number;
-        repliesUnsubscribe: number; recipients: number;
+        emailsOpened: number; emailsClicked: number; emailsBounced: number;
+        repliesPositive: number; repliesNegative: number; repliesNeutral: number; repliesAutoReply: number;
+        repliesDetail: Record<string, number>;
+        recipients: number;
       } | null; transactional: Record<string, number> | null }> }>(
         externalServices.emailGateway,
         `/orgs/stats?${deliveryParams}`,
@@ -315,15 +315,16 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
       s.emailsDelivered = b?.emailsDelivered ?? 0;
       s.emailsOpened = b?.emailsOpened ?? 0;
       s.emailsClicked = b?.emailsClicked ?? 0;
-      s.emailsReplied = b?.emailsReplied ?? 0;
       s.emailsBounced = b?.emailsBounced ?? 0;
-      s.repliesInterested = b?.repliesInterested ?? 0;
-      s.repliesMeetingBooked = b?.repliesMeetingBooked ?? 0;
-      s.repliesClosed = b?.repliesClosed ?? 0;
-      s.repliesNotInterested = b?.repliesNotInterested ?? 0;
+      s.repliesPositive = b?.repliesPositive ?? 0;
+      s.repliesNegative = b?.repliesNegative ?? 0;
       s.repliesNeutral = b?.repliesNeutral ?? 0;
-      s.repliesOutOfOffice = b?.repliesOutOfOffice ?? 0;
-      s.repliesUnsubscribe = b?.repliesUnsubscribe ?? 0;
+      s.repliesAutoReply = b?.repliesAutoReply ?? 0;
+      s.repliesDetail = b?.repliesDetail ?? {
+        interested: 0, meetingBooked: 0, closed: 0,
+        notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+        neutral: 0, autoReply: 0, outOfOffice: 0,
+      };
     }
 
     // Lead stats
@@ -355,10 +356,13 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
       leadsServed: 0, leadsContacted: 0, leadsBuffered: 0, leadsSkipped: 0,
       emailsGenerated: 0,
       emailsContacted: 0, emailsSent: 0, emailsDelivered: 0, emailsOpened: 0, emailsClicked: 0,
-      emailsBounced: 0, emailsReplied: 0,
-      repliesInterested: 0, repliesMeetingBooked: 0, repliesClosed: 0,
-      repliesNotInterested: 0, repliesNeutral: 0, repliesOutOfOffice: 0,
-      repliesUnsubscribe: 0,
+      emailsBounced: 0,
+      repliesPositive: 0, repliesNegative: 0, repliesNeutral: 0, repliesAutoReply: 0,
+      repliesDetail: {
+        interested: 0, meetingBooked: 0, closed: 0,
+        notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+        neutral: 0, autoReply: 0, outOfOffice: 0,
+      },
       totalCostInUsdCents: null, runCount: 0,
     };
     for (const stats of merged.values()) {
@@ -699,7 +703,7 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
           emailsGenerated: currentEmails,
           emailsSent: (delivery as any)?.emailsSent ?? 0,
           emailsOpened: (delivery as any)?.emailsOpened ?? 0,
-          repliesInterested: (delivery as any)?.repliesInterested ?? 0,
+          repliesPositive: (delivery as any)?.repliesPositive ?? 0,
         };
 
         res.write(`event: update\ndata: ${JSON.stringify(payload)}\n\n`);

--- a/src/routes/email-gateway.ts
+++ b/src/routes/email-gateway.ts
@@ -24,15 +24,16 @@ router.get("/email-gateway/stats", authenticate, requireOrg, requireUser, async 
       emailsDelivered: 0,
       emailsOpened: 0,
       emailsClicked: 0,
-      emailsReplied: 0,
       emailsBounced: 0,
-      repliesInterested: 0,
-      repliesMeetingBooked: 0,
-      repliesClosed: 0,
-      repliesNotInterested: 0,
+      repliesPositive: 0,
+      repliesNegative: 0,
       repliesNeutral: 0,
-      repliesOutOfOffice: 0,
-      repliesUnsubscribe: 0,
+      repliesAutoReply: 0,
+      repliesDetail: {
+        interested: 0, meetingBooked: 0, closed: 0,
+        notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+        neutral: 0, autoReply: 0, outOfOffice: 0,
+      },
     });
   } catch (error: any) {
     console.error("Get email-gateway stats error:", error);

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -214,6 +214,7 @@ router.post("/api-keys", authenticate, requireOrg, requireUser, async (req: Auth
       {
         method: "POST",
         body: {
+          userId: req.userId,
           createdBy: req.userId,
           name,
         },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -129,13 +129,29 @@ registry.registerPath({
 });
 
 // ===================================================================
+// SHARED REPLY SCHEMAS (email-gateway aggregate buckets + granular detail)
+// ===================================================================
+
+const RepliesDetailSchema = z.object({
+  interested: z.number(),
+  meetingBooked: z.number(),
+  closed: z.number(),
+  notInterested: z.number(),
+  wrongPerson: z.number(),
+  unsubscribe: z.number(),
+  neutral: z.number(),
+  autoReply: z.number(),
+  outOfOffice: z.number(),
+}).openapi("RepliesDetail");
+
+// ===================================================================
 // WORKFLOW RANKED & BEST (public + authenticated)
 // ===================================================================
 
 // All ranked/best endpoints now proxy to features-service
 const rankedQueryParams = z.object({
   featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
-  objective: z.string().openapi({ example: "repliesInterested" }).describe("Stats key to rank by (required). e.g. 'repliesInterested', 'leadsServed'."),
+  objective: z.string().openapi({ example: "repliesPositive" }).describe("Stats key to rank by (required). e.g. 'repliesPositive', 'leadsServed'."),
   groupBy: z.enum(["workflow", "brand"]).openapi({ example: "workflow" }).describe("'workflow' or 'brand' — group results by workflow or by brand."),
   limit: z.string().optional().openapi({ example: "10" }).describe("Max results (default 10, max 100)"),
 });
@@ -144,8 +160,6 @@ const bestQueryParams = z.object({
   featureDynastySlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature dynasty slug (required). Resolves to all versioned slugs in the lineage."),
   groupBy: z.enum(["workflow", "brand"]).openapi({ example: "workflow" }).describe("'workflow' or 'brand' — group results by workflow or by brand."),
 });
-
-// -- Workflow response schemas (mirroring workflow-service) --
 
 const WorkflowMetadataSchema = z
   .object({
@@ -166,39 +180,28 @@ const WorkflowMetadataSchema = z
   })
   .openapi("WorkflowMetadata");
 
-const WorkflowStatsSchema = z
-  .object({
-    totalCostInUsdCents: z.number().describe("Total cost across all completed runs"),
-    totalOutcomes: z.number().describe("Total outcome count for the ranked metric (dynamic per feature — e.g. replies, leads found, outlets found)"),
-    costPerOutcome: z.number().nullable().describe("Cost per outcome in USD cents, null if no outcomes"),
-    completedRuns: z.number().describe("Number of completed runs"),
-  })
-  .openapi("WorkflowStats");
-
-const RankedWorkflowItemSchema = z
-  .object({
-    workflow: WorkflowMetadataSchema,
-    stats: WorkflowStatsSchema,
-  })
-  .openapi("RankedWorkflowItem");
-
-const BestWorkflowRecordSchema = z
-  .object({
-    workflowSlug: z.string().describe("Slug of the workflow"),
-    workflowName: z.string().describe("Display name of the workflow"),
-    createdForBrandId: z.string().nullable().describe("Brand ID that created this workflow"),
-    value: z.number().describe("The record value (cost per outcome in USD cents)"),
-  })
-  .openapi("BestWorkflowRecord");
+// Ranked & best responses are pass-through from features-service.
+// stats is a dynamic map — keys depend on the feature's output definitions.
+// Do NOT define typed stats schemas here — features-service owns the shape.
 
 const rankedResponse = {
   200: {
-    description: "Ranked workflows with stats (from features-service)",
+    description: "Pass-through from features-service. Each result has a stats object with dynamic keys matching the feature's outputs (e.g. emailsSent, repliesPositive, positiveReplyRate). Always includes totalCostInUsdCents and completedRuns.",
     content: {
       "application/json": {
         schema: z.object({
-          results: z.array(RankedWorkflowItemSchema).describe("Workflows ranked by performance, best first"),
-        }).openapi("RankedWorkflowResponse"),
+          objective: z.string().describe("The stats key used for sorting"),
+          sortDirection: z.enum(["asc", "desc"]).describe("Sort direction applied"),
+          results: z.array(z.object({
+            workflow: WorkflowMetadataSchema.optional(),
+            brand: z.object({
+              id: z.string(),
+              name: z.string().nullable(),
+              domain: z.string().nullable(),
+            }).optional(),
+            stats: z.record(z.number().nullable()).describe("All output stats for the feature (raw counts + derived rates). Keys are dynamic per feature. Always includes totalCostInUsdCents and completedRuns."),
+          })).describe("Results ranked by the objective metric"),
+        }).openapi("RankedResponse"),
       },
     },
   },
@@ -207,19 +210,10 @@ const rankedResponse = {
 
 const bestResponse = {
   200: {
-    description: "Hero records — best cost-per-outcome for each dynamic metric. Metrics are resolved from the feature's declared outputs.",
+    description: "Pass-through from features-service. Best cost-per-outcome records per metric.",
     content: {
       "application/json": {
-        schema: z.object({
-          best: z.record(z.string(), BestWorkflowRecordSchema.nullable()).describe("Map of metric key (e.g. 'repliesInterested', 'leadsServed') to the workflow holding the best cost-per-outcome record for that metric. Null if no data."),
-        }).openapi("BestWorkflowResponse", {
-          example: {
-            best: {
-              repliesInterested: { workflowSlug: "sales-email-cold-outreach-sienna-v3", workflowName: "Sales Cold Outreach (Sienna)", createdForBrandId: "brand-uuid-456", value: 42 },
-              leadsServed: null,
-            },
-          },
-        }),
+        schema: z.object({}).passthrough().openapi("BestResponse"),
       },
     },
   },
@@ -616,7 +610,7 @@ registry.registerPath({
   tags: ["Campaigns"],
   summary: "Get campaign stats",
   description:
-    "Get campaign statistics (leads served/buffered/skipped, apollo metrics, emails sent/opened/clicked/replied, etc.)",
+    "Get campaign statistics (leads served/buffered/skipped, apollo metrics, emails sent/opened/clicked, reply aggregates, etc.)",
   security: authed,
   request: { params: CampaignIdParam },
   responses: {
@@ -645,14 +639,11 @@ registry.registerPath({
               emailsOpened: z.number(),
               emailsClicked: z.number(),
               emailsBounced: z.number(),
-              emailsReplied: z.number().optional(),
-              repliesInterested: z.number().optional(),
-              repliesMeetingBooked: z.number().optional(),
-              repliesClosed: z.number().optional(),
-              repliesNotInterested: z.number().optional(),
+              repliesPositive: z.number().optional(),
+              repliesNegative: z.number().optional(),
               repliesNeutral: z.number().optional(),
-              repliesOutOfOffice: z.number().optional(),
-              repliesUnsubscribe: z.number().optional(),
+              repliesAutoReply: z.number().optional(),
+              repliesDetail: RepliesDetailSchema.optional(),
               totalCostInUsdCents: z.string().nullable().optional().describe("Total cost from campaign-service budget tracking"),
               costBreakdown: z.array(z.object({
                 costName: z.string(),
@@ -712,14 +703,11 @@ registry.registerPath({
                   emailsOpened: z.number(),
                   emailsClicked: z.number(),
                   emailsBounced: z.number(),
-                  emailsReplied: z.number(),
-                  repliesInterested: z.number(),
-                  repliesMeetingBooked: z.number(),
-                  repliesClosed: z.number(),
-                  repliesNotInterested: z.number(),
+                  repliesPositive: z.number(),
+                  repliesNegative: z.number(),
                   repliesNeutral: z.number(),
-                  repliesOutOfOffice: z.number(),
-                  repliesUnsubscribe: z.number(),
+                  repliesAutoReply: z.number(),
+                  repliesDetail: RepliesDetailSchema,
                   totalCostInUsdCents: z.string().nullable(),
                   runCount: z.number(),
                 }),
@@ -986,6 +974,50 @@ const outletsRequiredHeaders = z.object({
   "x-workflow-slug": z.string().describe("Workflow slug — required by outlets-service"),
 });
 
+// Shared sub-schemas for journalist/outlet status (structured objects since journalists-service PR #122 / outlets-service v6.0.0)
+
+/** Boolean status for a single journalist (used by campaign-outlet-journalists and journalists/list per-journalist scopes) */
+const JournalistStatusBooleansSchema = z.object({
+  buffered: z.boolean(),
+  claimed: z.boolean(),
+  served: z.boolean(),
+  skipped: z.boolean(),
+  contacted: z.boolean(),
+  sent: z.boolean(),
+  delivered: z.boolean(),
+  opened: z.boolean(),
+  clicked: z.boolean(),
+  replied: z.boolean(),
+  replyClassification: z.enum(["positive", "negative", "neutral"]).nullable(),
+  bounced: z.boolean(),
+  unsubscribed: z.boolean(),
+  lastDeliveredAt: z.string().nullable(),
+}).describe("Cumulative status booleans merging DB statuses and email-gateway data.");
+
+/** Numeric status counts (used by outlets list/stats byOutreachStatus, journalists/list byOutreachStatus, and outlets/status aggregation) */
+const JournalistStatusCountsSchema = z.object({
+  buffered: z.number(),
+  claimed: z.number(),
+  served: z.number(),
+  skipped: z.number(),
+  contacted: z.number(),
+  sent: z.number(),
+  delivered: z.number(),
+  opened: z.number(),
+  clicked: z.number(),
+  replied: z.number(),
+  repliesPositive: z.number(),
+  repliesNegative: z.number(),
+  repliesNeutral: z.number(),
+  bounced: z.number(),
+  unsubscribed: z.number(),
+}).describe("Cumulative status counts across ALL journalists matching filters.");
+
+const JournalistGlobalSchema = z.object({
+  bounced: z.boolean().describe("Whether this email has bounced anywhere"),
+  unsubscribed: z.boolean().describe("Whether this email has unsubscribed anywhere"),
+}).nullable().describe("Global email signals (bounced/unsubscribed). Null if no email-gateway data.");
+
 const OutletIdParam = z.object({
   id: z.string().uuid().openapi({ description: "Outlet ID" }),
 });
@@ -1006,7 +1038,7 @@ registry.registerPath({
     query: z.object({
       campaignId: z.string().uuid().optional(),
       brandId: z.string().uuid().optional(),
-      status: z.enum(["open", "ended", "denied", "served", "skipped"]).optional(),
+      status: z.enum(["open", "served", "skipped"]).optional(),
       runId: z.string().optional().openapi({ description: "Filter by run ID (from discover endpoint)" }),
       featureSlugs: z.string().optional().describe("Filter by feature slugs (comma-separated). Use a single slug or multiple."),
       featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs."),
@@ -1028,9 +1060,17 @@ registry.registerPath({
                   outletUrl: z.string(),
                   outletDomain: z.string(),
                   createdAt: z.string().datetime(),
-                  outreachStatus: z.enum(["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]).describe("High watermark outreach status from journalists-service at the query's scope (campaign or brand). Falls back to most advanced DB status when no journalist data exists."),
-                  replyClassification: z.enum(["positive", "negative", "neutral"]).nullable().describe("Best reply classification when outreachStatus is 'replied'. Null otherwise."),
-                  relevanceScore: z.number().describe("Max relevance score across all per-campaign scores for this outlet (same high watermark logic as outreachStatus)."),
+                  status: z.object({
+                    totalJournalists: z.number(),
+                    brand: JournalistStatusCountsSchema.nullable().describe("Cumulative counts at brand scope. Present in brand mode, null in campaign mode."),
+                    byCampaign: z.record(JournalistStatusCountsSchema).nullable().describe("Per-campaign counts. Present in brand mode, null in campaign mode."),
+                    campaign: JournalistStatusCountsSchema.nullable().describe("Cumulative counts at campaign scope. Present in campaign mode, null in brand mode."),
+                    global: z.object({
+                      bounced: z.number(),
+                      unsubscribed: z.number(),
+                    }).describe("Global email signals (bounced/unsubscribed counts)."),
+                  }).nullable().describe("Structured status from journalists-service. Null when no journalist data exists for this outlet."),
+                  relevanceScore: z.number().describe("Max relevance score across all per-campaign scores for this outlet."),
                   campaigns: z.array(
                     z.object({
                       campaignId: z.string().uuid(),
@@ -1039,8 +1079,6 @@ registry.registerPath({
                       whyRelevant: z.string().optional(),
                       whyNotRelevant: z.string().optional(),
                       relevanceScore: z.number(),
-                      outreachStatus: z.enum(["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]).describe("Outreach status scoped to this specific campaign."),
-                      replyClassification: z.enum(["positive", "negative", "neutral"]).nullable().describe("Reply classification when outreachStatus is 'replied'. Null otherwise."),
                       overallRelevance: z.string().nullable().optional(),
                       relevanceRationale: z.string().nullable().optional(),
                       runId: z.string().nullable().optional(),
@@ -1050,7 +1088,7 @@ registry.registerPath({
                 }).openapi("OutletWithCampaigns"),
               ),
               total: z.number().int().describe("Total number of distinct outlets matching filters"),
-              byOutreachStatus: z.record(z.number()).describe("Map of outreach status to outlet count across ALL outlets (not affected by pagination). Statuses: open, ended, denied, served, contacted, delivered, replied, skipped."),
+              byOutreachStatus: JournalistStatusCountsSchema.describe("Cumulative status counts across ALL outlets (not affected by pagination)."),
             })
             .openapi("ListOutletsResponse"),
         },
@@ -1132,7 +1170,7 @@ registry.registerPath({
             outletsDiscovered: z.number().describe("Total outlets discovered matching the filters"),
             avgRelevanceScore: z.number().describe("Average relevance score across matching outlets"),
             searchQueriesUsed: z.number().describe("Number of distinct search queries used"),
-            byOutreachStatus: z.record(z.number()).optional().describe("Map of outreach status to outlet count. Enriched from journalists-service with DB status fallback."),
+            byOutreachStatus: JournalistStatusCountsSchema.optional().describe("Cumulative status counts across matching outlets. Enriched from journalists-service."),
             groups: z.array(z.object({
               key: z.string(),
               outletsDiscovered: z.number(),
@@ -1404,7 +1442,7 @@ registry.registerPath({
         "application/json": {
           schema: z
             .object({
-              status: z.enum(["open", "ended", "denied"]),
+              status: z.enum(["open", "served", "skipped"]),
               reason: z.string().optional(),
             })
             .openapi("UpdateOutletStatusRequest"),
@@ -1479,7 +1517,7 @@ registry.registerPath({
                   whyRelevant: z.string().nullable(),
                   whyNotRelevant: z.string().nullable(),
                   articleUrls: z.array(z.string()).nullable(),
-                  outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).describe("Outreach status: email-gateway status when available, otherwise local DB status"),
+                  status: JournalistStatusBooleansSchema,
                   runId: z.string().uuid().nullable().describe("The discovery run that created this journalist entry"),
                 }).passthrough(),
               ),
@@ -1493,33 +1531,6 @@ registry.registerPath({
     401: { description: "Unauthorized", content: errorContent },
   },
 });
-
-// Shared sub-schemas for journalist email delivery statuses (flat format since journalists-service PR #76)
-const JournalistScopeDeliverySchema = z.object({
-  contacted: z.boolean(),
-  delivered: z.boolean(),
-  opened: z.boolean(),
-  replied: z.boolean(),
-  replyClassification: z.enum(["positive", "negative", "neutral"]).nullable(),
-  bounced: z.boolean(),
-  unsubscribed: z.boolean(),
-  lastDeliveredAt: z.string().nullable(),
-}).nullable();
-
-const JournalistGlobalDeliverySchema = z.object({
-  email: z.object({ bounced: z.boolean(), unsubscribed: z.boolean() }),
-});
-
-const JournalistChannelStatusSchema = z.object({
-  campaign: JournalistScopeDeliverySchema,
-  brand: JournalistScopeDeliverySchema,
-  global: JournalistGlobalDeliverySchema,
-});
-
-const JournalistEmailStatusSchema = z.object({
-  broadcast: JournalistChannelStatusSchema,
-  transactional: JournalistChannelStatusSchema,
-}).nullable().describe("Email delivery statuses from email-gateway. Null if journalist has no email.");
 
 const JournalistCostSchema = z.object({
   totalCostInUsdCents: z.number(),
@@ -1564,10 +1575,12 @@ registry.registerPath({
                   lastName: z.string().nullable().openapi({ example: "Perez" }),
                   entityType: z.enum(["individual", "organization"]).openapi({ example: "individual" }),
                   outletId: z.string().uuid().openapi({ example: "f7e6d5c4-b3a2-4190-8877-665544332211" }),
-                  outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).openapi({ example: "contacted" }).describe("High watermark outreach status across all campaigns for this journalist. Represents the most advanced status reached in any campaign (e.g. if campaign A is 'served' and campaign B is 'replied', this will be 'replied')."),
                   email: z.string().nullable().describe("Global email (from journalists table apollo_email, fallback to best campaign email)"),
                   apolloPersonId: z.string().nullable(),
-                  emailStatus: JournalistEmailStatusSchema,
+                  brand: JournalistStatusBooleansSchema.nullable().describe("Cumulative status at brand scope (aggregate across campaigns). Present in brand mode, null in campaign mode."),
+                  byCampaign: z.record(JournalistStatusBooleansSchema).nullable().describe("Per-campaign status breakdown. Present in brand mode, null in campaign mode."),
+                  campaign: JournalistStatusBooleansSchema.nullable().describe("Cumulative status at campaign scope. Present in campaign mode, null in brand mode."),
+                  global: JournalistGlobalSchema,
                   cost: JournalistCostSchema,
                   campaigns: z.array(
                     z.object({
@@ -1575,7 +1588,6 @@ registry.registerPath({
                       campaignId: z.string().uuid(),
                       featureSlug: z.string().nullable(),
                       workflowSlug: z.string().nullable(),
-                      outreachStatus: z.enum(["buffered", "claimed", "served", "contacted", "delivered", "replied", "bounced", "skipped"]).openapi({ example: "served" }).describe("Outreach status for this specific campaign. Email-gateway status when available, otherwise local DB status."),
                       relevanceScore: z.string(),
                       whyRelevant: z.string(),
                       whyNotRelevant: z.string(),
@@ -1588,6 +1600,8 @@ registry.registerPath({
                   ).describe("Per-campaign entries for this journalist"),
                 }),
               ),
+              total: z.number().int().describe("Total journalists matching filters (not affected by pagination)"),
+              byOutreachStatus: JournalistStatusCountsSchema.describe("Cumulative status counts across ALL journalists matching filters."),
             })
             .openapi("JournalistListResponse"),
         },
@@ -1742,7 +1756,8 @@ registry.registerPath({
   tags: ["Journalists"],
   summary: "Get journalist stats with dynasty-aware filtering and grouping",
   description:
-    "Returns journalist counts grouped by outreach status (buffered, claimed, served, skipped, contacted, delivered, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply). " +
+    "Returns journalist counts with cumulative DB statuses (buffered, claimed, served, skipped) and full email-gateway passthrough " +
+    "(contacted, sent, delivered, opened, clicked, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply, recipients). " +
     "Supports filtering by brand, campaign, outlet, feature/workflow slugs, and dynasty slugs. " +
     "Optional groupBy returns per-slug breakdowns.",
   security: authed,
@@ -1754,10 +1769,12 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             totalJournalists: z.number(),
-            byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count. Statuses: buffered, claimed, served, skipped, contacted, delivered, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply."),
+            byOutreachStatus: z.record(z.number()).describe("Cumulative status counts. DB statuses (buffered, claimed, served, skipped) are cumulative. Email-gateway fields (contacted, sent, delivered, opened, clicked, bounced, repliesPositive, repliesNegative, repliesNeutral, repliesAutoReply, recipients) are passed through."),
+            repliesDetail: RepliesDetailSchema.optional().describe("Granular reply breakdown from email-gateway. Present when reply data exists."),
             groupedBy: z.record(z.object({
               totalJournalists: z.number(),
-              byOutreachStatus: z.record(z.number()).describe("Map of outreach status to count for this group"),
+              byOutreachStatus: z.record(z.number()).describe("Cumulative status counts for this group"),
+              repliesDetail: RepliesDetailSchema.optional().describe("Granular reply breakdown for this group"),
             })).optional().describe("Per-slug breakdown when groupBy is specified. Keys are slug values (or dynasty slugs for dynasty grouping)."),
           }).openapi("JournalistStatsResponse"),
         },
@@ -3561,14 +3578,11 @@ registry.registerPath({
               emailsOpened: z.number(),
               emailsClicked: z.number(),
               emailsBounced: z.number(),
-              emailsReplied: z.number(),
-              repliesInterested: z.number(),
-              repliesMeetingBooked: z.number(),
-              repliesClosed: z.number(),
-              repliesNotInterested: z.number(),
+              repliesPositive: z.number(),
+              repliesNegative: z.number(),
               repliesNeutral: z.number(),
-              repliesOutOfOffice: z.number(),
-              repliesUnsubscribe: z.number(),
+              repliesAutoReply: z.number(),
+              repliesDetail: RepliesDetailSchema,
             })
             .openapi("EmailGatewayStatsResponse"),
         },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2742,7 +2742,7 @@ export const CreateApiKeyRequestSchema = z
   .object({
     name: z
       .string()
-      .optional()
+      .min(1)
       .describe("Human-readable name for the API key"),
   })
   .openapi("CreateApiKeyRequest");

--- a/tests/unit/brand-delivery-stats.regression.test.ts
+++ b/tests/unit/brand-delivery-stats.regression.test.ts
@@ -83,17 +83,25 @@ describe("GET /v1/email-gateway/stats?brandId=brand-123", () => {
         return Promise.resolve({
           transactional: {
             emailsContacted: 50, emailsSent: 50, emailsDelivered: 48, emailsOpened: 30,
-            emailsClicked: 5, emailsReplied: 10, emailsBounced: 2,
-            repliesInterested: 2, repliesMeetingBooked: 3, repliesClosed: 0,
-            repliesNotInterested: 1, repliesNeutral: 1, repliesOutOfOffice: 1,
-            repliesUnsubscribe: 0, recipients: 50,
+            emailsClicked: 5, emailsBounced: 2,
+            repliesPositive: 5, repliesNegative: 1, repliesNeutral: 1, repliesAutoReply: 1,
+            repliesDetail: {
+              interested: 2, meetingBooked: 3, closed: 0,
+              notInterested: 1, wrongPerson: 0, unsubscribe: 0,
+              neutral: 1, autoReply: 0, outOfOffice: 1,
+            },
+            recipients: 50,
           },
           broadcast: {
             emailsContacted: 6, emailsSent: 6, emailsDelivered: 6, emailsOpened: 4,
-            emailsClicked: 0, emailsReplied: 1, emailsBounced: 0,
-            repliesInterested: 0, repliesMeetingBooked: 0, repliesClosed: 0,
-            repliesNotInterested: 1, repliesNeutral: 0, repliesOutOfOffice: 0,
-            repliesUnsubscribe: 0, recipients: 6,
+            emailsClicked: 0, emailsBounced: 0,
+            repliesPositive: 0, repliesNegative: 1, repliesNeutral: 0, repliesAutoReply: 0,
+            repliesDetail: {
+              interested: 0, meetingBooked: 0, closed: 0,
+              notInterested: 1, wrongPerson: 0, unsubscribe: 0,
+              neutral: 0, autoReply: 0, outOfOffice: 0,
+            },
+            recipients: 6,
           },
         });
       }
@@ -106,7 +114,7 @@ describe("GET /v1/email-gateway/stats?brandId=brand-123", () => {
     // Should return ONLY broadcast stats, not transactional
     expect(res.body.emailsSent).toBe(6);
     expect(res.body.emailsOpened).toBe(4);
-    expect(res.body.repliesNotInterested).toBe(1);
+    expect(res.body.repliesNegative).toBe(1);
     // Transactional values (50, 30) must NOT appear
     expect(res.body.emailsSent).not.toBe(56); // not 50+6
     expect(res.body.emailsSent).not.toBe(50);
@@ -122,7 +130,7 @@ describe("GET /v1/email-gateway/stats?brandId=brand-123", () => {
     expect(res.status).toBe(200);
     expect(res.body.emailsSent).toBe(0);
     expect(res.body.emailsOpened).toBe(0);
-    expect(res.body.repliesInterested).toBe(0);
+    expect(res.body.repliesPositive).toBe(0);
   });
 
   it("should return zeros when broadcast is null (only transactional exists)", async () => {
@@ -131,10 +139,14 @@ describe("GET /v1/email-gateway/stats?brandId=brand-123", () => {
     mockCallExternalService.mockResolvedValue({
       transactional: {
         emailsContacted: 50, emailsSent: 50, emailsDelivered: 48, emailsOpened: 30,
-        emailsClicked: 5, emailsReplied: 10, emailsBounced: 2,
-        repliesInterested: 2, repliesMeetingBooked: 3, repliesClosed: 0,
-        repliesNotInterested: 1, repliesNeutral: 1, repliesOutOfOffice: 1,
-        repliesUnsubscribe: 0, recipients: 50,
+        emailsClicked: 5, emailsBounced: 2,
+        repliesPositive: 5, repliesNegative: 1, repliesNeutral: 1, repliesAutoReply: 1,
+        repliesDetail: {
+          interested: 2, meetingBooked: 3, closed: 0,
+          notInterested: 1, wrongPerson: 0, unsubscribe: 0,
+          neutral: 1, autoReply: 0, outOfOffice: 1,
+        },
+        recipients: 50,
       },
       broadcast: null,
     });
@@ -145,7 +157,7 @@ describe("GET /v1/email-gateway/stats?brandId=brand-123", () => {
     // No broadcast = no outreach stats, should be zeros
     expect(res.body.emailsSent).toBe(0);
     expect(res.body.emailsOpened).toBe(0);
-    expect(res.body.repliesInterested).toBe(0);
+    expect(res.body.repliesPositive).toBe(0);
   });
 
   it("should make exactly one email-gateway call", async () => {
@@ -155,10 +167,14 @@ describe("GET /v1/email-gateway/stats?brandId=brand-123", () => {
       transactional: null,
       broadcast: {
         emailsContacted: 3, emailsSent: 3, emailsDelivered: 3, emailsOpened: 1,
-        emailsClicked: 0, emailsReplied: 0, emailsBounced: 0,
-        repliesInterested: 0, repliesMeetingBooked: 0, repliesClosed: 0,
-        repliesNotInterested: 0, repliesNeutral: 0, repliesOutOfOffice: 0,
-        repliesUnsubscribe: 0, recipients: 3,
+        emailsClicked: 0, emailsBounced: 0,
+        repliesPositive: 0, repliesNegative: 0, repliesNeutral: 0, repliesAutoReply: 0,
+        repliesDetail: {
+          interested: 0, meetingBooked: 0, closed: 0,
+          notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+          neutral: 0, autoReply: 0, outOfOffice: 0,
+        },
+        recipients: 3,
       },
     });
 

--- a/tests/unit/campaigns-grouped-stats.test.ts
+++ b/tests/unit/campaigns-grouped-stats.test.ts
@@ -59,10 +59,14 @@ function createApp() {
 function makeStats(overrides: Record<string, number> = {}) {
   return {
     emailsContacted: 0, emailsSent: 0, emailsDelivered: 0, emailsOpened: 0,
-    emailsClicked: 0, emailsReplied: 0, emailsBounced: 0,
-    repliesInterested: 0, repliesMeetingBooked: 0, repliesClosed: 0,
-    repliesNotInterested: 0, repliesNeutral: 0, repliesOutOfOffice: 0,
-    repliesUnsubscribe: 0, recipients: 0,
+    emailsClicked: 0, emailsBounced: 0,
+    repliesPositive: 0, repliesNegative: 0, repliesNeutral: 0, repliesAutoReply: 0,
+    repliesDetail: {
+      interested: 0, meetingBooked: 0, closed: 0,
+      notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+      neutral: 0, autoReply: 0, outOfOffice: 0,
+    },
+    recipients: 0,
     ...overrides,
   };
 }
@@ -81,12 +85,12 @@ describe("GET /v1/campaigns/stats", () => {
           groups: [
             {
               key: "c1",
-              broadcast: makeStats({ emailsContacted: 15, emailsSent: 10, emailsDelivered: 9, emailsOpened: 5, emailsClicked: 2, emailsBounced: 1, repliesInterested: 1 }),
+              broadcast: makeStats({ emailsContacted: 15, emailsSent: 10, emailsDelivered: 9, emailsOpened: 5, emailsClicked: 2, emailsBounced: 1, repliesPositive: 1 } as any),
               transactional: null,
             },
             {
               key: "c2",
-              broadcast: makeStats({ emailsContacted: 25, emailsSent: 20, emailsDelivered: 18, emailsOpened: 12, emailsClicked: 3, emailsBounced: 2, repliesNotInterested: 1 }),
+              broadcast: makeStats({ emailsContacted: 25, emailsSent: 20, emailsDelivered: 18, emailsOpened: 12, emailsClicked: 3, emailsBounced: 2, repliesNegative: 1 } as any),
               transactional: null,
             },
           ],
@@ -137,7 +141,7 @@ describe("GET /v1/campaigns/stats", () => {
     expect(c1.emailsContacted).toBe(15);
     expect(c1.emailsSent).toBe(10);
     expect(c1.emailsOpened).toBe(5);
-    expect(c1.repliesInterested).toBe(1);
+    expect(c1.repliesPositive).toBe(1);
     expect(c1.totalCostInUsdCents).toBe("500");
     expect(c1.runCount).toBe(15);
 
@@ -263,7 +267,7 @@ describe("GET /v1/campaigns/stats", () => {
     expect(c1.emailsContacted).toBe(8);
     expect(c1.emailsSent).toBe(5);
     expect(c1.emailsOpened).toBe(3);
-    expect(c1.repliesInterested).toBe(0);
+    expect(c1.repliesPositive).toBe(0);
   });
 });
 

--- a/tests/unit/journalists-list-proxy.test.ts
+++ b/tests/unit/journalists-list-proxy.test.ts
@@ -85,8 +85,9 @@ describe("GET /journalists/list OpenAPI schema", () => {
     expect(schemaContent).toContain("JournalistListResponse");
   });
 
-  it("should define JournalistEmailStatusSchema", () => {
-    expect(schemaContent).toContain("JournalistEmailStatusSchema");
+  it("should define JournalistStatusBooleansSchema and JournalistStatusCountsSchema", () => {
+    expect(schemaContent).toContain("JournalistStatusBooleansSchema");
+    expect(schemaContent).toContain("JournalistStatusCountsSchema");
   });
 
   it("should define JournalistCostSchema", () => {
@@ -157,7 +158,7 @@ describe("GET /journalists/list OpenAPI schema", () => {
     expect(op.responses["401"]).toBeDefined();
   });
 
-  it("should include outreachStatus, emailStatus, cost, and campaigns[] in response schema", () => {
+  it("should include structured status scopes (brand, byCampaign, campaign, global), cost, and campaigns[] in response schema", () => {
     const ref =
       openapi.paths["/v1/journalists/list"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema?.$ref;
     expect(ref).toBe("#/components/schemas/JournalistListResponse");
@@ -165,8 +166,10 @@ describe("GET /journalists/list OpenAPI schema", () => {
     expect(schema).toBeDefined();
     const journalistProps = schema.properties?.journalists?.items?.properties;
     expect(journalistProps).toBeDefined();
-    expect(journalistProps.outreachStatus).toBeDefined();
-    expect(journalistProps.emailStatus).toBeDefined();
+    expect(journalistProps.brand).toBeDefined();
+    expect(journalistProps.byCampaign).toBeDefined();
+    expect(journalistProps.campaign).toBeDefined();
+    expect(journalistProps.global).toBeDefined();
     expect(journalistProps.cost).toBeDefined();
     expect(journalistProps.campaigns).toBeDefined();
     // campaigns[] items use a $ref to JournalistCampaignEntry
@@ -174,17 +177,17 @@ describe("GET /journalists/list OpenAPI schema", () => {
     expect(campaignEntryRef).toBe("#/components/schemas/JournalistCampaignEntry");
     const campaignEntry = openapi.components?.schemas?.JournalistCampaignEntry;
     expect(campaignEntry).toBeDefined();
-    expect(campaignEntry.properties.outreachStatus).toBeDefined();
-    expect(campaignEntry.properties.consolidatedStatus).toBeUndefined();
-    expect(campaignEntry.properties.localStatus).toBeUndefined();
-    expect(campaignEntry.properties.emailGatewayStatus).toBeUndefined();
+    expect(campaignEntry.properties.outreachStatus).toBeUndefined();
     expect(campaignEntry.properties.relevanceScore).toBeDefined();
     expect(campaignEntry.properties.campaignId).toBeDefined();
+    // byOutreachStatus at top level
+    expect(schema.properties?.byOutreachStatus).toBeDefined();
+    expect(schema.properties?.total).toBeDefined();
   });
 
-  it("campaign entries should NOT have old status fields (replaced by outreachStatus)", () => {
+  it("campaign entries should NOT have old status fields (replaced by structured scopes)", () => {
     const campaignEntry = openapi.components?.schemas?.JournalistCampaignEntry;
-    expect(campaignEntry.properties.status).toBeUndefined();
+    expect(campaignEntry.properties.outreachStatus).toBeUndefined();
     expect(campaignEntry.properties.consolidatedStatus).toBeUndefined();
     expect(campaignEntry.properties.localStatus).toBeUndefined();
     expect(campaignEntry.properties.emailGatewayStatus).toBeUndefined();

--- a/tests/unit/journalists-proxy.test.ts
+++ b/tests/unit/journalists-proxy.test.ts
@@ -285,17 +285,21 @@ describe("Journalists OpenAPI schemas", () => {
     expect(block).toContain("campaignId:");
   });
 
-  it("should have outreachStatus in ListJournalistsResponse (replaces consolidatedStatus/localStatus/emailGatewayStatus)", () => {
+  it("should have structured status object in ListJournalistsResponse (replaces outreachStatus string)", () => {
     const start = schemaContent.indexOf("ListJournalistsResponse");
     const block = schemaContent.slice(Math.max(0, start - 800), start);
-    expect(block).toContain("outreachStatus:");
+    expect(block).toContain("status: JournalistStatusBooleansSchema");
     expect(block).not.toContain("consolidatedStatus:");
     expect(block).not.toContain("localStatus:");
     expect(block).not.toContain("emailGatewayStatus:");
-    expect(block).toContain('"buffered"');
-    expect(block).toContain('"delivered"');
-    expect(block).toContain('"replied"');
-    expect(block).toContain('"bounced"');
+    // Verify the shared schema defines all boolean status fields
+    expect(schemaContent).toContain("JournalistStatusBooleansSchema");
+    const schemaStart = schemaContent.indexOf("const JournalistStatusBooleansSchema");
+    const schemaBlock = schemaContent.slice(schemaStart, schemaStart + 600);
+    expect(schemaBlock).toContain("buffered: z.boolean()");
+    expect(schemaBlock).toContain("delivered: z.boolean()");
+    expect(schemaBlock).toContain("replied: z.boolean()");
+    expect(schemaBlock).toContain("bounced: z.boolean()");
   });
 
   it("should register GET /v1/journalists/stats", () => {

--- a/tests/unit/keys-identity.test.ts
+++ b/tests/unit/keys-identity.test.ts
@@ -67,7 +67,7 @@ describe("POST /v1/api-keys — identity forwarding via headers", () => {
     app = createApp();
   });
 
-  it("should pass createdBy and name in body, orgId/userId only in headers", async () => {
+  it("should pass userId, createdBy and name in body, orgId only in headers", async () => {
     const res = await request(app)
       .post("/v1/api-keys")
       .send({ name: "Polarity Course" });
@@ -80,12 +80,12 @@ describe("POST /v1/api-keys — identity forwarding via headers", () => {
     );
     expect(createCall).toBeDefined();
     expect(createCall!.body).toEqual({
+      userId: "user_test123",
       createdBy: "user_test123",
       name: "Polarity Course",
     });
-    // orgId and userId should NOT be in the body
+    // orgId should NOT be in the body — it goes via x-org-id header
     expect(createCall!.body).not.toHaveProperty("orgId");
-    expect(createCall!.body).not.toHaveProperty("userId");
   });
 });
 

--- a/tests/unit/openapi-response-schemas.test.ts
+++ b/tests/unit/openapi-response-schemas.test.ts
@@ -65,10 +65,9 @@ describe("OpenAPI spec — response schemas", () => {
     );
     expect(schemas.WorkflowMetadata.properties).not.toHaveProperty("brandId");
 
-    // BestWorkflowRecord uses createdForBrandId
-    expect(schemas.BestWorkflowRecord.properties).toHaveProperty(
-      "createdForBrandId",
-    );
+    // Ranked & best responses — pass-through from features-service
+    expect(schemas).toHaveProperty("RankedResponse");
+    expect(schemas).toHaveProperty("BestResponse");
   });
 
   it("should define campaign response schema with all key fields", () => {

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -251,10 +251,8 @@ describe("Outlets OpenAPI schemas", () => {
     expect(schemaContent).toContain("ListOutletsResponse");
     expect(schemaContent).toContain("OutletWithCampaigns");
     expect(schemaContent).toContain("OutletCampaignEntry");
-    expect(schemaContent).toContain("outreachStatus");
-    expect(schemaContent).toContain("replyClassification");
+    expect(schemaContent).toContain("JournalistStatusCountsSchema");
     expect(schemaContent).toContain("outletDomain");
-    // latestStatus was replaced by outreachStatus in outlets-service v5.0.0
     expect(schemaContent).not.toContain("latestStatus");
     expect(schemaContent).not.toContain("latestRelevanceScore");
   });
@@ -276,37 +274,24 @@ describe("Outlets OpenAPI schemas", () => {
     expect(getOutletsSection).toContain('"skipped"');
   });
 
-  it("outreachStatus enum should include enriched statuses (contacted, delivered, replied, skipped)", () => {
-    // Use ListOutletsResponse block which contains both outlet-level and campaign-level schemas
-    const start = schemaContent.indexOf("ListOutletsResponse");
-    const responseBlock = schemaContent.slice(Math.max(0, start - 3000), start);
-    for (const status of ["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]) {
-      expect(responseBlock).toContain(`"${status}"`);
-    }
-    // buffered, claimed, bounced removed from outlet-level enum in outlets-service v5.0.0
-    const outreachEnumBlock = responseBlock.slice(
-      responseBlock.indexOf("outreachStatus"),
-      responseBlock.indexOf("outreachStatus") + 400
-    );
-    expect(outreachEnumBlock).not.toContain('"buffered"');
-    expect(outreachEnumBlock).not.toContain('"claimed"');
-    expect(outreachEnumBlock).not.toContain('"bounced"');
+  it("outlet status should use structured StatusCounts object (replaces outreachStatus string)", () => {
+    const start = schemaContent.indexOf("OutletWithCampaigns");
+    const block = schemaContent.slice(Math.max(0, start - 2000), start);
+    // Should use JournalistStatusCountsSchema for structured status
+    expect(block).toContain("JournalistStatusCountsSchema");
+    // Should have brand/byCampaign/campaign/global scopes
+    expect(block).toContain("brand:");
+    expect(block).toContain("byCampaign:");
+    expect(block).toContain("campaign:");
+    expect(block).toContain("global:");
+    expect(block).toContain("totalJournalists:");
   });
 
-  it("per-campaign outreachStatus enum should match outlet-level enum", () => {
+  it("campaign entries should NOT have outreachStatus or replyClassification", () => {
     const idx = schemaContent.indexOf("OutletCampaignEntry");
-    const entrySection = schemaContent.slice(Math.max(0, idx - 1200), idx + 100);
-    for (const status of ["open", "ended", "denied", "served", "contacted", "delivered", "replied", "skipped"]) {
-      expect(entrySection).toContain(`"${status}"`);
-    }
-  });
-
-  it("should have replyClassification at both outlet and campaign level", () => {
-    const start = schemaContent.indexOf("ListOutletsResponse");
-    const responseBlock = schemaContent.slice(Math.max(0, start - 3000), start);
-    const matches = responseBlock.match(/replyClassification/g);
-    expect(matches).not.toBeNull();
-    expect(matches!.length).toBeGreaterThanOrEqual(2);
+    const entrySection = schemaContent.slice(Math.max(0, idx - 800), idx + 100);
+    expect(entrySection).not.toContain("outreachStatus");
+    expect(entrySection).not.toContain("replyClassification");
   });
 
   it("should register GET /v1/outlets/{id}", () => {

--- a/tests/unit/reply-breakdown-no-dummy.regression.test.ts
+++ b/tests/unit/reply-breakdown-no-dummy.regression.test.ts
@@ -68,10 +68,14 @@ function createApp() {
 function makeStats(overrides: Record<string, number> = {}) {
   return {
     emailsContacted: 0, emailsSent: 0, emailsDelivered: 0, emailsOpened: 0,
-    emailsClicked: 0, emailsReplied: 0, emailsBounced: 0,
-    repliesInterested: 0, repliesMeetingBooked: 0, repliesClosed: 0,
-    repliesNotInterested: 0, repliesNeutral: 0, repliesOutOfOffice: 0,
-    repliesUnsubscribe: 0, recipients: 0,
+    emailsClicked: 0, emailsBounced: 0,
+    repliesPositive: 0, repliesNegative: 0, repliesNeutral: 0, repliesAutoReply: 0,
+    repliesDetail: {
+      interested: 0, meetingBooked: 0, closed: 0,
+      notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+      neutral: 0, autoReply: 0, outOfOffice: 0,
+    },
+    recipients: 0,
     ...overrides,
   };
 }
@@ -118,13 +122,15 @@ describe("Reply breakdown: no dummy data when 0 replies", () => {
     const res = await request(app).get("/v1/campaigns/test-campaign-123/stats");
 
     expect(res.status).toBe(200);
-    expect(res.body.repliesInterested).toBe(0);
-    expect(res.body.repliesMeetingBooked).toBe(0);
-    expect(res.body.repliesClosed).toBe(0);
-    expect(res.body.repliesNotInterested).toBe(0);
+    expect(res.body.repliesPositive).toBe(0);
+    expect(res.body.repliesNegative).toBe(0);
     expect(res.body.repliesNeutral).toBe(0);
-    expect(res.body.repliesOutOfOffice).toBe(0);
-    expect(res.body.repliesUnsubscribe).toBe(0);
+    expect(res.body.repliesAutoReply).toBe(0);
+    expect(res.body.repliesDetail).toEqual({
+      interested: 0, meetingBooked: 0, closed: 0,
+      notInterested: 0, wrongPerson: 0, unsubscribe: 0,
+      neutral: 0, autoReply: 0, outOfOffice: 0,
+    });
   });
 
   it("should return reply classifications when replies exist", async () => {
@@ -136,9 +142,14 @@ describe("Reply breakdown: no dummy data when 0 replies", () => {
         return Promise.resolve({
           transactional: makeStats({ emailsSent: 10, emailsDelivered: 8, emailsOpened: 3, emailsClicked: 1, recipients: 10 }),
           broadcast: makeStats({
-            emailsSent: 5, emailsDelivered: 4, emailsOpened: 2, emailsReplied: 5, recipients: 5,
-            repliesInterested: 1, repliesMeetingBooked: 2, repliesNotInterested: 1, repliesOutOfOffice: 1,
-          }),
+            emailsSent: 5, emailsDelivered: 4, emailsOpened: 2, recipients: 5,
+            repliesPositive: 3, repliesNegative: 1, repliesAutoReply: 1,
+            repliesDetail: {
+              interested: 1, meetingBooked: 2, closed: 0,
+              notInterested: 1, wrongPerson: 0, unsubscribe: 0,
+              neutral: 0, autoReply: 0, outOfOffice: 1,
+            },
+          } as any),
         });
       }
       // Lead-service
@@ -163,9 +174,12 @@ describe("Reply breakdown: no dummy data when 0 replies", () => {
     const res = await request(app).get("/v1/campaigns/test-campaign-123/stats");
 
     expect(res.status).toBe(200);
-    expect(res.body.repliesInterested).toBe(1);
-    expect(res.body.repliesMeetingBooked).toBe(2);
-    expect(res.body.repliesNotInterested).toBe(1);
-    expect(res.body.repliesOutOfOffice).toBe(1);
+    expect(res.body.repliesPositive).toBe(3);
+    expect(res.body.repliesNegative).toBe(1);
+    expect(res.body.repliesAutoReply).toBe(1);
+    expect(res.body.repliesDetail.interested).toBe(1);
+    expect(res.body.repliesDetail.meetingBooked).toBe(2);
+    expect(res.body.repliesDetail.notInterested).toBe(1);
+    expect(res.body.repliesDetail.outOfOffice).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- key-service `POST /api-keys` requires `userId` in the request body, but api-service was only sending `createdBy` and `name` — causing a 400 from key-service, surfaced as 500 to the dashboard
- Added `userId: req.userId` to the proxied body
- Made `name` required (min 1 char) in `CreateApiKeyRequestSchema` to match key-service's contract — callers now get a clear 400 from api-service instead of a cryptic forwarded error

## Test plan
- [x] Updated `keys-identity.test.ts` to assert `userId` is included in the body
- [x] All 1114 tests pass
- [ ] Verify on staging: dashboard API key creation button works without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)