### PR TITLE
feat: proxy features-service /stats/dynasty endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8559,6 +8559,10 @@
         "type": "object",
         "properties": {}
       },
+      "DynastyStatsResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "GlobalStatsResponse": {
         "type": "object",
         "properties": {}
@@ -28809,6 +28813,173 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/features/stats/dynasty": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Dynasty stats (aggregated across all versions)",
+        "description": "Aggregated stats across the full upgrade chain of a feature dynasty (BFS lineage traversal). Use this when you need dynasty-wide stats instead of per-slug stats. Requires x-org-id. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "The stable dynasty slug (unversioned)",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "The stable dynasty slug (unversioned)",
+            "name": "dynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId",
+              "example": "campaignId"
+            },
+            "required": false,
+            "description": "Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand UUID",
+              "example": "brand-uuid-123"
+            },
+            "required": false,
+            "description": "Filter by brand UUID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign UUID",
+              "example": "campaign-uuid-456"
+            },
+            "required": false,
+            "description": "Filter by campaign UUID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by exact workflow slug"
+            },
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug"
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dynasty stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DynastyStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/features/stats": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -159,6 +159,29 @@ router.get("/features/stats/registry", authenticate, requireOrg, requireUser, as
 });
 
 /**
+ * GET /v1/features/stats/dynasty
+ * Aggregated stats across all versions of a dynasty. Proxied to features-service GET /stats/dynasty.
+ */
+router.get("/features/stats/dynasty", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["dynastySlug", "groupBy", "brandId", "campaignId", "workflowSlug", "workflowDynastySlug"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/stats/dynasty${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Dynasty stats error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get dynasty stats" });
+  }
+});
+
+/**
  * GET /v1/features/stats
  * Global stats cross-features, groupable by featureSlug/workflowSlug/brandId/campaignId
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6461,6 +6461,31 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/features/stats/dynasty",
+  tags: ["Features"],
+  summary: "Dynasty stats (aggregated across all versions)",
+  description:
+    "Aggregated stats across the full upgrade chain of a feature dynasty (BFS lineage traversal). Use this when you need dynasty-wide stats instead of per-slug stats. Requires x-org-id. Proxied from features-service.",
+  security: authed,
+  request: {
+    query: z.object({
+      dynastySlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("The stable dynasty slug (unversioned)"),
+      groupBy: z.string().optional().openapi({ example: "campaignId" }).describe("Group dimension: workflowSlug | workflowDynastySlug | brandId | campaignId"),
+      brandId: z.string().optional().openapi({ example: "brand-uuid-123" }).describe("Filter by brand UUID"),
+      campaignId: z.string().optional().openapi({ example: "campaign-uuid-456" }).describe("Filter by campaign UUID"),
+      workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug"),
+    }),
+  },
+  responses: {
+    200: { description: "Dynasty stats", content: { "application/json": { schema: z.object({}).passthrough().openapi("DynastyStatsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/features/stats",
   tags: ["Features"],
   summary: "Global stats cross-features",

--- a/tests/unit/features-dynasty-stats.test.ts
+++ b/tests/unit/features-dynasty-stats.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for GET /v1/features/stats/dynasty.
+ * Proxied to features-service GET /stats/dynasty.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCallExternalService = vi.fn();
+
+vi.mock("../../src/lib/service-client.js", () => ({
+  callExternalService: (...args: unknown[]) => mockCallExternalService(...args),
+  callExternalServiceWithStatus: (...args: unknown[]) => mockCallExternalService(...args),
+  externalServices: {
+    client: { url: "http://mock-client", apiKey: "k" },
+    emailgen: { url: "http://mock-emailgen", apiKey: "k" },
+    emailGateway: { url: "http://mock-email-gateway", apiKey: "k" },
+    campaign: { url: "http://mock-campaign", apiKey: "k" },
+    lead: { url: "http://mock-lead", apiKey: "k" },
+    key: { url: "http://mock-key", apiKey: "k" },
+    replyQualification: { url: "http://mock-rq", apiKey: "k" },
+    scraping: { url: "http://mock-scraping", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
+    brand: { url: "http://mock-brand", apiKey: "k" },
+    runs: { url: "http://mock-runs", apiKey: "k" },
+    workflow: { url: "http://mock-workflow", apiKey: "k" },
+    instantly: { url: "http://mock-instantly", apiKey: "k" },
+    billing: { url: "http://mock-billing", apiKey: "k" },
+    chat: { url: "http://mock-chat", apiKey: "k" },
+    features: { url: "http://mock-features", apiKey: "k" },
+  },
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (_req: any, _res: any, next: any) => next(),
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import express from "express";
+import request from "supertest";
+import featuresRouter from "../../src/routes/features.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", featuresRouter);
+  return app;
+}
+
+const MOCK_DYNASTY_STATS = {
+  dynastySlug: "sales-cold-email-outreach",
+  systemStats: { totalCostInUsdCents: 12000, completedRuns: 45, activeCampaigns: 5, firstRunAt: "2025-11-01T00:00:00Z", lastRunAt: "2026-03-28T00:00:00Z" },
+  stats: { emailsSent: 5400, repliesPositive: 216, positiveReplyRate: 0.04 },
+};
+
+describe("GET /v1/features/stats/dynasty", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("proxies to features-service /stats/dynasty with all query params", async () => {
+    const app = createApp();
+    mockCallExternalService.mockResolvedValue(MOCK_DYNASTY_STATS);
+
+    const res = await request(app).get(
+      "/v1/features/stats/dynasty?dynastySlug=sales-cold-email-outreach&groupBy=campaignId&brandId=b-1",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_DYNASTY_STATS);
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/stats/dynasty"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).toContain("dynastySlug=sales-cold-email-outreach");
+    expect(url).toContain("groupBy=campaignId");
+    expect(url).toContain("brandId=b-1");
+  });
+
+  it("forwards only allowed query params", async () => {
+    const app = createApp();
+    mockCallExternalService.mockResolvedValue(MOCK_DYNASTY_STATS);
+
+    await request(app).get(
+      "/v1/features/stats/dynasty?dynastySlug=sales-cold-email-outreach&randomParam=bad",
+    );
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/stats/dynasty"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).toContain("dynastySlug=sales-cold-email-outreach");
+    expect(url).not.toContain("randomParam");
+  });
+
+  it("returns 502 when features-service is unavailable", async () => {
+    const app = createApp();
+    mockCallExternalService.mockRejectedValue(new Error("Connection refused"));
+
+    const res = await request(app).get(
+      "/v1/features/stats/dynasty?dynastySlug=sales-cold-email-outreach",
+    );
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Connection refused");
+  });
+});

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -139,7 +139,7 @@ describe("Features proxy routes", () => {
     expect(content).toContain("buildInternalHeaders");
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(13);
+    expect(headerMatches!.length).toBe(14);
   });
 
   it("should proxy to externalServices.features", () => {


### PR DESCRIPTION
## Summary
- Adds proxy route `GET /v1/features/stats/dynasty` → features-service `GET /stats/dynasty`
- Supports query params: `dynastySlug` (required), `groupBy`, `brandId`, `campaignId`, `workflowSlug`, `workflowDynastySlug`
- Registers the endpoint in OpenAPI schema and regenerates `openapi.json`

## Context
The dashboard uses dynasty slugs everywhere, but `GET /v1/features/{slug}/stats` requires an exact versioned slug (e.g. `sales-cold-email-outreach-v4`). When the dashboard passes a dynasty slug, features-service finds no match and returns zero stats. The `/stats/dynasty` endpoint on features-service aggregates stats across all versions of a dynasty — it just wasn't proxied.

## Test plan
- [x] New test file `features-dynasty-stats.test.ts` (3 tests: query param forwarding, param allowlist, error propagation)
- [x] Updated `features-proxy.test.ts` buildInternalHeaders count (13 → 14)
- [x] Full test suite passes (1117 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)