### PR TITLE
feat: brand transfer proxy route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5571,6 +5571,75 @@
           "runs"
         ]
       },
+      "TransferBrandResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "description": "Brand ID that was transferred"
+          },
+          "sourceOrgId": {
+            "type": "string",
+            "description": "Original organization ID"
+          },
+          "targetOrgId": {
+            "type": "string",
+            "description": "New organization ID"
+          },
+          "serviceResults": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "updatedTables": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "required": [
+                    "updatedTables"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              ]
+            },
+            "description": "Per-service transfer results: updated table counts or error"
+          }
+        },
+        "required": [
+          "brandId",
+          "sourceOrgId",
+          "targetOrgId",
+          "serviceResults"
+        ]
+      },
+      "TransferBrandRequest": {
+        "type": "object",
+        "properties": {
+          "targetOrgId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal UUID of the target organization"
+          }
+        },
+        "required": [
+          "targetOrgId"
+        ]
+      },
       "EmailGatewayStatsResponse": {
         "type": "object",
         "properties": {
@@ -18941,6 +19010,158 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/transfer": {
+      "post": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Transfer a brand to another org",
+        "description": "Transfer a brand and all its associated solo-brand data to a different organization. The requesting user must be a member of both the source and target orgs. Brand-service orchestrates the transfer across all services. Co-branding rows (multiple brand IDs) are not transferred.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferBrandRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transfer completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferBrandResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing targetOrgId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "User is not a member of the target org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -288,4 +288,32 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
   }
 });
 
+/**
+ * POST /v1/brands/:id/transfer
+ * Transfer a brand to a different org. Proxied to brand-service which orchestrates the full transfer.
+ */
+router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { targetOrgId } = req.body as { targetOrgId?: string };
+    if (!targetOrgId) {
+      return res.status(400).json({ error: "targetOrgId is required" });
+    }
+
+    const result = await callExternalService(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/transfer`,
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: { targetOrgId },
+      },
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Brand transfer error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to transfer brand" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3544,6 +3544,57 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{id}/transfer",
+  tags: ["Brand"],
+  summary: "Transfer a brand to another org",
+  description:
+    "Transfer a brand and all its associated solo-brand data to a different organization. " +
+    "The requesting user must be a member of both the source and target orgs. " +
+    "Brand-service orchestrates the transfer across all services. " +
+    "Co-branding rows (multiple brand IDs) are not transferred.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            targetOrgId: z.string().uuid().describe("Internal UUID of the target organization"),
+          }).openapi("TransferBrandRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Transfer completed",
+      content: {
+        "application/json": {
+          schema: z.object({
+            brandId: z.string().describe("Brand ID that was transferred"),
+            sourceOrgId: z.string().describe("Original organization ID"),
+            targetOrgId: z.string().describe("New organization ID"),
+            serviceResults: z.record(
+              z.string(),
+              z.union([
+                z.object({ updatedTables: z.record(z.string(), z.number()) }),
+                z.object({ error: z.string() }),
+              ]),
+            ).describe("Per-service transfer results: updated table counts or error"),
+          }).openapi("TransferBrandResponse"),
+        },
+      },
+    },
+    400: { description: "Missing targetOrgId", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "User is not a member of the target org", content: errorContent },
+    404: { description: "Brand not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // EMAIL-GATEWAY (delivery stats)
 // ===================================================================

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * POST /v1/brands/:id/transfer
+ * Proxy to brand-service POST /orgs/brands/:id/transfer
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+describe("POST /v1/brands/:id/transfer", () => {
+  let app: express.Express;
+  let capturedUrl: string;
+  let capturedBody: Record<string, unknown> | undefined;
+  let capturedHeaders: Record<string, string>;
+
+  const transferResult = {
+    brandId: "brand-abc",
+    sourceOrgId: "org_test456",
+    targetOrgId: "org_target789",
+    serviceResults: {
+      "campaign-service": { updatedTables: { campaigns: 3 } },
+      "lead-service": { updatedTables: { leads: 12 } },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = "";
+    capturedBody = undefined;
+    capturedHeaders = {};
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(init?.body as string);
+      capturedHeaders = Object.fromEntries(
+        Object.entries(init?.headers || {}).map(([k, v]) => [k.toLowerCase(), v]),
+      ) as Record<string, string>;
+      return { ok: true, json: () => Promise.resolve(transferResult) };
+    });
+  });
+
+  it("should proxy to brand-service /orgs/brands/:id/transfer", async () => {
+    const res = await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .send({ targetOrgId: "org_target789" });
+
+    expect(res.status).toBe(200);
+    expect(capturedUrl).toContain("/orgs/brands/brand-abc/transfer");
+    expect(capturedBody).toEqual({ targetOrgId: "org_target789" });
+  });
+
+  it("should return the full transfer result from brand-service", async () => {
+    const res = await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .send({ targetOrgId: "org_target789" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(transferResult);
+  });
+
+  it("should forward identity headers", async () => {
+    await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .send({ targetOrgId: "org_target789" });
+
+    expect(capturedHeaders["x-org-id"]).toBe("org_test456");
+    expect(capturedHeaders["x-user-id"]).toBe("user_test123");
+  });
+
+  it("should return 400 when targetOrgId is missing", async () => {
+    const res = await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("targetOrgId is required");
+  });
+
+  it("should forward upstream error status", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve('{"error":"User is not a member of the target org"}'),
+    }));
+
+    const res = await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .send({ targetOrgId: "org_target789" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("not a member");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /v1/brands/:id/transfer` proxy route → brand-service `POST /orgs/brands/:id/transfer`
- Add OpenAPI schema (`TransferBrandRequest` / `TransferBrandResponse`) with full error documentation
- Transparent proxy — api-service authenticates and forwards, brand-service orchestrates the full cross-service transfer

## Context
Brand transfer moves a brand and all its solo-brand data from one org to another. Brand-service is the orchestrator — it verifies membership via client-service, discovers services via api-registry, calls `POST /internal/transfer-brand` on each, and stores the audit log.

## Test plan
- [x] 5 unit tests covering: proxy path, response forwarding, identity headers, 400 on missing body, upstream error forwarding
- [x] OpenAPI spec regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)