### PR TITLE
feat: resolve Clerk org ID in brand transfer endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5632,8 +5632,7 @@
         "properties": {
           "targetOrgId": {
             "type": "string",
-            "format": "uuid",
-            "description": "Internal UUID of the target organization"
+            "description": "Clerk org ID (e.g. org_xxx) of the target organization — resolved to internal UUID server-side"
           }
         },
         "required": [

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -290,7 +290,8 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
 
 /**
  * POST /v1/brands/:id/transfer
- * Transfer a brand to a different org. Proxied to brand-service which orchestrates the full transfer.
+ * Transfer a brand to a different org. Resolves the Clerk org ID to an internal UUID,
+ * then proxies to brand-service which orchestrates the full transfer.
  */
 router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
@@ -299,13 +300,39 @@ router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async
       return res.status(400).json({ error: "targetOrgId is required" });
     }
 
+    // Resolve Clerk org ID → internal UUID via client-service
+    const externalUserId = req.headers["x-external-user-id"] as string | undefined;
+    if (!externalUserId) {
+      return res.status(400).json({ error: "x-external-user-id header required for brand transfer" });
+    }
+
+    const resolved = await callExternalService<{ orgId: string; userId: string }>(
+      externalServices.client,
+      "/resolve",
+      {
+        method: "POST",
+        body: { externalOrgId: targetOrgId, externalUserId },
+      },
+    );
+
+    if (!resolved.orgId) {
+      return res.status(400).json({ error: "Failed to resolve target org" });
+    }
+
+    if (resolved.orgId === req.orgId) {
+      return res.status(400).json({ error: "Target org is the same as the source org" });
+    }
+
+    // TODO: verify user membership in target org via client-service
+    // GET /orgs/{resolved.orgId}/members/{req.userId} — pending client-service endpoint
+
     const result = await callExternalService(
       externalServices.brand,
       `/orgs/brands/${req.params.id}/transfer`,
       {
         method: "POST",
         headers: buildInternalHeaders(req),
-        body: { targetOrgId },
+        body: { targetOrgId: resolved.orgId },
       },
     );
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3561,7 +3561,7 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
-            targetOrgId: z.string().uuid().describe("Internal UUID of the target organization"),
+            targetOrgId: z.string().describe("Clerk org ID (e.g. org_xxx) of the target organization — resolved to internal UUID server-side"),
           }).openapi("TransferBrandRequest"),
         },
       },

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -4,7 +4,7 @@ import express from "express";
 
 /**
  * POST /v1/brands/:id/transfer
- * Proxy to brand-service POST /orgs/brands/:id/transfer
+ * Resolves Clerk org ID → internal UUID, then proxies to brand-service POST /orgs/brands/:id/transfer
  */
 
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -32,86 +32,151 @@ function buildApp() {
   return app;
 }
 
+const RESOLVED_TARGET_ORG_ID = "resolved-target-uuid";
+
+const transferResult = {
+  brandId: "brand-abc",
+  sourceOrgId: "org_test456",
+  targetOrgId: RESOLVED_TARGET_ORG_ID,
+  serviceResults: {
+    "campaign-service": { updatedTables: { campaigns: 3 } },
+    "lead-service": { updatedTables: { leads: 12 } },
+  },
+};
+
+function mockFetchResolveAndTransfer() {
+  let brandServiceUrl = "";
+  let brandServiceBody: Record<string, unknown> | undefined;
+  let brandServiceHeaders: Record<string, string> = {};
+
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+
+    // client-service /resolve call
+    if (String(url).includes("/resolve")) {
+      return {
+        ok: true,
+        json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
+      };
+    }
+
+    // brand-service /transfer call
+    brandServiceUrl = url;
+    brandServiceBody = body;
+    brandServiceHeaders = Object.fromEntries(
+      Object.entries(init?.headers || {}).map(([k, v]) => [k.toLowerCase(), v]),
+    ) as Record<string, string>;
+    return { ok: true, json: () => Promise.resolve(transferResult) };
+  });
+
+  return { getBrandServiceCall: () => ({ url: brandServiceUrl, body: brandServiceBody, headers: brandServiceHeaders }) };
+}
+
 describe("POST /v1/brands/:id/transfer", () => {
   let app: express.Express;
-  let capturedUrl: string;
-  let capturedBody: Record<string, unknown> | undefined;
-  let capturedHeaders: Record<string, string>;
-
-  const transferResult = {
-    brandId: "brand-abc",
-    sourceOrgId: "org_test456",
-    targetOrgId: "org_target789",
-    serviceResults: {
-      "campaign-service": { updatedTables: { campaigns: 3 } },
-      "lead-service": { updatedTables: { leads: 12 } },
-    },
-  };
 
   beforeEach(() => {
     vi.clearAllMocks();
     app = buildApp();
-    capturedUrl = "";
-    capturedBody = undefined;
-    capturedHeaders = {};
-
-    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      capturedUrl = url;
-      capturedBody = JSON.parse(init?.body as string);
-      capturedHeaders = Object.fromEntries(
-        Object.entries(init?.headers || {}).map(([k, v]) => [k.toLowerCase(), v]),
-      ) as Record<string, string>;
-      return { ok: true, json: () => Promise.resolve(transferResult) };
-    });
   });
 
-  it("should proxy to brand-service /orgs/brands/:id/transfer", async () => {
+  it("should resolve Clerk org ID and proxy to brand-service", async () => {
+    const { getBrandServiceCall } = mockFetchResolveAndTransfer();
+
     const res = await request(app)
       .post("/v1/brands/brand-abc/transfer")
-      .send({ targetOrgId: "org_target789" });
+      .set("x-external-user-id", "clerk_user_ext")
+      .send({ targetOrgId: "org_clerk_target" });
 
     expect(res.status).toBe(200);
-    expect(capturedUrl).toContain("/orgs/brands/brand-abc/transfer");
-    expect(capturedBody).toEqual({ targetOrgId: "org_target789" });
+    const call = getBrandServiceCall();
+    expect(call.url).toContain("/orgs/brands/brand-abc/transfer");
+    expect(call.body).toEqual({ targetOrgId: RESOLVED_TARGET_ORG_ID });
   });
 
   it("should return the full transfer result from brand-service", async () => {
+    mockFetchResolveAndTransfer();
+
     const res = await request(app)
       .post("/v1/brands/brand-abc/transfer")
-      .send({ targetOrgId: "org_target789" });
+      .set("x-external-user-id", "clerk_user_ext")
+      .send({ targetOrgId: "org_clerk_target" });
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(transferResult);
   });
 
-  it("should forward identity headers", async () => {
+  it("should forward identity headers to brand-service", async () => {
+    const { getBrandServiceCall } = mockFetchResolveAndTransfer();
+
     await request(app)
       .post("/v1/brands/brand-abc/transfer")
-      .send({ targetOrgId: "org_target789" });
+      .set("x-external-user-id", "clerk_user_ext")
+      .send({ targetOrgId: "org_clerk_target" });
 
-    expect(capturedHeaders["x-org-id"]).toBe("org_test456");
-    expect(capturedHeaders["x-user-id"]).toBe("user_test123");
+    const call = getBrandServiceCall();
+    expect(call.headers["x-org-id"]).toBe("org_test456");
+    expect(call.headers["x-user-id"]).toBe("user_test123");
   });
 
   it("should return 400 when targetOrgId is missing", async () => {
     const res = await request(app)
       .post("/v1/brands/brand-abc/transfer")
+      .set("x-external-user-id", "clerk_user_ext")
       .send({});
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("targetOrgId is required");
   });
 
-  it("should forward upstream error status", async () => {
-    global.fetch = vi.fn().mockImplementation(async () => ({
-      ok: false,
-      status: 403,
-      text: () => Promise.resolve('{"error":"User is not a member of the target org"}'),
-    }));
+  it("should return 400 when x-external-user-id header is missing", async () => {
+    const res = await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .send({ targetOrgId: "org_clerk_target" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("x-external-user-id");
+  });
+
+  it("should return 400 when target org resolves to same as source org", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/resolve")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ orgId: "org_test456", userId: "user_test123", orgCreated: false, userCreated: false }),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
 
     const res = await request(app)
       .post("/v1/brands/brand-abc/transfer")
-      .send({ targetOrgId: "org_target789" });
+      .set("x-external-user-id", "clerk_user_ext")
+      .send({ targetOrgId: "org_same_as_source" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("same as the source");
+  });
+
+  it("should forward upstream error status from brand-service", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/resolve")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
+        };
+      }
+      return {
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('{"error":"User is not a member of the target org"}'),
+      };
+    });
+
+    const res = await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .set("x-external-user-id", "clerk_user_ext")
+      .send({ targetOrgId: "org_clerk_target" });
 
     expect(res.status).toBe(403);
     expect(res.body.error).toContain("not a member");


### PR DESCRIPTION
## Summary
- The dashboard sends Clerk org IDs (e.g. `org_xxx`) as `targetOrgId` in brand transfer requests
- api-service now resolves this to an internal UUID via client-service `/resolve` before proxying to brand-service
- Validates that the resolved target org is different from the source org
- Returns 400 if `x-external-user-id` header is missing (needed for resolution)

## Test plan
- [x] 7 unit tests covering: resolve + proxy, identity header forwarding, missing targetOrgId, missing external user ID header, same-org validation, upstream error forwarding
- [x] Full test suite passes (108 files, 1124 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)