### PR TITLE
fix: forward identity headers on brand transfer membership check

### DIFF
--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -328,6 +328,7 @@ router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async
       await callExternalService(
         externalServices.client,
         `/orgs/${resolved.orgId}/members/${req.userId}`,
+        { headers: buildInternalHeaders(req) },
       );
     } catch (membershipError: any) {
       if (membershipError.statusCode === 404) {

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (req: any, _res: any, next: any) => {
     req.userId = "user_test123";
     req.orgId = "org_test456";
+    req.runId = "run_test789";
     req.authType = "admin";
     next();
   },
@@ -187,6 +188,36 @@ describe("POST /v1/brands/:id/transfer", () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toContain("not a member of the target org");
+  });
+
+  it("should forward identity headers to client-service membership check (regression: missing x-run-id)", async () => {
+    let membershipHeaders: Record<string, string> = {};
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/resolve")) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
+        };
+      }
+      if (String(url).includes("/members/")) {
+        membershipHeaders = Object.fromEntries(
+          Object.entries(init?.headers || {}).map(([k, v]) => [k.toLowerCase(), v]),
+        ) as Record<string, string>;
+        return { ok: true, json: () => Promise.resolve({}) };
+      }
+      return { ok: true, json: () => Promise.resolve(transferResult) };
+    });
+
+    const res = await request(app)
+      .post("/v1/brands/brand-abc/transfer")
+      .set("x-external-user-id", "clerk_user_ext")
+      .send({ targetOrgId: "org_clerk_target" });
+
+    expect(res.status).toBe(200);
+    expect(membershipHeaders["x-org-id"]).toBe("org_test456");
+    expect(membershipHeaders["x-user-id"]).toBe("user_test123");
+    expect(membershipHeaders["x-run-id"]).toBe("run_test789");
   });
 
   it("should forward upstream error status from brand-service", async () => {


### PR DESCRIPTION
## Summary
- The `POST /v1/brands/:id/transfer` route's membership verification call to client-service (`/orgs/:orgId/members/:userId`) was missing identity headers, causing a 400 "Missing x-run-id header"
- Added `{ headers: buildInternalHeaders(req) }` to the membership check call, consistent with all other service-to-service calls
- Added regression test verifying `x-org-id`, `x-user-id`, and `x-run-id` are forwarded on the membership check

## Test plan
- [x] Existing brand transfer tests pass (9/9)
- [x] New regression test verifies identity headers on membership call
- [ ] Verify brand transfer works end-to-end on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)