### PR TITLE
feat: migrate client-service calls to /internal/ prefix

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -195,7 +195,7 @@ async function resolveExternalIds(
       userId: string;
     }>(
       externalServices.client,
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body,

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -308,7 +308,7 @@ router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async
 
     const resolved = await callExternalService<{ orgId: string; userId: string }>(
       externalServices.client,
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: { externalOrgId: targetOrgId, externalUserId },
@@ -327,8 +327,7 @@ router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async
     try {
       await callExternalService(
         externalServices.client,
-        `/orgs/${resolved.orgId}/members/${req.userId}`,
-        { headers: buildInternalHeaders(req) },
+        `/internal/orgs/${resolved.orgId}/members/${req.userId}`,
       );
     } catch (membershipError: any) {
       if (membershipError.statusCode === 404) {

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { authenticate, requireOrg, AuthenticatedRequest } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
-import { buildInternalHeaders } from "../lib/internal-headers.js";
 import { ResolveUserRequestSchema, ListUsersQuerySchema } from "../schemas.js";
 
 const router = Router();
@@ -20,11 +19,10 @@ router.post("/users/resolve", authenticate, requireOrg, async (req: Authenticate
 
     const result = await callExternalService(
       externalServices.client,
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: parsed.data,
-        headers: buildInternalHeaders(req),
       }
     );
     res.json(result);
@@ -53,8 +51,7 @@ router.get("/users", authenticate, requireOrg, async (req: AuthenticatedRequest,
 
     const result = await callExternalService(
       externalServices.client,
-      `/users?${params.toString()}`,
-      { headers: buildInternalHeaders(req) },
+      `/internal/users?${params.toString()}`,
     );
     res.json(result);
   } catch (error: any) {

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -83,7 +83,7 @@ describe("Auth middleware — admin key via X-API-Key", () => {
     expect(mockCall).toHaveBeenCalledTimes(1);
     expect(mockCall).toHaveBeenCalledWith(
       expect.objectContaining({ url: "http://client-service" }),
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: {
@@ -112,7 +112,7 @@ describe("Auth middleware — admin key via X-API-Key", () => {
     expect(res.status).toBe(200);
     expect(mockCall).toHaveBeenCalledWith(
       expect.objectContaining({ url: "http://client-service" }),
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: {
@@ -141,7 +141,7 @@ describe("Auth middleware — admin key via X-API-Key", () => {
     expect(res.status).toBe(200);
     expect(mockCall).toHaveBeenCalledWith(
       expect.objectContaining({ url: "http://client-service" }),
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: {

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -59,7 +59,7 @@ describe("Auth middleware — admin auth requires both external ID headers", () 
 
 describe("Auth middleware — identity resolution via POST /resolve", () => {
   it("should resolve external IDs via client-service POST /resolve", () => {
-    expect(content).toContain('"/resolve"');
+    expect(content).toContain('"/internal/resolve"');
     expect(content).toContain("externalServices.client");
     expect(content).toContain('method: "POST"');
   });

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -51,8 +51,8 @@ function mockFetchResolveAndTransfer() {
   let brandServiceHeaders: Record<string, string> = {};
 
   global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-    // client-service /resolve call (match the exact path, not substring)
-    if (String(url).endsWith("/resolve")) {
+    // client-service /internal/resolve call
+    if (String(url).includes("/internal/resolve")) {
       return {
         ok: true,
         json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
@@ -145,7 +145,7 @@ describe("POST /v1/brands/:id/transfer", () => {
 
   it("should return 400 when target org resolves to same as source org", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (String(url).endsWith("/resolve")) {
+      if (String(url).includes("/internal/resolve")) {
         return {
           ok: true,
           json: () => Promise.resolve({ orgId: "org_test456", userId: "user_test123", orgCreated: false, userCreated: false }),
@@ -165,7 +165,7 @@ describe("POST /v1/brands/:id/transfer", () => {
 
   it("should return 403 when user is not a member of target org", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (String(url).endsWith("/resolve")) {
+      if (String(url).includes("/internal/resolve")) {
         return {
           ok: true,
           json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
@@ -190,20 +190,18 @@ describe("POST /v1/brands/:id/transfer", () => {
     expect(res.body.error).toContain("not a member of the target org");
   });
 
-  it("should forward identity headers to client-service membership check (regression: missing x-run-id)", async () => {
-    let membershipHeaders: Record<string, string> = {};
+  it("should call client-service membership check at /internal/ path", async () => {
+    let membershipUrl = "";
 
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      if (String(url).endsWith("/resolve")) {
+      if (String(url).includes("/internal/resolve")) {
         return {
           ok: true,
           json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
         };
       }
       if (String(url).includes("/members/")) {
-        membershipHeaders = Object.fromEntries(
-          Object.entries(init?.headers || {}).map(([k, v]) => [k.toLowerCase(), v]),
-        ) as Record<string, string>;
+        membershipUrl = url;
         return { ok: true, json: () => Promise.resolve({}) };
       }
       return { ok: true, json: () => Promise.resolve(transferResult) };
@@ -215,14 +213,13 @@ describe("POST /v1/brands/:id/transfer", () => {
       .send({ targetOrgId: "org_clerk_target" });
 
     expect(res.status).toBe(200);
-    expect(membershipHeaders["x-org-id"]).toBe("org_test456");
-    expect(membershipHeaders["x-user-id"]).toBe("user_test123");
-    expect(membershipHeaders["x-run-id"]).toBe("run_test789");
+    expect(membershipUrl).toContain("/internal/orgs/");
+    expect(membershipUrl).toContain(`/members/user_test123`);
   });
 
   it("should forward upstream error status from brand-service", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (String(url).endsWith("/resolve")) {
+      if (String(url).includes("/internal/resolve")) {
         return {
           ok: true,
           json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),


### PR DESCRIPTION
## Summary
- client-service is moving all endpoints behind `/internal/*` and dropping the `x-run-id` requirement
- Updates all 5 client-service call sites in api-service:
  - `POST /resolve` → `POST /internal/resolve` (auth.ts, brand.ts, users.ts)
  - `GET /users` → `GET /internal/users` (users.ts)
  - `GET /orgs/:id/members/:uid` → `GET /internal/orgs/:id/members/:uid` (brand.ts)
- Removes identity header forwarding (`buildInternalHeaders`) from client-service calls — only `x-api-key` is needed now (added automatically by `callExternalService`)
- Removes unused `buildInternalHeaders` import from users.ts

## Test plan
- [x] 69 tests pass across auth, brand-transfer, users-resolve, auth-middleware test suites
- [ ] Coordinate deploy with client-service `/internal/` migration — both must ship together

🤖 Generated with [Claude Code](https://claude.com/claude-code)