### PR TITLE
chore: sync hotfix v0.14.1 to staging (conflict resolved)

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -195,7 +195,7 @@ async function resolveExternalIds(
       userId: string;
     }>(
       externalServices.client,
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body,

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -308,7 +308,7 @@ router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async
 
     const resolved = await callExternalService<{ orgId: string; userId: string }>(
       externalServices.client,
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: { externalOrgId: targetOrgId, externalUserId },
@@ -327,7 +327,7 @@ router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async
     try {
       await callExternalService(
         externalServices.client,
-        `/orgs/${resolved.orgId}/members/${req.userId}`,
+        `/internal/orgs/${resolved.orgId}/members/${req.userId}`,
       );
     } catch (membershipError: any) {
       if (membershipError.statusCode === 404) {

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -20,7 +20,7 @@ router.post("/users/resolve", authenticate, requireOrg, async (req: Authenticate
 
     const result = await callExternalService(
       externalServices.client,
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: parsed.data,
@@ -53,7 +53,7 @@ router.get("/users", authenticate, requireOrg, async (req: AuthenticatedRequest,
 
     const result = await callExternalService(
       externalServices.client,
-      `/users?${params.toString()}`,
+      `/internal/users?${params.toString()}`,
       { headers: buildInternalHeaders(req) },
     );
     res.json(result);

--- a/tests/unit/auth-middleware.test.ts
+++ b/tests/unit/auth-middleware.test.ts
@@ -83,7 +83,7 @@ describe("Auth middleware — admin key via X-API-Key", () => {
     expect(mockCall).toHaveBeenCalledTimes(1);
     expect(mockCall).toHaveBeenCalledWith(
       expect.objectContaining({ url: "http://client-service" }),
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: {
@@ -112,7 +112,7 @@ describe("Auth middleware — admin key via X-API-Key", () => {
     expect(res.status).toBe(200);
     expect(mockCall).toHaveBeenCalledWith(
       expect.objectContaining({ url: "http://client-service" }),
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: {
@@ -141,7 +141,7 @@ describe("Auth middleware — admin key via X-API-Key", () => {
     expect(res.status).toBe(200);
     expect(mockCall).toHaveBeenCalledWith(
       expect.objectContaining({ url: "http://client-service" }),
-      "/resolve",
+      "/internal/resolve",
       {
         method: "POST",
         body: {

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -59,7 +59,7 @@ describe("Auth middleware — admin auth requires both external ID headers", () 
 
 describe("Auth middleware — identity resolution via POST /resolve", () => {
   it("should resolve external IDs via client-service POST /resolve", () => {
-    expect(content).toContain('"/resolve"');
+    expect(content).toContain('"/internal/resolve"');
     expect(content).toContain("externalServices.client");
     expect(content).toContain('method: "POST"');
   });

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -51,7 +51,7 @@ function mockFetchResolveAndTransfer() {
 
   global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
     // client-service /resolve call (match the exact path, not substring)
-    if (String(url).endsWith("/resolve")) {
+    if (String(url).includes("/internal/resolve")) {
       return {
         ok: true,
         json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
@@ -144,7 +144,7 @@ describe("POST /v1/brands/:id/transfer", () => {
 
   it("should return 400 when target org resolves to same as source org", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (String(url).endsWith("/resolve")) {
+      if (String(url).includes("/internal/resolve")) {
         return {
           ok: true,
           json: () => Promise.resolve({ orgId: "org_test456", userId: "user_test123", orgCreated: false, userCreated: false }),
@@ -164,7 +164,7 @@ describe("POST /v1/brands/:id/transfer", () => {
 
   it("should return 403 when user is not a member of target org", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (String(url).endsWith("/resolve")) {
+      if (String(url).includes("/internal/resolve")) {
         return {
           ok: true,
           json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),
@@ -191,7 +191,7 @@ describe("POST /v1/brands/:id/transfer", () => {
 
   it("should forward upstream error status from brand-service", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (String(url).endsWith("/resolve")) {
+      if (String(url).includes("/internal/resolve")) {
         return {
           ok: true,
           json: () => Promise.resolve({ orgId: RESOLVED_TARGET_ORG_ID, userId: "user_test123", orgCreated: false, userCreated: false }),


### PR DESCRIPTION
## Summary
- Syncs hotfix v0.14.1 (client-service `/internal/` path migration) from main into staging
- Resolves merge conflict in `brand.ts` — staging had PR #382's `buildInternalHeaders` workaround, main has the final `/internal/` path without headers
- Replaces stuck PR #385 which couldn't auto-merge due to conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)