### PR TITLE
feat: add GET /v1/brands/:id/transfers proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5639,6 +5639,112 @@
           "targetOrgId"
         ]
       },
+      "BrandTransferHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "transfers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "brandId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "sourceOrgId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "targetOrgId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "initiatedByUserId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "serviceResults": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "updatedTables": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "tableName": {
+                                  "type": "string"
+                                },
+                                "count": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "tableName",
+                                "count"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "updatedTables"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "skipped": {
+                            "type": "boolean",
+                            "enum": [
+                              true
+                            ]
+                          }
+                        },
+                        "required": [
+                          "skipped"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "brandId",
+                "sourceOrgId",
+                "targetOrgId",
+                "initiatedByUserId",
+                "serviceResults",
+                "createdAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "transfers"
+        ]
+      },
       "EmailGatewayStatsResponse": {
         "type": "object",
         "properties": {
@@ -19161,6 +19267,119 @@
           },
           "404": {
             "description": "Brand not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/transfers": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get transfer history for a brand",
+        "description": "Returns the audit log of all transfers for a given brand, including per-service results.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transfer history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandTransferHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -353,4 +353,25 @@ router.post("/brands/:id/transfer", authenticate, requireOrg, requireUser, async
   }
 });
 
+/**
+ * GET /v1/brands/:id/transfers
+ * Get transfer history for a brand.
+ */
+router.get("/brands/:id/transfers", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.brand,
+      `/internal/brand-transfers?brandId=${req.params.id}`,
+      {
+        headers: buildInternalHeaders(req),
+      },
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Brand transfer history error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get transfer history" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3595,6 +3595,49 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{id}/transfers",
+  tags: ["Brand"],
+  summary: "Get transfer history for a brand",
+  description: "Returns the audit log of all transfers for a given brand, including per-service results.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+  },
+  responses: {
+    200: {
+      description: "Transfer history",
+      content: {
+        "application/json": {
+          schema: z.object({
+            transfers: z.array(
+              z.object({
+                id: z.string().uuid(),
+                brandId: z.string().uuid(),
+                sourceOrgId: z.string().uuid(),
+                targetOrgId: z.string().uuid(),
+                initiatedByUserId: z.string().uuid(),
+                serviceResults: z.record(
+                  z.string(),
+                  z.union([
+                    z.object({ updatedTables: z.array(z.object({ tableName: z.string(), count: z.number() })) }),
+                    z.object({ error: z.string() }),
+                    z.object({ skipped: z.literal(true) }),
+                  ]),
+                ),
+                createdAt: z.string(),
+              }),
+            ),
+          }).openapi("BrandTransferHistoryResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // EMAIL-GATEWAY (delivery stats)
 // ===================================================================

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -244,3 +244,62 @@ describe("POST /v1/brands/:id/transfer", () => {
     expect(res.body.error).toContain("Brand-service internal error");
   });
 });
+
+describe("GET /v1/brands/:id/transfers", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  const transferHistory = {
+    transfers: [
+      {
+        id: "transfer-uuid-1",
+        brandId: "brand-abc",
+        sourceOrgId: "org-old",
+        targetOrgId: "org-new",
+        initiatedByUserId: "user_test123",
+        serviceResults: {
+          "campaign-service": { updatedTables: [{ tableName: "campaigns", count: 3 }] },
+        },
+        createdAt: "2026-04-25T00:00:00.000Z",
+      },
+    ],
+  };
+
+  it("should proxy to brand-service and return transfer history", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/internal/brand-transfers")) {
+        return { ok: true, json: () => Promise.resolve(transferHistory) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const res = await request(app)
+      .get("/v1/brands/brand-abc/transfers");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(transferHistory);
+
+    const fetchCall = (global.fetch as any).mock.calls[0];
+    expect(fetchCall[0]).toContain("/internal/brand-transfers?brandId=brand-abc");
+  });
+
+  it("should forward upstream errors from brand-service", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => {
+      return {
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('{"error":"DB error"}'),
+      };
+    });
+
+    const res = await request(app)
+      .get("/v1/brands/brand-abc/transfers");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("DB error");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /v1/brands/:id/transfers` proxy route to expose brand transfer audit history from brand-service
- Proxies to `GET /internal/brand-transfers?brandId={id}` on brand-service
- Adds OpenAPI schema for the response (transfers array with per-service results)
- Adds tests for success and error forwarding

## Test plan
- [x] Unit tests pass (11 tests)
- [ ] Verify on staging: `GET /v1/brands/{brandId}/transfers` returns transfer history

🤖 Generated with [Claude Code](https://claude.com/claude-code)