### PR TITLE
feat: add outgoing/incoming brand transfer history proxies

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5745,6 +5745,218 @@
           "transfers"
         ]
       },
+      "OutgoingBrandTransferResponse": {
+        "type": "object",
+        "properties": {
+          "transfers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "brandId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "sourceOrgId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "targetOrgId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "initiatedByUserId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "serviceResults": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "updatedTables": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "tableName": {
+                                  "type": "string"
+                                },
+                                "count": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "tableName",
+                                "count"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "updatedTables"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "skipped": {
+                            "type": "boolean",
+                            "enum": [
+                              true
+                            ]
+                          }
+                        },
+                        "required": [
+                          "skipped"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "brandId",
+                "sourceOrgId",
+                "targetOrgId",
+                "initiatedByUserId",
+                "serviceResults",
+                "createdAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "transfers"
+        ]
+      },
+      "IncomingBrandTransferResponse": {
+        "type": "object",
+        "properties": {
+          "transfers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "brandId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "sourceOrgId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "targetOrgId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "initiatedByUserId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "serviceResults": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "updatedTables": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "tableName": {
+                                  "type": "string"
+                                },
+                                "count": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "tableName",
+                                "count"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "updatedTables"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "skipped": {
+                            "type": "boolean",
+                            "enum": [
+                              true
+                            ]
+                          }
+                        },
+                        "required": [
+                          "skipped"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "brandId",
+                "sourceOrgId",
+                "targetOrgId",
+                "initiatedByUserId",
+                "serviceResults",
+                "createdAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "transfers"
+        ]
+      },
       "EmailGatewayStatsResponse": {
         "type": "object",
         "properties": {
@@ -19374,6 +19586,234 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BrandTransferHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brand-transfers/outgoing": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get outgoing brand transfers for the current org",
+        "description": "Returns transfers where the current org is the source (brand was transferred out).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by brand ID"
+            },
+            "required": false,
+            "description": "Filter by brand ID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outgoing transfer history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutgoingBrandTransferResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brand-transfers/incoming": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get incoming brand transfers for the current org",
+        "description": "Returns transfers where the current org is the target (brand was transferred in).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by brand ID"
+            },
+            "required": false,
+            "description": "Filter by brand ID",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Incoming transfer history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IncomingBrandTransferResponse"
                 }
               }
             }

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -374,4 +374,50 @@ router.get("/brands/:id/transfers", authenticate, requireOrg, async (req: Authen
   }
 });
 
+/**
+ * GET /v1/brand-transfers/outgoing
+ * Transfers where the current org is the source.
+ */
+router.get("/brand-transfers/outgoing", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const brandId = req.query.brandId as string | undefined;
+    const qs = brandId ? `?brandId=${brandId}` : "";
+    const result = await callExternalService(
+      externalServices.brand,
+      `/orgs/brand-transfers/outgoing${qs}`,
+      {
+        headers: buildInternalHeaders(req),
+      },
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Outgoing transfer history error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get outgoing transfers" });
+  }
+});
+
+/**
+ * GET /v1/brand-transfers/incoming
+ * Transfers where the current org is the target.
+ */
+router.get("/brand-transfers/incoming", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const brandId = req.query.brandId as string | undefined;
+    const qs = brandId ? `?brandId=${brandId}` : "";
+    const result = await callExternalService(
+      externalServices.brand,
+      `/orgs/brand-transfers/incoming${qs}`,
+      {
+        headers: buildInternalHeaders(req),
+      },
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Incoming transfer history error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get incoming transfers" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3638,6 +3638,79 @@ registry.registerPath({
   },
 });
 
+const brandTransferHistorySchema = z.object({
+  transfers: z.array(
+    z.object({
+      id: z.string().uuid(),
+      brandId: z.string().uuid(),
+      sourceOrgId: z.string().uuid(),
+      targetOrgId: z.string().uuid(),
+      initiatedByUserId: z.string().uuid(),
+      serviceResults: z.record(
+        z.string(),
+        z.union([
+          z.object({ updatedTables: z.array(z.object({ tableName: z.string(), count: z.number() })) }),
+          z.object({ error: z.string() }),
+          z.object({ skipped: z.literal(true) }),
+        ]),
+      ),
+      createdAt: z.string(),
+    }),
+  ),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brand-transfers/outgoing",
+  tags: ["Brand"],
+  summary: "Get outgoing brand transfers for the current org",
+  description: "Returns transfers where the current org is the source (brand was transferred out).",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().optional().describe("Filter by brand ID"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Outgoing transfer history",
+      content: {
+        "application/json": {
+          schema: brandTransferHistorySchema.openapi("OutgoingBrandTransferResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brand-transfers/incoming",
+  tags: ["Brand"],
+  summary: "Get incoming brand transfers for the current org",
+  description: "Returns transfers where the current org is the target (brand was transferred in).",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().optional().describe("Filter by brand ID"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Incoming transfer history",
+      content: {
+        "application/json": {
+          schema: brandTransferHistorySchema.openapi("IncomingBrandTransferResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // EMAIL-GATEWAY (delivery stats)
 // ===================================================================

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -303,3 +303,91 @@ describe("GET /v1/brands/:id/transfers", () => {
     expect(res.body.error).toContain("DB error");
   });
 });
+
+const orgTransferHistory = {
+  transfers: [
+    {
+      id: "transfer-uuid-2",
+      brandId: "brand-xyz",
+      sourceOrgId: "org_test456",
+      targetOrgId: "org-target",
+      initiatedByUserId: "user_test123",
+      serviceResults: {
+        "lead-service": { updatedTables: [{ tableName: "leads", count: 5 }] },
+      },
+      createdAt: "2026-04-25T12:00:00.000Z",
+    },
+  ],
+};
+
+describe("GET /v1/brand-transfers/outgoing", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("should proxy to brand-service outgoing endpoint", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/orgs/brand-transfers/outgoing")) {
+        return { ok: true, json: () => Promise.resolve(orgTransferHistory) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const res = await request(app).get("/v1/brand-transfers/outgoing");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(orgTransferHistory);
+    const fetchCall = (global.fetch as any).mock.calls[0];
+    expect(fetchCall[0]).toContain("/orgs/brand-transfers/outgoing");
+  });
+
+  it("should forward brandId query param", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => {
+      return { ok: true, json: () => Promise.resolve({ transfers: [] }) };
+    });
+
+    await request(app).get("/v1/brand-transfers/outgoing?brandId=brand-xyz");
+
+    const fetchCall = (global.fetch as any).mock.calls[0];
+    expect(fetchCall[0]).toContain("?brandId=brand-xyz");
+  });
+});
+
+describe("GET /v1/brand-transfers/incoming", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("should proxy to brand-service incoming endpoint", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("/orgs/brand-transfers/incoming")) {
+        return { ok: true, json: () => Promise.resolve(orgTransferHistory) };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+
+    const res = await request(app).get("/v1/brand-transfers/incoming");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(orgTransferHistory);
+    const fetchCall = (global.fetch as any).mock.calls[0];
+    expect(fetchCall[0]).toContain("/orgs/brand-transfers/incoming");
+  });
+
+  it("should forward brandId query param", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => {
+      return { ok: true, json: () => Promise.resolve({ transfers: [] }) };
+    });
+
+    await request(app).get("/v1/brand-transfers/incoming?brandId=brand-xyz");
+
+    const fetchCall = (global.fetch as any).mock.calls[0];
+    expect(fetchCall[0]).toContain("?brandId=brand-xyz");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /v1/brand-transfers/outgoing` — transfers where the current org is the source
- Adds `GET /v1/brand-transfers/incoming` — transfers where the current org is the target
- Both accept optional `?brandId=` filter
- Proxies to brand-service `GET /orgs/brand-transfers/{outgoing|incoming}`
- OpenAPI schemas + 4 new tests (15 total in brand-transfer suite)

## Test plan
- [x] Unit tests pass (15 tests)
- [ ] Verify on staging after brand-service PR #174 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)