### PR TITLE
feat: restore POST /v1/features/{slug}/prefill proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8829,6 +8829,54 @@
         "type": "object",
         "properties": {}
       },
+      "PrefillFeatureResponse": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string"
+          },
+          "brandId": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "text",
+              "full"
+            ]
+          },
+          "prefilled": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            }
+          }
+        },
+        "required": [
+          "slug",
+          "brandId",
+          "format",
+          "prefilled"
+        ]
+      },
+      "PrefillFeatureRequest": {
+        "type": "object",
+        "properties": {
+          "brandIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Non-empty array of brand UUIDs to prefill from",
+            "example": [
+              "brand-uuid-123"
+            ]
+          }
+        },
+        "required": [
+          "brandIds"
+        ]
+      },
       "FeatureStatsResponse": {
         "type": "object",
         "properties": {}
@@ -28647,6 +28695,163 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/{featureSlug}/prefill": {
+      "post": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Prefill feature inputs from brand data",
+        "description": "Calls brand-service to extract field values for the feature's inputs. Returns pre-filled values keyed by input key. Requires brandIds in the request body. Use ?format=text for flattened strings, ?format=full for structured values with per-brand breakdown. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug",
+              "example": "pr-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "featureSlug",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "text",
+                "full"
+              ],
+              "description": "Response format: 'text' returns flattened strings, 'full' returns structured values with per-brand breakdown"
+            },
+            "required": false,
+            "description": "Response format: 'text' returns flattened strings, 'full' returns structured values with per-brand breakdown",
+            "name": "format",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrefillFeatureRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pre-filled input values",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrefillFeatureResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid brandIds",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -161,6 +161,39 @@ router.get("/features/stats", authenticate, requireOrg, requireUser, async (req:
 });
 
 /**
+ * POST /v1/features/:slug/prefill
+ * Prefill feature form using brand data. Called by dashboard for "New Campaign".
+ */
+router.post("/features/:slug/prefill", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandIds, ...restBody } = req.body as { brandIds?: string[]; [k: string]: unknown };
+    if (!brandIds || !Array.isArray(brandIds) || brandIds.length === 0) {
+      return res.status(400).json({ error: "brandIds (non-empty string array) is required in the request body" });
+    }
+
+    const format = req.query.format;
+    const qs = format ? `?format=${encodeURIComponent(format as string)}` : "";
+    const headers: Record<string, string> = {
+      ...buildInternalHeaders(req),
+      "x-brand-id": brandIds.join(","),
+    };
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}/prefill${qs}`,
+      {
+        method: "POST",
+        headers,
+        body: restBody,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Prefill feature error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to prefill feature" });
+  }
+});
+
+/**
  * GET /v1/features/:slug
  * Get a single feature by slug
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6480,6 +6480,52 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "post",
+  path: "/v1/features/{featureSlug}/prefill",
+  tags: ["Features"],
+  summary: "Prefill feature inputs from brand data",
+  description:
+    "Calls brand-service to extract field values for the feature's inputs. Returns pre-filled values keyed by input key. " +
+    "Requires brandIds in the request body. Use ?format=text for flattened strings, ?format=full for structured values with per-brand breakdown. " +
+    "Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ featureSlug: z.string().openapi({ example: "pr-cold-email-outreach" }).describe("Feature slug") }),
+    query: z.object({
+      format: z.enum(["text", "full"]).optional().describe("Response format: 'text' returns flattened strings, 'full' returns structured values with per-brand breakdown"),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            brandIds: z.array(z.string()).openapi({ example: ["brand-uuid-123"] }).describe("Non-empty array of brand UUIDs to prefill from"),
+          }).openapi("PrefillFeatureRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Pre-filled input values",
+      content: {
+        "application/json": {
+          schema: z.object({
+            slug: z.string(),
+            brandId: z.string(),
+            format: z.enum(["text", "full"]),
+            prefilled: z.record(z.unknown()),
+          }).openapi("PrefillFeatureResponse"),
+        },
+      },
+    },
+    400: { description: "Missing or invalid brandIds", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "get",
   path: "/v1/features/{featureSlug}/stats",
   tags: ["Features"],

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -139,11 +139,37 @@ describe("Features proxy routes", () => {
     expect(content).not.toContain('"/features/stats/dynasty"');
   });
 
-  it("should NOT have removed endpoints (inputs, prefill, create, update, batch upsert)", () => {
+  it("should NOT have removed endpoints (inputs, create, update, batch upsert)", () => {
     expect(content).not.toContain('"/features/:slug/inputs"');
-    expect(content).not.toContain('"/features/:slug/prefill"');
-    expect(content).not.toContain("router.post");
     expect(content).not.toContain("router.put");
+  });
+
+  it("should have POST /features/:slug/prefill with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/features/:slug/prefill"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should validate brandIds in prefill body", () => {
+    expect(content).toContain("brandIds");
+    expect(content).toContain("brandIds (non-empty string array) is required");
+  });
+
+  it("should forward format query param on prefill", () => {
+    const prefillIdx = content.indexOf('"/features/:slug/prefill"');
+    const prefillBlock = content.slice(prefillIdx, prefillIdx + 600);
+    expect(prefillBlock).toContain("format");
+  });
+
+  it("should set x-brand-id header from brandIds body on prefill", () => {
+    const prefillIdx = content.indexOf('"/features/:slug/prefill"');
+    const prefillBlock = content.slice(prefillIdx, prefillIdx + 900);
+    expect(prefillBlock).toContain('"x-brand-id"');
+    expect(prefillBlock).toContain("brandIds.join");
   });
 });
 
@@ -188,12 +214,15 @@ describe("Features OpenAPI schemas", () => {
     expect(schemaContent).toContain('tags: ["Features"]');
   });
 
+  it("should register POST /v1/features/{featureSlug}/prefill", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/prefill"');
+  });
+
   it("should NOT register removed dynasty/write endpoints", () => {
     expect(schemaContent).not.toContain('path: "/v1/features/dynasty"');
     expect(schemaContent).not.toContain('path: "/v1/features/by-dynasty/');
     expect(schemaContent).not.toContain('path: "/v1/features/stats/dynasty"');
     expect(schemaContent).not.toContain('path: "/v1/features/{slug}/inputs"');
-    expect(schemaContent).not.toContain('path: "/v1/features/{slug}/prefill"');
     expect(schemaContent).not.toContain('path: "/public/features/dynasty/slugs"');
   });
 });


### PR DESCRIPTION
## Summary
- Restores `POST /v1/features/{featureSlug}/prefill` proxy route accidentally removed in PR #394 (dynasty cleanup)
- The dashboard calls this endpoint on `/campaigns/new` to prefill form inputs from brand data — without it, users see an empty form
- Validates `brandIds` in request body, forwards as `x-brand-id` header, passes `format` query param through

## Changes
- `src/routes/features.ts` — restored prefill route with `authenticate + requireOrg + requireUser`
- `src/schemas.ts` — added OpenAPI schema registration
- `openapi.json` — regenerated
- `tests/unit/features-proxy.test.ts` — regression tests for prefill route, updated negative assertions

## Test plan
- [x] All 1104 tests pass
- [ ] Deploy to staging, verify `POST /v1/features/pr-cold-email-outreach/prefill?format=text` returns prefilled data
- [ ] Verify dashboard `/campaigns/new` page shows pre-filled form fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)