### PR TITLE
feat: public stats proxy routes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8881,6 +8881,18 @@
         "type": "object",
         "properties": {}
       },
+      "PublicUserStatsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PublicBillingStatsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PublicRunStatsResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "PublicFeaturesListResponse": {
         "type": "object",
         "properties": {}
@@ -29040,6 +29052,99 @@
           },
           "500": {
             "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/stats/users": {
+      "get": {
+        "tags": [
+          "Public Stats"
+        ],
+        "summary": "Public user/org stats (no auth)",
+        "description": "Returns total orgs, total users, and monthly growth breakdown. No authentication required. Proxied from client-service.",
+        "responses": {
+          "200": {
+            "description": "User/org stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicUserStatsResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/stats/billing": {
+      "get": {
+        "tags": [
+          "Public Stats"
+        ],
+        "summary": "Public billing stats (no auth)",
+        "description": "Returns total accounts, accounts with payment method, and credit balance/usage aggregates. No authentication required. Proxied from billing-service.",
+        "responses": {
+          "200": {
+            "description": "Billing stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBillingStatsResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/stats/runs": {
+      "get": {
+        "tags": [
+          "Public Stats"
+        ],
+        "summary": "Public run stats (no auth)",
+        "description": "Returns run counts by status and monthly completed breakdown. No authentication required. Proxied from runs-service.",
+        "responses": {
+          "200": {
+            "description": "Run stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRunStatsResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream error",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import outletsRoutes from "./routes/outlets.js";
 import journalistsRoutes from "./routes/journalists.js";
 import articlesRoutes from "./routes/articles.js";
 import featuresRoutes from "./routes/features.js";
+import publicStatsRoutes from "./routes/public-stats.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
@@ -162,6 +163,7 @@ app.use(
 app.use(healthRoutes);
 app.use(pressKitsRoutes); // public press-kit endpoints (no auth)
 app.use(featuresRoutes);  // public features endpoints (no auth)
+app.use(publicStatsRoutes); // public stats endpoints (no auth)
 
 // Internal platform routes (API key only, no identity)
 app.use("/internal", internalEmailsRoutes);

--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -1,0 +1,57 @@
+import { Router, Request, Response } from "express";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+
+const router = Router();
+
+/**
+ * GET /public/stats/users
+ * Public user/org stats. Proxied to client-service GET /public/stats/users.
+ */
+router.get("/public/stats/users", async (_req: Request, res: Response) => {
+  try {
+    const result = await callExternalService(
+      externalServices.client,
+      "/public/stats/users",
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public stats users error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public user stats" });
+  }
+});
+
+/**
+ * GET /public/stats/billing
+ * Public billing stats. Proxied to billing-service GET /public/stats/billing.
+ */
+router.get("/public/stats/billing", async (_req: Request, res: Response) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      "/public/stats/billing",
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public stats billing error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public billing stats" });
+  }
+});
+
+/**
+ * GET /public/stats/runs
+ * Public run stats. Proxied to runs-service GET /public/stats/runs.
+ */
+router.get("/public/stats/runs", async (_req: Request, res: Response) => {
+  try {
+    const result = await callExternalService(
+      externalServices.runs,
+      "/public/stats/runs",
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public stats runs error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public run stats" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6552,6 +6552,51 @@ registry.registerPath({
 });
 
 // ---------------------------------------------------------------------------
+// PUBLIC STATS (no auth — landing page endpoints)
+// ---------------------------------------------------------------------------
+
+registry.registerPath({
+  method: "get",
+  path: "/public/stats/users",
+  tags: ["Public Stats"],
+  summary: "Public user/org stats (no auth)",
+  description:
+    "Returns total orgs, total users, and monthly growth breakdown. " +
+    "No authentication required. Proxied from client-service.",
+  responses: {
+    200: { description: "User/org stats", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicUserStatsResponse") } } },
+    502: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/public/stats/billing",
+  tags: ["Public Stats"],
+  summary: "Public billing stats (no auth)",
+  description:
+    "Returns total accounts, accounts with payment method, and credit balance/usage aggregates. " +
+    "No authentication required. Proxied from billing-service.",
+  responses: {
+    200: { description: "Billing stats", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicBillingStatsResponse") } } },
+    502: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/public/stats/runs",
+  tags: ["Public Stats"],
+  summary: "Public run stats (no auth)",
+  description:
+    "Returns run counts by status and monthly completed breakdown. " +
+    "No authentication required. Proxied from runs-service.",
+  responses: {
+    200: { description: "Run stats", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicRunStatsResponse") } } },
+    502: { description: "Upstream error", content: errorContent },
+  },
+});
+
 // PUBLIC FEATURES (no auth — landing page endpoints)
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/public-stats.test.ts
+++ b/tests/unit/public-stats.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCallExternalService = vi.fn();
+
+vi.mock("../../src/lib/service-client.js", () => ({
+  callExternalService: (...args: unknown[]) => mockCallExternalService(...args),
+  callExternalServiceWithStatus: (...args: unknown[]) => mockCallExternalService(...args),
+  externalServices: {
+    client: { url: "http://mock-client", apiKey: "k" },
+    emailgen: { url: "http://mock-emailgen", apiKey: "k" },
+    emailGateway: { url: "http://mock-email-gateway", apiKey: "k" },
+    campaign: { url: "http://mock-campaign", apiKey: "k" },
+    lead: { url: "http://mock-lead", apiKey: "k" },
+    key: { url: "http://mock-key", apiKey: "k" },
+    replyQualification: { url: "http://mock-rq", apiKey: "k" },
+    scraping: { url: "http://mock-scraping", apiKey: "k" },
+    transactionalEmail: { url: "http://mock-transactional-email", apiKey: "k" },
+    brand: { url: "http://mock-brand", apiKey: "k" },
+    runs: { url: "http://mock-runs", apiKey: "k" },
+    workflow: { url: "http://mock-workflow", apiKey: "k" },
+    instantly: { url: "http://mock-instantly", apiKey: "k" },
+    billing: { url: "http://mock-billing", apiKey: "k" },
+    chat: { url: "http://mock-chat", apiKey: "k" },
+    features: { url: "http://mock-features", apiKey: "k" },
+    stripe: { url: "http://mock-stripe", apiKey: "k" },
+    apiRegistry: { url: "http://mock-api-registry", apiKey: "k" },
+    pressKits: { url: "http://mock-press-kits", apiKey: "k" },
+    outlet: { url: "http://mock-outlet", apiKey: "k" },
+    journalist: { url: "http://mock-journalist", apiKey: "k" },
+    articles: { url: "http://mock-articles", apiKey: "k" },
+  },
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (_req: any, _res: any, next: any) => next(),
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import express from "express";
+import request from "supertest";
+import publicStatsRouter from "../../src/routes/public-stats.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(publicStatsRouter);
+  return app;
+}
+
+const MOCK_USER_STATS = {
+  totalOrgs: 38,
+  totalUsers: 142,
+  monthlyGrowth: [
+    { month: "2026-01", newOrgs: 8, newUsers: 15 },
+    { month: "2026-02", newOrgs: 12, newUsers: 28 },
+  ],
+};
+
+const MOCK_BILLING_STATS = {
+  totalAccounts: 35,
+  accountsWithPaymentMethod: 12,
+  totalCreditBalanceCents: 450000,
+  totalCreditedCents: 1200000,
+  totalConsumedCents: 750000,
+};
+
+const MOCK_RUN_STATS = {
+  byStatus: { completed: 8420, failed: 310, running: 5 },
+  monthly: [
+    { month: "2026-01", completed: 1200, failed: 50, running: 0 },
+    { month: "2026-02", completed: 2100, failed: 80, running: 0 },
+  ],
+};
+
+beforeEach(() => {
+  mockCallExternalService.mockReset();
+});
+
+describe("GET /public/stats/users", () => {
+  it("proxies to client-service and returns user stats", async () => {
+    mockCallExternalService.mockResolvedValueOnce(MOCK_USER_STATS);
+    const app = createApp();
+    const res = await request(app).get("/public/stats/users");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_USER_STATS);
+    expect(mockCallExternalService).toHaveBeenCalledWith(
+      { url: "http://mock-client", apiKey: "k" },
+      "/public/stats/users",
+    );
+  });
+
+  it("returns 502 when client-service is down", async () => {
+    mockCallExternalService.mockRejectedValueOnce(new Error("connection refused"));
+    const app = createApp();
+    const res = await request(app).get("/public/stats/users");
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("connection refused");
+  });
+});
+
+describe("GET /public/stats/billing", () => {
+  it("proxies to billing-service and returns billing stats", async () => {
+    mockCallExternalService.mockResolvedValueOnce(MOCK_BILLING_STATS);
+    const app = createApp();
+    const res = await request(app).get("/public/stats/billing");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_BILLING_STATS);
+    expect(mockCallExternalService).toHaveBeenCalledWith(
+      { url: "http://mock-billing", apiKey: "k" },
+      "/public/stats/billing",
+    );
+  });
+
+  it("returns 502 when billing-service is down", async () => {
+    mockCallExternalService.mockRejectedValueOnce(new Error("timeout"));
+    const app = createApp();
+    const res = await request(app).get("/public/stats/billing");
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("timeout");
+  });
+});
+
+describe("GET /public/stats/runs", () => {
+  it("proxies to runs-service and returns run stats", async () => {
+    mockCallExternalService.mockResolvedValueOnce(MOCK_RUN_STATS);
+    const app = createApp();
+    const res = await request(app).get("/public/stats/runs");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_RUN_STATS);
+    expect(mockCallExternalService).toHaveBeenCalledWith(
+      { url: "http://mock-runs", apiKey: "k" },
+      "/public/stats/runs",
+    );
+  });
+
+  it("returns 502 when runs-service is down", async () => {
+    mockCallExternalService.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const app = createApp();
+    const res = await request(app).get("/public/stats/runs");
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("ECONNREFUSED");
+  });
+
+  it("forwards upstream status code when available", async () => {
+    const err = new Error("Not found") as Error & { statusCode: number };
+    err.statusCode = 404;
+    mockCallExternalService.mockRejectedValueOnce(err);
+    const app = createApp();
+    const res = await request(app).get("/public/stats/runs");
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- 3 new public pass-through proxy routes (no auth) for landing page stats:
  - `GET /public/stats/users` → client-service `GET /public/stats/users`
  - `GET /public/stats/billing` → billing-service `GET /public/stats/billing`
  - `GET /public/stats/runs` → runs-service `GET /public/stats/runs`
- Transparent proxy — same paths, no transforms
- 7 unit tests (happy path + upstream errors for each route)
- OpenAPI spec updated with 3 new paths under "Public Stats" tag

## Dependencies
- client-service PR #53 (merged)
- billing-service PR #64 (merged)
- runs-service PR #92 (merged)

## Test plan
- [x] 7 unit tests pass (proxy behavior + error forwarding)
- [x] Full test suite: 106 files, 1099 tests pass
- [ ] Verify on staging after deploy: `curl /public/stats/users`, `/public/stats/billing`, `/public/stats/runs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)