### PR TITLE
feat: add /internal/admin/* read-only SQL proxy endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
     "@sentry/node": "^8.0.0",
     "cors": "^2.8.5",
     "express": "^4.21.0",
+    "pg": "^8.20.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
+    "@types/pg": "^8.20.0",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.0.18",
     "supertest": "^7.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       express:
         specifier: ^4.21.0
         version: 4.22.1
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -42,6 +45,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.35
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
@@ -694,66 +700,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -870,6 +889,9 @@ packages:
 
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
@@ -1464,16 +1486,42 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
   pg-protocol@1.12.0:
     resolution: {integrity: sha512-uOANXNRACNdElMXJ0tPz6RBM0XQ61nONGAwlt8da5zs/iUOOCLBQOHSXnrC6fMsvtjxbOJrZZl5IScGv+7mpbg==}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1623,6 +1671,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2658,7 +2710,13 @@ snapshots:
 
   '@types/pg-pool@2.0.6':
     dependencies:
-      '@types/pg': 8.6.1
+      '@types/pg': 8.20.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 20.19.35
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/pg@8.6.1':
     dependencies:
@@ -3327,9 +3385,20 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
   pg-int8@1.0.1: {}
 
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
   pg-protocol@1.12.0: {}
+
+  pg-protocol@1.13.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -3338,6 +3407,20 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -3518,6 +3601,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import journalistsRoutes from "./routes/journalists.js";
 import articlesRoutes from "./routes/articles.js";
 import featuresRoutes from "./routes/features.js";
 import publicStatsRoutes from "./routes/public-stats.js";
+import adminRoutes from "./routes/admin.js";
 import { apiReference } from "@scalar/express-api-reference";
 import { readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
@@ -166,6 +167,7 @@ app.use(featuresRoutes);  // public features endpoints (no auth)
 app.use(publicStatsRoutes); // public stats endpoints (no auth)
 
 // Internal platform routes (API key only, no identity)
+app.use("/internal", adminRoutes);
 app.use("/internal", internalEmailsRoutes);
 app.use("/platform-chat", platformChatRoutes);
 app.use("/platform-keys", platformKeysRoutes);

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,0 +1,184 @@
+import { Router, Request, Response } from "express";
+import { authenticatePlatform } from "../middleware/auth.js";
+import pg from "pg";
+
+const { Pool } = pg;
+
+const router = Router();
+
+// ── Service → DATABASE_URL env var registry ─────────────────────────────────
+const SERVICE_DB_REGISTRY: Record<string, string> = {
+  "brand-service": "ADMIN_DB_BRAND_SERVICE",
+  "runs-service": "ADMIN_DB_RUNS_SERVICE",
+  "client-service": "ADMIN_DB_CLIENT_SERVICE",
+  "campaign-service": "ADMIN_DB_CAMPAIGN_SERVICE",
+  "costs-service": "ADMIN_DB_COSTS_SERVICE",
+  "key-service": "ADMIN_DB_KEY_SERVICE",
+  "workflow-service": "ADMIN_DB_WORKFLOW_SERVICE",
+  "transactional-email-service": "ADMIN_DB_TRANSACTIONAL_EMAIL_SERVICE",
+  "features-service": "ADMIN_DB_FEATURES_SERVICE",
+  "outlets-service": "ADMIN_DB_OUTLETS_SERVICE",
+  "lead-service": "ADMIN_DB_LEAD_SERVICE",
+  "scraping-service": "ADMIN_DB_SCRAPING_SERVICE",
+  "chat-service": "ADMIN_DB_CHAT_SERVICE",
+};
+
+// Lazy-initialized pools per service
+const pools = new Map<string, pg.Pool>();
+
+function getPool(serviceName: string): pg.Pool | null {
+  const envVar = SERVICE_DB_REGISTRY[serviceName];
+  if (!envVar) return null;
+
+  const connectionString = process.env[envVar];
+  if (!connectionString) return null;
+
+  let pool = pools.get(serviceName);
+  if (!pool) {
+    pool = new Pool({ connectionString, max: 3 });
+    pools.set(serviceName, pool);
+  }
+  return pool;
+}
+
+// ── GET /admin/services ─────────────────────────────────────────────────────
+router.get("/admin/services", authenticatePlatform, (_req: Request, res: Response) => {
+  const services = Object.keys(SERVICE_DB_REGISTRY).map((name) => ({
+    name,
+    available: !!process.env[SERVICE_DB_REGISTRY[name]],
+  }));
+  res.json({ services });
+});
+
+// ── GET /admin/services/:name/tables ────────────────────────────────────────
+router.get("/admin/services/:name/tables", authenticatePlatform, async (req: Request, res: Response) => {
+  const { name } = req.params;
+  const pool = getPool(name);
+  if (!pool) {
+    return res.status(404).json({ error: `Service "${name}" not found or DB not configured` });
+  }
+
+  const result = await pool.query(
+    `SELECT table_name FROM information_schema.tables
+     WHERE table_schema = 'public'
+     ORDER BY table_name`
+  );
+
+  res.json({ tables: result.rows.map((r) => r.table_name) });
+});
+
+// ── GET /admin/services/:name/tables/:table/schema ──────────────────────────
+router.get("/admin/services/:name/tables/:table/schema", authenticatePlatform, async (req: Request, res: Response) => {
+  const { name, table } = req.params;
+  const pool = getPool(name);
+  if (!pool) {
+    return res.status(404).json({ error: `Service "${name}" not found or DB not configured` });
+  }
+
+  // Validate table exists
+  const tableCheck = await pool.query(
+    `SELECT 1 FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = $1`,
+    [table]
+  );
+  if (tableCheck.rowCount === 0) {
+    return res.status(404).json({ error: `Table "${table}" not found` });
+  }
+
+  const result = await pool.query(
+    `SELECT column_name, data_type, is_nullable, column_default
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1
+     ORDER BY ordinal_position`,
+    [table]
+  );
+
+  res.json({
+    table,
+    columns: result.rows.map((r) => ({
+      name: r.column_name,
+      type: r.data_type,
+      nullable: r.is_nullable === "YES",
+      default: r.column_default,
+    })),
+  });
+});
+
+// ── GET /admin/services/:name/tables/:table/rows ────────────────────────────
+router.get("/admin/services/:name/tables/:table/rows", authenticatePlatform, async (req: Request, res: Response) => {
+  const { name, table } = req.params;
+  const pool = getPool(name);
+  if (!pool) {
+    return res.status(404).json({ error: `Service "${name}" not found or DB not configured` });
+  }
+
+  // Validate table exists and get columns
+  const columnsResult = await pool.query(
+    `SELECT column_name, data_type
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1
+     ORDER BY ordinal_position`,
+    [table]
+  );
+  if (columnsResult.rowCount === 0) {
+    return res.status(404).json({ error: `Table "${table}" not found` });
+  }
+
+  const validColumns = columnsResult.rows.map((r) => r.column_name);
+  const textColumns = columnsResult.rows
+    .filter((r) => ["character varying", "text", "varchar", "char", "character"].includes(r.data_type))
+    .map((r) => r.column_name);
+
+  // Parse query params
+  const limit = parseInt(req.query.limit as string, 10) || 50;
+  const offset = parseInt(req.query.offset as string, 10) || 0;
+  const sort = (req.query.sort as string) || "created_at";
+  const order = ((req.query.order as string) || "desc").toLowerCase();
+  const search = req.query.search as string | undefined;
+
+  // Validate sort column
+  if (!validColumns.includes(sort)) {
+    return res.status(400).json({
+      error: `Invalid sort column "${sort}". Valid columns: ${validColumns.join(", ")}`,
+    });
+  }
+
+  // Validate order
+  if (order !== "asc" && order !== "desc") {
+    return res.status(400).json({ error: `Invalid order "${order}". Must be "asc" or "desc"` });
+  }
+
+  // Build query
+  const params: unknown[] = [];
+  let whereClause = "";
+
+  if (search && textColumns.length > 0) {
+    const conditions = textColumns.map((col, i) => {
+      params.push(`%${search}%`);
+      return `"${col}" ILIKE $${i + 1}`;
+    });
+    whereClause = `WHERE ${conditions.join(" OR ")}`;
+  }
+
+  // Sort column is validated above — safe to interpolate
+  const query = `SELECT * FROM "${table}" ${whereClause} ORDER BY "${sort}" ${order} LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+  params.push(limit, offset);
+
+  // Get total count
+  const countQuery = `SELECT COUNT(*) as total FROM "${table}" ${whereClause}`;
+  const countParams = params.slice(0, params.length - 2); // exclude limit/offset
+
+  const [dataResult, countResult] = await Promise.all([
+    pool.query(query, params),
+    pool.query(countQuery, countParams),
+  ]);
+
+  res.json({
+    rows: dataResult.rows,
+    total: parseInt(countResult.rows[0].total, 10),
+    limit,
+    offset,
+  });
+});
+
+export default router;

--- a/tests/unit/admin-sql-proxy.test.ts
+++ b/tests/unit/admin-sql-proxy.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock pg before importing the route
+const mockQuery = vi.fn();
+
+vi.mock("pg", () => {
+  class MockPool {
+    query = mockQuery;
+  }
+  return {
+    default: { Pool: MockPool },
+  };
+});
+
+// Mock auth — keep authenticatePlatform real
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return {
+    ...actual,
+    authenticate: (_req: any, _res: any, next: any) => next(),
+    requireOrg: (_req: any, _res: any, next: any) => next(),
+    requireUser: (_req: any, _res: any, next: any) => next(),
+  };
+});
+
+import adminRoutes from "../../src/routes/admin.js";
+
+const VALID_API_KEY = "test-admin-distribute-key";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/internal", adminRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+  process.env.ADMIN_DB_BRAND_SERVICE = "postgres://localhost/brand";
+  process.env.ADMIN_DB_RUNS_SERVICE = "postgres://localhost/runs";
+});
+
+describe("GET /internal/admin/services", () => {
+  it("returns list of services with availability", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.services).toBeInstanceOf(Array);
+    expect(res.body.services.length).toBeGreaterThan(0);
+
+    const brandService = res.body.services.find((s: any) => s.name === "brand-service");
+    expect(brandService).toBeDefined();
+    expect(brandService.available).toBe(true);
+
+    const chatService = res.body.services.find((s: any) => s.name === "chat-service");
+    expect(chatService).toBeDefined();
+    expect(chatService.available).toBe(false);
+  });
+
+  it("rejects requests without API key", async () => {
+    const app = createApp();
+    const res = await request(app).get("/internal/admin/services");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /internal/admin/services/:name/tables", () => {
+  it("returns table names for a valid service", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ table_name: "brands" }, { table_name: "extractions" }],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.tables).toEqual(["brands", "extractions"]);
+  });
+
+  it("returns 404 for non-existent service", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/nonexistent-service/tables")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("not found");
+  });
+});
+
+describe("GET /internal/admin/services/:name/tables/:table/schema", () => {
+  it("returns column schema for a valid table", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ "?column?": 1 }] });
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { column_name: "id", data_type: "uuid", is_nullable: "NO", column_default: "gen_random_uuid()" },
+        { column_name: "name", data_type: "text", is_nullable: "YES", column_default: null },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables/brands/schema")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.table).toBe("brands");
+    expect(res.body.columns).toHaveLength(2);
+    expect(res.body.columns[0]).toEqual({
+      name: "id",
+      type: "uuid",
+      nullable: false,
+      default: "gen_random_uuid()",
+    });
+  });
+
+  it("returns 404 for non-existent table", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables/nonexistent/schema")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("not found");
+  });
+
+  it("returns 404 for non-existent service", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/nonexistent-service/tables/brands/schema")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /internal/admin/services/:name/tables/:table/rows", () => {
+  it("returns paginated rows", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rowCount: 3,
+      rows: [
+        { column_name: "id", data_type: "uuid" },
+        { column_name: "name", data_type: "text" },
+        { column_name: "created_at", data_type: "timestamp with time zone" },
+      ],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "1", name: "test", created_at: "2024-01-01" }],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total: "1" }],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables/brands/rows?limit=10&offset=0")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.rows).toHaveLength(1);
+    expect(res.body.total).toBe(1);
+    expect(res.body.limit).toBe(10);
+    expect(res.body.offset).toBe(0);
+  });
+
+  it("rejects invalid sort column (SQL injection prevention)", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rowCount: 2,
+      rows: [
+        { column_name: "id", data_type: "uuid" },
+        { column_name: "name", data_type: "text" },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables/brands/rows?sort=id;DROP TABLE brands")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid sort column");
+  });
+
+  it("rejects invalid order value", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ column_name: "id", data_type: "uuid" }],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables/brands/rows?sort=id&order=INVALID")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid order");
+  });
+
+  it("returns 404 for non-existent table", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables/nonexistent/rows")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("supports search across text columns", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rowCount: 2,
+      rows: [
+        { column_name: "id", data_type: "uuid" },
+        { column_name: "name", data_type: "text" },
+        { column_name: "created_at", data_type: "timestamp with time zone" },
+      ],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "1", name: "Acme Corp" }],
+    });
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total: "1" }],
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/admin/services/brand-service/tables/brands/rows?search=acme")
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(200);
+
+    // Verify the data query used ILIKE
+    const dataCall = mockQuery.mock.calls[1];
+    expect(dataCall[0]).toContain("ILIKE");
+    expect(dataCall[1][0]).toBe("%acme%");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 4 read-only admin endpoints for browsing backend service databases from the admin panel (admin.distribute.you)
- `GET /internal/admin/services` — lists all services with DB availability status
- `GET /internal/admin/services/:name/tables` — lists table names from information_schema
- `GET /internal/admin/services/:name/tables/:table/schema` — returns column names, types, nullability
- `GET /internal/admin/services/:name/tables/:table/rows` — paginated rows with sorting, search (ILIKE across text columns)
- Protected by `authenticatePlatform` (API key auth, no identity resolution)
- SQL injection prevented: sort column validated against schema, order restricted to asc/desc, all queries parameterized, no raw user SQL input
- Lazy-initialized pg Pool per service, keyed by env vars (e.g. `ADMIN_DB_BRAND_SERVICE`)

## Test plan
- [x] 12 Vitest + Supertest tests covering all 4 endpoints
- [x] 404 for non-existent service/table
- [x] SQL injection rejected via sort column validation
- [x] Invalid order value rejected
- [x] Search ILIKE across text columns verified
- [x] Auth rejection without API key
- [x] Full test suite passes (1123 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)