### PR TITLE
fix: admin tables endpoint returns correct field names

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -83,12 +83,21 @@ router.get("/admin/services/:name/tables", authenticatePlatform, async (req: Req
   }
 
   const result = await pool.query(
-    `SELECT table_name FROM information_schema.tables
-     WHERE table_schema = 'public'
-     ORDER BY table_name`
+    `SELECT t.table_name,
+            COALESCE(s.n_live_tup, 0) AS row_count
+     FROM information_schema.tables t
+     LEFT JOIN pg_stat_user_tables s
+       ON s.schemaname = t.table_schema AND s.relname = t.table_name
+     WHERE t.table_schema = 'public'
+     ORDER BY t.table_name`
   );
 
-  res.json({ tables: result.rows.map((r) => r.table_name) });
+  res.json({
+    tables: result.rows.map((r) => ({
+      name: r.table_name,
+      rowCount: parseInt(r.row_count, 10),
+    })),
+  });
 });
 
 // ── GET /admin/services/:name/tables/:table/schema ──────────────────────────
@@ -110,20 +119,30 @@ router.get("/admin/services/:name/tables/:table/schema", authenticatePlatform, a
   }
 
   const result = await pool.query(
-    `SELECT column_name, data_type, is_nullable, column_default
-     FROM information_schema.columns
-     WHERE table_schema = 'public' AND table_name = $1
-     ORDER BY ordinal_position`,
+    `SELECT c.column_name, c.data_type, c.is_nullable,
+            CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_primary_key
+     FROM information_schema.columns c
+     LEFT JOIN (
+       SELECT kcu.column_name
+       FROM information_schema.table_constraints tc
+       JOIN information_schema.key_column_usage kcu
+         ON tc.constraint_name = kcu.constraint_name
+         AND tc.table_schema = kcu.table_schema
+       WHERE tc.table_schema = 'public'
+         AND tc.table_name = $1
+         AND tc.constraint_type = 'PRIMARY KEY'
+     ) pk ON pk.column_name = c.column_name
+     WHERE c.table_schema = 'public' AND c.table_name = $1
+     ORDER BY c.ordinal_position`,
     [table]
   );
 
   res.json({
-    table,
     columns: result.rows.map((r) => ({
       name: r.column_name,
       type: r.data_type,
       nullable: r.is_nullable === "YES",
-      default: r.column_default,
+      isPrimaryKey: r.is_primary_key,
     })),
   });
 });

--- a/tests/unit/admin-sql-proxy.test.ts
+++ b/tests/unit/admin-sql-proxy.test.ts
@@ -71,9 +71,12 @@ describe("GET /internal/admin/services", () => {
 });
 
 describe("GET /internal/admin/services/:name/tables", () => {
-  it("returns table names for a valid service", async () => {
+  it("returns table objects with name and rowCount", async () => {
     mockQuery.mockResolvedValueOnce({
-      rows: [{ table_name: "brands" }, { table_name: "extractions" }],
+      rows: [
+        { table_name: "brands", row_count: "42" },
+        { table_name: "extractions", row_count: "7" },
+      ],
     });
 
     const app = createApp();
@@ -82,7 +85,10 @@ describe("GET /internal/admin/services/:name/tables", () => {
       .set("X-API-Key", VALID_API_KEY);
 
     expect(res.status).toBe(200);
-    expect(res.body.tables).toEqual(["brands", "extractions"]);
+    expect(res.body.tables).toEqual([
+      { name: "brands", rowCount: 42 },
+      { name: "extractions", rowCount: 7 },
+    ]);
   });
 
   it("returns 404 for non-existent service", async () => {
@@ -97,12 +103,12 @@ describe("GET /internal/admin/services/:name/tables", () => {
 });
 
 describe("GET /internal/admin/services/:name/tables/:table/schema", () => {
-  it("returns column schema for a valid table", async () => {
+  it("returns column schema with isPrimaryKey", async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ "?column?": 1 }] });
     mockQuery.mockResolvedValueOnce({
       rows: [
-        { column_name: "id", data_type: "uuid", is_nullable: "NO", column_default: "gen_random_uuid()" },
-        { column_name: "name", data_type: "text", is_nullable: "YES", column_default: null },
+        { column_name: "id", data_type: "uuid", is_nullable: "NO", is_primary_key: true },
+        { column_name: "name", data_type: "text", is_nullable: "YES", is_primary_key: false },
       ],
     });
 
@@ -112,13 +118,18 @@ describe("GET /internal/admin/services/:name/tables/:table/schema", () => {
       .set("X-API-Key", VALID_API_KEY);
 
     expect(res.status).toBe(200);
-    expect(res.body.table).toBe("brands");
     expect(res.body.columns).toHaveLength(2);
     expect(res.body.columns[0]).toEqual({
       name: "id",
       type: "uuid",
       nullable: false,
-      default: "gen_random_uuid()",
+      isPrimaryKey: true,
+    });
+    expect(res.body.columns[1]).toEqual({
+      name: "name",
+      type: "text",
+      nullable: true,
+      isPrimaryKey: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- **`/internal/admin/services/:name/tables`**: Was returning plain strings (`["brands"]`), now returns `[{ name: "brands", rowCount: 42 }]` with row counts from `pg_stat_user_tables`
- **`/internal/admin/services/:name/tables/:table/schema`**: Was returning `{ name, type, nullable, default }`, now returns `{ name, type, nullable, isPrimaryKey }` — matches what the admin dashboard expects
- **`/rows`** endpoint was already correct (no changes)

## Test plan
- [x] All 12 existing admin tests pass with updated assertions
- [ ] Verify admin.distribute.you shows table names and row counts
- [ ] Verify schema view shows primary key indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)