### PR TITLE
refactor(api): adapt billing proxy to fractional-cents contract

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7242,8 +7242,9 @@
             "description": "Organization ID"
           },
           "creditBalanceCents": {
-            "type": "number",
-            "description": "Current credit balance in cents"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Current credit balance in cents (decimal string, full precision)"
           },
           "hasAutoReload": {
             "type": "boolean",
@@ -7254,14 +7255,16 @@
             "description": "Whether a payment method is on file"
           },
           "reloadAmountCents": {
-            "type": "number",
+            "type": "string",
             "nullable": true,
-            "description": "Auto-reload amount in cents (null if not configured)"
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Auto-reload amount in cents (decimal string, null if not configured)"
           },
           "reloadThresholdCents": {
-            "type": "number",
+            "type": "string",
             "nullable": true,
-            "description": "Balance threshold in cents that triggers auto-reload (null if not configured)"
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Balance threshold in cents that triggers auto-reload (decimal string, null if not configured)"
           },
           "createdAt": {
             "type": "string",
@@ -7283,8 +7286,9 @@
         "type": "object",
         "properties": {
           "balance_cents": {
-            "type": "number",
-            "description": "Current balance in cents"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Current balance in cents (decimal string, full precision)"
           },
           "depleted": {
             "type": "boolean",
@@ -7313,8 +7317,9 @@
                   "description": "Transaction type (e.g. 'credit', 'debit')"
                 },
                 "amountCents": {
-                  "type": "number",
-                  "description": "Amount in cents"
+                  "type": "string",
+                  "pattern": "^\\d+(\\.\\d+)?$",
+                  "description": "Amount in cents (decimal string, full precision)"
                 },
                 "description": {
                   "type": "string",
@@ -7351,8 +7356,9 @@
             "description": "Organization ID"
           },
           "creditBalanceCents": {
-            "type": "number",
-            "description": "Current credit balance in cents"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Current credit balance in cents (decimal string, full precision)"
           },
           "hasAutoReload": {
             "type": "boolean",
@@ -7363,14 +7369,16 @@
             "description": "Whether a payment method is on file"
           },
           "reloadAmountCents": {
-            "type": "number",
+            "type": "string",
             "nullable": true,
-            "description": "Auto-reload amount in cents"
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Auto-reload amount in cents (decimal string)"
           },
           "reloadThresholdCents": {
-            "type": "number",
+            "type": "string",
             "nullable": true,
-            "description": "Balance threshold in cents that triggers auto-reload"
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Balance threshold in cents that triggers auto-reload (decimal string)"
           },
           "createdAt": {
             "type": "string",
@@ -7392,15 +7400,28 @@
         "type": "object",
         "properties": {
           "reload_amount_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true,
-            "description": "Auto-reload amount in cents"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)?$"
+              }
+            ],
+            "description": "Auto-reload amount in cents (integer or decimal string)"
           },
           "reload_threshold_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Balance threshold in cents that triggers auto-reload"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)?$"
+              }
+            ],
+            "description": "Balance threshold in cents that triggers auto-reload (integer or decimal string)"
           }
         },
         "required": [
@@ -7419,8 +7440,9 @@
             "description": "Organization ID"
           },
           "creditBalanceCents": {
-            "type": "number",
-            "description": "Current credit balance in cents"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Current credit balance in cents (decimal string, full precision)"
           },
           "hasAutoReload": {
             "type": "boolean",
@@ -7431,14 +7453,16 @@
             "description": "Whether a payment method is on file"
           },
           "reloadAmountCents": {
-            "type": "number",
+            "type": "string",
             "nullable": true,
-            "description": "Auto-reload amount in cents"
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Auto-reload amount in cents (decimal string)"
           },
           "reloadThresholdCents": {
-            "type": "number",
+            "type": "string",
             "nullable": true,
-            "description": "Balance threshold in cents that triggers auto-reload"
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Balance threshold in cents that triggers auto-reload (decimal string)"
           },
           "createdAt": {
             "type": "string",
@@ -7464,8 +7488,9 @@
             "description": "Whether the deduction succeeded"
           },
           "balance_cents": {
-            "type": "number",
-            "description": "Balance after deduction"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Balance after deduction (decimal string, full precision)"
           },
           "depleted": {
             "type": "boolean",
@@ -7482,10 +7507,16 @@
         "type": "object",
         "properties": {
           "amount_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true,
-            "description": "Amount to deduct in cents"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)?$"
+              }
+            ],
+            "description": "Amount to deduct in cents (integer or decimal string for fractional cents)"
           },
           "description": {
             "type": "string",
@@ -7534,10 +7565,16 @@
             "description": "URL to redirect on cancellation"
           },
           "reload_amount_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true,
-            "description": "Amount to reload in cents"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)?$"
+              }
+            ],
+            "description": "Amount to reload in cents (integer or decimal string)"
           }
         },
         "required": [
@@ -8924,13 +8961,19 @@
             "type": "integer"
           },
           "totalCreditBalanceCents": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Total credit balance across all accounts (decimal string, full precision)"
           },
           "totalCreditedCents": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Total credits added across all accounts (decimal string, full precision)"
           },
           "totalConsumedCents": {
-            "type": "integer"
+            "type": "string",
+            "pattern": "^\\d+(\\.\\d+)?$",
+            "description": "Total credits consumed across all accounts (decimal string, full precision)"
           },
           "monthlyGrowth": {
             "type": "array",
@@ -8942,16 +8985,19 @@
                   "description": "Period label (e.g. '2026-03' or '2026-W14')"
                 },
                 "credited_cents": {
-                  "type": "integer",
-                  "description": "Total credits added in this period"
+                  "type": "string",
+                  "pattern": "^\\d+(\\.\\d+)?$",
+                  "description": "Total credits added in this period (decimal string, full precision)"
                 },
                 "consumed_cents": {
-                  "type": "integer",
-                  "description": "Total credits consumed in this period"
+                  "type": "string",
+                  "pattern": "^\\d+(\\.\\d+)?$",
+                  "description": "Total credits consumed in this period (decimal string, full precision)"
                 },
                 "revenue_cents": {
-                  "type": "integer",
-                  "description": "Actual Stripe payments (source=reload only, excludes welcome/promo credits)"
+                  "type": "string",
+                  "pattern": "^\\d+(\\.\\d+)?$",
+                  "description": "Actual Stripe payments (source=reload only, excludes welcome/promo credits) (decimal string, full precision)"
                 }
               },
               "required": [
@@ -8973,16 +9019,19 @@
                   "description": "Period label (e.g. '2026-03' or '2026-W14')"
                 },
                 "credited_cents": {
-                  "type": "integer",
-                  "description": "Total credits added in this period"
+                  "type": "string",
+                  "pattern": "^\\d+(\\.\\d+)?$",
+                  "description": "Total credits added in this period (decimal string, full precision)"
                 },
                 "consumed_cents": {
-                  "type": "integer",
-                  "description": "Total credits consumed in this period"
+                  "type": "string",
+                  "pattern": "^\\d+(\\.\\d+)?$",
+                  "description": "Total credits consumed in this period (decimal string, full precision)"
                 },
                 "revenue_cents": {
-                  "type": "integer",
-                  "description": "Actual Stripe payments (source=reload only, excludes welcome/promo credits)"
+                  "type": "string",
+                  "pattern": "^\\d+(\\.\\d+)?$",
+                  "description": "Actual Stripe payments (source=reload only, excludes welcome/promo credits) (decimal string, full precision)"
                 }
               },
               "required": [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4931,25 +4931,31 @@ registry.registerPath({
 // BILLING
 // ===================================================================
 
+// billing-service stores cents as numeric(16,10) and returns full-precision
+// decimal strings (e.g. "100.4200000000"). Inbound endpoints accept either
+// integer or decimal string. See billing-service PR #83.
+const DECIMAL_CENTS_REGEX = /^\d+(\.\d+)?$/;
+const decimalCentsString = z.string().regex(DECIMAL_CENTS_REGEX);
+const inboundCents = z.union([z.number(), decimalCentsString]);
+
 export const ConfigureAutoReloadRequestSchema = z
   .object({
-    reload_amount_cents: z
-      .number()
-      .int()
-      .positive()
-      .describe("Auto-reload amount in cents"),
-    reload_threshold_cents: z
-      .number()
-      .int()
-      .min(0)
+    reload_amount_cents: inboundCents.describe(
+      "Auto-reload amount in cents (integer or decimal string)",
+    ),
+    reload_threshold_cents: inboundCents
       .optional()
-      .describe("Balance threshold in cents that triggers auto-reload"),
+      .describe(
+        "Balance threshold in cents that triggers auto-reload (integer or decimal string)",
+      ),
   })
   .openapi("ConfigureAutoReloadRequest");
 
 export const DeductCreditsRequestSchema = z
   .object({
-    amount_cents: z.number().int().positive().describe("Amount to deduct in cents"),
+    amount_cents: inboundCents.describe(
+      "Amount to deduct in cents (integer or decimal string for fractional cents)",
+    ),
     description: z.string().min(1).describe("Reason for the deduction"),
     user_id: z.string().uuid().optional().describe("User ID"),
   })
@@ -4959,11 +4965,9 @@ export const CreateCheckoutSessionRequestSchema = z
   .object({
     success_url: z.string().url().describe("URL to redirect after successful payment"),
     cancel_url: z.string().url().describe("URL to redirect on cancellation"),
-    reload_amount_cents: z
-      .number()
-      .int()
-      .positive()
-      .describe("Amount to reload in cents"),
+    reload_amount_cents: inboundCents.describe(
+      "Amount to reload in cents (integer or decimal string)",
+    ),
   })
   .openapi("CreateCheckoutSessionRequest");
 
@@ -4988,11 +4992,11 @@ registry.registerPath({
           schema: z.object({
             id: z.string().describe("Account ID"),
             orgId: z.string().describe("Organization ID"),
-            creditBalanceCents: z.number().describe("Current credit balance in cents"),
+            creditBalanceCents: decimalCentsString.describe("Current credit balance in cents (decimal string, full precision)"),
             hasAutoReload: z.boolean().describe("Whether auto-reload is enabled (true when payment method + reload config are both set)"),
             hasPaymentMethod: z.boolean().describe("Whether a payment method is on file"),
-            reloadAmountCents: z.number().nullable().describe("Auto-reload amount in cents (null if not configured)"),
-            reloadThresholdCents: z.number().nullable().describe("Balance threshold in cents that triggers auto-reload (null if not configured)"),
+            reloadAmountCents: decimalCentsString.nullable().describe("Auto-reload amount in cents (decimal string, null if not configured)"),
+            reloadThresholdCents: decimalCentsString.nullable().describe("Balance threshold in cents that triggers auto-reload (decimal string, null if not configured)"),
             createdAt: z.string().describe("ISO timestamp"),
           }).openapi("BillingAccountResponse"),
         },
@@ -5017,7 +5021,7 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
-            balance_cents: z.number().describe("Current balance in cents"),
+            balance_cents: decimalCentsString.describe("Current balance in cents (decimal string, full precision)"),
             depleted: z.boolean().describe("True if balance is zero or negative"),
           }).openapi("BalanceResponse"),
         },
@@ -5044,7 +5048,7 @@ registry.registerPath({
             transactions: z.array(z.object({
               id: z.string().describe("Transaction ID"),
               type: z.string().describe("Transaction type (e.g. 'credit', 'debit')"),
-              amountCents: z.number().describe("Amount in cents"),
+              amountCents: decimalCentsString.describe("Amount in cents (decimal string, full precision)"),
               description: z.string().describe("Transaction description"),
               createdAt: z.string().describe("ISO timestamp"),
             })),
@@ -5079,11 +5083,11 @@ registry.registerPath({
           schema: z.object({
             id: z.string().describe("Account ID"),
             orgId: z.string().describe("Organization ID"),
-            creditBalanceCents: z.number().describe("Current credit balance in cents"),
+            creditBalanceCents: decimalCentsString.describe("Current credit balance in cents (decimal string, full precision)"),
             hasAutoReload: z.boolean().describe("Whether auto-reload is enabled"),
             hasPaymentMethod: z.boolean().describe("Whether a payment method is on file"),
-            reloadAmountCents: z.number().nullable().describe("Auto-reload amount in cents"),
-            reloadThresholdCents: z.number().nullable().describe("Balance threshold in cents that triggers auto-reload"),
+            reloadAmountCents: decimalCentsString.nullable().describe("Auto-reload amount in cents (decimal string)"),
+            reloadThresholdCents: decimalCentsString.nullable().describe("Balance threshold in cents that triggers auto-reload (decimal string)"),
             createdAt: z.string().describe("ISO timestamp"),
           }).openapi("ConfigureAutoReloadResponse"),
         },
@@ -5110,11 +5114,11 @@ registry.registerPath({
           schema: z.object({
             id: z.string().describe("Account ID"),
             orgId: z.string().describe("Organization ID"),
-            creditBalanceCents: z.number().describe("Current credit balance in cents"),
+            creditBalanceCents: decimalCentsString.describe("Current credit balance in cents (decimal string, full precision)"),
             hasAutoReload: z.boolean().describe("Whether auto-reload is enabled"),
             hasPaymentMethod: z.boolean().describe("Whether a payment method is on file"),
-            reloadAmountCents: z.number().nullable().describe("Auto-reload amount in cents"),
-            reloadThresholdCents: z.number().nullable().describe("Balance threshold in cents that triggers auto-reload"),
+            reloadAmountCents: decimalCentsString.nullable().describe("Auto-reload amount in cents (decimal string)"),
+            reloadThresholdCents: decimalCentsString.nullable().describe("Balance threshold in cents that triggers auto-reload (decimal string)"),
             createdAt: z.string().describe("ISO timestamp"),
           }).openapi("DisableAutoReloadResponse"),
         },
@@ -5146,7 +5150,7 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             success: z.boolean().describe("Whether the deduction succeeded"),
-            balance_cents: z.number().describe("Balance after deduction"),
+            balance_cents: decimalCentsString.describe("Balance after deduction (decimal string, full precision)"),
             depleted: z.boolean().describe("True if balance is zero or negative after deduction"),
           }).openapi("DeductCreditsResponse"),
         },
@@ -6579,9 +6583,9 @@ registry.registerPath({
 
 const BillingGrowthRowSchema = z.object({
   period: z.string().describe("Period label (e.g. '2026-03' or '2026-W14')"),
-  credited_cents: z.number().int().describe("Total credits added in this period"),
-  consumed_cents: z.number().int().describe("Total credits consumed in this period"),
-  revenue_cents: z.number().int().describe("Actual Stripe payments (source=reload only, excludes welcome/promo credits)"),
+  credited_cents: decimalCentsString.describe("Total credits added in this period (decimal string, full precision)"),
+  consumed_cents: decimalCentsString.describe("Total credits consumed in this period (decimal string, full precision)"),
+  revenue_cents: decimalCentsString.describe("Actual Stripe payments (source=reload only, excludes welcome/promo credits) (decimal string, full precision)"),
 });
 
 registry.registerPath({
@@ -6601,9 +6605,9 @@ registry.registerPath({
           schema: z.object({
             totalAccounts: z.number().int(),
             accountsWithPaymentMethod: z.number().int(),
-            totalCreditBalanceCents: z.number().int(),
-            totalCreditedCents: z.number().int(),
-            totalConsumedCents: z.number().int(),
+            totalCreditBalanceCents: decimalCentsString.describe("Total credit balance across all accounts (decimal string, full precision)"),
+            totalCreditedCents: decimalCentsString.describe("Total credits added across all accounts (decimal string, full precision)"),
+            totalConsumedCents: decimalCentsString.describe("Total credits consumed across all accounts (decimal string, full precision)"),
             monthlyGrowth: z.array(BillingGrowthRowSchema).describe("Monthly growth breakdown"),
             weeklyGrowth: z.array(BillingGrowthRowSchema).describe("Weekly growth breakdown"),
           }).openapi("PublicBillingStatsResponse"),

--- a/tests/unit/billing-proxy-fractional.test.ts
+++ b/tests/unit/billing-proxy-fractional.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCallExternalService = vi.fn();
+
+vi.mock("../../src/lib/service-client.js", () => ({
+  callExternalService: (...args: unknown[]) => mockCallExternalService(...args),
+  callExternalServiceWithStatus: (...args: unknown[]) => mockCallExternalService(...args),
+  externalServices: {
+    billing: { url: "http://mock-billing", apiKey: "k" },
+  },
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.orgId = "org-test";
+    req.userId = "user-test";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import express from "express";
+import request from "supertest";
+import billingRouter from "../../src/routes/billing.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(billingRouter);
+  return app;
+}
+
+beforeEach(() => {
+  mockCallExternalService.mockReset();
+});
+
+describe("billing proxy — fractional cents (decimal-string contract)", () => {
+  it("GET /billing/accounts/balance returns decimal string balance_cents untouched", async () => {
+    const upstream = { balance_cents: "100.4200000000", depleted: false };
+    mockCallExternalService.mockResolvedValue(upstream);
+
+    const res = await request(createApp()).get("/billing/accounts/balance");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstream);
+    expect(typeof res.body.balance_cents).toBe("string");
+    expect(res.body.balance_cents).toBe("100.4200000000");
+  });
+
+  it("GET /billing/accounts returns decimal-string credit/reload fields untouched", async () => {
+    const upstream = {
+      id: "acc_1",
+      orgId: "org-test",
+      creditBalanceCents: "12345.6789012345",
+      hasAutoReload: true,
+      hasPaymentMethod: true,
+      reloadAmountCents: "500000.0000000000",
+      reloadThresholdCents: "100.0000000000",
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    mockCallExternalService.mockResolvedValue(upstream);
+
+    const res = await request(createApp()).get("/billing/accounts");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstream);
+    expect(typeof res.body.creditBalanceCents).toBe("string");
+    expect(typeof res.body.reloadAmountCents).toBe("string");
+    expect(typeof res.body.reloadThresholdCents).toBe("string");
+  });
+
+  it("GET /billing/accounts handles null reload fields", async () => {
+    const upstream = {
+      id: "acc_2",
+      orgId: "org-test",
+      creditBalanceCents: "0.0000000000",
+      hasAutoReload: false,
+      hasPaymentMethod: false,
+      reloadAmountCents: null,
+      reloadThresholdCents: null,
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    mockCallExternalService.mockResolvedValue(upstream);
+
+    const res = await request(createApp()).get("/billing/accounts");
+
+    expect(res.status).toBe(200);
+    expect(res.body.reloadAmountCents).toBeNull();
+    expect(res.body.reloadThresholdCents).toBeNull();
+  });
+
+  it("POST /billing/credits/deduct forwards decimal-string amount_cents byte-identical", async () => {
+    const upstream = { success: true, balance_cents: "99.5800000000", depleted: false };
+    mockCallExternalService.mockResolvedValue(upstream);
+
+    const reqBody = { amount_cents: "0.42", description: "test deduction" };
+    const res = await request(createApp())
+      .post("/billing/credits/deduct")
+      .send(reqBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstream);
+
+    // Inspect the call to service-client and assert the body forwarded as-is
+    expect(mockCallExternalService).toHaveBeenCalled();
+    const [, , opts] = mockCallExternalService.mock.calls[0] as [
+      unknown,
+      unknown,
+      { method?: string; body?: unknown },
+    ];
+    expect(opts?.method).toBe("POST");
+    expect(opts?.body).toEqual(reqBody);
+    expect((opts?.body as any).amount_cents).toBe("0.42");
+  });
+
+  it("POST /billing/credits/deduct forwards integer amount_cents (legacy) byte-identical", async () => {
+    const upstream = { success: true, balance_cents: "900.0000000000", depleted: false };
+    mockCallExternalService.mockResolvedValue(upstream);
+
+    const reqBody = { amount_cents: 100, description: "legacy integer call" };
+    const res = await request(createApp())
+      .post("/billing/credits/deduct")
+      .send(reqBody);
+
+    expect(res.status).toBe(200);
+    const [, , opts] = mockCallExternalService.mock.calls[0] as [
+      unknown,
+      unknown,
+      { body?: unknown },
+    ];
+    expect(opts?.body).toEqual(reqBody);
+    expect((opts?.body as any).amount_cents).toBe(100);
+    expect(typeof (opts?.body as any).amount_cents).toBe("number");
+  });
+
+  it("PATCH /billing/accounts/auto-reload forwards decimal-string fields untouched", async () => {
+    const upstream = {
+      id: "acc_3",
+      orgId: "org-test",
+      creditBalanceCents: "100.0000000000",
+      hasAutoReload: true,
+      hasPaymentMethod: true,
+      reloadAmountCents: "1000.5000000000",
+      reloadThresholdCents: "50.2500000000",
+      createdAt: "2026-01-01T00:00:00Z",
+    };
+    mockCallExternalService.mockResolvedValue(upstream);
+
+    const reqBody = {
+      reload_amount_cents: "1000.5",
+      reload_threshold_cents: "50.25",
+    };
+    const res = await request(createApp())
+      .patch("/billing/accounts/auto-reload")
+      .send(reqBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstream);
+    const [, , opts] = mockCallExternalService.mock.calls[0] as [
+      unknown,
+      unknown,
+      { body?: unknown },
+    ];
+    expect(opts?.body).toEqual(reqBody);
+  });
+});

--- a/tests/unit/public-stats.test.ts
+++ b/tests/unit/public-stats.test.ts
@@ -58,19 +58,20 @@ const MOCK_USER_STATS = {
   ],
 };
 
+// Fractional decimal-string cents — billing-service v2 contract (PR #83).
 const MOCK_BILLING_STATS = {
   totalAccounts: 35,
   accountsWithPaymentMethod: 12,
-  totalCreditBalanceCents: 450000,
-  totalCreditedCents: 1200000,
-  totalConsumedCents: 750000,
+  totalCreditBalanceCents: "450000.4200000000",
+  totalCreditedCents: "1200000.0000000000",
+  totalConsumedCents: "750000.5800000000",
   monthlyGrowth: [
-    { period: "2026-01", credited_cents: 200000, consumed_cents: 120000, revenue_cents: 80000 },
-    { period: "2026-02", credited_cents: 350000, consumed_cents: 210000, revenue_cents: 150000 },
+    { period: "2026-01", credited_cents: "200000.0000000000", consumed_cents: "120000.4200000000", revenue_cents: "80000.0000000000" },
+    { period: "2026-02", credited_cents: "350000.0000000000", consumed_cents: "210000.0000000000", revenue_cents: "150000.0000000000" },
   ],
   weeklyGrowth: [
-    { period: "2026-W14", credited_cents: 50000, consumed_cents: 30000, revenue_cents: 20000 },
-    { period: "2026-W15", credited_cents: 75000, consumed_cents: 48000, revenue_cents: 35000 },
+    { period: "2026-W14", credited_cents: "50000.0000000000", consumed_cents: "30000.0000000000", revenue_cents: "20000.0000000000" },
+    { period: "2026-W15", credited_cents: "75000.0000000000", consumed_cents: "48000.0000000000", revenue_cents: "35000.0000000000" },
   ],
 };
 
@@ -130,10 +131,13 @@ describe("GET /public/stats/billing", () => {
     expect(res.body.weeklyGrowth).toEqual(MOCK_BILLING_STATS.weeklyGrowth);
     expect(res.body.monthlyGrowth[0]).toEqual({
       period: "2026-01",
-      credited_cents: 200000,
-      consumed_cents: 120000,
-      revenue_cents: 80000,
+      credited_cents: "200000.0000000000",
+      consumed_cents: "120000.4200000000",
+      revenue_cents: "80000.0000000000",
     });
+    // precision preserved as string, not coerced to number
+    expect(typeof res.body.monthlyGrowth[0].consumed_cents).toBe("string");
+    expect(typeof res.body.totalCreditBalanceCents).toBe("string");
     expect(res.body.weeklyGrowth).toHaveLength(2);
   });
 


### PR DESCRIPTION
## Summary

Adapts api-service OpenAPI documentation to billing-service v2 fractional-cents contract (billing-service PR #83). api-service is a transparent passthrough proxy and does not parse, round, or coerce `*_cents` values — runtime behavior is already correct. This PR updates the documented contract + tests.

- Outbound `*_cents` response schemas → `z.string()` with regex `^\d+(\.\d+)?$` (decimal-string contract)
- Inbound `*_cents` request schemas → `z.union([z.number(), decimalCentsString])` (accept integer OR decimal string)
- Regenerated `openapi.json`
- New runtime test (`billing-proxy-fractional.test.ts`) covers passthrough of fractional outbound + integer/decimal inbound
- `public-stats.test.ts` fixtures switched to decimal strings

### Acceptance criteria not applicable here

- **AC-3** (`Number()` → `parseFloat()`): `grep -rn 'Number(.*_cents' src/` returns nothing — api-service has zero arithmetic on `*_cents`. Belongs to consumers (dashboard, runs-service).
- **AC-4** (display rounding via `Math.ceil(parseFloat(x))`): api-service is a backend proxy; never displays human-facing balances. `Math.ceil` belongs in `distribute.you` frontend.

## ⚠️ Deployment ordering

**Do NOT merge until billing-service v2 (PR #83) is live in staging.**

If api-service ships first, downstream `*_cents` are still integers in staging and the OpenAPI spec will lie until billing-service catches up. The runtime impact is zero (passthrough), but consumers reading the spec will see decimal strings while billing returns integers.

Sequence:
1. Merge + deploy billing-service v2 to staging.
2. Verify staging billing endpoints return decimal strings.
3. Merge this PR; Railway auto-deploys api-service to staging.
4. Promote both services to prod together (use `release.sh`).

## Test plan

- [x] `pnpm test` — 109 files / 1130 tests pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm generate:openapi` — regenerated, committed
- [x] Audit: `grep -rn 'Number(.*_cents' src/` returns nothing
- [ ] Post-billing-deploy manual: curl `/v1/billing/accounts/balance` with seeded fractional balance → response shows decimal string

🤖 Generated with [Claude Code](https://claude.com/claude-code)