### PR TITLE
feat(api): expose GET /v1/events for dashboard log views

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6090,6 +6090,99 @@
           "groups"
         ]
       },
+      "RunEvent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "runId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "service": {
+            "type": "string"
+          },
+          "event": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "level": {
+            "type": "string",
+            "enum": [
+              "info",
+              "warn",
+              "error"
+            ]
+          },
+          "data": {
+            "nullable": true
+          },
+          "orgId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "brandIds": {
+            "type": "string",
+            "nullable": true
+          },
+          "campaignId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "workflowSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "runId",
+          "service",
+          "event",
+          "detail",
+          "level",
+          "orgId",
+          "userId",
+          "brandIds",
+          "campaignId",
+          "workflowSlug",
+          "featureSlug",
+          "createdAt"
+        ]
+      },
+      "ListEventsResponse": {
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RunEvent"
+            }
+          }
+        },
+        "required": [
+          "events"
+        ]
+      },
       "ScrapeResultResponse": {
         "type": "object",
         "properties": {}
@@ -20263,6 +20356,205 @@
           },
           "400": {
             "description": "Missing groupBy parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/events": {
+      "get": {
+        "tags": [
+          "Runs"
+        ],
+        "summary": "List run events for the authenticated org",
+        "description": "Transparent proxy to runs-service GET /v1/events. orgId is injected from the auth context — never trusted from client query. Use this endpoint to render per-campaign log views in the dashboard. Events are ordered by createdAt DESC.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter to a single campaign"
+            },
+            "required": false,
+            "description": "Filter to a single campaign",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by brand ID (single UUID)"
+            },
+            "required": false,
+            "description": "Filter by brand ID (single UUID)",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "info",
+                "warn",
+                "error"
+              ],
+              "description": "Filter by event severity"
+            },
+            "required": false,
+            "description": "Filter by event severity",
+            "name": "level",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by emitting service name"
+            },
+            "required": false,
+            "description": "Filter by emitting service name",
+            "name": "service",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow slug"
+            },
+            "required": false,
+            "description": "Filter by workflow slug",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug"
+            },
+            "required": false,
+            "description": "Filter by feature slug",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Page size — forwarded as-is to runs-service"
+            },
+            "required": false,
+            "description": "Page size — forwarded as-is to runs-service",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Page offset — forwarded as-is to runs-service"
+            },
+            "required": false,
+            "description": "Page offset — forwarded as-is to runs-service",
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of run events for the org, newest first",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListEventsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Organization context required",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -72,13 +72,28 @@ router.get("/runs/stats/costs", authenticate, requireOrg, requireUser, async (re
 
 /**
  * GET /v1/events
- * Cross-run event listing from runs-service. Admin-only (authenticatePlatform).
- * Query params forwarded: service, orgId, brandId, campaignId, limit, offset
+ * Cross-run event listing from runs-service for the authenticated org.
+ * orgId is injected from the auth context — never trusted from client query.
+ * Whitelisted query params are forwarded: campaignId, brandId, level, limit,
+ * offset, service, workflowSlug, featureSlug.
  */
-router.get("/events", authenticatePlatform, async (req: AuthenticatedRequest, res) => {
+const EVENTS_QUERY_WHITELIST = [
+  "campaignId",
+  "brandId",
+  "level",
+  "limit",
+  "offset",
+  "service",
+  "workflowSlug",
+  "featureSlug",
+] as const;
+
+router.get("/events", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const qs = new URLSearchParams();
-    for (const [key, val] of Object.entries(req.query)) {
+    qs.set("orgId", req.orgId!);
+    for (const key of EVENTS_QUERY_WHITELIST) {
+      const val = req.query[key];
       if (val != null) qs.set(key, String(val));
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3816,6 +3816,67 @@ registry.registerPath({
   },
 });
 
+// ===================================================================
+// RUN EVENTS
+// ===================================================================
+
+const RunEventSchema = z
+  .object({
+    id: z.string().uuid(),
+    runId: z.string().uuid(),
+    service: z.string(),
+    event: z.string(),
+    detail: z.string().nullable(),
+    level: z.enum(["info", "warn", "error"]),
+    data: z.unknown().nullable().optional(),
+    orgId: z.string().uuid().nullable(),
+    userId: z.string().uuid().nullable(),
+    brandIds: z.string().nullable(),
+    campaignId: z.string().uuid().nullable(),
+    workflowSlug: z.string().nullable(),
+    featureSlug: z.string().nullable(),
+    createdAt: z.string(),
+  })
+  .openapi("RunEvent");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/events",
+  tags: ["Runs"],
+  summary: "List run events for the authenticated org",
+  description:
+    "Transparent proxy to runs-service GET /v1/events. orgId is injected from the auth context — never trusted from client query. " +
+    "Use this endpoint to render per-campaign log views in the dashboard. Events are ordered by createdAt DESC.",
+  security: authed,
+  request: {
+    query: z.object({
+      campaignId: z.string().uuid().optional().describe("Filter to a single campaign"),
+      brandId: z.string().optional().describe("Filter by brand ID (single UUID)"),
+      level: z.enum(["info", "warn", "error"]).optional().describe("Filter by event severity"),
+      service: z.string().optional().describe("Filter by emitting service name"),
+      workflowSlug: z.string().optional().describe("Filter by workflow slug"),
+      featureSlug: z.string().optional().describe("Filter by feature slug"),
+      limit: z.string().optional().describe("Page size — forwarded as-is to runs-service"),
+      offset: z.string().optional().describe("Page offset — forwarded as-is to runs-service"),
+    }).openapi("ListEventsQuery"),
+  },
+  responses: {
+    200: {
+      description: "List of run events for the org, newest first",
+      content: {
+        "application/json": {
+          schema: z.object({
+            events: z.array(RunEventSchema),
+          }).openapi("ListEventsResponse"),
+        },
+      },
+    },
+    400: { description: "Organization context required", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/v1/scraping/scrape/{id}",

--- a/tests/unit/events-proxy.test.ts
+++ b/tests/unit/events-proxy.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+let mockFetchResponse: { ok: boolean; status: number; body: unknown } = {
+  ok: true,
+  status: 200,
+  body: { events: [] },
+};
+
+let mockAuth: { userId?: string; orgId?: string; authType?: "user_key" | "admin"; allowAuth?: boolean } = {
+  userId: "user_test123",
+  orgId: "org_test456",
+  authType: "user_key",
+  allowAuth: true,
+};
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, res: any, next: any) => {
+    if (!mockAuth.allowAuth) return res.status(401).json({ error: "Missing authentication" });
+    req.userId = mockAuth.userId;
+    req.orgId = mockAuth.orgId;
+    req.authType = mockAuth.authType;
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  authenticatePlatform: (req: any, res: any, next: any) => {
+    req.authType = "admin";
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+import runsRoutes from "../../src/routes/runs.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", runsRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fetchCalls = [];
+  mockFetchResponse = { ok: true, status: 200, body: { events: [] } };
+  mockAuth = { userId: "user_test123", orgId: "org_test456", authType: "user_key", allowAuth: true };
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    fetchCalls.push({
+      url,
+      method: init?.method,
+      headers: init?.headers as Record<string, string> | undefined,
+    });
+    return {
+      ok: mockFetchResponse.ok,
+      status: mockFetchResponse.status,
+      json: () => Promise.resolve(mockFetchResponse.body),
+      text: () => Promise.resolve(JSON.stringify(mockFetchResponse.body)),
+    };
+  });
+});
+
+describe("GET /v1/events", () => {
+  it("proxies to runs-service /v1/events with orgId from auth (not client query)", async () => {
+    mockFetchResponse = {
+      ok: true,
+      status: 200,
+      body: { events: [{ id: "evt-1", level: "info" }] },
+    };
+    const app = createApp();
+
+    const res = await request(app)
+      .get("/v1/events?campaignId=96c89229-f5d2-4659-a8dc-0d5b45639cae")
+      .set("Authorization", "Bearer distrib.usr_xxx");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ events: [{ id: "evt-1", level: "info" }] });
+
+    const call = fetchCalls.find((c) => c.url.includes("/v1/events"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("/v1/events");
+    expect(call!.url).toContain("campaignId=96c89229-f5d2-4659-a8dc-0d5b45639cae");
+    expect(call!.url).toContain("orgId=org_test456");
+  });
+
+  it("forwards whitelisted query params: campaignId, brandId, level, limit, offset, service, workflowSlug, featureSlug", async () => {
+    const app = createApp();
+
+    await request(app)
+      .get("/v1/events")
+      .query({
+        campaignId: "c-1",
+        brandId: "b-1",
+        level: "error",
+        limit: "50",
+        offset: "10",
+        service: "workflow-service",
+        workflowSlug: "pr-outreach",
+        featureSlug: "lead-serve",
+      })
+      .set("Authorization", "Bearer distrib.usr_xxx");
+
+    const call = fetchCalls.find((c) => c.url.includes("/v1/events"));
+    expect(call).toBeDefined();
+    const url = call!.url;
+    expect(url).toContain("campaignId=c-1");
+    expect(url).toContain("brandId=b-1");
+    expect(url).toContain("level=error");
+    expect(url).toContain("limit=50");
+    expect(url).toContain("offset=10");
+    expect(url).toContain("service=workflow-service");
+    expect(url).toContain("workflowSlug=pr-outreach");
+    expect(url).toContain("featureSlug=lead-serve");
+    expect(url).toContain("orgId=org_test456");
+  });
+
+  it("ignores client-supplied orgId — auth orgId wins", async () => {
+    const app = createApp();
+
+    await request(app)
+      .get("/v1/events?orgId=attacker-org")
+      .set("Authorization", "Bearer distrib.usr_xxx");
+
+    const call = fetchCalls.find((c) => c.url.includes("/v1/events"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("orgId=org_test456");
+    expect(call!.url).not.toContain("orgId=attacker-org");
+  });
+
+  it("returns 401 when no auth", async () => {
+    mockAuth.allowAuth = false;
+    const app = createApp();
+
+    const res = await request(app).get("/v1/events");
+    expect(res.status).toBe(401);
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it("returns 400 when authenticated but no orgId resolved", async () => {
+    mockAuth = { userId: "user_test123", orgId: undefined, authType: "user_key", allowAuth: true };
+    const app = createApp();
+
+    const res = await request(app)
+      .get("/v1/events")
+      .set("Authorization", "Bearer distrib.usr_xxx");
+
+    expect(res.status).toBe(400);
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it("propagates non-2xx from runs-service — no silent empty fallback", async () => {
+    mockFetchResponse = {
+      ok: false,
+      status: 503,
+      body: { error: "runs-service down" },
+    };
+    const app = createApp();
+
+    const res = await request(app)
+      .get("/v1/events?campaignId=c-1")
+      .set("Authorization", "Bearer distrib.usr_xxx");
+
+    expect(res.status).toBe(503);
+    expect(res.body).not.toEqual({ events: [] });
+  });
+});
+
+describe("OpenAPI spec", () => {
+  it("has GET /v1/events registered", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const openapiPath = path.join(__dirname, "../../openapi.json");
+    const spec = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+    expect(spec.paths).toHaveProperty("/v1/events");
+    expect(spec.paths["/v1/events"]).toHaveProperty("get");
+    const op = spec.paths["/v1/events"].get;
+    expect(op.security).toBeDefined();
+    expect(op.security.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace admin-only `/v1/events` proxy with a client-facing endpoint (`authenticate + requireOrg + requireUser`)
- `orgId` injected from auth context — never trusted from client query
- Whitelist forwarded query params: `campaignId`, `brandId`, `level`, `limit`, `offset`, `service`, `workflowSlug`, `featureSlug`
- Non-2xx from runs-service propagates as-is — no silent empty fallback
- OpenAPI spec regenerated (`/v1/events` registered under `Runs` tag with `RunEvent` / `ListEventsResponse` schemas)

## Test plan
- [x] `pnpm test tests/unit/events-proxy.test.ts` — 7/7 pass
- [x] Full suite: `pnpm test` — 1137/1137 pass
- [x] `pnpm build` clean (TS strict)
- [ ] Staging: `curl -H 'Authorization: Bearer <user_key>' https://api-staging.distribute.you/v1/events?campaignId=96c89229-f5d2-4659-a8dc-0d5b45639cae` returns events
- [ ] No-auth → 401
- [ ] Auth without orgId → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)