### PR TITLE
feat(api): proxy GET /v1/orgs/google/accounts to google-service v0.20.0

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9320,6 +9320,53 @@
           "nextCursor"
         ]
       },
+      "GoogleAccountSummary": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Google account email"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active"
+            ],
+            "description": "Connection status"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "OAuth scopes granted"
+          },
+          "connectedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp the account was connected"
+          }
+        },
+        "required": [
+          "email",
+          "status",
+          "scopes",
+          "connectedAt"
+        ]
+      },
+      "GoogleAccountsListResponse": {
+        "type": "object",
+        "properties": {
+          "accounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GoogleAccountSummary"
+            }
+          }
+        },
+        "required": [
+          "accounts"
+        ]
+      },
       "GoogleContact": {
         "type": "object",
         "properties": {
@@ -30476,6 +30523,99 @@
             }
           }
         }
+      }
+    },
+    "/v1/orgs/google/accounts": {
+      "get": {
+        "tags": [
+          "Google CRM"
+        ],
+        "summary": "List connected Google accounts for the org",
+        "description": "Returns one entry per Google account connected to the org (Gmail + People readonly). Used by the dashboard CRM page to show which Google identity is linked.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connected Google accounts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleAccountsListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/orgs/google/contacts": {

--- a/src/routes/google.ts
+++ b/src/routes/google.ts
@@ -72,6 +72,20 @@ router.get("/orgs/google/messages", authenticate, requireOrg, requireUser, async
   }
 });
 
+// GET /v1/orgs/google/accounts — list connected Google accounts for the org
+router.get("/orgs/google/accounts", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.google,
+      "/orgs/google/accounts",
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list Google accounts" });
+  }
+});
+
 // GET /v1/orgs/google/contacts — list raw Google contacts (bronze)
 router.get("/orgs/google/contacts", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6854,6 +6854,21 @@ const GoogleContactsResponseSchema = z
   })
   .openapi("GoogleContactsResponse");
 
+const GoogleAccountSummarySchema = z
+  .object({
+    email: z.string().openapi({ description: "Google account email" }),
+    status: z.literal("active").openapi({ description: "Connection status" }),
+    scopes: z.array(z.string()).openapi({ description: "OAuth scopes granted" }),
+    connectedAt: z.string().openapi({ description: "ISO 8601 timestamp the account was connected" }),
+  })
+  .openapi("GoogleAccountSummary");
+
+const GoogleAccountsListResponseSchema = z
+  .object({
+    accounts: z.array(GoogleAccountSummarySchema),
+  })
+  .openapi("GoogleAccountsListResponse");
+
 registry.registerPath({
   method: "post",
   path: "/v1/orgs/google/auth/start",
@@ -6927,6 +6942,21 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Paginated raw Gmail messages", content: { "application/json": { schema: GoogleMessagesResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/google/accounts",
+  tags: ["Google CRM"],
+  summary: "List connected Google accounts for the org",
+  description:
+    "Returns one entry per Google account connected to the org (Gmail + People readonly). " +
+    "Used by the dashboard CRM page to show which Google identity is linked.",
+  security: authed,
+  responses: {
+    200: { description: "Connected Google accounts", content: { "application/json": { schema: GoogleAccountsListResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
   },
 });

--- a/tests/unit/google-proxy.test.ts
+++ b/tests/unit/google-proxy.test.ts
@@ -94,16 +94,26 @@ describe("Google CRM proxy routes", () => {
     }
   });
 
+  it("should have GET /orgs/google/accounts with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/google/accounts"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
   it("should call externalServices.google for every endpoint", () => {
     const matches = content.match(/externalServices\.google/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(5);
+    expect(matches!.length).toBe(6);
   });
 
   it("should use buildInternalHeaders for every endpoint", () => {
     const matches = content.match(/buildInternalHeaders\(req\)/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(5);
+    expect(matches!.length).toBe(6);
   });
 
   it("should preserve downstream paths (no path renaming)", () => {
@@ -112,6 +122,7 @@ describe("Google CRM proxy routes", () => {
     expect(content).toContain('"/orgs/google/sync"');
     expect(content).toContain('/orgs/google/messages');
     expect(content).toContain('/orgs/google/contacts');
+    expect(content).toContain('"/orgs/google/accounts"');
   });
 });
 
@@ -181,8 +192,24 @@ describe("Google CRM OpenAPI schemas", () => {
     expect(schemaContent).toContain("GoogleContactsResponse");
   });
 
+  it("should register GET /v1/orgs/google/accounts", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/google/accounts"');
+    expect(schemaContent).toContain("GoogleAccountsListResponse");
+    expect(schemaContent).toContain("GoogleAccountSummary");
+  });
+
   it("should use Google CRM tag", () => {
     expect(schemaContent).toContain('tags: ["Google CRM"]');
+  });
+});
+
+describe("Google CRM accounts endpoint in openapi.json", () => {
+  it("should include /v1/orgs/google/accounts in committed openapi.json", () => {
+    const openapiPath = path.join(__dirname, "../../openapi.json");
+    const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+    expect(openapi.paths).toBeDefined();
+    expect(openapi.paths["/v1/orgs/google/accounts"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/google/accounts"].get).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/orgs/google/accounts` proxy to google-service v0.20.0
- Mirrors the existing `/v1/orgs/google/*` pattern in `src/routes/google.ts` (authenticate + requireOrg + requireUser, identity headers via `buildInternalHeaders`)
- Adds `GoogleAccountSummary` + `GoogleAccountsListResponse` Zod schemas, registry path entry, regenerated `openapi.json`

## Why

Dashboard CRM page (apps/dashboard #1009) needs to display the connected Google account email after OAuth. Today it calls `/v1/orgs/google/accounts` and gets 404.

Downstream contract (google-service v0.20.0):
```
GET /orgs/google/accounts -> { accounts: [{ email, status, scopes, connectedAt }] }
```

## ⚠️ Deployment ordering

**Do NOT merge until google-service v0.20.0 is live in the target environment** (staging first, then prod via release.sh promote). If api-service ships before google-service, the proxy returns 502 from missing downstream route.

Per Orchestrator instruction: PR opened, NOT auto-merged. Orchestrator owns the merge + promote sequence.

## Test plan

- [x] `pnpm test` (1187 tests pass; 27 in `tests/unit/google-proxy.test.ts`)
- [x] `pnpm build` regenerates `openapi.json` cleanly
- [x] `openapi.json` contains `/v1/orgs/google/accounts` (verified)
- [ ] After merge + staging deploy: `curl https://api.staging.distribute.you/openapi.json` shows `/v1/orgs/google/accounts` (Orchestrator verifies)
- [ ] After release.sh promote: same check on `api.distribute.you`

## Out of scope

- Disconnect / revoke endpoint
- Multi-account UI
- Dashboard changes (already shipping in apps/dashboard #1009)

🤖 Generated with [Claude Code](https://claude.com/claude-code)