### PR TITLE
fix(api): proxy GET /v1/orgs/google/sync/:jobId for async sync polling

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9265,6 +9265,106 @@
           "contacts"
         ]
       },
+      "GoogleSyncJobSummary": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "accounts": {
+            "type": "integer"
+          },
+          "gmail": {
+            "type": "object",
+            "properties": {
+              "inserted": {
+                "type": "integer"
+              },
+              "updated": {
+                "type": "integer"
+              },
+              "unchanged": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "inserted",
+              "updated",
+              "unchanged"
+            ]
+          },
+          "contacts": {
+            "type": "object",
+            "properties": {
+              "inserted": {
+                "type": "integer"
+              },
+              "updated": {
+                "type": "integer"
+              },
+              "unchanged": {
+                "type": "integer"
+              },
+              "deleted": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "inserted",
+              "updated",
+              "unchanged",
+              "deleted"
+            ]
+          }
+        },
+        "required": [
+          "accounts",
+          "gmail",
+          "contacts"
+        ],
+        "description": "Sync result summary, present only when status='succeeded'."
+      },
+      "GoogleSyncJobStatusResponse": {
+        "type": "object",
+        "properties": {
+          "jobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "succeeded",
+              "failed"
+            ],
+            "description": "Job lifecycle state. Poll until status != 'running'."
+          },
+          "summary": {
+            "$ref": "#/components/schemas/GoogleSyncJobSummary"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "description": "Error message, present only when status='failed'."
+          },
+          "startedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp the job was claimed."
+          },
+          "finishedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO 8601 timestamp the job finished, null while running."
+          }
+        },
+        "required": [
+          "jobId",
+          "status",
+          "summary",
+          "error",
+          "startedAt",
+          "finishedAt"
+        ]
+      },
       "GoogleMessage": {
         "type": "object",
         "properties": {
@@ -30397,6 +30497,119 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/orgs/google/sync/{jobId}": {
+      "get": {
+        "tags": [
+          "Google CRM"
+        ],
+        "summary": "Poll Google sync job status",
+        "description": "Returns the current status of an async Google sync job started via POST /v1/orgs/google/sync. Poll every few seconds until status is 'succeeded' or 'failed'.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Sync job id returned by POST /v1/orgs/google/sync"
+            },
+            "required": true,
+            "name": "jobId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync job status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleSyncJobStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sync job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/orgs/google/messages": {

--- a/src/routes/google.ts
+++ b/src/routes/google.ts
@@ -52,6 +52,21 @@ router.post("/orgs/google/sync", authenticate, requireOrg, requireUser, async (r
   }
 });
 
+// GET /v1/orgs/google/sync/:jobId — poll status of an async Google sync job
+router.get("/orgs/google/sync/:jobId", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const jobId = req.params.jobId;
+    const result = await callExternalService(
+      externalServices.google,
+      `/orgs/google/sync/${jobId}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch Google sync job status" });
+  }
+});
+
 // GET /v1/orgs/google/messages — list raw Gmail messages (bronze)
 router.get("/orgs/google/messages", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6817,6 +6817,42 @@ const GoogleSyncResponseSchema = z
   })
   .openapi("GoogleSyncResponse");
 
+const GoogleSyncJobSummarySchema = z
+  .object({
+    accounts: z.number().int(),
+    gmail: z.object({
+      inserted: z.number().int(),
+      updated: z.number().int(),
+      unchanged: z.number().int(),
+    }),
+    contacts: z.object({
+      inserted: z.number().int(),
+      updated: z.number().int(),
+      unchanged: z.number().int(),
+      deleted: z.number().int(),
+    }),
+  })
+  .openapi("GoogleSyncJobSummary");
+
+const GoogleSyncJobStatusResponseSchema = z
+  .object({
+    jobId: z.string().uuid(),
+    status: z.enum(["running", "succeeded", "failed"]).openapi({
+      description: "Job lifecycle state. Poll until status != 'running'.",
+    }),
+    summary: GoogleSyncJobSummarySchema.nullable().openapi({
+      description: "Sync result summary, present only when status='succeeded'.",
+    }),
+    error: z.string().nullable().openapi({
+      description: "Error message, present only when status='failed'.",
+    }),
+    startedAt: z.string().openapi({ description: "ISO 8601 timestamp the job was claimed." }),
+    finishedAt: z.string().nullable().openapi({
+      description: "ISO 8601 timestamp the job finished, null while running.",
+    }),
+  })
+  .openapi("GoogleSyncJobStatusResponse");
+
 const GoogleMessageSchema = z
   .object({
     id: z.string().uuid(),
@@ -6923,6 +6959,30 @@ registry.registerPath({
   responses: {
     200: { description: "Sync summary", content: { "application/json": { schema: GoogleSyncResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/google/sync/{jobId}",
+  tags: ["Google CRM"],
+  summary: "Poll Google sync job status",
+  description:
+    "Returns the current status of an async Google sync job started via POST /v1/orgs/google/sync. " +
+    "Poll every few seconds until status is 'succeeded' or 'failed'.",
+  security: authed,
+  request: {
+    params: z.object({
+      jobId: z.string().uuid().openapi({ description: "Sync job id returned by POST /v1/orgs/google/sync" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Sync job status",
+      content: { "application/json": { schema: GoogleSyncJobStatusResponseSchema } },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Sync job not found", content: errorContent },
   },
 });
 

--- a/tests/unit/google-proxy.test.ts
+++ b/tests/unit/google-proxy.test.ts
@@ -54,6 +54,24 @@ describe("Google CRM proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
+  it("should have GET /orgs/google/sync/:jobId with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/google/sync/:jobId"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward jobId param into downstream path on GET /orgs/google/sync/:jobId", () => {
+    const idx = content.indexOf('"/orgs/google/sync/:jobId"');
+    expect(idx).toBeGreaterThan(-1);
+    const section = content.slice(idx, idx + 600);
+    expect(section).toContain("req.params.jobId");
+    expect(section).toMatch(/\/orgs\/google\/sync\/\$\{[^}]*jobId[^}]*\}/);
+  });
+
   it("should have GET /orgs/google/messages with auth + requireOrg + requireUser", () => {
     const line = content.split("\n").find((l) =>
       l.includes("router.get") && l.includes('"/orgs/google/messages"')
@@ -107,19 +125,20 @@ describe("Google CRM proxy routes", () => {
   it("should call externalServices.google for every endpoint", () => {
     const matches = content.match(/externalServices\.google/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(6);
+    expect(matches!.length).toBe(7);
   });
 
   it("should use buildInternalHeaders for every endpoint", () => {
     const matches = content.match(/buildInternalHeaders\(req\)/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(6);
+    expect(matches!.length).toBe(7);
   });
 
   it("should preserve downstream paths (no path renaming)", () => {
     expect(content).toContain('"/orgs/google/auth/start"');
     expect(content).toContain('/orgs/google/auth/callback');
     expect(content).toContain('"/orgs/google/sync"');
+    expect(content).toContain('"/orgs/google/sync/:jobId"');
     expect(content).toContain('/orgs/google/messages');
     expect(content).toContain('/orgs/google/contacts');
     expect(content).toContain('"/orgs/google/accounts"');
@@ -182,6 +201,20 @@ describe("Google CRM OpenAPI schemas", () => {
     expect(schemaContent).toContain("GoogleSyncResponse");
   });
 
+  it("should register GET /v1/orgs/google/sync/{jobId}", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/google/sync/{jobId}"');
+    expect(schemaContent).toContain("GoogleSyncJobStatusResponse");
+  });
+
+  it("should declare status enum running/succeeded/failed on GoogleSyncJobStatusResponse", () => {
+    const idx = schemaContent.indexOf("GoogleSyncJobStatusResponseSchema");
+    expect(idx).toBeGreaterThan(-1);
+    const section = schemaContent.slice(idx, idx + 1500);
+    expect(section).toContain('"running"');
+    expect(section).toContain('"succeeded"');
+    expect(section).toContain('"failed"');
+  });
+
   it("should register GET /v1/orgs/google/messages", () => {
     expect(schemaContent).toContain('path: "/v1/orgs/google/messages"');
     expect(schemaContent).toContain("GoogleMessagesResponse");
@@ -210,6 +243,16 @@ describe("Google CRM accounts endpoint in openapi.json", () => {
     expect(openapi.paths).toBeDefined();
     expect(openapi.paths["/v1/orgs/google/accounts"]).toBeDefined();
     expect(openapi.paths["/v1/orgs/google/accounts"].get).toBeDefined();
+  });
+});
+
+describe("Google CRM sync job poll endpoint in openapi.json", () => {
+  it("should include /v1/orgs/google/sync/{jobId} GET in committed openapi.json", () => {
+    const openapiPath = path.join(__dirname, "../../openapi.json");
+    const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+    expect(openapi.paths).toBeDefined();
+    expect(openapi.paths["/v1/orgs/google/sync/{jobId}"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/google/sync/{jobId}"].get).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Production hotfix. Dashboard ([distribute.you#1017](https://github.com/shamanic-technologies/distribute.you/pull/1017)) flipped the Google CRM sync button to async: `POST /api/v1/orgs/google/sync` now returns `202 + jobId`, then the dashboard polls `GET /api/v1/orgs/google/sync/:jobId` every 4s until `status != "running"`. google-service v0.21.0 ([google-service#63](https://github.com/shamanic-technologies/google-service/pull/63)) ships both endpoints.

api-service only proxied the POST. The GET poll was missing, so dashboard polling 404s in prod RIGHT NOW (`Sync status check failed (404): Not found`).

This PR adds the missing GET proxy:

- Mirrors POST `/orgs/google/sync` exactly: `authenticate + requireOrg + requireUser`, identity headers via `buildInternalHeaders`, downstream path preserved (`/orgs/google/sync/:jobId`), no rename, no body transform.
- New Zod schema `GoogleSyncJobStatusResponse` with status enum (`running` / `succeeded` / `failed`).
- Registers `GET /v1/orgs/google/sync/{jobId}` in OpenAPI; `openapi.json` regenerated.

## Test plan

- [x] `pnpm test` green locally (1192 / 1192).
- [x] `pnpm build` regenerates `openapi.json` with new path entry.
- [ ] After Railway redeploy: dashboard "Sync now" button on CRM page in prod runs spinner to completion and renders the summary card (no 404).

## Notes

- Existing `GoogleSyncResponseSchema` for POST still describes the old synchronous summary shape — the actual google-service POST response is now `{ jobId, status: "running" }` with `202`. Out of scope for this hotfix; flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)