### PR TITLE
fix(api): improve error handling and add infra guards

### DIFF
--- a/src/lib/delivery-stats.ts
+++ b/src/lib/delivery-stats.ts
@@ -63,7 +63,7 @@ export async function fetchDeliveryStats(
       headers: buildInternalHeaders(req),
     }
   ).catch((err) => {
-    console.warn("[delivery-stats] Email-gateway stats failed:", (err as Error).message);
+    console.error("[delivery-stats] Email-gateway stats failed:", (err as Error).message);
     return null;
   });
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -65,6 +65,19 @@ function getPool(serviceName: string): pg.Pool | null {
   return pool;
 }
 
+// Graceful shutdown: close all PG pools
+const shutdownPools = async () => {
+  const entries = [...pools.entries()];
+  if (entries.length === 0) return;
+  console.log(`[admin] Closing ${entries.length} PG pool(s)...`);
+  await Promise.allSettled(entries.map(([name, pool]) =>
+    pool.end().catch((err) => console.error(`[admin] Failed to close pool "${name}":`, err.message))
+  ));
+  console.log("[admin] All PG pools closed.");
+};
+process.on("SIGTERM", shutdownPools);
+process.on("SIGINT", shutdownPools);
+
 // ── GET /admin/services ─────────────────────────────────────────────────────
 router.get("/admin/services", authenticatePlatform, (_req: Request, res: Response) => {
   const services = Object.keys(SERVICE_DB_REGISTRY).map((name) => ({

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -275,7 +275,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
         `/orgs/stats?${deliveryParams}`,
         { headers: internalHeaders },
       ).catch((err) => {
-        console.warn("[campaigns/stats] email-gateway groupBy failed:", (err as Error).message);
+        console.error("[campaigns/stats] email-gateway groupBy failed:", (err as Error).message);
         return null;
       }),
       callExternalService<{ groups: Array<{ key: string; totalLeads: number; byOutreachStatus?: { contacted?: number }; buffered: number; skipped: number }> }>(
@@ -283,7 +283,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
         `/orgs/stats?${leadParams}`,
         { headers: internalHeaders },
       ).catch((err) => {
-        console.warn("[campaigns/stats] lead-service groupBy failed:", (err as Error).message);
+        console.error("[campaigns/stats] lead-service groupBy failed:", (err as Error).message);
         return null;
       }),
       callExternalService<{ groups: Array<{ key: string; stats: { emailsGenerated: number } }> }>(
@@ -291,7 +291,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
         `/stats?${emailgenParams}`,
         { headers: internalHeaders },
       ).catch((err) => {
-        console.warn("[campaigns/stats] content-generation groupBy failed:", (err as Error).message);
+        console.error("[campaigns/stats] content-generation groupBy failed:", (err as Error).message);
         return null;
       }),
       callExternalService<{ groups: Array<{ dimensions: Record<string, string | null>; totalCostInUsdCents: string; runCount: number }> }>(
@@ -299,7 +299,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
         `/v1/stats/costs?${runsParams}`,
         { headers: internalHeaders },
       ).catch((err) => {
-        console.warn("[campaigns/stats] runs-service groupBy failed:", (err as Error).message);
+        console.error("[campaigns/stats] runs-service groupBy failed:", (err as Error).message);
         return null;
       }),
     ]);
@@ -313,6 +313,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
 
     // Delivery stats (broadcast only)
     for (const g of deliveryGroups?.groups ?? []) {
+      if (!g.key) continue;
       const s = ensure(g.key);
       const b = g.broadcast;
       s.recipientStats = b?.recipientStats ?? EMPTY_DELIVERY_STATS.recipientStats;
@@ -321,6 +322,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
 
     // Lead stats (new shape: totalLeads, byOutreachStatus.contacted, buffered, skipped)
     for (const g of leadGroups?.groups ?? []) {
+      if (!g.key) continue;
       const s = ensure(g.key);
       s.leadsServed = g.totalLeads;
       s.leadsContacted = g.byOutreachStatus?.contacted ?? 0;
@@ -330,6 +332,7 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
 
     // Emailgen stats
     for (const g of emailgenGroups?.groups ?? []) {
+      if (!g.key) continue;
       const s = ensure(g.key);
       s.emailsGenerated = g.stats.emailsGenerated;
     }
@@ -650,17 +653,17 @@ router.get("/campaigns/:id/stream", authenticate, requireOrg, requireUser, async
           externalServices.campaign,
           `/campaigns/${id}`,
           { headers: internalHeaders }
-        ).catch(() => null),
+        ).catch((err) => { console.error("[campaigns/sse] Failed to fetch campaign-service status:", (err as Error).message); return null; }),
         callExternalService<{ totalLeads: number; buffered: number; skipped: number }>(
           externalServices.lead,
           `/orgs/stats?campaignId=${id}`,
           { headers: internalHeaders }
-        ).catch(() => null),
+        ).catch((err) => { console.error("[campaigns/sse] Failed to fetch lead-service stats:", (err as Error).message); return null; }),
         callExternalService<{ stats?: { emailsGenerated?: number } }>(
           externalServices.emailgen,
           `/stats?campaignId=${encodeURIComponent(id)}`,
           { headers: internalHeaders }
-        ).catch(() => null),
+        ).catch((err) => { console.error("[campaigns/sse] Failed to fetch emailgen-service stats:", (err as Error).message); return null; }),
         fetchDeliveryStats({ campaignId: id }, req),
       ]);
 


### PR DESCRIPTION
## Summary
- **Q1/Q2**: Upgrade `console.warn` to `console.error` in campaigns stats and delivery-stats catch handlers so upstream service failures are visible at error log level
- **Q3**: Add `console.error` logging to 3 silent `.catch(() => null)` handlers in the SSE polling loop (campaign-service, lead-service, emailgen-service)
- **Q4**: Add `SIGTERM`/`SIGINT` handlers in admin.ts to gracefully close all PG connection pools on shutdown
- **Q5**: Intentionally skipped — keys.ts routes use `authenticate` (not `requireOrg`), so the `if (!req.orgId)` guards are the only orgId validation and are NOT redundant
- **Q6**: Add `if (!g.key) continue` guard in 3 campaigns stats merge loops to skip groups without a key field

## Test plan
- [x] All 1192 tests pass (111 test files)
- [x] Build has pre-existing TS errors on main (unrelated `@distribute/runs-client` module), no regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)