### PR TITLE
fix(security): harden API gateway against 7 audit findings

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9565,20 +9565,6 @@
         }
       }
     },
-    "/debug/config": {
-      "get": {
-        "tags": [
-          "Health"
-        ],
-        "summary": "Debug configuration",
-        "description": "Returns debug info about external service configuration",
-        "responses": {
-          "200": {
-            "description": "Debug configuration data"
-          }
-        }
-      }
-    },
     "/openapi.json": {
       "get": {
         "tags": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,17 +61,18 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 // CORS - allow dashboard, MCP clients, and public landing pages
+const corsOrigins: string[] = [
+  "https://dashboard.distribute.you",
+  "https://distribute.you",
+  "https://performance.distribute.you",
+  "https://landing.distribute.you",
+  "https://sales-cold-emails.distribute.you",
+];
+if (process.env.NODE_ENV !== "production") {
+  corsOrigins.push("http://localhost:3000", "http://localhost:3001", "http://localhost:3007");
+}
 app.use(cors({
-  origin: [
-    "https://dashboard.distribute.you",
-    "https://distribute.you",
-    "https://performance.distribute.you",
-    "https://landing.distribute.you",
-    "https://sales-cold-emails.distribute.you",
-    "http://localhost:3000",
-    "http://localhost:3001",
-    "http://localhost:3007",
-  ],
+  origin: corsOrigins,
   credentials: true,
 }));
 

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -149,14 +149,10 @@ export async function callExternalServiceWithStatus<T>(
 
     if (!response.ok) {
       const errorText = await response.text();
-      let errorMessage: string;
-      try {
-        const errorJson = JSON.parse(errorText);
-        errorMessage = errorJson.error || `Service call failed: ${response.status}`;
-      } catch {
-        errorMessage = `Service call failed: ${response.status} - ${errorText}`;
-      }
-      const err = new Error(errorMessage) as Error & { statusCode: number };
+      // Log full upstream error server-side for debugging
+      console.error(`[callExternalService] ${method} ${url} upstream error ${response.status}:`, errorText);
+      // Return generic message to client — never leak upstream details
+      const err = new Error(`Service call failed: ${response.status}`) as Error & { statusCode: number };
       err.statusCode = response.status;
       throw err;
     }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,6 +1,22 @@
 import { Request, Response, NextFunction } from "express";
+import { timingSafeEqual } from "crypto";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { createRun, updateRun } from "@distribute/runs-client";
+
+/**
+ * Timing-safe comparison of two strings.
+ * Returns false for length mismatch without leaking timing info.
+ */
+function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Compare against self to consume constant time, then return false
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
 
 export interface AuthenticatedRequest extends Request {
   userId?: string;
@@ -36,7 +52,8 @@ export async function authenticate(
 
     if (apiKey) {
       // ── Path 1: Admin auth via X-API-Key ──
-      if (apiKey !== process.env.ADMIN_DISTRIBUTE_API_KEY) {
+      const expectedKey = process.env.ADMIN_DISTRIBUTE_API_KEY;
+      if (!expectedKey || !safeCompare(apiKey, expectedKey)) {
         return res.status(401).json({ error: "Invalid admin key" });
       }
       req.authType = "admin";
@@ -219,7 +236,8 @@ export async function authenticatePlatform(
   next: NextFunction
 ) {
   const apiKey = req.headers["x-api-key"] as string | undefined;
-  if (!apiKey || apiKey !== process.env.ADMIN_DISTRIBUTE_API_KEY) {
+  const expectedKey = process.env.ADMIN_DISTRIBUTE_API_KEY;
+  if (!apiKey || !expectedKey || !safeCompare(apiKey, expectedKey)) {
     return res.status(401).json({ error: "Invalid or missing platform API key" });
   }
   req.authType = "admin";

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -167,7 +167,23 @@ router.get("/admin/services/:name/tables/:table/rows", authenticatePlatform, asy
     return res.status(404).json({ error: `Table "${table}" not found` });
   }
 
+  // Strict identifier regex — reject anything that isn't a valid PostgreSQL identifier
+  const IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
   const validColumns = columnsResult.rows.map((r) => r.column_name);
+
+  // S7: Validate all column names from information_schema before use in SQL
+  for (const col of validColumns) {
+    if (!IDENTIFIER_RE.test(col)) {
+      return res.status(500).json({ error: "Invalid column name detected in schema" });
+    }
+  }
+
+  // S1: Validate table name against strict identifier regex
+  if (!IDENTIFIER_RE.test(table)) {
+    return res.status(400).json({ error: "Invalid table name" });
+  }
+
   const textColumns = columnsResult.rows
     .filter((r) => ["character varying", "text", "varchar", "char", "character"].includes(r.data_type))
     .map((r) => r.column_name);
@@ -203,7 +219,7 @@ router.get("/admin/services/:name/tables/:table/rows", authenticatePlatform, asy
     whereClause = `WHERE ${conditions.join(" OR ")}`;
   }
 
-  // Sort column is validated above — safe to interpolate
+  // Sort column and table name are validated above — safe to interpolate
   const query = `SELECT * FROM "${table}" ${whereClause} ORDER BY "${sort}" ${order} LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
   params.push(limit, offset);
 

--- a/src/routes/google.ts
+++ b/src/routes/google.ts
@@ -58,7 +58,7 @@ router.get("/orgs/google/sync/:jobId", authenticate, requireOrg, requireUser, as
     const jobId = req.params.jobId;
     const result = await callExternalService(
       externalServices.google,
-      `/orgs/google/sync/${jobId}`,
+      `/orgs/google/sync/${encodeURIComponent(jobId)}`,
       { headers: buildInternalHeaders(req) }
     );
     res.json(result);

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { externalServices } from "../lib/service-client.js";
 
 const router = Router();
 
@@ -8,21 +7,6 @@ router.get("/health", (req, res) => {
     status: "ok",
     service: "api-gateway",
     version: "1.0.0",
-  });
-});
-
-// Debug endpoint to check config (temporary)
-router.get("/debug/config", (req, res) => {
-  res.json({
-    scraping: {
-      url: externalServices.scraping.url,
-      hasApiKey: !!externalServices.scraping.apiKey,
-      apiKeyLength: externalServices.scraping.apiKey?.length || 0,
-    },
-    replyQualification: {
-      url: externalServices.replyQualification.url,
-      hasApiKey: !!externalServices.replyQualification.apiKey,
-    },
   });
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -107,17 +107,6 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/debug/config",
-  tags: ["Health"],
-  summary: "Debug configuration",
-  description: "Returns debug info about external service configuration",
-  responses: {
-    200: { description: "Debug configuration data" },
-  },
-});
-
-registry.registerPath({
-  method: "get",
   path: "/openapi.json",
   tags: ["Health"],
   summary: "OpenAPI specification",

--- a/tests/unit/brand-extracted-fields.test.ts
+++ b/tests/unit/brand-extracted-fields.test.ts
@@ -102,7 +102,7 @@ describe("GET /v1/brands/:id/extracted-fields", () => {
     const res = await request(app).get("/v1/brands/nonexistent/extracted-fields");
 
     expect(res.status).toBe(404);
-    expect(res.body.error).toContain("Brand not found");
+    expect(res.body.error).toContain("Service call failed: 404");
   });
 
   it("should return 500 when brand-service fails", async () => {
@@ -115,6 +115,6 @@ describe("GET /v1/brands/:id/extracted-fields", () => {
     const res = await request(app).get("/v1/brands/brand-abc/extracted-fields");
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toContain("Internal error");
+    expect(res.body.error).toContain("Service call failed: 500");
   });
 });

--- a/tests/unit/brand-extracted-images.test.ts
+++ b/tests/unit/brand-extracted-images.test.ts
@@ -111,7 +111,7 @@ describe("GET /v1/brands/:id/extracted-images", () => {
     const res = await request(app).get("/v1/brands/nonexistent/extracted-images");
 
     expect(res.status).toBe(404);
-    expect(res.body.error).toContain("Brand not found");
+    expect(res.body.error).toContain("Service call failed: 404");
   });
 
   it("should return 500 when brand-service fails", async () => {
@@ -124,6 +124,6 @@ describe("GET /v1/brands/:id/extracted-images", () => {
     const res = await request(app).get("/v1/brands/brand-abc/extracted-images");
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toContain("Internal error");
+    expect(res.body.error).toContain("Service call failed: 500");
   });
 });

--- a/tests/unit/brand-transfer.test.ts
+++ b/tests/unit/brand-transfer.test.ts
@@ -241,7 +241,7 @@ describe("POST /v1/brands/:id/transfer", () => {
       .send({ targetOrgId: "org_clerk_target" });
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toContain("Brand-service internal error");
+    expect(res.body.error).toContain("Service call failed: 500");
   });
 });
 
@@ -300,7 +300,7 @@ describe("GET /v1/brands/:id/transfers", () => {
       .get("/v1/brands/brand-abc/transfers");
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toContain("DB error");
+    expect(res.body.error).toContain("Service call failed: 500");
   });
 });
 

--- a/tests/unit/brand-upsert.test.ts
+++ b/tests/unit/brand-upsert.test.ts
@@ -89,6 +89,6 @@ describe("POST /v1/brands – upsert brand", () => {
       .send({ url: "https://example.com" });
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toContain("Connection refused");
+    expect(res.body.error).toContain("Service call failed: 500");
   });
 });

--- a/tests/unit/campaign-duplicate-name.test.ts
+++ b/tests/unit/campaign-duplicate-name.test.ts
@@ -79,7 +79,7 @@ describe("Campaign duplicate name handling (409 Conflict)", () => {
     const res = await request(app).post("/v1/campaigns").send(validCampaignBody);
 
     expect(res.status).toBe(409);
-    expect(res.body.error).toContain("already exists");
+    expect(res.body.error).toContain("Service call failed: 409");
   });
 
   it("PATCH /v1/campaigns/:id should return 409 when campaign name already exists", async () => {
@@ -102,6 +102,6 @@ describe("Campaign duplicate name handling (409 Conflict)", () => {
       .send({ name: "Duplicate Name" });
 
     expect(res.status).toBe(409);
-    expect(res.body.error).toContain("already exists");
+    expect(res.body.error).toContain("Service call failed: 409");
   });
 });

--- a/tests/unit/campaign-target-audience.test.ts
+++ b/tests/unit/campaign-target-audience.test.ts
@@ -249,6 +249,6 @@ describe("POST /v1/campaigns with featureInputs", () => {
     const res = await request(app).post("/v1/campaigns").send(validBody);
     // features-service 404 is forwarded — unknown feature slug
     expect(res.status).toBe(404);
-    expect(res.body.error).toContain("Feature not found");
+    expect(res.body.error).toContain("Service call failed: 404");
   });
 });

--- a/tests/unit/content-compose.test.ts
+++ b/tests/unit/content-compose.test.ts
@@ -137,7 +137,7 @@ describe("POST /v1/content/compose", () => {
       .send(validBody);
 
     expect(res.status).toBe(503);
-    expect(res.body.error).toContain("Service unavailable");
+    expect(res.body.error).toContain("Service call failed: 503");
   });
 
   it("should forward layout field to downstream service", async () => {

--- a/tests/unit/icp-suggestion-keytype.regression.test.ts
+++ b/tests/unit/icp-suggestion-keytype.regression.test.ts
@@ -93,8 +93,7 @@ describe("POST /v1/brand/icp-suggestion", () => {
       .send({ brandUrl: "https://example.com" });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain("Anthropic API key not configured");
-    expect(res.body.error).toContain("API Keys");
+    expect(res.body.error).toContain("Service call failed: 400");
   });
 
   it("should return 400 when brandUrl is missing", async () => {

--- a/tests/unit/service-client-error-handling.test.ts
+++ b/tests/unit/service-client-error-handling.test.ts
@@ -8,7 +8,7 @@ describe("callExternalService error handling", () => {
     vi.restoreAllMocks();
   });
 
-  it("should extract error message from JSON error response", async () => {
+  it("should return generic error message (not upstream details) for JSON error response", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -19,15 +19,15 @@ describe("callExternalService error handling", () => {
     );
 
     await expect(callExternalService(service, "/validate")).rejects.toThrow(
-      "Invalid API key format",
-    );
-    // Must NOT contain the raw JSON wrapper
-    await expect(callExternalService(service, "/validate")).rejects.not.toThrow(
       "Service call failed: 401",
+    );
+    // Must NOT leak upstream error details
+    await expect(callExternalService(service, "/validate")).rejects.not.toThrow(
+      "Invalid API key format",
     );
   });
 
-  it("should fall back to raw text when response is not JSON", async () => {
+  it("should return generic error message (not upstream details) for non-JSON response", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -38,7 +38,11 @@ describe("callExternalService error handling", () => {
     );
 
     await expect(callExternalService(service, "/health")).rejects.toThrow(
-      "Service call failed: 500 - Internal Server Error",
+      "Service call failed: 500",
+    );
+    // Must NOT leak upstream error text
+    await expect(callExternalService(service, "/health")).rejects.not.toThrow(
+      "Internal Server Error",
     );
   });
 


### PR DESCRIPTION
## Summary
- **S1**: SQL injection — validate table names with strict identifier regex (`/^[a-zA-Z_][a-zA-Z0-9_]*$/`) before SQL interpolation in admin.ts
- **S2**: Remove `/debug/config` endpoint that leaked `hasApiKey` and `apiKeyLength` for services
- **S3**: Replace `!==` admin key comparison with `crypto.timingSafeEqual` to prevent timing attacks
- **S4**: Encode `jobId` with `encodeURIComponent` to prevent path traversal in google.ts
- **S5**: Sanitize upstream error messages — log full details server-side, return generic `Service call failed: {status}` to client
- **S6**: Restrict localhost CORS origins to `NODE_ENV !== 'production'` only
- **S7**: Validate column names from `information_schema` against strict identifier regex before use in ILIKE clauses

## Test plan
- [x] All 1192 existing tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Updated 8 test files to expect sanitized (generic) error messages instead of leaked upstream details

🤖 Generated with [Claude Code](https://claude.com/claude-code)