### PR TITLE
fix: rename signatureName to workflowDynastySignatureName, drop WorkflowStyleSchema reference

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -202,9 +202,9 @@
             "type": "string",
             "description": "SHA-256 hash of the canonical DAG"
           },
-          "signatureName": {
+          "workflowDynastySignatureName": {
             "type": "string",
-            "description": "Human-readable name for this DAG variant"
+            "description": "Human-readable name for this DAG variant within the dynasty"
           }
         },
         "required": [
@@ -218,7 +218,7 @@
           "createdForBrandId",
           "featureSlug",
           "signature",
-          "signatureName"
+          "workflowDynastySignatureName"
         ]
       },
       "RankedResponse": {
@@ -6156,9 +6156,9 @@
                 "type": "string",
                 "description": "SHA-256 hash of the canonical DAG"
               },
-              "signatureName": {
+              "workflowDynastySignatureName": {
                 "type": "string",
-                "description": "Human-readable name for this DAG variant"
+                "description": "Human-readable name for this DAG variant within the dynasty"
               },
               "action": {
                 "type": "string",
@@ -6172,11 +6172,6 @@
                 "type": "string",
                 "nullable": true,
                 "description": "Human ID if styled after an expert"
-              },
-              "styleName": {
-                "type": "string",
-                "nullable": true,
-                "description": "Base style name for versioning (e.g. 'hormozi')"
               }
             },
             "required": [
@@ -6184,10 +6179,9 @@
               "name",
               "featureSlug",
               "signature",
-              "signatureName",
+              "workflowDynastySignatureName",
               "action",
-              "humanId",
-              "styleName"
+              "humanId"
             ]
           },
           "dag": {
@@ -6223,37 +6217,6 @@
           "dag",
           "generatedDescription"
         ]
-      },
-      "WorkflowStyle": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "human",
-              "brand"
-            ],
-            "description": "Style source type"
-          },
-          "humanId": {
-            "type": "string",
-            "description": "Human ID from human-service. Required when type is 'human'."
-          },
-          "brandId": {
-            "type": "string",
-            "description": "Brand ID from brand-service. Required when type is 'brand'."
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Display name of the human or brand (e.g. 'Hormozi', 'My Brand')"
-          }
-        },
-        "required": [
-          "type",
-          "name"
-        ],
-        "description": "Optional style configuration. When provided, the workflow is generated in the style of an industry expert or brand."
       },
       "CreateWorkflowRequest": {
         "type": "object",
@@ -6294,9 +6257,6 @@
               }
             },
             "description": "Optional hints to guide DAG generation"
-          },
-          "style": {
-            "$ref": "#/components/schemas/WorkflowStyle"
           }
         },
         "required": [
@@ -6326,9 +6286,9 @@
                 "type": "string",
                 "description": "SHA-256 hash of the canonical DAG"
               },
-              "signatureName": {
+              "workflowDynastySignatureName": {
                 "type": "string",
-                "description": "Human-readable name for this DAG variant"
+                "description": "Human-readable name for this DAG variant within the dynasty"
               },
               "action": {
                 "type": "string",
@@ -6342,11 +6302,6 @@
                 "type": "string",
                 "nullable": true,
                 "description": "Human ID if styled after an expert"
-              },
-              "styleName": {
-                "type": "string",
-                "nullable": true,
-                "description": "Base style name for versioning (e.g. 'hormozi')"
               }
             },
             "required": [
@@ -6354,10 +6309,9 @@
               "name",
               "featureSlug",
               "signature",
-              "signatureName",
+              "workflowDynastySignatureName",
               "action",
-              "humanId",
-              "styleName"
+              "humanId"
             ]
           },
           "dag": {

--- a/shared/content/src/workflows.ts
+++ b/shared/content/src/workflows.ts
@@ -63,7 +63,7 @@ export interface ParsedWorkflowName {
   category: WorkflowCategory;
   channel: WorkflowChannel;
   audienceType: WorkflowAudienceType;
-  signatureName: string;
+  workflowDynastySignatureName: string;
   sectionKey: string;
 }
 
@@ -109,7 +109,7 @@ export function parseWorkflowSlug(slug: string): ParsedWorkflowName | null {
           category,
           channel,
           audienceType: twoWord as WorkflowAudienceType,
-          signatureName,
+          workflowDynastySignatureName: signatureName,
           sectionKey: `${category}-${channel}-${twoWord}`,
         };
       }
@@ -126,7 +126,7 @@ export function getSectionKey(workflowSlug: string): string | null {
 
 /** Extract signatureName from a workflow slug. Returns null if slug doesn't match expected format. */
 export function getSignatureName(workflowSlug: string): string | null {
-  return parseWorkflowSlug(workflowSlug)?.signatureName ?? null;
+  return parseWorkflowSlug(workflowSlug)?.workflowDynastySignatureName ?? null;
 }
 
 /** Resolve category for a workflow slug. Returns null if slug doesn't match expected format. */
@@ -138,7 +138,7 @@ export function getWorkflowCategory(workflowSlug: string): WorkflowCategory | nu
 export function getWorkflowDisplayName(workflowSlug: string): string {
   const parsed = parseWorkflowSlug(workflowSlug);
   if (parsed) {
-    return parsed.signatureName.charAt(0).toUpperCase() + parsed.signatureName.slice(1);
+    return parsed.workflowDynastySignatureName.charAt(0).toUpperCase() + parsed.workflowDynastySignatureName.slice(1);
   }
   return workflowSlug
     .split("-")

--- a/shared/content/tests/workflows.test.ts
+++ b/shared/content/tests/workflows.test.ts
@@ -72,7 +72,7 @@ describe("parseWorkflowSlug", () => {
       category: "sales",
       channel: "email",
       audienceType: "cold-outreach",
-      signatureName: "sienna",
+      workflowDynastySignatureName: "sienna",
       sectionKey: "sales-email-cold-outreach",
     });
   });
@@ -83,7 +83,7 @@ describe("parseWorkflowSlug", () => {
       category: "pr",
       channel: "email",
       audienceType: "cold-outreach",
-      signatureName: "sequoia",
+      workflowDynastySignatureName: "sequoia",
       sectionKey: "pr-email-cold-outreach",
     });
   });

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -556,7 +556,7 @@ router.post("/workflows/create", authenticate, requireOrg, requireUser, async (r
       });
     }
 
-    const { featureSlug, description, hints, style } = parsed.data;
+    const { featureSlug, description, hints } = parsed.data;
 
     const result = await callExternalService(
       externalServices.workflow,
@@ -570,7 +570,6 @@ router.post("/workflows/create", authenticate, requireOrg, requireUser, async (r
           featureSlug,
           description,
           hints,
-          ...(style && { style }),
         },
       }
     );

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -190,7 +190,7 @@ const WorkflowMetadataSchema = z
     audienceType: z.string().optional().describe("Audience type (e.g. 'cold-outreach')"),
     featureSlug: z.string().describe("Feature slug this workflow belongs to (e.g. 'pr-cold-email-outreach')"),
     signature: z.string().describe("SHA-256 hash of the canonical DAG"),
-    signatureName: z.string().describe("Human-readable name for this DAG variant"),
+    workflowDynastySignatureName: z.string().describe("Human-readable name for this DAG variant within the dynasty"),
   })
   .openapi("WorkflowMetadata");
 
@@ -3936,21 +3936,6 @@ registry.registerPath({
   },
 });
 
-export const WorkflowStyleSchema = z
-  .object({
-    type: z.enum(["human", "brand"]).describe("Style source type"),
-    humanId: z
-      .string()
-      .optional()
-      .describe("Human ID from human-service. Required when type is 'human'."),
-    brandId: z
-      .string()
-      .optional()
-      .describe("Brand ID from brand-service. Required when type is 'brand'."),
-    name: z.string().min(1).describe("Display name of the human or brand (e.g. 'Hormozi', 'My Brand')"),
-  })
-  .openapi("WorkflowStyle");
-
 export const CreateWorkflowRequestSchema = z
   .object({
     featureSlug: z
@@ -3974,9 +3959,6 @@ export const CreateWorkflowRequestSchema = z
       })
       .optional()
       .describe("Optional hints to guide DAG generation"),
-    style: WorkflowStyleSchema.optional().describe(
-      "Optional style configuration. When provided, the workflow is generated in the style of an industry expert or brand."
-    ),
   })
   .openapi("CreateWorkflowRequest");
 
@@ -4006,10 +3988,9 @@ const generateWorkflowResponse = z
       name: z.string().describe("Auto-generated workflow slug"),
       featureSlug: z.string().describe("Feature slug this workflow belongs to"),
       signature: z.string().describe("SHA-256 hash of the canonical DAG"),
-      signatureName: z.string().describe("Human-readable name for this DAG variant"),
+      workflowDynastySignatureName: z.string().describe("Human-readable name for this DAG variant within the dynasty"),
       action: z.enum(["created", "updated"]).describe("Whether the workflow was created or updated"),
       humanId: z.string().nullable().describe("Human ID if styled after an expert"),
-      styleName: z.string().nullable().describe("Base style name for versioning (e.g. 'hormozi')"),
     }),
     dag: z.object({
       nodes: z.array(z.any()).describe("DAG nodes"),

--- a/tests/unit/workflows-create.test.ts
+++ b/tests/unit/workflows-create.test.ts
@@ -42,13 +42,12 @@ describe("POST /v1/workflows/create route", () => {
     expect(block).toContain("userId: req.userId");
   });
 
-  it("should forward featureSlug, description, hints, and style from request body", () => {
+  it("should forward featureSlug, description, and hints from request body", () => {
     const createIdx = content.indexOf('router.post("/workflows/create"');
     const block = content.slice(createIdx, createIdx + 1000);
     expect(block).toContain("featureSlug");
     expect(block).toContain("description");
     expect(block).toContain("hints");
-    expect(block).toContain("style");
   });
 
   it("should return 400 on invalid request", () => {
@@ -97,13 +96,6 @@ describe("CreateWorkflowRequestSchema", () => {
     expect(schemaSection).toContain("services");
     expect(schemaSection).toContain("nodeTypes");
     expect(schemaSection).toContain("expectedInputs");
-  });
-
-  it("should have optional style referencing WorkflowStyleSchema", () => {
-    const start = content.indexOf("CreateWorkflowRequestSchema");
-    const end = content.indexOf('.openapi("CreateWorkflowRequest")', start);
-    const schemaSection = content.slice(start, end);
-    expect(schemaSection).toContain("WorkflowStyleSchema");
   });
 
   it("should register POST /v1/workflows/create path in OpenAPI", () => {


### PR DESCRIPTION
## Summary

Sync api-service to workflow-service v0.13.x ([workflow-service#267](https://github.com/shamanic-technologies/workflow-service/pull/267)).

- Rename Zod field `signatureName` -> `workflowDynastySignatureName` on `WorkflowMetadataSchema` and `CreateWorkflowResponse.workflow`.
- Remove `WorkflowStyleSchema` / `WorkflowStyle` (deleted upstream) and its usage in `CreateWorkflowRequestSchema`.
- Remove `styleName` from `CreateWorkflowResponse.workflow`.
- Drop `style` passthrough in `POST /v1/workflows/create` handler.
- Rename `ParsedWorkflowName.signatureName` -> `workflowDynastySignatureName` in `shared/content` for consistency; update tests.
- Regenerate `openapi.json`.

## ⚠️ DO NOT MERGE — Deployment ordering

This change is part of a coordinated wave that must roll out together on staging:

1. ✅ workflow-service PR #267 (already merged to staging at 2026-05-10T03:17Z)
2. 🟡 api-service (this PR)
3. ⬜ distribute.you (separate PR — frontend consumers)

Merging this PR alone will break the dashboard while distribute.you still references `signatureName` / `styleName`. Orchestrator coordinates the merge train.

## Test plan

- [x] `npm run build` green
- [x] `npm test` — 1191/1191 passing
- [x] `openapi.json` regenerated; grep confirms `workflowDynastySignatureName` present, `signatureName` / `WorkflowStyle` / `styleName` absent
- [ ] Smoke-test dashboard against staging api-service after distribute.you ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)