### PR TITLE
feat(api): proxy expert-quotes + ai-visibility-score for dashboard entity sidebars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,11 @@ API_REGISTRY_SERVICE_API_KEY=your-api-registry-service-api-key
 # Google CRM service (Gmail + People bronze ingestion)
 GOOGLE_SERVICE_URL=https://google.distribute.you
 GOOGLE_SERVICE_API_KEY=your-google-service-api-key
+
+# Journalists Quotes service (Featured.com expert-quote outreach)
+JOURNALISTS_QUOTES_SERVICE_URL=https://journalists-quotes.distribute.you
+JOURNALISTS_QUOTES_SERVICE_API_KEY=your-journalists-quotes-service-api-key
+
+# AI Visibility Score service (LLM brand-visibility audits)
+AI_VISIBILITY_SERVICE_URL=https://ai-visibility-score.distribute.you
+AI_VISIBILITY_SERVICE_API_KEY=your-ai-visibility-service-api-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ API gateway that sits between the dashboard (frontend) and all backend microserv
 
 api-service is a **transparent proxy**. It authenticates, applies middleware, and forwards requests — it does NOT redefine, rename, or transform downstream routes.
 
+**"Transparent" does NOT mean "generic catch-all".** Every downstream endpoint requires its own explicit Express handler in `src/routes/<service>.ts`, its own Zod schema in `src/schemas.ts`, and a re-generated `openapi.json`. There is no `app.use("/v1/*", genericProxy)` and adding one is out of scope for any normal feature PR — it would break OpenAPI auto-generation, per-route auth-tier enforcement, query-param whitelisting, and ~30 existing `*-proxy.test.ts` files. If you think you need a generic catch-all, that is a standalone architectural proposal, not a "while we're here" tweak.
+
+"Transparent" means: no path rename, no aggregation, no body transform, no field stripping, no header injection beyond the standard identity headers. It does NOT mean fewer files.
+
 ### Rules
 
 1. **No path renaming.** The path sent to the downstream service must match the actual route on that service. Always check the API registry (`mcp__api-registry__list_service_endpoints`) for the correct path before writing a proxy route.

--- a/openapi.json
+++ b/openapi.json
@@ -78,6 +78,14 @@
     {
       "name": "Google CRM",
       "description": "Google CRM (Gmail + People bronze) ingestion"
+    },
+    {
+      "name": "Expert Quotes",
+      "description": "Expert quote outreach (journalists-quotes-service proxy)"
+    },
+    {
+      "name": "AI Visibility",
+      "description": "AI visibility-score audits (ai-visibility-score-service proxy)"
     }
   ],
   "components": {
@@ -9517,6 +9525,677 @@
         "required": [
           "items",
           "nextCursor"
+        ]
+      },
+      "QuoteRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "featuredQuestionId": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "mediaOutlet": {
+            "type": "string",
+            "nullable": true
+          },
+          "opportunityText": {
+            "type": "string"
+          },
+          "pitchUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "deadline": {
+            "type": "string",
+            "nullable": true
+          },
+          "fetchedAt": {
+            "type": "string"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "featuredQuestionId",
+          "source",
+          "mediaOutlet",
+          "opportunityText",
+          "pitchUrl",
+          "deadline",
+          "fetchedAt",
+          "orgId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "QuoteRequestsListResponse": {
+        "type": "object",
+        "properties": {
+          "quoteRequests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuoteRequest"
+            }
+          }
+        },
+        "required": [
+          "quoteRequests"
+        ]
+      },
+      "QuoteRequestsStatsResponse": {
+        "type": "object",
+        "properties": {
+          "totalRequests": {
+            "type": "integer"
+          },
+          "totalPitched": {
+            "type": "integer"
+          },
+          "totalSelected": {
+            "type": "integer"
+          },
+          "totalPublished": {
+            "type": "integer"
+          },
+          "totalNotSelected": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "totalRequests",
+          "totalPitched",
+          "totalSelected",
+          "totalPublished",
+          "totalNotSelected"
+        ]
+      },
+      "QuoteRequestResponse": {
+        "type": "object",
+        "properties": {
+          "quoteRequest": {
+            "$ref": "#/components/schemas/QuoteRequest"
+          }
+        },
+        "required": [
+          "quoteRequest"
+        ]
+      },
+      "QuotePitch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "quoteRequestId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "featuredQuestionId": {
+            "type": "integer"
+          },
+          "featuredProfileId": {
+            "type": "integer"
+          },
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "draft": {
+            "type": "string"
+          },
+          "submittedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "drafted",
+              "submitted",
+              "selected",
+              "published",
+              "not_selected",
+              "error"
+            ]
+          },
+          "featuredArticleUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentRunId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "runId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "quoteRequestId",
+          "featuredQuestionId",
+          "featuredProfileId",
+          "campaignId",
+          "brandId",
+          "draft",
+          "submittedAt",
+          "status",
+          "featuredArticleUrl",
+          "error",
+          "parentRunId",
+          "runId",
+          "orgId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "QuotePitchesListResponse": {
+        "type": "object",
+        "properties": {
+          "quotePitches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuotePitch"
+            }
+          }
+        },
+        "required": [
+          "quotePitches"
+        ]
+      },
+      "QuotePitchResponse": {
+        "type": "object",
+        "properties": {
+          "quotePitch": {
+            "$ref": "#/components/schemas/QuotePitch"
+          }
+        },
+        "required": [
+          "quotePitch"
+        ]
+      },
+      "VisibilityScoreWeights": {
+        "type": "object",
+        "properties": {
+          "brandMentionRate": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "citationRate": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "positionScore": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "shareOfVoice": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "sentiment": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "brandAndUrlRate": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        },
+        "required": [
+          "brandMentionRate",
+          "citationRate",
+          "positionScore",
+          "shareOfVoice",
+          "sentiment",
+          "brandAndUrlRate"
+        ]
+      },
+      "VisibilityScoreRun": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentRunId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "runId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "brandName": {
+            "type": "string"
+          },
+          "llmProvider": {
+            "type": "string"
+          },
+          "llmModel": {
+            "type": "string"
+          },
+          "promptGenModel": {
+            "type": "string"
+          },
+          "extractionProvider": {
+            "type": "string"
+          },
+          "extractionModel": {
+            "type": "string"
+          },
+          "nPrompts": {
+            "type": "number"
+          },
+          "weights": {
+            "$ref": "#/components/schemas/VisibilityScoreWeights"
+          },
+          "visibilityScore": {
+            "type": "string",
+            "nullable": true
+          },
+          "brandMentionRate": {
+            "type": "string",
+            "nullable": true
+          },
+          "shareOfVoice": {
+            "type": "string",
+            "nullable": true
+          },
+          "netSentiment": {
+            "type": "string",
+            "nullable": true
+          },
+          "citationRate": {
+            "type": "string",
+            "nullable": true
+          },
+          "avgPosition": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "completedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "orgId",
+          "brandId",
+          "parentRunId",
+          "runId",
+          "domain",
+          "brandName",
+          "llmProvider",
+          "llmModel",
+          "promptGenModel",
+          "extractionProvider",
+          "extractionModel",
+          "nPrompts",
+          "weights",
+          "visibilityScore",
+          "brandMentionRate",
+          "shareOfVoice",
+          "netSentiment",
+          "citationRate",
+          "avgPosition",
+          "status",
+          "startedAt",
+          "completedAt",
+          "createdAt"
+        ]
+      },
+      "VisibilityScoreRunWithDelta": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VisibilityScoreRun"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "visibility_score_delta": {
+                "type": "string",
+                "nullable": true
+              },
+              "share_of_voice_delta": {
+                "type": "string",
+                "nullable": true
+              },
+              "net_sentiment_delta": {
+                "type": "string",
+                "nullable": true
+              },
+              "position_delta": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "visibility_score_delta",
+              "share_of_voice_delta",
+              "net_sentiment_delta",
+              "position_delta"
+            ]
+          }
+        ]
+      },
+      "VisibilityScoreRunsListResponse": {
+        "type": "object",
+        "properties": {
+          "runs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisibilityScoreRunWithDelta"
+            }
+          },
+          "limit": {
+            "type": "number"
+          },
+          "offset": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "runs",
+          "limit",
+          "offset"
+        ]
+      },
+      "VisibilityScorePrompt": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "promptIndex": {
+            "type": "number"
+          },
+          "promptText": {
+            "type": "string"
+          },
+          "responseText": {
+            "type": "string"
+          },
+          "responseLengthChars": {
+            "type": "number",
+            "nullable": true
+          },
+          "brandFound": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "brandCount": {
+            "type": "number",
+            "nullable": true
+          },
+          "brandPosition": {
+            "type": "number",
+            "nullable": true
+          },
+          "urlFound": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "urlCount": {
+            "type": "number",
+            "nullable": true
+          },
+          "brandAndUrlCoOccurrence": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "maxBrandsInResponse": {
+            "type": "number",
+            "nullable": true
+          },
+          "sentiment": {
+            "type": "string",
+            "nullable": true
+          },
+          "sentimentScore": {
+            "type": "string",
+            "nullable": true
+          },
+          "citationUrls": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "latencyMs": {
+            "type": "number",
+            "nullable": true
+          },
+          "tokensInput": {
+            "type": "number",
+            "nullable": true
+          },
+          "tokensOutput": {
+            "type": "number",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "promptIndex",
+          "promptText",
+          "responseText",
+          "responseLengthChars",
+          "brandFound",
+          "brandCount",
+          "brandPosition",
+          "urlFound",
+          "urlCount",
+          "brandAndUrlCoOccurrence",
+          "maxBrandsInResponse",
+          "sentiment",
+          "sentimentScore",
+          "citationUrls",
+          "latencyMs",
+          "tokensInput",
+          "tokensOutput"
+        ]
+      },
+      "VisibilityScoreCompetitor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "promptIdFk": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "competitorName": {
+            "type": "string"
+          },
+          "competitorUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "position": {
+            "type": "number",
+            "nullable": true
+          },
+          "sentiment": {
+            "type": "string",
+            "nullable": true
+          },
+          "sentimentScore": {
+            "type": "string",
+            "nullable": true
+          },
+          "citationUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "promptIdFk",
+          "competitorName",
+          "competitorUrl",
+          "position",
+          "sentiment",
+          "sentimentScore",
+          "citationUrl"
+        ]
+      },
+      "VisibilityScoreTopCompetitor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "mention_count": {
+            "type": "number"
+          },
+          "avg_position": {
+            "type": "number",
+            "nullable": true
+          },
+          "share_of_voice": {
+            "type": "number"
+          },
+          "net_sentiment": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "url",
+          "mention_count",
+          "avg_position",
+          "share_of_voice",
+          "net_sentiment"
+        ]
+      },
+      "VisibilityScoreCitationOpportunity": {
+        "type": "object",
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "domain",
+          "count"
+        ]
+      },
+      "VisibilityScoreRunDetailResponse": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "$ref": "#/components/schemas/VisibilityScoreRun"
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisibilityScorePrompt"
+            }
+          },
+          "competitors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisibilityScoreCompetitor"
+            }
+          },
+          "top_competitors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisibilityScoreTopCompetitor"
+            }
+          },
+          "citation_opportunities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VisibilityScoreCitationOpportunity"
+            }
+          }
+        },
+        "required": [
+          "run",
+          "prompts",
+          "competitors",
+          "top_competitors",
+          "citation_opportunities"
         ]
       }
     },
@@ -30932,6 +31611,851 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/quote-requests": {
+      "get": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "List quote requests for the org",
+        "description": "Pure pass-through to journalists-quotes-service GET /orgs/quote-requests. Filter by campaign_id and/or source. Caller controls pagination via limit/offset.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "campaign_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "source",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of quote requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuoteRequestsListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/quote-requests/stats": {
+      "get": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "Aggregate stats for quote requests + pitches",
+        "description": "Pass-through to journalists-quotes-service GET /orgs/quote-requests/stats.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "campaign_id",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quote request stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuoteRequestsStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/quote-requests/{id}": {
+      "get": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "Get a single quote request",
+        "description": "Pass-through to journalists-quotes-service GET /orgs/quote-requests/{id}.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Quote request id"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quote request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuoteRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Quote request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/quote-pitches": {
+      "get": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "List quote pitches for the org",
+        "description": "Pure pass-through to journalists-quotes-service GET /orgs/quote-pitches. Filter by campaign_id and/or status. Caller controls pagination via limit/offset.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "campaign_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "drafted",
+                "submitted",
+                "selected",
+                "published",
+                "not_selected",
+                "error"
+              ]
+            },
+            "required": false,
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of quote pitches",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotePitchesListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/quote-pitches/{id}": {
+      "get": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "Get a single quote pitch",
+        "description": "Pass-through to journalists-quotes-service GET /orgs/quote-pitches/{id}.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Quote pitch id"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quote pitch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotePitchResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Quote pitch not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/visibility-score-runs": {
+      "get": {
+        "tags": [
+          "AI Visibility"
+        ],
+        "summary": "List visibility-score runs with deltas",
+        "description": "Pure pass-through to ai-visibility-score-service GET /orgs/visibility-score-runs. Each row includes a delta block vs. the immediately previous run for the same brand. Filter by brandId, domain, or date range (from/to).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "domain",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of visibility-score runs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VisibilityScoreRunsListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/visibility-score-runs/{id}": {
+      "get": {
+        "tags": [
+          "AI Visibility"
+        ],
+        "summary": "Get a single visibility-score run",
+        "description": "Pass-through to ai-visibility-score-service GET /orgs/visibility-score-runs/{id}. Returns run + prompts[] + competitors[] + top_competitors[] + citation_opportunities[].",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Visibility-score run id"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Visibility-score run bundle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VisibilityScoreRunDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -72,6 +72,8 @@ Authorization: Bearer distrib.usr_abc123...
     { name: "Internal", description: "Platform-level operations (API key auth, no identity headers)" },
     { name: "Platform", description: "Service discovery and platform configuration" },
     { name: "Google CRM", description: "Google CRM (Gmail + People bronze) ingestion" },
+    { name: "Expert Quotes", description: "Expert quote outreach (journalists-quotes-service proxy)" },
+    { name: "AI Visibility", description: "AI visibility-score audits (ai-visibility-score-service proxy)" },
   ],
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,8 @@ import journalistsRoutes from "./routes/journalists.js";
 import articlesRoutes from "./routes/articles.js";
 import featuresRoutes from "./routes/features.js";
 import googleRoutes from "./routes/google.js";
+import quotesRoutes from "./routes/quotes.js";
+import visibilityRoutes from "./routes/visibility.js";
 import publicStatsRoutes from "./routes/public-stats.js";
 import costsRoutes from "./routes/costs.js";
 import adminRoutes from "./routes/admin.js";
@@ -206,6 +208,8 @@ app.use("/v1", journalistsRoutes);
 app.use("/v1", articlesRoutes);
 app.use("/v1", featuresRoutes);
 app.use("/v1", googleRoutes);
+app.use("/v1", quotesRoutes);
+app.use("/v1", visibilityRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -108,6 +108,30 @@ export const externalServices = {
       return v;
     },
   },
+  journalistsQuotes: {
+    get url(): string {
+      const v = process.env.JOURNALISTS_QUOTES_SERVICE_URL;
+      if (!v) throw new Error("JOURNALISTS_QUOTES_SERVICE_URL env var is required");
+      return v;
+    },
+    get apiKey(): string {
+      const v = process.env.JOURNALISTS_QUOTES_SERVICE_API_KEY;
+      if (!v) throw new Error("JOURNALISTS_QUOTES_SERVICE_API_KEY env var is required");
+      return v;
+    },
+  },
+  aiVisibility: {
+    get url(): string {
+      const v = process.env.AI_VISIBILITY_SERVICE_URL;
+      if (!v) throw new Error("AI_VISIBILITY_SERVICE_URL env var is required");
+      return v;
+    },
+    get apiKey(): string {
+      const v = process.env.AI_VISIBILITY_SERVICE_API_KEY;
+      if (!v) throw new Error("AI_VISIBILITY_SERVICE_API_KEY env var is required");
+      return v;
+    },
+  },
 };
 
 interface ServiceCallOptions {

--- a/src/routes/quotes.ts
+++ b/src/routes/quotes.ts
@@ -1,0 +1,97 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+// GET /v1/orgs/quote-requests — list quote requests for the org
+router.get("/orgs/quote-requests", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["campaign_id", "source", "limit", "offset"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      `/orgs/quote-requests${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list quote requests" });
+  }
+});
+
+// GET /v1/orgs/quote-requests/stats — aggregate stats for quote requests + pitches
+// MUST be declared BEFORE /orgs/quote-requests/:id so Express does not match "stats" as :id.
+router.get("/orgs/quote-requests/stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query["campaign_id"]) params.set("campaign_id", req.query["campaign_id"] as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      `/orgs/quote-requests/stats${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch quote request stats" });
+  }
+});
+
+// GET /v1/orgs/quote-requests/:id — get a single quote request
+router.get("/orgs/quote-requests/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const id = req.params.id;
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      `/orgs/quote-requests/${encodeURIComponent(id)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch quote request" });
+  }
+});
+
+// GET /v1/orgs/quote-pitches — list quote pitches for the org
+router.get("/orgs/quote-pitches", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["campaign_id", "status", "limit", "offset"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      `/orgs/quote-pitches${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list quote pitches" });
+  }
+});
+
+// GET /v1/orgs/quote-pitches/:id — get a single quote pitch
+router.get("/orgs/quote-pitches/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const id = req.params.id;
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      `/orgs/quote-pitches/${encodeURIComponent(id)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch quote pitch" });
+  }
+});
+
+export default router;

--- a/src/routes/visibility.ts
+++ b/src/routes/visibility.ts
@@ -1,0 +1,43 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+// GET /v1/orgs/visibility-score-runs — list visibility-score runs with deltas
+router.get("/orgs/visibility-score-runs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "domain", "from", "to", "limit", "offset"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.aiVisibility,
+      `/orgs/visibility-score-runs${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list visibility-score runs" });
+  }
+});
+
+// GET /v1/orgs/visibility-score-runs/:id — single run with prompts[], competitors[], top_competitors[], citation_opportunities[]
+router.get("/orgs/visibility-score-runs/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const id = req.params.id;
+    const result = await callExternalService(
+      externalServices.aiVisibility,
+      `/orgs/visibility-score-runs/${encodeURIComponent(id)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch visibility-score run" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7029,3 +7029,354 @@ registry.registerPath({
     401: { description: "Unauthorized", content: errorContent },
   },
 });
+
+// ===================================================================
+// EXPERT QUOTES (journalists-quotes-service proxy)
+// ===================================================================
+
+const QuoteRequestSchema = z
+  .object({
+    id: z.string().uuid(),
+    featuredQuestionId: z.number().int(),
+    source: z.string(),
+    mediaOutlet: z.string().nullable(),
+    opportunityText: z.string(),
+    pitchUrl: z.string().nullable(),
+    deadline: z.string().nullable(),
+    fetchedAt: z.string(),
+    orgId: z.string().uuid(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("QuoteRequest");
+
+const QuoteRequestsListResponseSchema = z
+  .object({ quoteRequests: z.array(QuoteRequestSchema) })
+  .openapi("QuoteRequestsListResponse");
+
+const QuoteRequestResponseSchema = z
+  .object({ quoteRequest: QuoteRequestSchema })
+  .openapi("QuoteRequestResponse");
+
+const QuoteRequestsStatsResponseSchema = z
+  .object({
+    totalRequests: z.number().int(),
+    totalPitched: z.number().int(),
+    totalSelected: z.number().int(),
+    totalPublished: z.number().int(),
+    totalNotSelected: z.number().int(),
+  })
+  .openapi("QuoteRequestsStatsResponse");
+
+const QuotePitchStatusEnum = z.enum([
+  "drafted",
+  "submitted",
+  "selected",
+  "published",
+  "not_selected",
+  "error",
+]);
+
+const QuotePitchSchema = z
+  .object({
+    id: z.string().uuid(),
+    quoteRequestId: z.string().uuid(),
+    featuredQuestionId: z.number().int(),
+    featuredProfileId: z.number().int(),
+    campaignId: z.string().uuid(),
+    brandId: z.string().uuid(),
+    draft: z.string(),
+    submittedAt: z.string().nullable(),
+    status: QuotePitchStatusEnum,
+    featuredArticleUrl: z.string().nullable(),
+    error: z.string().nullable(),
+    parentRunId: z.string().uuid().nullable(),
+    runId: z.string().uuid().nullable(),
+    orgId: z.string().uuid(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("QuotePitch");
+
+const QuotePitchesListResponseSchema = z
+  .object({ quotePitches: z.array(QuotePitchSchema) })
+  .openapi("QuotePitchesListResponse");
+
+const QuotePitchResponseSchema = z
+  .object({ quotePitch: QuotePitchSchema })
+  .openapi("QuotePitchResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/quote-requests",
+  tags: ["Expert Quotes"],
+  summary: "List quote requests for the org",
+  description:
+    "Pure pass-through to journalists-quotes-service GET /orgs/quote-requests. " +
+    "Filter by campaign_id and/or source. Caller controls pagination via limit/offset.",
+  security: authed,
+  request: {
+    query: z.object({
+      campaign_id: z.string().uuid().optional(),
+      source: z.string().optional(),
+      limit: z.string().optional(),
+      offset: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "List of quote requests", content: { "application/json": { schema: QuoteRequestsListResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/quote-requests/stats",
+  tags: ["Expert Quotes"],
+  summary: "Aggregate stats for quote requests + pitches",
+  description: "Pass-through to journalists-quotes-service GET /orgs/quote-requests/stats.",
+  security: authed,
+  request: {
+    query: z.object({
+      campaign_id: z.string().uuid().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "Quote request stats", content: { "application/json": { schema: QuoteRequestsStatsResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/quote-requests/{id}",
+  tags: ["Expert Quotes"],
+  summary: "Get a single quote request",
+  description: "Pass-through to journalists-quotes-service GET /orgs/quote-requests/{id}.",
+  security: authed,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: "Quote request id" }),
+    }),
+  },
+  responses: {
+    200: { description: "Quote request", content: { "application/json": { schema: QuoteRequestResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Quote request not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/quote-pitches",
+  tags: ["Expert Quotes"],
+  summary: "List quote pitches for the org",
+  description:
+    "Pure pass-through to journalists-quotes-service GET /orgs/quote-pitches. " +
+    "Filter by campaign_id and/or status. Caller controls pagination via limit/offset.",
+  security: authed,
+  request: {
+    query: z.object({
+      campaign_id: z.string().uuid().optional(),
+      status: QuotePitchStatusEnum.optional(),
+      limit: z.string().optional(),
+      offset: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "List of quote pitches", content: { "application/json": { schema: QuotePitchesListResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/quote-pitches/{id}",
+  tags: ["Expert Quotes"],
+  summary: "Get a single quote pitch",
+  description: "Pass-through to journalists-quotes-service GET /orgs/quote-pitches/{id}.",
+  security: authed,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: "Quote pitch id" }),
+    }),
+  },
+  responses: {
+    200: { description: "Quote pitch", content: { "application/json": { schema: QuotePitchResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Quote pitch not found", content: errorContent },
+  },
+});
+
+// ===================================================================
+// AI VISIBILITY (ai-visibility-score-service proxy)
+// ===================================================================
+
+const VisibilityScoreWeightsSchema = z
+  .object({
+    brandMentionRate: z.number().min(0).max(1),
+    citationRate: z.number().min(0).max(1),
+    positionScore: z.number().min(0).max(1),
+    shareOfVoice: z.number().min(0).max(1),
+    sentiment: z.number().min(0).max(1),
+    brandAndUrlRate: z.number().min(0).max(1),
+  })
+  .openapi("VisibilityScoreWeights");
+
+const VisibilityScoreRunBaseSchema = z
+  .object({
+    id: z.string().uuid(),
+    orgId: z.string().uuid(),
+    brandId: z.string().uuid(),
+    parentRunId: z.string().uuid().nullable(),
+    runId: z.string().uuid().nullable(),
+    domain: z.string(),
+    brandName: z.string(),
+    llmProvider: z.string(),
+    llmModel: z.string(),
+    promptGenModel: z.string(),
+    extractionProvider: z.string(),
+    extractionModel: z.string(),
+    nPrompts: z.number(),
+    weights: VisibilityScoreWeightsSchema,
+    visibilityScore: z.string().nullable(),
+    brandMentionRate: z.string().nullable(),
+    shareOfVoice: z.string().nullable(),
+    netSentiment: z.string().nullable(),
+    citationRate: z.string().nullable(),
+    avgPosition: z.string().nullable(),
+    status: z.string(),
+    startedAt: z.string().nullable(),
+    completedAt: z.string().nullable(),
+    createdAt: z.string(),
+  })
+  .passthrough()
+  .openapi("VisibilityScoreRun");
+
+const VisibilityScoreRunWithDeltaSchema = VisibilityScoreRunBaseSchema.extend({
+  visibility_score_delta: z.string().nullable(),
+  share_of_voice_delta: z.string().nullable(),
+  net_sentiment_delta: z.string().nullable(),
+  position_delta: z.string().nullable(),
+})
+  .passthrough()
+  .openapi("VisibilityScoreRunWithDelta");
+
+const VisibilityScoreRunsListResponseSchema = z
+  .object({
+    runs: z.array(VisibilityScoreRunWithDeltaSchema),
+    limit: z.number(),
+    offset: z.number(),
+  })
+  .openapi("VisibilityScoreRunsListResponse");
+
+const VisibilityScorePromptSchema = z
+  .object({
+    id: z.string().uuid(),
+    promptIndex: z.number(),
+    promptText: z.string(),
+    responseText: z.string(),
+    responseLengthChars: z.number().nullable(),
+    brandFound: z.boolean().nullable(),
+    brandCount: z.number().nullable(),
+    brandPosition: z.number().nullable(),
+    urlFound: z.boolean().nullable(),
+    urlCount: z.number().nullable(),
+    brandAndUrlCoOccurrence: z.boolean().nullable(),
+    maxBrandsInResponse: z.number().nullable(),
+    sentiment: z.string().nullable(),
+    sentimentScore: z.string().nullable(),
+    citationUrls: z.array(z.string()).nullable(),
+    latencyMs: z.number().nullable(),
+    tokensInput: z.number().nullable(),
+    tokensOutput: z.number().nullable(),
+  })
+  .openapi("VisibilityScorePrompt");
+
+const VisibilityScoreCompetitorSchema = z
+  .object({
+    id: z.string().uuid(),
+    promptIdFk: z.string().uuid(),
+    competitorName: z.string(),
+    competitorUrl: z.string().nullable(),
+    position: z.number().nullable(),
+    sentiment: z.string().nullable(),
+    sentimentScore: z.string().nullable(),
+    citationUrl: z.string().nullable(),
+  })
+  .openapi("VisibilityScoreCompetitor");
+
+const VisibilityScoreTopCompetitorSchema = z
+  .object({
+    name: z.string(),
+    url: z.string().nullable(),
+    mention_count: z.number(),
+    avg_position: z.number().nullable(),
+    share_of_voice: z.number(),
+    net_sentiment: z.number(),
+  })
+  .openapi("VisibilityScoreTopCompetitor");
+
+const VisibilityScoreCitationOpportunitySchema = z
+  .object({
+    domain: z.string(),
+    count: z.number(),
+  })
+  .openapi("VisibilityScoreCitationOpportunity");
+
+const VisibilityScoreRunDetailResponseSchema = z
+  .object({
+    run: VisibilityScoreRunBaseSchema,
+    prompts: z.array(VisibilityScorePromptSchema),
+    competitors: z.array(VisibilityScoreCompetitorSchema),
+    top_competitors: z.array(VisibilityScoreTopCompetitorSchema),
+    citation_opportunities: z.array(VisibilityScoreCitationOpportunitySchema),
+  })
+  .openapi("VisibilityScoreRunDetailResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/visibility-score-runs",
+  tags: ["AI Visibility"],
+  summary: "List visibility-score runs with deltas",
+  description:
+    "Pure pass-through to ai-visibility-score-service GET /orgs/visibility-score-runs. " +
+    "Each row includes a delta block vs. the immediately previous run for the same brand. " +
+    "Filter by brandId, domain, or date range (from/to).",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().optional(),
+      domain: z.string().optional(),
+      from: z.string().optional(),
+      to: z.string().optional(),
+      limit: z.coerce.number().int().optional(),
+      offset: z.coerce.number().int().optional(),
+    }),
+  },
+  responses: {
+    200: { description: "List of visibility-score runs", content: { "application/json": { schema: VisibilityScoreRunsListResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/visibility-score-runs/{id}",
+  tags: ["AI Visibility"],
+  summary: "Get a single visibility-score run",
+  description:
+    "Pass-through to ai-visibility-score-service GET /orgs/visibility-score-runs/{id}. " +
+    "Returns run + prompts[] + competitors[] + top_competitors[] + citation_opportunities[].",
+  security: authed,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: "Visibility-score run id" }),
+    }),
+  },
+  responses: {
+    200: { description: "Visibility-score run bundle", content: { "application/json": { schema: VisibilityScoreRunDetailResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Run not found", content: errorContent },
+  },
+});

--- a/tests/unit/quotes-proxy.test.ts
+++ b/tests/unit/quotes-proxy.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/quotes.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+describe("Expert quotes proxy routes", () => {
+  it("should have GET /orgs/quote-requests with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/quote-requests"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should have GET /orgs/quote-requests/stats with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/quote-requests/stats"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should mount /orgs/quote-requests/stats BEFORE /orgs/quote-requests/:id (Express order matters)", () => {
+    const statsIdx = content.indexOf('"/orgs/quote-requests/stats"');
+    const idIdx = content.indexOf('"/orgs/quote-requests/:id"');
+    expect(statsIdx).toBeGreaterThan(-1);
+    expect(idIdx).toBeGreaterThan(-1);
+    expect(statsIdx).toBeLessThan(idIdx);
+  });
+
+  it("should have GET /orgs/quote-requests/:id with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/quote-requests/:id"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward :id param into downstream path on GET /orgs/quote-requests/:id", () => {
+    const idx = content.indexOf('"/orgs/quote-requests/:id"');
+    const section = content.slice(idx, idx + 700);
+    expect(section).toContain("req.params.id");
+    expect(section).toMatch(/\/orgs\/quote-requests\/\$\{[^}]*encodeURIComponent[^}]*\}/);
+  });
+
+  it("should have GET /orgs/quote-pitches with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/quote-pitches"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should have GET /orgs/quote-pitches/:id with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/quote-pitches/:id"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward :id param into downstream path on GET /orgs/quote-pitches/:id", () => {
+    const idx = content.indexOf('"/orgs/quote-pitches/:id"');
+    const section = content.slice(idx, idx + 700);
+    expect(section).toContain("req.params.id");
+    expect(section).toMatch(/\/orgs\/quote-pitches\/\$\{[^}]*encodeURIComponent[^}]*\}/);
+  });
+
+  it("should forward campaign_id/source/limit/offset on GET /orgs/quote-requests", () => {
+    const idx = content.indexOf('"/orgs/quote-requests"');
+    const section = content.slice(idx, idx + 800);
+    for (const param of ["campaign_id", "source", "limit", "offset"]) {
+      expect(section).toContain(`"${param}"`);
+    }
+  });
+
+  it("should forward campaign_id on GET /orgs/quote-requests/stats", () => {
+    const idx = content.indexOf('"/orgs/quote-requests/stats"');
+    const section = content.slice(idx, idx + 800);
+    expect(section).toContain('"campaign_id"');
+  });
+
+  it("should forward campaign_id/status/limit/offset on GET /orgs/quote-pitches", () => {
+    const idx = content.indexOf('"/orgs/quote-pitches"');
+    const section = content.slice(idx, idx + 800);
+    for (const param of ["campaign_id", "status", "limit", "offset"]) {
+      expect(section).toContain(`"${param}"`);
+    }
+  });
+
+  it("should call externalServices.journalistsQuotes for every endpoint (5x)", () => {
+    const matches = content.match(/externalServices\.journalistsQuotes/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(5);
+  });
+
+  it("should use buildInternalHeaders for every endpoint (5x)", () => {
+    const matches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(5);
+  });
+
+  it("should preserve downstream paths (no path renaming)", () => {
+    expect(content).toContain('"/orgs/quote-requests"');
+    expect(content).toContain('"/orgs/quote-requests/stats"');
+    expect(content).toContain('"/orgs/quote-requests/:id"');
+    expect(content).toContain('"/orgs/quote-pitches"');
+    expect(content).toContain('"/orgs/quote-pitches/:id"');
+  });
+});
+
+describe("journalistsQuotes service client", () => {
+  it("should have journalistsQuotes entry in externalServices", () => {
+    expect(serviceClientContent).toContain("journalistsQuotes: {");
+  });
+
+  it("should read JOURNALISTS_QUOTES_SERVICE_URL with no fallback", () => {
+    expect(serviceClientContent).toContain("JOURNALISTS_QUOTES_SERVICE_URL");
+    expect(serviceClientContent).toContain("JOURNALISTS_QUOTES_SERVICE_URL env var is required");
+  });
+
+  it("should read JOURNALISTS_QUOTES_SERVICE_API_KEY with no fallback", () => {
+    expect(serviceClientContent).toContain("JOURNALISTS_QUOTES_SERVICE_API_KEY");
+    expect(serviceClientContent).toContain("JOURNALISTS_QUOTES_SERVICE_API_KEY env var is required");
+  });
+
+  it("should throw when JOURNALISTS_QUOTES_SERVICE_URL is unset", async () => {
+    const original = process.env.JOURNALISTS_QUOTES_SERVICE_URL;
+    delete process.env.JOURNALISTS_QUOTES_SERVICE_URL;
+    try {
+      const { externalServices } = await import("../../src/lib/service-client.js");
+      expect(() => externalServices.journalistsQuotes.url).toThrow(/JOURNALISTS_QUOTES_SERVICE_URL/);
+    } finally {
+      if (original !== undefined) process.env.JOURNALISTS_QUOTES_SERVICE_URL = original;
+    }
+  });
+
+  it("should throw when JOURNALISTS_QUOTES_SERVICE_API_KEY is unset", async () => {
+    const original = process.env.JOURNALISTS_QUOTES_SERVICE_API_KEY;
+    delete process.env.JOURNALISTS_QUOTES_SERVICE_API_KEY;
+    try {
+      const { externalServices } = await import("../../src/lib/service-client.js");
+      expect(() => externalServices.journalistsQuotes.apiKey).toThrow(/JOURNALISTS_QUOTES_SERVICE_API_KEY/);
+    } finally {
+      if (original !== undefined) process.env.JOURNALISTS_QUOTES_SERVICE_API_KEY = original;
+    }
+  });
+});
+
+describe("Expert quotes OpenAPI schemas", () => {
+  it("should register GET /v1/orgs/quote-requests", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/quote-requests"');
+    expect(schemaContent).toContain("QuoteRequestsListResponse");
+  });
+
+  it("should register GET /v1/orgs/quote-requests/stats", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/quote-requests/stats"');
+    expect(schemaContent).toContain("QuoteRequestsStatsResponse");
+  });
+
+  it("should register GET /v1/orgs/quote-requests/{id}", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/quote-requests/{id}"');
+    expect(schemaContent).toContain("QuoteRequestResponse");
+  });
+
+  it("should register GET /v1/orgs/quote-pitches", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/quote-pitches"');
+    expect(schemaContent).toContain("QuotePitchesListResponse");
+  });
+
+  it("should register GET /v1/orgs/quote-pitches/{id}", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/quote-pitches/{id}"');
+    expect(schemaContent).toContain("QuotePitchResponse");
+  });
+
+  it("should use Expert Quotes tag", () => {
+    expect(schemaContent).toContain('tags: ["Expert Quotes"]');
+  });
+});
+
+describe("Expert quotes endpoints in openapi.json", () => {
+  const openapiPath = path.join(__dirname, "../../openapi.json");
+  const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+  it("should include /v1/orgs/quote-requests GET in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/quote-requests"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/quote-requests"].get).toBeDefined();
+  });
+
+  it("should include /v1/orgs/quote-requests/stats GET in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/quote-requests/stats"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/quote-requests/stats"].get).toBeDefined();
+  });
+
+  it("should include /v1/orgs/quote-requests/{id} GET in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/quote-requests/{id}"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/quote-requests/{id}"].get).toBeDefined();
+  });
+
+  it("should include /v1/orgs/quote-pitches GET in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/quote-pitches"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/quote-pitches"].get).toBeDefined();
+  });
+
+  it("should include /v1/orgs/quote-pitches/{id} GET in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/quote-pitches/{id}"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/quote-pitches/{id}"].get).toBeDefined();
+  });
+});
+
+describe("Quotes routes are mounted in index.ts", () => {
+  it("should import and mount quotes routes", () => {
+    expect(indexContent).toContain("quotesRoutes");
+    expect(indexContent).toContain("./routes/quotes");
+  });
+
+  it("should mount at /v1", () => {
+    expect(indexContent).toContain('app.use("/v1", quotesRoutes)');
+  });
+});

--- a/tests/unit/visibility-proxy.test.ts
+++ b/tests/unit/visibility-proxy.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const routePath = path.join(__dirname, "../../src/routes/visibility.ts");
+const content = fs.readFileSync(routePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+const serviceClientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const serviceClientContent = fs.readFileSync(serviceClientPath, "utf-8");
+
+describe("AI visibility proxy routes", () => {
+  it("should have GET /orgs/visibility-score-runs with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/visibility-score-runs"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should have GET /orgs/visibility-score-runs/:id with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/orgs/visibility-score-runs/:id"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward :id param into downstream path on GET /orgs/visibility-score-runs/:id", () => {
+    const idx = content.indexOf('"/orgs/visibility-score-runs/:id"');
+    const section = content.slice(idx, idx + 700);
+    expect(section).toContain("req.params.id");
+    expect(section).toMatch(/\/orgs\/visibility-score-runs\/\$\{[^}]*encodeURIComponent[^}]*\}/);
+  });
+
+  it("should forward brandId/domain/from/to/limit/offset on GET /orgs/visibility-score-runs", () => {
+    const idx = content.indexOf('"/orgs/visibility-score-runs"');
+    const section = content.slice(idx, idx + 800);
+    for (const param of ["brandId", "domain", "from", "to", "limit", "offset"]) {
+      expect(section).toContain(`"${param}"`);
+    }
+  });
+
+  it("should call externalServices.aiVisibility for every endpoint (2x)", () => {
+    const matches = content.match(/externalServices\.aiVisibility/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(2);
+  });
+
+  it("should use buildInternalHeaders for every endpoint (2x)", () => {
+    const matches = content.match(/buildInternalHeaders\(req\)/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(2);
+  });
+
+  it("should preserve downstream paths (no path renaming)", () => {
+    expect(content).toContain('"/orgs/visibility-score-runs"');
+    expect(content).toContain('"/orgs/visibility-score-runs/:id"');
+  });
+});
+
+describe("aiVisibility service client", () => {
+  it("should have aiVisibility entry in externalServices", () => {
+    expect(serviceClientContent).toContain("aiVisibility: {");
+  });
+
+  it("should read AI_VISIBILITY_SERVICE_URL with no fallback", () => {
+    expect(serviceClientContent).toContain("AI_VISIBILITY_SERVICE_URL");
+    expect(serviceClientContent).toContain("AI_VISIBILITY_SERVICE_URL env var is required");
+  });
+
+  it("should read AI_VISIBILITY_SERVICE_API_KEY with no fallback", () => {
+    expect(serviceClientContent).toContain("AI_VISIBILITY_SERVICE_API_KEY");
+    expect(serviceClientContent).toContain("AI_VISIBILITY_SERVICE_API_KEY env var is required");
+  });
+
+  it("should throw when AI_VISIBILITY_SERVICE_URL is unset", async () => {
+    const original = process.env.AI_VISIBILITY_SERVICE_URL;
+    delete process.env.AI_VISIBILITY_SERVICE_URL;
+    try {
+      const { externalServices } = await import("../../src/lib/service-client.js");
+      expect(() => externalServices.aiVisibility.url).toThrow(/AI_VISIBILITY_SERVICE_URL/);
+    } finally {
+      if (original !== undefined) process.env.AI_VISIBILITY_SERVICE_URL = original;
+    }
+  });
+
+  it("should throw when AI_VISIBILITY_SERVICE_API_KEY is unset", async () => {
+    const original = process.env.AI_VISIBILITY_SERVICE_API_KEY;
+    delete process.env.AI_VISIBILITY_SERVICE_API_KEY;
+    try {
+      const { externalServices } = await import("../../src/lib/service-client.js");
+      expect(() => externalServices.aiVisibility.apiKey).toThrow(/AI_VISIBILITY_SERVICE_API_KEY/);
+    } finally {
+      if (original !== undefined) process.env.AI_VISIBILITY_SERVICE_API_KEY = original;
+    }
+  });
+});
+
+describe("AI visibility OpenAPI schemas", () => {
+  it("should register GET /v1/orgs/visibility-score-runs", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/visibility-score-runs"');
+    expect(schemaContent).toContain("VisibilityScoreRunsListResponse");
+  });
+
+  it("should register GET /v1/orgs/visibility-score-runs/{id}", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/visibility-score-runs/{id}"');
+    expect(schemaContent).toContain("VisibilityScoreRunDetailResponse");
+  });
+
+  it("should use AI Visibility tag", () => {
+    expect(schemaContent).toContain('tags: ["AI Visibility"]');
+  });
+});
+
+describe("AI visibility endpoints in openapi.json", () => {
+  const openapiPath = path.join(__dirname, "../../openapi.json");
+  const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+  it("should include /v1/orgs/visibility-score-runs GET in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/visibility-score-runs"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/visibility-score-runs"].get).toBeDefined();
+  });
+
+  it("should include /v1/orgs/visibility-score-runs/{id} GET in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/visibility-score-runs/{id}"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/visibility-score-runs/{id}"].get).toBeDefined();
+  });
+});
+
+describe("Visibility routes are mounted in index.ts", () => {
+  it("should import and mount visibility routes", () => {
+    expect(indexContent).toContain("visibilityRoutes");
+    expect(indexContent).toContain("./routes/visibility");
+  });
+
+  it("should mount at /v1", () => {
+    expect(indexContent).toContain('app.use("/v1", visibilityRoutes)');
+  });
+});


### PR DESCRIPTION
## Summary

Adds 7 GET proxy endpoints required by the **dashboard generic feature page** (distribute.you #1027 already merged) to render entity sidebars for the new `pr-expert-quote-outreach` and `ai-visibility-scoring` feature seeds.

| Path | Upstream | Purpose |
|------|----------|---------|
| `GET /v1/orgs/quote-requests` | journalists-quotes-service | list quote requests |
| `GET /v1/orgs/quote-requests/stats` | journalists-quotes-service | aggregate stats (also consumed by features-service stats fan-out) |
| `GET /v1/orgs/quote-requests/:id` | journalists-quotes-service | single quote request |
| `GET /v1/orgs/quote-pitches` | journalists-quotes-service | list quote pitches |
| `GET /v1/orgs/quote-pitches/:id` | journalists-quotes-service | single quote pitch |
| `GET /v1/orgs/visibility-score-runs` | ai-visibility-score-service | list runs with deltas |
| `GET /v1/orgs/visibility-score-runs/:id` | ai-visibility-score-service | run + prompts[] + competitors[] + top_competitors[] + citation_opportunities[] |

All routes follow the existing `routes/google.ts` convention:
- `authenticate + requireOrg + requireUser` middleware chain
- Identity headers forwarded via `buildInternalHeaders(req)`
- Fail-loud getter on env vars (throws if `JOURNALISTS_QUOTES_SERVICE_URL` / `AI_VISIBILITY_SERVICE_URL` etc. are missing)
- No path renaming, no body transforms, no `.default()` / `.max()` on `limit`
- `quote-requests/stats` mounted **before** `quote-requests/:id` so Express does not match `stats` as `:id`

Schemas added in `src/schemas.ts` under new tags `Expert Quotes` + `AI Visibility`. `openapi.json` regenerated.

New env vars documented in `.env.example`:
- `JOURNALISTS_QUOTES_SERVICE_URL` / `JOURNALISTS_QUOTES_SERVICE_API_KEY`
- `AI_VISIBILITY_SERVICE_URL` / `AI_VISIBILITY_SERVICE_API_KEY`

## ⚠️ Deployment ordering

**DO NOT auto-merge.** This proxy depends on:
1. **features-service PR #166** (KevinLourd/quotes-visibility-stats-v2 → staging) — registers stats keys + entity types + adds stats fan-out in producer services. Must merge first.
2. **journalists-quotes-service** + **ai-visibility-score-service** must be live in staging Railway with the entity-list endpoints (already shipped per api-registry). Verify health before merging this.
3. **Railway env vars** in api-service staging must be set: `JOURNALISTS_QUOTES_SERVICE_URL`, `JOURNALISTS_QUOTES_SERVICE_API_KEY`, `AI_VISIBILITY_SERVICE_URL`, `AI_VISIBILITY_SERVICE_API_KEY`. Service boots will throw on first request to these routes if any are missing.

Merging this PR before (1)+(2)+(3) → dashboard sidebars 502 in staging. Orchestrator owns merge sequencing.

## Test plan

- [x] `pnpm test` — 1243 tests across 113 files, all green (added `tests/unit/quotes-proxy.test.ts` + `tests/unit/visibility-proxy.test.ts`)
- [x] `pnpm run build` — `tsc` clean, `openapi.json` regenerated
- [x] `openapi.json` paths verified for all 7 new endpoints
- [ ] After Railway env vars set + producer services live in staging: smoke `GET /v1/orgs/quote-requests` and `GET /v1/orgs/visibility-score-runs` from dashboard staging → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
