### PR TITLE
docs(env): document missing service env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
 
 # Internal services (Railway private networking)
 CLIENT_SERVICE_URL=http://client-service.railway.internal
+CLIENT_SERVICE_API_KEY=your-client-service-api-key
 
 # External services (public URLs, need API keys)
 CONTENT_GENERATION_SERVICE_URL=https://content-generation.distribute.you
@@ -24,6 +25,7 @@ BILLING_SERVICE_URL=https://billing.distribute.you
 BILLING_SERVICE_API_KEY=your-billing-service-api-key
 BRAND_SERVICE_API_KEY=your-brand-service-api-key
 LEAD_SERVICE_API_KEY=your-lead-service-api-key
+CAMPAIGN_SERVICE_URL=https://campaign.distribute.you
 CAMPAIGN_SERVICE_API_KEY=your-campaign-service-api-key
 KEY_SERVICE_API_KEY=your-key-service-api-key
 REPLY_QUALIFICATION_SERVICE_API_KEY=your-reply-qualification-api-key
@@ -56,3 +58,86 @@ JOURNALISTS_QUOTES_SERVICE_API_KEY=your-journalists-quotes-service-api-key
 # AI Visibility Score service (LLM brand-visibility audits)
 AI_VISIBILITY_SCORE_SERVICE_URL=https://ai-visibility-score.distribute.you
 AI_VISIBILITY_SCORE_SERVICE_API_KEY=your-ai-visibility-score-service-api-key
+
+# Articles service (press article generation + tracking)
+ARTICLES_SERVICE_URL=https://articles.distribute.you
+ARTICLES_SERVICE_API_KEY=your-articles-service-api-key
+
+# Runs service (workflow run tracking)
+RUNS_SERVICE_URL=https://runs.distribute.you
+RUNS_SERVICE_API_KEY=your-runs-service-api-key
+
+# Workflow service (workflow definitions + execution)
+WORKFLOW_SERVICE_URL=https://workflow.distribute.you
+WORKFLOW_SERVICE_API_KEY=your-workflow-service-api-key
+
+# Costs service (per-run cost accounting)
+COSTS_SERVICE_URL=https://costs.distribute.you
+COSTS_SERVICE_API_KEY=your-costs-service-api-key
+
+# Features service (feature flag / entitlement registry)
+FEATURES_SERVICE_URL=https://features.distribute.you
+FEATURES_SERVICE_API_KEY=your-features-service-api-key
+
+# Outlets service (media outlets directory)
+OUTLETS_SERVICE_URL=https://outlets.distribute.you
+OUTLETS_SERVICE_API_KEY=your-outlets-service-api-key
+
+# Press Kits service (brand press-kit hosting)
+PRESS_KITS_SERVICE_URL=https://press-kits.mcpfactory.org
+PRESS_KITS_SERVICE_API_KEY=your-press-kits-service-api-key
+
+# Journalists service (journalist directory + outreach)
+JOURNALISTS_SERVICE_URL=https://journalists.distribute.you
+JOURNALISTS_SERVICE_API_KEY=your-journalists-service-api-key
+
+# Instantly service (Instantly.ai cold-email integration)
+INSTANTLY_SERVICE_URL=https://instantly.distribute.you
+INSTANTLY_SERVICE_API_KEY=your-instantly-service-api-key
+
+# Stripe service (Stripe billing wrapper)
+STRIPE_SERVICE_URL=https://stripe.distribute.you
+STRIPE_SERVICE_API_KEY=your-stripe-service-api-key
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Admin DB query passthroughs (used by /internal/admin/query in src/routes/admin.ts)
+# Each entry is a Postgres connection string for the corresponding service's DB.
+# Only configure the ones you need to query — missing entries return 404.
+# ──────────────────────────────────────────────────────────────────────────────
+AHREF_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/ahref
+API_REGISTRY_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/api_registry
+API_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/api_service
+APOLLO_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/apollo
+ARTICLES_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/articles
+ARTICLES_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/articles_v1
+BILLING_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/billing
+BRAND_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/brand
+CAMPAIGN_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/campaign
+CHAT_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/chat
+CLIENT_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/client
+CLOUDFLARE_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/cloudflare
+CONTENT_GENERATION_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/content_generation
+COSTS_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/costs
+EMAIL_GATEWAY_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/email_gateway
+EMAIL_GATEWAY_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/email_gateway_v1
+FEATURES_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/features
+GOOGLE_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/google
+GOOGLE_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/google_v1
+HUMAN_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/human
+INSTANTLY_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/instantly
+INSTANTLY_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/instantly_v1
+JOURNALISTS_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/journalists
+JOURNALISTS_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/journalists_v1
+KEY_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/key
+LEAD_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/lead
+OUTLETS_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/outlets
+OUTLETS_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/outlets_v1
+POSTMARK_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/postmark
+PRESS_KITS_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/press_kits
+PRESS_KITS_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/press_kits_v1
+RUNS_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/runs
+SCRAPING_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/scraping
+STRIPE_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/stripe
+TRANSACTIONAL_EMAIL_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/transactional_email
+WORKFLOW_SERVICE_DATABASE_URL=postgres://user:pass@host:5432/workflow
+WORKFLOW_SERVICE_V1_DATABASE_URL=postgres://user:pass@host:5432/workflow_v1


### PR DESCRIPTION
## Summary

Brings `.env.example` in sync with all `process.env.*` reads in `src/lib/service-client.ts` and `src/routes/admin.ts`.

### What changed

- Added 11 `*_SERVICE_URL` + `*_SERVICE_API_KEY` pairs that the service client reads but were absent from `.env.example`: articles, runs, workflow, costs, features, outlets, press-kits, journalists, instantly, stripe; plus the missing `CAMPAIGN_SERVICE_URL` and `CLIENT_SERVICE_API_KEY`.
- Added all `*_SERVICE_DATABASE_URL` entries referenced by the `SERVICE_DB_REGISTRY` map in `src/routes/admin.ts` (consumed by `/internal/admin/query`). Each line is grouped under a clear comment block.

### What did NOT change

- No source code changes.
- No defaults / runtime behavior changes.

## Verification

- `grep -oE 'process\.env\.[A-Z_]+' src/lib/service-client.ts src/routes/admin.ts | sort -u` — every match exists in `.env.example`.
- `pnpm build` succeeds.
- `pnpm test` — 1242/1242 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)