### PR TITLE
feat(visibility): forward campaignId on visibility-score-runs (GET + POST)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9922,6 +9922,30 @@
           "offset"
         ]
       },
+      "VisibilityScoreRunCreateResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "required": [
+          "results"
+        ]
+      },
+      "VisibilityScoreRunCreateRequest": {
+        "type": "object",
+        "properties": {
+          "campaignId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "VisibilityScorePrompt": {
         "type": "object",
         "properties": {
@@ -32170,7 +32194,7 @@
           "AI Visibility"
         ],
         "summary": "List visibility-score runs with deltas",
-        "description": "Pure pass-through to ai-visibility-score-service GET /orgs/visibility-score-runs. Each row includes a delta block vs. the immediately previous run for the same brand. Filter by brandId, domain, or date range (from/to).",
+        "description": "Pure pass-through to ai-visibility-score-service GET /orgs/visibility-score-runs. Each row includes a delta block vs. the immediately previous run for the same brand. Filter by brandId, domain, campaignId, or date range (from/to).",
         "security": [
           {
             "bearerAuth": []
@@ -32192,6 +32216,15 @@
             },
             "required": false,
             "name": "domain",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "campaignId",
             "in": "query"
           },
           {
@@ -32306,6 +32339,106 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "AI Visibility"
+        ],
+        "summary": "Run a visibility-score audit for a single brand",
+        "description": "Pass-through to ai-visibility-score-service POST /orgs/visibility-score-runs. Runs an N-prompt LLM audit against the brand identified by `x-brand-id`. Optional `campaignId` in the body associates the run with a campaign.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VisibilityScoreRunCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Run results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VisibilityScoreRunCreateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/orgs/visibility-score-runs/{id}": {

--- a/src/routes/visibility.ts
+++ b/src/routes/visibility.ts
@@ -9,7 +9,7 @@ const router = Router();
 router.get("/orgs/visibility-score-runs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "domain", "from", "to", "limit", "offset"]) {
+    for (const key of ["brandId", "domain", "from", "to", "limit", "offset", "campaignId"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";
@@ -22,6 +22,20 @@ router.get("/orgs/visibility-score-runs", authenticate, requireOrg, requireUser,
     res.json(result);
   } catch (error: any) {
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to list visibility-score runs" });
+  }
+});
+
+// POST /v1/orgs/visibility-score-runs — start a visibility-score audit
+router.post("/orgs/visibility-score-runs", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.aiVisibility,
+      `/orgs/visibility-score-runs`,
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to start visibility-score run" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7315,6 +7315,18 @@ const VisibilityScoreRunDetailResponseSchema = z
   })
   .openapi("VisibilityScoreRunDetailResponse");
 
+const VisibilityScoreRunCreateRequestSchema = z
+  .object({
+    campaignId: z.string().uuid().optional(),
+  })
+  .openapi("VisibilityScoreRunCreateRequest");
+
+const VisibilityScoreRunCreateResponseSchema = z
+  .object({
+    results: z.array(z.object({}).passthrough()),
+  })
+  .openapi("VisibilityScoreRunCreateResponse");
+
 registry.registerPath({
   method: "get",
   path: "/v1/orgs/visibility-score-runs",
@@ -7323,12 +7335,13 @@ registry.registerPath({
   description:
     "Pure pass-through to ai-visibility-score-service GET /orgs/visibility-score-runs. " +
     "Each row includes a delta block vs. the immediately previous run for the same brand. " +
-    "Filter by brandId, domain, or date range (from/to).",
+    "Filter by brandId, domain, campaignId, or date range (from/to).",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().uuid().optional(),
       domain: z.string().optional(),
+      campaignId: z.string().uuid().optional(),
       from: z.string().optional(),
       to: z.string().optional(),
       limit: z.coerce.number().int().optional(),
@@ -7337,6 +7350,27 @@ registry.registerPath({
   },
   responses: {
     200: { description: "List of visibility-score runs", content: { "application/json": { schema: VisibilityScoreRunsListResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/orgs/visibility-score-runs",
+  tags: ["AI Visibility"],
+  summary: "Run a visibility-score audit for a single brand",
+  description:
+    "Pass-through to ai-visibility-score-service POST /orgs/visibility-score-runs. " +
+    "Runs an N-prompt LLM audit against the brand identified by `x-brand-id`. " +
+    "Optional `campaignId` in the body associates the run with a campaign.",
+  security: authed,
+  request: {
+    body: {
+      content: { "application/json": { schema: VisibilityScoreRunCreateRequestSchema } },
+    },
+  },
+  responses: {
+    200: { description: "Run results", content: { "application/json": { schema: VisibilityScoreRunCreateResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
   },
 });

--- a/tests/unit/visibility-proxy.test.ts
+++ b/tests/unit/visibility-proxy.test.ts
@@ -42,24 +42,42 @@ describe("AI visibility proxy routes", () => {
     expect(section).toMatch(/\/orgs\/visibility-score-runs\/\$\{[^}]*encodeURIComponent[^}]*\}/);
   });
 
-  it("should forward brandId/domain/from/to/limit/offset on GET /orgs/visibility-score-runs", () => {
+  it("should forward brandId/domain/from/to/limit/offset/campaignId on GET /orgs/visibility-score-runs", () => {
     const idx = content.indexOf('"/orgs/visibility-score-runs"');
     const section = content.slice(idx, idx + 800);
-    for (const param of ["brandId", "domain", "from", "to", "limit", "offset"]) {
+    for (const param of ["brandId", "domain", "from", "to", "limit", "offset", "campaignId"]) {
       expect(section).toContain(`"${param}"`);
     }
   });
 
-  it("should call externalServices.aiVisibility for every endpoint (2x)", () => {
-    const matches = content.match(/externalServices\.aiVisibility/g);
-    expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(2);
+  it("should have POST /orgs/visibility-score-runs with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/orgs/visibility-score-runs"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
   });
 
-  it("should use buildInternalHeaders for every endpoint (2x)", () => {
+  it("should forward req.body on POST /orgs/visibility-score-runs", () => {
+    const idx = content.indexOf('router.post("/orgs/visibility-score-runs"');
+    expect(idx).toBeGreaterThan(-1);
+    const section = content.slice(idx, idx + 900);
+    expect(section).toContain('method: "POST"');
+    expect(section).toContain("body: req.body");
+  });
+
+  it("should call externalServices.aiVisibility for every endpoint (3x)", () => {
+    const matches = content.match(/externalServices\.aiVisibility/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(3);
+  });
+
+  it("should use buildInternalHeaders for every endpoint (3x)", () => {
     const matches = content.match(/buildInternalHeaders\(req\)/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(2);
+    expect(matches!.length).toBe(3);
   });
 
   it("should preserve downstream paths (no path renaming)", () => {
@@ -117,6 +135,27 @@ describe("AI visibility OpenAPI schemas", () => {
     expect(schemaContent).toContain("VisibilityScoreRunDetailResponse");
   });
 
+  it("should expose campaignId on GET /v1/orgs/visibility-score-runs query", () => {
+    const idx = schemaContent.indexOf('path: "/v1/orgs/visibility-score-runs"');
+    const section = schemaContent.slice(idx, idx + 1200);
+    expect(section).toMatch(/campaignId:\s*z\.string\(\)\.uuid\(\)\.optional\(\)/);
+  });
+
+  it("should register POST /v1/orgs/visibility-score-runs", () => {
+    const idx = schemaContent.indexOf('path: "/v1/orgs/visibility-score-runs"');
+    const next = schemaContent.indexOf('path: "/v1/orgs/visibility-score-runs"', idx + 1);
+    // Two registrations of that exact path expected: one GET, one POST.
+    expect(idx).toBeGreaterThan(-1);
+    expect(next).toBeGreaterThan(-1);
+  });
+
+  it("should accept optional campaignId in POST body schema", () => {
+    expect(schemaContent).toMatch(/VisibilityScoreRunCreateRequest/);
+    const reqIdx = schemaContent.indexOf("VisibilityScoreRunCreateRequest");
+    const section = schemaContent.slice(Math.max(0, reqIdx - 400), reqIdx + 400);
+    expect(section).toMatch(/campaignId:\s*z\.string\(\)\.uuid\(\)\.optional\(\)/);
+  });
+
   it("should use AI Visibility tag", () => {
     expect(schemaContent).toContain('tags: ["AI Visibility"]');
   });
@@ -134,6 +173,17 @@ describe("AI visibility endpoints in openapi.json", () => {
   it("should include /v1/orgs/visibility-score-runs/{id} GET in committed openapi.json", () => {
     expect(openapi.paths["/v1/orgs/visibility-score-runs/{id}"]).toBeDefined();
     expect(openapi.paths["/v1/orgs/visibility-score-runs/{id}"].get).toBeDefined();
+  });
+
+  it("should include /v1/orgs/visibility-score-runs POST in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/visibility-score-runs"].post).toBeDefined();
+  });
+
+  it("should list campaignId as a query parameter on GET /v1/orgs/visibility-score-runs", () => {
+    const get = openapi.paths["/v1/orgs/visibility-score-runs"].get;
+    const params = (get.parameters ?? []) as Array<{ name: string; in: string }>;
+    const found = params.find((p) => p.name === "campaignId" && p.in === "query");
+    expect(found).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `campaignId` to GET `/v1/orgs/visibility-score-runs` query whitelist; forward to ai-visibility-score-service.
- Add POST `/v1/orgs/visibility-score-runs` proxy route (was missing); forward optional `campaignId` in body.
- Update OpenAPI schemas + regenerate `openapi.json`.

Unblocks the dashboard campaign-detail page for the ai-visibility-scoring feature — it currently sees every visibility run for the brand instead of only runs tied to the current campaign.

⚠️ Deployment ordering
Sister PR in `ai-visibility-score-service` introduces the `campaign_id` column and accepts/filters on `campaignId`. Both backends must deploy to staging before the dashboard PR lands. This PR is a pure passthrough — safe to merge first; campaignId is silently ignored downstream until the sister PR ships.

## Test plan
- [x] All 1246 unit tests pass
- [x] `pnpm build` succeeds (tsc + openapi gen)
- [x] `openapi.json`: POST `/v1/orgs/visibility-score-runs` present; GET lists `campaignId` query param
- [ ] Post-deploy: `curl /v1/orgs/visibility-score-runs?brandId=X` returns unchanged response
- [ ] Post-deploy (after sister PR): `curl /v1/orgs/visibility-score-runs?brandId=X&campaignId=Y` returns filtered subset
- [ ] Post-deploy: POST with `campaignId` in body reaches downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)