### PR TITLE
hotfix: Expose 6 LLM-payload debug fields on visibility-score response (judge/extractor/prompt-gen system+user)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9824,6 +9824,16 @@
             "type": "string",
             "nullable": true
           },
+          "promptGenSystemPrompt": {
+            "type": "string",
+            "nullable": true,
+            "description": "Exact system prompt string sent to the prompt-generator LLM (one call per run, drives the prompts the judges then answer)."
+          },
+          "promptGenUserMessage": {
+            "type": "string",
+            "nullable": true,
+            "description": "Exact user message string sent to the prompt-generator LLM. Includes the brand context fields (industry, audience, offerings, geography) — these influence which prompts get generated."
+          },
           "status": {
             "type": "string"
           },
@@ -9959,6 +9969,26 @@
           "promptText": {
             "type": "string"
           },
+          "judgeSystemPrompt": {
+            "type": "string",
+            "nullable": true,
+            "description": "Exact system prompt string sent to the judge LLM. Persisted for full debug transparency."
+          },
+          "judgeUserMessage": {
+            "type": "string",
+            "nullable": true,
+            "description": "Exact user message string sent to the judge LLM. Equals `promptText` (server does NOT inject brand context into the judge call)."
+          },
+          "extractorSystemPrompt": {
+            "type": "string",
+            "nullable": true,
+            "description": "Exact system prompt string sent to the extractor LLM (the extractor analyzes the judge's output)."
+          },
+          "extractorUserMessage": {
+            "type": "string",
+            "nullable": true,
+            "description": "Exact user message string sent to the extractor LLM. Includes `Target brand: <name + domain>` + the judge response."
+          },
           "responseText": {
             "type": "string"
           },
@@ -10026,6 +10056,10 @@
           "id",
           "promptIndex",
           "promptText",
+          "judgeSystemPrompt",
+          "judgeUserMessage",
+          "extractorSystemPrompt",
+          "extractorUserMessage",
           "responseText",
           "responseLengthChars",
           "brandFound",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7226,6 +7226,14 @@ const VisibilityScoreRunBaseSchema = z
     netSentiment: z.string().nullable(),
     citationRate: z.string().nullable(),
     avgPosition: z.string().nullable(),
+    promptGenSystemPrompt: z.string().nullable().optional().openapi({
+      description:
+        "Exact system prompt string sent to the prompt-generator LLM (one call per run, drives the prompts the judges then answer).",
+    }),
+    promptGenUserMessage: z.string().nullable().optional().openapi({
+      description:
+        "Exact user message string sent to the prompt-generator LLM. Includes the brand context fields (industry, audience, offerings, geography) — these influence which prompts get generated.",
+    }),
     status: z.string(),
     startedAt: z.string().nullable(),
     completedAt: z.string().nullable(),
@@ -7256,6 +7264,20 @@ const VisibilityScorePromptSchema = z
     id: z.string().uuid(),
     promptIndex: z.number(),
     promptText: z.string(),
+    judgeSystemPrompt: z.string().nullable().openapi({
+      description: "Exact system prompt string sent to the judge LLM. Persisted for full debug transparency.",
+    }),
+    judgeUserMessage: z.string().nullable().openapi({
+      description:
+        "Exact user message string sent to the judge LLM. Equals `promptText` (server does NOT inject brand context into the judge call).",
+    }),
+    extractorSystemPrompt: z.string().nullable().openapi({
+      description: "Exact system prompt string sent to the extractor LLM (the extractor analyzes the judge's output).",
+    }),
+    extractorUserMessage: z.string().nullable().openapi({
+      description:
+        "Exact user message string sent to the extractor LLM. Includes `Target brand: <name + domain>` + the judge response.",
+    }),
     responseText: z.string(),
     responseLengthChars: z.number().nullable(),
     brandFound: z.boolean().nullable(),

--- a/tests/unit/visibility-proxy.test.ts
+++ b/tests/unit/visibility-proxy.test.ts
@@ -185,6 +185,34 @@ describe("AI visibility endpoints in openapi.json", () => {
     const found = params.find((p) => p.name === "campaignId" && p.in === "query");
     expect(found).toBeDefined();
   });
+
+  it("should expose 4 new debug fields on VisibilityScorePrompt schema", () => {
+    const props = openapi.components.schemas.VisibilityScorePrompt.properties;
+    expect(props.judgeSystemPrompt).toBeDefined();
+    expect(props.judgeUserMessage).toBeDefined();
+    expect(props.extractorSystemPrompt).toBeDefined();
+    expect(props.extractorUserMessage).toBeDefined();
+  });
+
+  it("should expose 2 new debug fields on VisibilityScoreRun schema", () => {
+    const props = openapi.components.schemas.VisibilityScoreRun.properties;
+    expect(props.promptGenSystemPrompt).toBeDefined();
+    expect(props.promptGenUserMessage).toBeDefined();
+  });
+});
+
+describe("AI visibility debug fields in schemas.ts", () => {
+  it("should declare 4 new prompt-level debug fields", () => {
+    expect(schemaContent).toMatch(/judgeSystemPrompt:\s*z\.string\(\)\.nullable\(\)/);
+    expect(schemaContent).toMatch(/judgeUserMessage:\s*z\.string\(\)\.nullable\(\)/);
+    expect(schemaContent).toMatch(/extractorSystemPrompt:\s*z\.string\(\)\.nullable\(\)/);
+    expect(schemaContent).toMatch(/extractorUserMessage:\s*z\.string\(\)\.nullable\(\)/);
+  });
+
+  it("should declare 2 new run-level prompt-gen debug fields", () => {
+    expect(schemaContent).toMatch(/promptGenSystemPrompt:\s*z\.string\(\)\.nullable\(\)\.optional\(\)/);
+    expect(schemaContent).toMatch(/promptGenUserMessage:\s*z\.string\(\)\.nullable\(\)\.optional\(\)/);
+  });
 });
 
 describe("Visibility routes are mounted in index.ts", () => {


### PR DESCRIPTION
Automated by release.sh