### PR TITLE
feat(billing): collapse billing response schemas to passthrough (post-billing-service #107)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7132,55 +7132,7 @@
       },
       "BillingAccountResponse": {
         "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Account ID"
-          },
-          "orgId": {
-            "type": "string",
-            "description": "Organization ID"
-          },
-          "creditBalanceCents": {
-            "type": "string",
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Current credit balance in cents (decimal string, full precision)"
-          },
-          "hasAutoReload": {
-            "type": "boolean",
-            "description": "Whether auto-reload is enabled (true when payment method + reload config are both set)"
-          },
-          "hasPaymentMethod": {
-            "type": "boolean",
-            "description": "Whether a payment method is on file"
-          },
-          "reloadAmountCents": {
-            "type": "string",
-            "nullable": true,
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Auto-reload amount in cents (decimal string, null if not configured)"
-          },
-          "reloadThresholdCents": {
-            "type": "string",
-            "nullable": true,
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Balance threshold in cents that triggers auto-reload (decimal string, null if not configured)"
-          },
-          "createdAt": {
-            "type": "string",
-            "description": "ISO timestamp"
-          }
-        },
-        "required": [
-          "id",
-          "orgId",
-          "creditBalanceCents",
-          "hasAutoReload",
-          "hasPaymentMethod",
-          "reloadAmountCents",
-          "reloadThresholdCents",
-          "createdAt"
-        ]
+        "properties": {}
       },
       "BalanceResponse": {
         "type": "object",
@@ -7202,99 +7154,11 @@
       },
       "TransactionListResponse": {
         "type": "object",
-        "properties": {
-          "transactions": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Transaction ID"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Transaction type (e.g. 'credit', 'debit')"
-                },
-                "amountCents": {
-                  "type": "string",
-                  "pattern": "^\\d+(\\.\\d+)?$",
-                  "description": "Amount in cents (decimal string, full precision)"
-                },
-                "description": {
-                  "type": "string",
-                  "description": "Transaction description"
-                },
-                "createdAt": {
-                  "type": "string",
-                  "description": "ISO timestamp"
-                }
-              },
-              "required": [
-                "id",
-                "type",
-                "amountCents",
-                "description",
-                "createdAt"
-              ]
-            }
-          }
-        },
-        "required": [
-          "transactions"
-        ]
+        "properties": {}
       },
       "ConfigureAutoReloadResponse": {
         "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Account ID"
-          },
-          "orgId": {
-            "type": "string",
-            "description": "Organization ID"
-          },
-          "creditBalanceCents": {
-            "type": "string",
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Current credit balance in cents (decimal string, full precision)"
-          },
-          "hasAutoReload": {
-            "type": "boolean",
-            "description": "Whether auto-reload is enabled"
-          },
-          "hasPaymentMethod": {
-            "type": "boolean",
-            "description": "Whether a payment method is on file"
-          },
-          "reloadAmountCents": {
-            "type": "string",
-            "nullable": true,
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Auto-reload amount in cents (decimal string)"
-          },
-          "reloadThresholdCents": {
-            "type": "string",
-            "nullable": true,
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Balance threshold in cents that triggers auto-reload (decimal string)"
-          },
-          "createdAt": {
-            "type": "string",
-            "description": "ISO timestamp"
-          }
-        },
-        "required": [
-          "id",
-          "orgId",
-          "creditBalanceCents",
-          "hasAutoReload",
-          "hasPaymentMethod",
-          "reloadAmountCents",
-          "reloadThresholdCents",
-          "createdAt"
-        ]
+        "properties": {}
       },
       "ConfigureAutoReloadRequest": {
         "type": "object",
@@ -7330,55 +7194,7 @@
       },
       "DisableAutoReloadResponse": {
         "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Account ID"
-          },
-          "orgId": {
-            "type": "string",
-            "description": "Organization ID"
-          },
-          "creditBalanceCents": {
-            "type": "string",
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Current credit balance in cents (decimal string, full precision)"
-          },
-          "hasAutoReload": {
-            "type": "boolean",
-            "description": "Whether auto-reload is enabled"
-          },
-          "hasPaymentMethod": {
-            "type": "boolean",
-            "description": "Whether a payment method is on file"
-          },
-          "reloadAmountCents": {
-            "type": "string",
-            "nullable": true,
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Auto-reload amount in cents (decimal string)"
-          },
-          "reloadThresholdCents": {
-            "type": "string",
-            "nullable": true,
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Balance threshold in cents that triggers auto-reload (decimal string)"
-          },
-          "createdAt": {
-            "type": "string",
-            "description": "ISO timestamp"
-          }
-        },
-        "required": [
-          "id",
-          "orgId",
-          "creditBalanceCents",
-          "hasAutoReload",
-          "hasPaymentMethod",
-          "reloadAmountCents",
-          "reloadThresholdCents",
-          "createdAt"
-        ]
+        "properties": {}
       },
       "DeductCreditsResponse": {
         "type": "object",
@@ -8853,106 +8669,7 @@
       },
       "PublicBillingStatsResponse": {
         "type": "object",
-        "properties": {
-          "totalAccounts": {
-            "type": "integer"
-          },
-          "accountsWithPaymentMethod": {
-            "type": "integer"
-          },
-          "totalCreditBalanceCents": {
-            "type": "string",
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Total credit balance across all accounts (decimal string, full precision)"
-          },
-          "totalCreditedCents": {
-            "type": "string",
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Total credits added across all accounts (decimal string, full precision)"
-          },
-          "totalConsumedCents": {
-            "type": "string",
-            "pattern": "^\\d+(\\.\\d+)?$",
-            "description": "Total credits consumed across all accounts (decimal string, full precision)"
-          },
-          "monthlyGrowth": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "period": {
-                  "type": "string",
-                  "description": "Period label (e.g. '2026-03' or '2026-W14')"
-                },
-                "credited_cents": {
-                  "type": "string",
-                  "pattern": "^\\d+(\\.\\d+)?$",
-                  "description": "Total credits added in this period (decimal string, full precision)"
-                },
-                "consumed_cents": {
-                  "type": "string",
-                  "pattern": "^\\d+(\\.\\d+)?$",
-                  "description": "Total credits consumed in this period (decimal string, full precision)"
-                },
-                "revenue_cents": {
-                  "type": "string",
-                  "pattern": "^\\d+(\\.\\d+)?$",
-                  "description": "Actual Stripe payments (source=reload only, excludes welcome/promo credits) (decimal string, full precision)"
-                }
-              },
-              "required": [
-                "period",
-                "credited_cents",
-                "consumed_cents",
-                "revenue_cents"
-              ]
-            },
-            "description": "Monthly growth breakdown"
-          },
-          "weeklyGrowth": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "period": {
-                  "type": "string",
-                  "description": "Period label (e.g. '2026-03' or '2026-W14')"
-                },
-                "credited_cents": {
-                  "type": "string",
-                  "pattern": "^\\d+(\\.\\d+)?$",
-                  "description": "Total credits added in this period (decimal string, full precision)"
-                },
-                "consumed_cents": {
-                  "type": "string",
-                  "pattern": "^\\d+(\\.\\d+)?$",
-                  "description": "Total credits consumed in this period (decimal string, full precision)"
-                },
-                "revenue_cents": {
-                  "type": "string",
-                  "pattern": "^\\d+(\\.\\d+)?$",
-                  "description": "Actual Stripe payments (source=reload only, excludes welcome/promo credits) (decimal string, full precision)"
-                }
-              },
-              "required": [
-                "period",
-                "credited_cents",
-                "consumed_cents",
-                "revenue_cents"
-              ]
-            },
-            "description": "Weekly growth breakdown"
-          }
-        },
-        "required": [
-          "totalAccounts",
-          "accountsWithPaymentMethod",
-          "totalCreditBalanceCents",
-          "totalCreditedCents",
-          "totalConsumedCents",
-          "monthlyGrowth",
-          "weeklyGrowth"
-        ]
+        "properties": {}
       },
       "PublicRunStatsResponse": {
         "type": "object",
@@ -24047,7 +23764,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Billing account data",
+            "description": "Billing account data — pass-through from billing-service",
             "content": {
               "application/json": {
                 "schema": {
@@ -24253,7 +23970,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Transaction list",
+            "description": "Transaction list — pass-through from billing-service",
             "content": {
               "application/json": {
                 "schema": {
@@ -24365,7 +24082,7 @@
         },
         "responses": {
           "200": {
-            "description": "Auto-reload configured",
+            "description": "Auto-reload configured — pass-through from billing-service",
             "content": {
               "application/json": {
                 "schema": {
@@ -24476,7 +24193,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Auto-reload disabled",
+            "description": "Auto-reload disabled — pass-through from billing-service",
             "content": {
               "application/json": {
                 "schema": {
@@ -30282,10 +29999,10 @@
           "Public Stats"
         ],
         "summary": "Public billing stats (no auth)",
-        "description": "Returns total accounts, accounts with payment method, credit balance/usage aggregates, and monthly/weekly growth breakdowns. No authentication required. Proxied from billing-service.",
+        "description": "Returns total accounts, payment-method coverage, grant/credit aggregates, and monthly/weekly growth breakdowns. No authentication required. Proxied from billing-service.",
         "responses": {
           "200": {
-            "description": "Billing stats",
+            "description": "Billing stats — pass-through from billing-service",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4933,19 +4933,10 @@ registry.registerPath({
   security: authed,
   responses: {
     200: {
-      description: "Billing account data",
+      description: "Billing account data — pass-through from billing-service",
       content: {
         "application/json": {
-          schema: z.object({
-            id: z.string().describe("Account ID"),
-            orgId: z.string().describe("Organization ID"),
-            creditBalanceCents: decimalCentsString.describe("Current credit balance in cents (decimal string, full precision)"),
-            hasAutoReload: z.boolean().describe("Whether auto-reload is enabled (true when payment method + reload config are both set)"),
-            hasPaymentMethod: z.boolean().describe("Whether a payment method is on file"),
-            reloadAmountCents: decimalCentsString.nullable().describe("Auto-reload amount in cents (decimal string, null if not configured)"),
-            reloadThresholdCents: decimalCentsString.nullable().describe("Balance threshold in cents that triggers auto-reload (decimal string, null if not configured)"),
-            createdAt: z.string().describe("ISO timestamp"),
-          }).openapi("BillingAccountResponse"),
+          schema: z.object({}).passthrough().openapi("BillingAccountResponse"),
         },
       },
     },
@@ -4988,18 +4979,10 @@ registry.registerPath({
   security: authed,
   responses: {
     200: {
-      description: "Transaction list",
+      description: "Transaction list — pass-through from billing-service",
       content: {
         "application/json": {
-          schema: z.object({
-            transactions: z.array(z.object({
-              id: z.string().describe("Transaction ID"),
-              type: z.string().describe("Transaction type (e.g. 'credit', 'debit')"),
-              amountCents: decimalCentsString.describe("Amount in cents (decimal string, full precision)"),
-              description: z.string().describe("Transaction description"),
-              createdAt: z.string().describe("ISO timestamp"),
-            })),
-          }).openapi("TransactionListResponse"),
+          schema: z.object({}).passthrough().openapi("TransactionListResponse"),
         },
       },
     },
@@ -5024,19 +5007,10 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "Auto-reload configured",
+      description: "Auto-reload configured — pass-through from billing-service",
       content: {
         "application/json": {
-          schema: z.object({
-            id: z.string().describe("Account ID"),
-            orgId: z.string().describe("Organization ID"),
-            creditBalanceCents: decimalCentsString.describe("Current credit balance in cents (decimal string, full precision)"),
-            hasAutoReload: z.boolean().describe("Whether auto-reload is enabled"),
-            hasPaymentMethod: z.boolean().describe("Whether a payment method is on file"),
-            reloadAmountCents: decimalCentsString.nullable().describe("Auto-reload amount in cents (decimal string)"),
-            reloadThresholdCents: decimalCentsString.nullable().describe("Balance threshold in cents that triggers auto-reload (decimal string)"),
-            createdAt: z.string().describe("ISO timestamp"),
-          }).openapi("ConfigureAutoReloadResponse"),
+          schema: z.object({}).passthrough().openapi("ConfigureAutoReloadResponse"),
         },
       },
     },
@@ -5055,19 +5029,10 @@ registry.registerPath({
   security: authed,
   responses: {
     200: {
-      description: "Auto-reload disabled",
+      description: "Auto-reload disabled — pass-through from billing-service",
       content: {
         "application/json": {
-          schema: z.object({
-            id: z.string().describe("Account ID"),
-            orgId: z.string().describe("Organization ID"),
-            creditBalanceCents: decimalCentsString.describe("Current credit balance in cents (decimal string, full precision)"),
-            hasAutoReload: z.boolean().describe("Whether auto-reload is enabled"),
-            hasPaymentMethod: z.boolean().describe("Whether a payment method is on file"),
-            reloadAmountCents: decimalCentsString.nullable().describe("Auto-reload amount in cents (decimal string)"),
-            reloadThresholdCents: decimalCentsString.nullable().describe("Balance threshold in cents that triggers auto-reload (decimal string)"),
-            createdAt: z.string().describe("ISO timestamp"),
-          }).openapi("DisableAutoReloadResponse"),
+          schema: z.object({}).passthrough().openapi("DisableAutoReloadResponse"),
         },
       },
     },
@@ -6528,36 +6493,21 @@ registry.registerPath({
   },
 });
 
-const BillingGrowthRowSchema = z.object({
-  period: z.string().describe("Period label (e.g. '2026-03' or '2026-W14')"),
-  credited_cents: decimalCentsString.describe("Total credits added in this period (decimal string, full precision)"),
-  consumed_cents: decimalCentsString.describe("Total credits consumed in this period (decimal string, full precision)"),
-  revenue_cents: decimalCentsString.describe("Actual Stripe payments (source=reload only, excludes welcome/promo credits) (decimal string, full precision)"),
-});
-
 registry.registerPath({
   method: "get",
   path: "/public/stats/billing",
   tags: ["Public Stats"],
   summary: "Public billing stats (no auth)",
   description:
-    "Returns total accounts, accounts with payment method, credit balance/usage aggregates, " +
+    "Returns total accounts, payment-method coverage, grant/credit aggregates, " +
     "and monthly/weekly growth breakdowns. " +
     "No authentication required. Proxied from billing-service.",
   responses: {
     200: {
-      description: "Billing stats",
+      description: "Billing stats — pass-through from billing-service",
       content: {
         "application/json": {
-          schema: z.object({
-            totalAccounts: z.number().int(),
-            accountsWithPaymentMethod: z.number().int(),
-            totalCreditBalanceCents: decimalCentsString.describe("Total credit balance across all accounts (decimal string, full precision)"),
-            totalCreditedCents: decimalCentsString.describe("Total credits added across all accounts (decimal string, full precision)"),
-            totalConsumedCents: decimalCentsString.describe("Total credits consumed across all accounts (decimal string, full precision)"),
-            monthlyGrowth: z.array(BillingGrowthRowSchema).describe("Monthly growth breakdown"),
-            weeklyGrowth: z.array(BillingGrowthRowSchema).describe("Weekly growth breakdown"),
-          }).openapi("PublicBillingStatsResponse"),
+          schema: z.object({}).passthrough().openapi("PublicBillingStatsResponse"),
         },
       },
     },

--- a/tests/unit/billing-proxy-fractional.test.ts
+++ b/tests/unit/billing-proxy-fractional.test.ts
@@ -49,11 +49,13 @@ describe("billing proxy — fractional cents (decimal-string contract)", () => {
     expect(res.body.balance_cents).toBe("100.4200000000");
   });
 
-  it("GET /billing/accounts returns decimal-string credit/reload fields untouched", async () => {
+  it("GET /billing/accounts returns decimal-string grant/spent/available/reload fields untouched", async () => {
     const upstream = {
       id: "acc_1",
       orgId: "org-test",
-      creditBalanceCents: "12345.6789012345",
+      grantsCents: "12345.6789012345",
+      runsSpentCents: "2345.6789012345",
+      availableCents: "10000.0000000000",
       hasAutoReload: true,
       hasPaymentMethod: true,
       reloadAmountCents: "500000.0000000000",
@@ -66,7 +68,9 @@ describe("billing proxy — fractional cents (decimal-string contract)", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(upstream);
-    expect(typeof res.body.creditBalanceCents).toBe("string");
+    expect(typeof res.body.grantsCents).toBe("string");
+    expect(typeof res.body.runsSpentCents).toBe("string");
+    expect(typeof res.body.availableCents).toBe("string");
     expect(typeof res.body.reloadAmountCents).toBe("string");
     expect(typeof res.body.reloadThresholdCents).toBe("string");
   });
@@ -75,7 +79,9 @@ describe("billing proxy — fractional cents (decimal-string contract)", () => {
     const upstream = {
       id: "acc_2",
       orgId: "org-test",
-      creditBalanceCents: "0.0000000000",
+      grantsCents: "0.0000000000",
+      runsSpentCents: "0.0000000000",
+      availableCents: "0.0000000000",
       hasAutoReload: false,
       hasPaymentMethod: false,
       reloadAmountCents: null,
@@ -139,7 +145,9 @@ describe("billing proxy — fractional cents (decimal-string contract)", () => {
     const upstream = {
       id: "acc_3",
       orgId: "org-test",
-      creditBalanceCents: "100.0000000000",
+      grantsCents: "100.0000000000",
+      runsSpentCents: "10.0000000000",
+      availableCents: "90.0000000000",
       hasAutoReload: true,
       hasPaymentMethod: true,
       reloadAmountCents: "1000.5000000000",

--- a/tests/unit/billing-proxy.test.ts
+++ b/tests/unit/billing-proxy.test.ts
@@ -123,8 +123,16 @@ describe("Billing OpenAPI schemas", () => {
     expect(schemaContent).not.toContain('"byok", "payg"');
   });
 
-  it("should have hasAutoReload in BillingAccountResponse", () => {
-    expect(schemaContent).toContain("hasAutoReload");
+  it("billing response schemas are passthrough (transparent proxy contract)", () => {
+    // Post-billing-service-#107: api-service no longer redeclares billing
+    // response field shapes. Each billing response schema collapses to
+    // z.object({}).passthrough() so downstream renames flow through without
+    // a coordinated api-service edit. See PR for rationale.
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("BillingAccountResponse")');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("TransactionListResponse")');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("ConfigureAutoReloadResponse")');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("DisableAutoReloadResponse")');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("PublicBillingStatsResponse")');
   });
 });
 

--- a/tests/unit/public-stats.test.ts
+++ b/tests/unit/public-stats.test.ts
@@ -58,20 +58,20 @@ const MOCK_USER_STATS = {
   ],
 };
 
-// Fractional decimal-string cents — billing-service v2 contract (PR #83).
+// Fractional decimal-string cents — billing-service contract post-#107
+// (creditBalance/consumed fields removed; grants is the accurate label).
 const MOCK_BILLING_STATS = {
   totalAccounts: 35,
   accountsWithPaymentMethod: 12,
-  totalCreditBalanceCents: "450000.4200000000",
+  totalGrantsCents: "450000.4200000000",
   totalCreditedCents: "1200000.0000000000",
-  totalConsumedCents: "750000.5800000000",
   monthlyGrowth: [
-    { period: "2026-01", credited_cents: "200000.0000000000", consumed_cents: "120000.4200000000", revenue_cents: "80000.0000000000" },
-    { period: "2026-02", credited_cents: "350000.0000000000", consumed_cents: "210000.0000000000", revenue_cents: "150000.0000000000" },
+    { period: "2026-01", credited_cents: "200000.0000000000", revenue_cents: "80000.0000000000" },
+    { period: "2026-02", credited_cents: "350000.0000000000", revenue_cents: "150000.0000000000" },
   ],
   weeklyGrowth: [
-    { period: "2026-W14", credited_cents: "50000.0000000000", consumed_cents: "30000.0000000000", revenue_cents: "20000.0000000000" },
-    { period: "2026-W15", credited_cents: "75000.0000000000", consumed_cents: "48000.0000000000", revenue_cents: "35000.0000000000" },
+    { period: "2026-W14", credited_cents: "50000.0000000000", revenue_cents: "20000.0000000000" },
+    { period: "2026-W15", credited_cents: "75000.0000000000", revenue_cents: "35000.0000000000" },
   ],
 };
 
@@ -132,12 +132,11 @@ describe("GET /public/stats/billing", () => {
     expect(res.body.monthlyGrowth[0]).toEqual({
       period: "2026-01",
       credited_cents: "200000.0000000000",
-      consumed_cents: "120000.4200000000",
       revenue_cents: "80000.0000000000",
     });
     // precision preserved as string, not coerced to number
-    expect(typeof res.body.monthlyGrowth[0].consumed_cents).toBe("string");
-    expect(typeof res.body.totalCreditBalanceCents).toBe("string");
+    expect(typeof res.body.monthlyGrowth[0].credited_cents).toBe("string");
+    expect(typeof res.body.totalGrantsCents).toBe("string");
     expect(res.body.weeklyGrowth).toHaveLength(2);
   });
 


### PR DESCRIPTION
## Summary

- billing-service #107 (merged to staging, commit 687790a) renamed/removed public fields on the billing-account, transaction, and public-stats responses. api-service's Zod schemas were redeclaring those fields and went out-of-sync with staging billing-service.
- Rather than chase every billing-service field rename in api-service, collapse the five affected response shapes to `z.object({}).passthrough()` per the existing `/public/stats/users`, `/public/stats/runs`, `/public/features` convention. api-service is a transparent proxy — schemas redeclaring downstream field shapes just create cross-service merge ordering pain on every billing-service rename.
- Test mocks updated to the post-#107 shape so they exercise the real field names (`grantsCents`, `runsSpentCents`, `availableCents`, `totalGrantsCents`) that flow through the proxy at runtime.

Schemas collapsed to passthrough:
- `GET /v1/billing/accounts`
- `GET /v1/billing/accounts/transactions`
- `PATCH /v1/billing/accounts/auto-reload`
- `DELETE /v1/billing/accounts/auto-reload`
- `GET /public/stats/billing` (plus `BillingGrowthRowSchema` deleted)

`GET /v1/billing/accounts/balance` keeps its typed schema — its `balance_cents` decimal-string contract is unaffected by #107.

`Transaction.type` enum: spec asked to drop `"deduction"`, but api-service uses `z.string()` (free-form), not `z.enum([...])` — no enum entry exists to remove.

`openapi.json` regenerated: **-294 / +11 lines**.

## ⚠️ Deployment ordering

This PR migrates api-service to the post-#107 billing field shape. **It MUST be on prod before billing-service can be promoted to prod** — billing-service staging already carries the breaking change.

- Auto-merge to **staging**.
- Do NOT promote to prod here. Prod promotion is gated on (a) dashboard migration AND (b) billing-service prod promotion.

## Test plan

- [x] `pnpm build` regenerates `openapi.json` clean
- [x] `pnpm test` — 1231/1231 green
- [x] `grep -rn "creditBalanceCents\|totalCreditBalanceCents\|totalConsumedCents\|consumed_cents" src/` → 0 hits
- [x] `tests/unit/billing-proxy.test.ts` now asserts each billing response schema collapses to `z.object({}).passthrough()`
- [ ] Post-merge: hit staging `/v1/billing/accounts` via the dashboard, confirm `grantsCents` / `runsSpentCents` / `availableCents` flow through

🤖 Generated with [Claude Code](https://claude.com/claude-code)