### PR TITLE
fix(openapi): correct GET /v1/runs response schema to match runs-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -647,114 +647,109 @@
           "campaign"
         ]
       },
-      "ErrorSummary": {
+      "RunWithOwnCost": {
         "type": "object",
         "properties": {
-          "failedStep": {
+          "id": {
             "type": "string",
-            "description": "Which DAG step failed (e.g. 'fetch_lead', 'generate_email')"
+            "format": "uuid",
+            "description": "Run ID"
           },
-          "message": {
+          "organizationId": {
             "type": "string",
-            "description": "Cleaned error message without stack traces"
+            "nullable": true,
+            "format": "uuid"
           },
-          "rootCause": {
+          "userId": {
             "type": "string",
-            "description": "User-friendly root cause (e.g. 'billing-service unavailable')"
-          }
-        },
-        "required": [
-          "failedStep",
-          "message",
-          "rootCause"
-        ],
-        "description": "Structured error summary for failed runs. Contains a user-friendly rootCause, the failedStep, and a cleaned message. Only present when status is 'failed'."
-      },
-      "RunCostData": {
-        "type": "object",
-        "properties": {
+            "nullable": true,
+            "format": "uuid"
+          },
+          "brandIds": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "campaignId": {
+            "type": "string",
+            "nullable": true
+          },
+          "workflowSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "serviceName": {
+            "type": "string"
+          },
+          "taskName": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
             "description": "Run status (e.g. completed, failed)"
           },
-          "startedAt": {
+          "parentRunId": {
             "type": "string",
             "nullable": true,
+            "format": "uuid"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time",
             "description": "ISO timestamp when the run started"
           },
           "completedAt": {
             "type": "string",
             "nullable": true,
+            "format": "date-time",
             "description": "ISO timestamp when the run completed"
           },
-          "totalCostInUsdCents": {
+          "createdAt": {
             "type": "string",
-            "nullable": true,
-            "description": "Total cost in USD cents"
+            "format": "date-time"
           },
-          "costs": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "costName": {
-                  "type": "string"
-                },
-                "totalCostInUsdCents": {
-                  "type": "string"
-                },
-                "actualCostInUsdCents": {
-                  "type": "string"
-                },
-                "provisionedCostInUsdCents": {
-                  "type": "string"
-                },
-                "quantity": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "costName",
-                "totalCostInUsdCents",
-                "actualCostInUsdCents",
-                "provisionedCostInUsdCents",
-                "quantity"
-              ]
-            },
-            "description": "Per-cost-name breakdown"
-          },
-          "serviceName": {
+          "updatedAt": {
             "type": "string",
-            "nullable": true
+            "format": "date-time"
           },
-          "taskName": {
+          "ownCostInUsdCents": {
             "type": "string",
-            "nullable": true
+            "description": "Sum of this run's own costs (excludes descendants)"
           },
-          "error": {
+          "ownActualCostInUsdCents": {
             "type": "string",
-            "description": "Raw error message (for debugging). Only present on failed runs."
+            "description": "Sum of this run's own costs with status='actual'"
           },
-          "errorSummary": {
-            "$ref": "#/components/schemas/ErrorSummary"
-          },
-          "descendantRuns": {
-            "type": "array",
-            "items": {
-              "nullable": true
-            },
-            "description": "Child runs"
+          "ownProvisionedCostInUsdCents": {
+            "type": "string",
+            "description": "Sum of this run's own costs with status='provisioned'"
           }
         },
         "required": [
-          "status",
-          "startedAt",
-          "completedAt",
-          "totalCostInUsdCents",
-          "costs",
+          "id",
+          "organizationId",
+          "userId",
+          "brandIds",
+          "campaignId",
+          "workflowSlug",
+          "featureSlug",
           "serviceName",
           "taskName",
-          "descendantRuns"
+          "status",
+          "parentRunId",
+          "startedAt",
+          "completedAt",
+          "createdAt",
+          "updatedAt",
+          "ownCostInUsdCents",
+          "ownActualCostInUsdCents",
+          "ownProvisionedCostInUsdCents"
         ]
       },
       "ListRunsResponse": {
@@ -763,7 +758,7 @@
           "runs": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/RunCostData"
+              "$ref": "#/components/schemas/RunWithOwnCost"
             }
           },
           "offset": {
@@ -1093,6 +1088,118 @@
           "campaigns"
         ]
       },
+      "ErrorSummary": {
+        "type": "object",
+        "properties": {
+          "failedStep": {
+            "type": "string",
+            "description": "Which DAG step failed (e.g. 'fetch_lead', 'generate_email')"
+          },
+          "message": {
+            "type": "string",
+            "description": "Cleaned error message without stack traces"
+          },
+          "rootCause": {
+            "type": "string",
+            "description": "User-friendly root cause (e.g. 'billing-service unavailable')"
+          }
+        },
+        "required": [
+          "failedStep",
+          "message",
+          "rootCause"
+        ],
+        "description": "Structured error summary for failed runs. Contains a user-friendly rootCause, the failedStep, and a cleaned message. Only present when status is 'failed'."
+      },
+      "RunCostData": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Run status (e.g. completed, failed)"
+          },
+          "startedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp when the run started"
+          },
+          "completedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp when the run completed"
+          },
+          "totalCostInUsdCents": {
+            "type": "string",
+            "nullable": true,
+            "description": "Total cost in USD cents"
+          },
+          "costs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "costName": {
+                  "type": "string"
+                },
+                "totalCostInUsdCents": {
+                  "type": "string"
+                },
+                "actualCostInUsdCents": {
+                  "type": "string"
+                },
+                "provisionedCostInUsdCents": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "costName",
+                "totalCostInUsdCents",
+                "actualCostInUsdCents",
+                "provisionedCostInUsdCents",
+                "quantity"
+              ]
+            },
+            "description": "Per-cost-name breakdown"
+          },
+          "serviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "taskName": {
+            "type": "string",
+            "nullable": true
+          },
+          "error": {
+            "type": "string",
+            "description": "Raw error message (for debugging). Only present on failed runs."
+          },
+          "errorSummary": {
+            "$ref": "#/components/schemas/ErrorSummary"
+          },
+          "descendantRuns": {
+            "type": "array",
+            "items": {
+              "nullable": true
+            },
+            "description": "Child runs"
+          }
+        },
+        "required": [
+          "status",
+          "startedAt",
+          "completedAt",
+          "totalCostInUsdCents",
+          "costs",
+          "serviceName",
+          "taskName",
+          "descendantRuns"
+        ],
+        "description": "Generation run cost data, null if no run"
+      },
       "CampaignEmailsResponse": {
         "type": "object",
         "properties": {
@@ -1166,15 +1273,7 @@
                   "description": "ISO timestamp"
                 },
                 "generationRun": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/RunCostData"
-                    },
-                    {
-                      "nullable": true,
-                      "description": "Generation run cost data, null if no run"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RunCostData"
                 }
               },
               "required": [
@@ -7391,14 +7490,7 @@
                   "type": "string"
                 },
                 "generationRun": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/RunCostData"
-                    },
-                    {
-                      "nullable": true
-                    }
-                  ]
+                  "$ref": "#/components/schemas/RunCostData"
                 }
               },
               "required": [
@@ -11068,7 +11160,7 @@
           "Runs"
         ],
         "summary": "List runs",
-        "description": "Transparent proxy to runs-service GET /v1/runs. Supports all runs-service query params: campaignId, brandId, userId, workflowSlug, featureSlug, serviceName, taskName, status, parentRunId, startedAfter, startedBefore, limit, offset.",
+        "description": "Transparent proxy to runs-service GET /v1/runs. Supports all runs-service query params: campaignId, brandId, userId, workflowSlug, featureSlug, serviceName, taskName, status, parentRunId, startedAfter, startedBefore, limit, offset. Results are sorted by startedAt DESC (most recent first). Each item is a run with own-cost totals only; for the per-cost-name breakdown of a single run, call GET /v1/runs/{id}.",
         "security": [
           {
             "bearerAuth": []
@@ -11239,7 +11331,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List of runs with cost totals",
+            "description": "List of runs with own-cost totals. One item per run; per-cost-name breakdown is on GET /v1/runs/{id}.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -403,6 +403,32 @@ const RunCostDataSchema = z
   })
   .openapi("RunCostData");
 
+// Mirror of runs-service `RunWithOwnCost` (RunSchema + own-cost totals).
+// Used by GET /v1/runs (list). One item per run, own-cost totals only;
+// per-cost-name breakdown lives on GET /v1/runs/{id}.
+const RunWithOwnCostSchema = z
+  .object({
+    id: z.string().uuid().describe("Run ID"),
+    organizationId: z.string().uuid().nullable(),
+    userId: z.string().uuid().nullable(),
+    brandIds: z.array(z.string()).nullable(),
+    campaignId: z.string().nullable(),
+    workflowSlug: z.string().nullable(),
+    featureSlug: z.string().nullable(),
+    serviceName: z.string(),
+    taskName: z.string(),
+    status: z.string().describe("Run status (e.g. completed, failed)"),
+    parentRunId: z.string().uuid().nullable(),
+    startedAt: z.string().datetime().describe("ISO timestamp when the run started"),
+    completedAt: z.string().datetime().nullable().describe("ISO timestamp when the run completed"),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    ownCostInUsdCents: z.string().describe("Sum of this run's own costs (excludes descendants)"),
+    ownActualCostInUsdCents: z.string().describe("Sum of this run's own costs with status='actual'"),
+    ownProvisionedCostInUsdCents: z.string().describe("Sum of this run's own costs with status='provisioned'"),
+  })
+  .openapi("RunWithOwnCost");
+
 // -- Response schemas --
 
 const CampaignSchema = z
@@ -581,7 +607,10 @@ registry.registerPath({
     "Transparent proxy to runs-service GET /v1/runs. " +
     "Supports all runs-service query params: campaignId, brandId, userId, " +
     "workflowSlug, featureSlug, serviceName, taskName, status, parentRunId, " +
-    "startedAfter, startedBefore, limit, offset.",
+    "startedAfter, startedBefore, limit, offset. " +
+    "Results are sorted by startedAt DESC (most recent first). " +
+    "Each item is a run with own-cost totals only; for the per-cost-name " +
+    "breakdown of a single run, call GET /v1/runs/{id}.",
   security: authed,
   request: {
     query: z.object({
@@ -602,11 +631,13 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "List of runs with cost totals",
+      description:
+        "List of runs with own-cost totals. One item per run; " +
+        "per-cost-name breakdown is on GET /v1/runs/{id}.",
       content: {
         "application/json": {
           schema: z.object({
-            runs: z.array(RunCostDataSchema),
+            runs: z.array(RunWithOwnCostSchema),
             offset: z.number(),
             limit: z.number().optional(),
           }).openapi("ListRunsResponse"),

--- a/tests/unit/runs-list-openapi.test.ts
+++ b/tests/unit/runs-list-openapi.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("OpenAPI spec — GET /v1/runs response shape", () => {
+  const spec = JSON.parse(
+    readFileSync(resolve(__dirname, "../../openapi.json"), "utf-8"),
+  );
+
+  const listRuns = spec.paths["/v1/runs"].get;
+  const responseRef: string =
+    listRuns.responses["200"].content["application/json"].schema.$ref;
+  const responseSchemaName = responseRef.replace("#/components/schemas/", "");
+  const responseSchema = spec.components.schemas[responseSchemaName];
+  const runsRef: string = responseSchema.properties.runs.items.$ref;
+  const runSchemaName = runsRef.replace("#/components/schemas/", "");
+  const runSchema = spec.components.schemas[runSchemaName];
+
+  it("references a schema that is NOT the per-cost-name RunCostData", () => {
+    expect(runSchemaName).not.toBe("RunCostData");
+  });
+
+  it("each run includes id as a required uuid field", () => {
+    expect(runSchema.properties.id).toBeDefined();
+    expect(runSchema.properties.id.format).toBe("uuid");
+    expect(runSchema.required).toContain("id");
+  });
+
+  it("each run includes ownCostInUsdCents as a required field", () => {
+    expect(runSchema.properties.ownCostInUsdCents).toBeDefined();
+    expect(runSchema.required).toContain("ownCostInUsdCents");
+  });
+
+  it("each run does NOT include costs[] (only on GET /v1/runs/{id})", () => {
+    expect(runSchema.properties.costs).toBeUndefined();
+  });
+
+  it("each run does NOT include totalCostInUsdCents (only on GET /v1/runs/{id})", () => {
+    expect(runSchema.properties.totalCostInUsdCents).toBeUndefined();
+  });
+
+  it("each run does NOT include descendantRuns (only on GET /v1/runs/{id})", () => {
+    expect(runSchema.properties.descendantRuns).toBeUndefined();
+  });
+
+  it("operation description documents default sort startedAt DESC", () => {
+    expect(listRuns.description).toMatch(/startedAt DESC/i);
+  });
+
+  it("RunCostData schema is still defined (used by other endpoints)", () => {
+    expect(spec.components.schemas.RunCostData).toBeDefined();
+    expect(spec.components.schemas.RunCostData.properties.costs).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

api-service's openapi declared `ListRunsResponse.runs[]` as `RunCostData` (per-cost-name breakdown + `totalCostInUsdCents` + `descendantRuns` + `error`/`errorSummary`). But the actual runs-service `GET /v1/runs` handler returns `RunWithOwnCost` — `Run` + `ownCostInUsdCents`/`ownActualCostInUsdCents`/`ownProvisionedCostInUsdCents` — with `id` (uuid, required) and no `costs[]`. Per-cost-name breakdown is only on `GET /v1/runs/{id}`.

The drift caused [distribute.you#1060](https://github.com/shamanic-technologies/distribute.you/pull/1060) to ship a bug; [distribute.you#1061](https://github.com/shamanic-technologies/distribute.you/pull/1061) patches it on the consumer side. This PR is the source-of-truth fix in the gateway spec.

## Changes
- Add `RunWithOwnCostSchema` mirroring runs-service's `RunWithOwnCost` (id required uuid, organizationId/userId/brandIds, parentRunId, startedAt/completedAt, ownCost/ownActualCost/ownProvisionedCost — all in USD cents as decimal strings).
- Switch `GET /v1/runs` `ListRunsResponse.runs[]` to reference `RunWithOwnCost`.
- Document default sort (`startedAt DESC`) and "own-cost totals only; per-cost-name breakdown on GET /v1/runs/{id}" on both the operation description and the 200 response description.
- Add `tests/unit/runs-list-openapi.test.ts` (8 assertions) covering the corrected shape + the regression that `RunCostData` is preserved.
- Re-generate `openapi.json`.

## Out of scope (other `RunCostData` users — possible sibling drift)
`RunCostData` is also referenced by:
- `src/schemas.ts:756` — `GET /v1/campaigns/{id}/emails` `generationRun`
- `src/schemas.ts:3400` — `GET /v1/brands/{id}/runs`
- `src/schemas.ts:5251` — `GET /v1/brands/{id}/emails` `generationRun`

Confirming whether each of these endpoints really returns the per-cost-name breakdown is a separate audit — kept out of this PR to stay narrowly scoped to the task spec.

## Verified against runs-service@staging
- `src/routes/runs.ts:519-615` — handler selects `RunWithOwnCost` shape, orders `desc(runs.startedAt)`.
- `src/schemas.ts:36-60` — `RunSchema` + `RunWithOwnCostSchema` definitions.
- `src/schemas.ts:206-212` — `ListRunsResponseSchema = { runs: RunWithOwnCost[], limit?, offset }`.

## Test plan
- [x] `pnpm test` — 1239 tests pass (113 files)
- [x] `pnpm build` — typecheck + openapi generation green
- [x] New `runs-list-openapi.test.ts` — 8 assertions green
- [ ] Post-merge: `curl https://api-staging.distribute.you/openapi.json | jq '.paths."/v1/runs".get.responses."200".content."application/json".schema'` → references `ListRunsResponse → runs[].$ref = RunWithOwnCost`
- [ ] Post-merge: `curl staging/v1/runs?limit=2` → items contain `id` + `ownCostInUsdCents`, no `costs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)