### PR TITLE
feat(runs,campaigns): drop featureDynastySlug forwarding to runs-service (DIS-14 follow-up)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -20030,7 +20030,7 @@
           "Runs"
         ],
         "summary": "Get cost stats from runs-service",
-        "description": "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug. Filter by brandId, campaignId, taskName, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug.",
+        "description": "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName, workflowDynastySlug. Filter by brandId, campaignId, taskName, workflowSlug, featureSlug, workflowDynastySlug.",
         "security": [
           {
             "bearerAuth": []
@@ -20040,10 +20040,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug"
+              "description": "Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug"
             },
             "required": true,
-            "description": "Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug",
+            "description": "Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug",
             "name": "groupBy",
             "in": "query"
           },
@@ -20105,16 +20105,6 @@
             "required": false,
             "description": "Filter by workflow dynasty slug (resolved to all versioned slugs)",
             "name": "workflowDynastySlug",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Filter by feature dynasty slug (resolved to all versioned slugs)"
-            },
-            "required": false,
-            "description": "Filter by feature dynasty slug (resolved to all versioned slugs)",
-            "name": "featureDynastySlug",
             "in": "query"
           },
           {

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -216,7 +216,12 @@ router.get("/campaigns/stats", authenticate, requireOrg, requireUser, async (req
 
     const runsParams = new URLSearchParams({ orgId, groupBy: "campaignId" });
     if (brandId) runsParams.set("brandId", brandId);
-    for (const [k, v] of Object.entries(slugFilters)) runsParams.set(k, v);
+    // featureDynastySlug intentionally skipped for runs-service (v0.31.3 dropped it).
+    // Other downstream services in this aggregator still accept it.
+    for (const [k, v] of Object.entries(slugFilters)) {
+      if (k === "featureDynastySlug") continue;
+      runsParams.set(k, v);
+    }
 
     // 4 parallel calls
     const [deliveryGroups, leadGroups, emailgenGroups, costGroups] = await Promise.all([

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -51,7 +51,9 @@ router.get("/runs/stats/costs", authenticate, requireOrg, requireUser, async (re
       orgId,
       groupBy,
     });
-    for (const key of ["brandId", "campaignId", "taskName", "workflowSlug", "featureSlug", "workflowDynastySlug", "featureDynastySlug"]) {
+    // featureDynastySlug intentionally omitted — runs-service v0.31.3 (DIS-14) dropped the param.
+    // Inbound callers (e.g. dashboard) may still send it; we accept it silently and don't forward.
+    for (const key of ["brandId", "campaignId", "taskName", "workflowSlug", "featureSlug", "workflowDynastySlug"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3582,18 +3582,17 @@ registry.registerPath({
   tags: ["Runs"],
   summary: "Get cost stats from runs-service",
   description:
-    "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug. Filter by brandId, campaignId, taskName, workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug.",
+    "Get cost statistics grouped by a dimension. Supports groupBy=brandId, costName, campaignId, serviceName, workflowDynastySlug. Filter by brandId, campaignId, taskName, workflowSlug, featureSlug, workflowDynastySlug.",
   security: authed,
   request: {
     query: z.object({
-      groupBy: z.string().describe("Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug, featureDynastySlug"),
+      groupBy: z.string().describe("Grouping dimension: brandId, costName, campaignId, serviceName, workflowDynastySlug"),
       brandId: z.string().optional().describe("Filter by brand ID"),
       campaignId: z.string().optional().describe("Filter by campaign ID"),
       taskName: z.string().optional().describe("Filter by task name (e.g. lead-serve)"),
       workflowSlug: z.string().optional().describe("Filter by exact workflow slug"),
       featureSlug: z.string().optional().describe("Filter by exact feature slug"),
       workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug (resolved to all versioned slugs)"),
-      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs)"),
     }),
   },
   responses: {

--- a/tests/unit/campaigns-grouped-stats.test.ts
+++ b/tests/unit/campaigns-grouped-stats.test.ts
@@ -262,6 +262,31 @@ describe("GET /v1/campaigns/stats", () => {
     }
   });
 
+  it("should NOT forward featureDynastySlug to runs-service (runs-service v0.31.3 dropped it), but should still forward to other services", async () => {
+    const app = createApp();
+
+    mockCallExternalService.mockResolvedValue({ groups: [] });
+
+    await request(app).get("/v1/campaigns/stats?brandId=brand-1&featureDynastySlug=pr-cold-email-outreach");
+
+    const callsByService = (url: string) =>
+      mockCallExternalService.mock.calls.filter(
+        (call: any[]) => (call[0] as any).url === url,
+      );
+
+    // runs-service: featureDynastySlug MUST NOT appear
+    const runsCalls = callsByService("http://mock-runs");
+    expect(runsCalls).toHaveLength(1);
+    expect(runsCalls[0][1] as string).not.toContain("featureDynastySlug=");
+
+    // email-gateway / lead-service / content-generation: featureDynastySlug still forwarded
+    for (const url of ["http://mock-email-gw", "http://mock-lead", "http://mock-emailgen"]) {
+      const calls = callsByService(url);
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1] as string).toContain("featureDynastySlug=pr-cold-email-outreach");
+    }
+  });
+
   it("should use only broadcast stats from email-gateway, not transactional", async () => {
     const app = createApp();
 

--- a/tests/unit/dynasty-slug-forwarding.test.ts
+++ b/tests/unit/dynasty-slug-forwarding.test.ts
@@ -49,10 +49,15 @@ describe("Dynasty slug forwarding — outlets/stats", () => {
 });
 
 describe("Dynasty slug forwarding — runs/stats/costs", () => {
-  it("should forward dynasty slug filters on GET /runs/stats/costs", () => {
-    for (const param of [...dynastyParams, "workflowSlug", "featureSlug"]) {
-      expect(runsRoute).toContain(`"${param}"`);
+  it("should forward supported slug filters on GET /runs/stats/costs (no featureDynastySlug — runs-service v0.31.3 dropped it)", () => {
+    const runsStatsSection = runsRoute.slice(
+      runsRoute.indexOf('"/runs/stats/costs"'),
+      runsRoute.indexOf('"/events"'),
+    );
+    for (const param of ["workflowDynastySlug", "workflowSlug", "featureSlug"]) {
+      expect(runsStatsSection).toContain(`"${param}"`);
     }
+    expect(runsStatsSection).not.toContain(`"featureDynastySlug"`);
   });
 });
 
@@ -135,15 +140,15 @@ describe("Dynasty slug OpenAPI schemas", () => {
     expect(featureSlugStatsSection).toContain("workflowDynastySlug");
   });
 
-  it("should include dynasty slug filters in /v1/runs/stats/costs query schema", () => {
+  it("should include supported slug filters in /v1/runs/stats/costs query schema (no featureDynastySlug — runs-service v0.31.3 dropped it)", () => {
     const runsStatsSection = schemaContent.slice(
       schemaContent.indexOf('path: "/v1/runs/stats/costs"'),
       schemaContent.indexOf('path: "/v1/runs/stats/costs"') + 1200,
     );
-    expect(runsStatsSection).toContain("featureDynastySlug");
     expect(runsStatsSection).toContain("workflowDynastySlug");
     expect(runsStatsSection).toContain("featureSlug");
     expect(runsStatsSection).toContain("workflowSlug");
+    expect(runsStatsSection).not.toContain("featureDynastySlug");
   });
 
   it("should include dynasty slug filters in /v1/email-gateway/stats query schema", () => {
@@ -220,13 +225,13 @@ describe("Dynasty slug params in generated openapi.json", () => {
     expect(paramNames).toContain("workflowDynastySlug");
   });
 
-  it("should have dynasty query params on /v1/runs/stats/costs", () => {
+  it("should have supported slug query params on /v1/runs/stats/costs (no featureDynastySlug — runs-service v0.31.3 dropped it)", () => {
     const params = openapiSpec.paths["/v1/runs/stats/costs"]?.get?.parameters ?? [];
     const paramNames = params.map((p: { name: string }) => p.name);
     expect(paramNames).toContain("workflowDynastySlug");
-    expect(paramNames).toContain("featureDynastySlug");
     expect(paramNames).toContain("workflowSlug");
     expect(paramNames).toContain("featureSlug");
+    expect(paramNames).not.toContain("featureDynastySlug");
   });
 
   it("should have dynasty query params on /v1/email-gateway/stats (plural workflowSlugs/featureSlugs)", () => {


### PR DESCRIPTION
## Summary
- runs-service v0.31.3 (DIS-14) eradicated `featureDynastySlug` end-to-end. This PR removes outbound forwarding of the param from api-service to runs-service at all sites, while leaving inbound acceptance intact (option **c** from the task brief).

## Scope (api-service only)
- `src/routes/runs.ts:54` — dropped `featureDynastySlug` from the `GET /v1/runs/stats/costs` forward whitelist.
- `src/routes/campaigns.ts:217-222` — only the runs-service iteration of the `/v1/campaigns/stats` aggregator now skips `featureDynastySlug`. Other downstream services (email-gateway, lead-service, content-generation) still receive it — those drops are separate Wave B follow-ups.
- `src/schemas.ts` `/v1/runs/stats/costs` block — removed `featureDynastySlug` Zod query field + description references. `openapi.json` regenerated.

## Inbound behavior (option c)
- `?featureDynastySlug=<x>` from dashboard → silently accepted, NOT forwarded to runs-service. Response is over-broad until dashboard migrates (separate workspace). No 400 — keeps dashboard pages live.
- `?groupBy=featureDynastySlug` → passes through; runs-service returns 400 verbatim per CLAUDE.md rule 7 (no error sanitizing). Affects only `getBrandCostsByFeature` dashboard helper, accepted per brief.

## Out of scope
8 silver services (apollo, articles, content-generation, email-gateway, journalists, lead, outlets, press-kits) + distribute.you still accept `featureDynastySlug`. Per DIS-14 follow-ups, each repo gets its own PR.

## Test plan
- [x] `pnpm test` — 113 files, 1246 tests all green
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Inverted regression tests in `tests/unit/dynasty-slug-forwarding.test.ts` (runs whitelist, runs schema block, openapi.json) now assert `featureDynastySlug` is ABSENT
- [x] New behavioral test in `tests/unit/campaigns-grouped-stats.test.ts` asserts runs-service URL has no `featureDynastySlug=`, while email-gateway/lead/emailgen URLs still do
- [ ] Manual (post-staging deploy): dashboard `/report/.../workflows` still loads with `?featureDynastySlug=` from current dashboard code
- [ ] Manual: `mcp__api-registry-staging__get_endpoint_details api GET /v1/runs/stats/costs` confirms `featureDynastySlug` no longer documented

Linear: DIS-14 (runs-service Wave A) — this is the api-service follow-up listed in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)