### PR TITLE
feat(emails): proxy manual reply qualifications (POST + GET)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7041,6 +7041,53 @@
           "stats"
         ]
       },
+      "ManualQualificationCreateResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "ManualQualificationCreateRequest": {
+        "type": "object",
+        "properties": {
+          "campaign_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Logical campaign id (groups sub-campaigns for the same workflow run)"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Lead email address"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "lead_interested",
+              "lead_meeting_booked",
+              "lead_closed",
+              "lead_not_interested",
+              "lead_wrong_person",
+              "lead_neutral",
+              "lead_out_of_office",
+              "auto_reply_received"
+            ],
+            "description": "Manual reply qualification status — mirrors Instantly webhook reply event_type values exactly. Set by a human via the dashboard when Instantly fails to detect a reply (e.g. reply received on a non-leurre email account)."
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 2000,
+            "description": "Optional free-text human note for audit"
+          }
+        },
+        "required": [
+          "campaign_id",
+          "email",
+          "status"
+        ]
+      },
+      "ManualQualificationListResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "DeployTemplatesResponse": {
         "type": "object",
         "properties": {
@@ -24456,6 +24503,272 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TransactionalEmailStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/emails/manual-qualifications": {
+      "post": {
+        "tags": [
+          "Emails"
+        ],
+        "summary": "Set a manual reply qualification for a (campaign, lead) pair",
+        "description": "Record a human-set reply classification for a lead in a campaign. Used when Instantly's automatic webhook reply classification fails to detect a reply (e.g. the reply was sent to a non-leurre account that Instantly does not monitor). Idempotent: re-POSTing the same status for the same (campaign, lead) returns `idempotent: true` with the existing row. Transparent proxy to email-gateway → instantly-service; the response shape is owned upstream.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManualQualificationCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Manual qualification recorded (or idempotent no-op)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManualQualificationCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error from upstream",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "(campaign, lead) not found in caller's org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      },
+      "get": {
+        "tags": [
+          "Emails"
+        ],
+        "summary": "List manual reply qualifications (org-scoped audit history)",
+        "description": "Returns the caller-org's manual qualification history, sorted by `qualifiedAt` DESC. Optionally filter by `campaign_id` and/or `email`. Cross-org rows are blocked at the instantly-service layer. Transparent proxy to email-gateway → instantly-service; the response shape is owned upstream.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Filter by logical campaign id"
+            },
+            "required": false,
+            "description": "Filter by logical campaign id",
+            "name": "campaign_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "email",
+              "description": "Filter by lead email"
+            },
+            "required": false,
+            "description": "Filter by lead email",
+            "name": "email",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Max rows to return (upstream default 200, max 500)"
+            },
+            "required": false,
+            "description": "Max rows to return (upstream default 200, max 500)",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of manual qualifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManualQualificationListResponse"
                 }
               }
             }

--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -142,6 +142,68 @@ router.get("/emails/stats", authenticate, requireOrg, async (req: AuthenticatedR
 });
 
 /**
+ * POST /v1/emails/manual-qualifications
+ * Record a manual reply qualification for a (campaign, lead) pair.
+ * Transparent proxy to email-gateway → instantly-service. Body forwarded byte-identical.
+ */
+router.post(
+  "/emails/manual-qualifications",
+  authenticate,
+  requireOrg,
+  requireUser,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const result = await callExternalService(
+        externalServices.emailGateway,
+        "/orgs/manual-qualifications",
+        {
+          method: "POST",
+          headers: buildInternalHeaders(req),
+          body: req.body,
+        },
+      );
+      res.json(result);
+    } catch (error: any) {
+      console.error("[api-service] Manual qualification create error:", error.message);
+      res.status(error.statusCode || 500).json({ error: error.message || "Failed to record manual qualification" });
+    }
+  },
+);
+
+/**
+ * GET /v1/emails/manual-qualifications
+ * List manual reply qualifications for the caller's org.
+ * Transparent proxy to email-gateway → instantly-service.
+ */
+router.get(
+  "/emails/manual-qualifications",
+  authenticate,
+  requireOrg,
+  requireUser,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const params = new URLSearchParams();
+      for (const key of ["campaign_id", "email", "limit"]) {
+        const v = req.query[key];
+        if (typeof v === "string" && v.length > 0) params.set(key, v);
+      }
+      const qs = params.toString();
+      const path = qs ? `/orgs/manual-qualifications?${qs}` : "/orgs/manual-qualifications";
+
+      const result = await callExternalService(
+        externalServices.emailGateway,
+        path,
+        { headers: buildInternalHeaders(req) },
+      );
+      res.json(result);
+    } catch (error: any) {
+      console.error("[api-service] Manual qualification list error:", error.message);
+      res.status(error.statusCode || 500).json({ error: error.message || "Failed to list manual qualifications" });
+    }
+  },
+);
+
+/**
  * PUT /v1/emails/templates
  * Deploy (upsert) email templates — idempotent, safe to call on every cold start
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5060,6 +5060,32 @@ export const DeployEmailTemplatesRequestSchema = z
   })
   .openapi("DeployEmailTemplatesRequest");
 
+// ───────────────────────────────────────────────────────────────────────────
+// Manual reply qualifications (forwarded to email-gateway → instantly-service)
+// ───────────────────────────────────────────────────────────────────────────
+
+const ManualQualificationStatusEnum = z.enum([
+  "lead_interested",
+  "lead_meeting_booked",
+  "lead_closed",
+  "lead_not_interested",
+  "lead_wrong_person",
+  "lead_neutral",
+  "lead_out_of_office",
+  "auto_reply_received",
+]);
+
+export const ManualQualificationCreateRequestSchema = z
+  .object({
+    campaign_id: z.string().min(1).describe("Logical campaign id (groups sub-campaigns for the same workflow run)"),
+    email: z.string().email().describe("Lead email address"),
+    status: ManualQualificationStatusEnum.describe(
+      "Manual reply qualification status — mirrors Instantly webhook reply event_type values exactly. Set by a human via the dashboard when Instantly fails to detect a reply (e.g. reply received on a non-leurre email account).",
+    ),
+    notes: z.string().max(2000).optional().describe("Optional free-text human note for audit"),
+  })
+  .openapi("ManualQualificationCreateRequest");
+
 registry.registerPath({
   method: "get",
   path: "/v1/emails",
@@ -5178,6 +5204,69 @@ registry.registerPath({
               }),
             })
             .openapi("TransactionalEmailStatsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/emails/manual-qualifications",
+  tags: ["Emails"],
+  summary: "Set a manual reply qualification for a (campaign, lead) pair",
+  description:
+    "Record a human-set reply classification for a lead in a campaign. Used when Instantly's automatic webhook reply " +
+    "classification fails to detect a reply (e.g. the reply was sent to a non-leurre account that Instantly does not monitor). " +
+    "Idempotent: re-POSTing the same status for the same (campaign, lead) returns `idempotent: true` with the existing row. " +
+    "Transparent proxy to email-gateway → instantly-service; the response shape is owned upstream.",
+  security: authed,
+  request: {
+    body: {
+      content: { "application/json": { schema: ManualQualificationCreateRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Manual qualification recorded (or idempotent no-op)",
+      content: {
+        "application/json": {
+          schema: z.object({}).passthrough().openapi("ManualQualificationCreateResponse"),
+        },
+      },
+    },
+    400: { description: "Validation error from upstream", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "(campaign, lead) not found in caller's org", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/emails/manual-qualifications",
+  tags: ["Emails"],
+  summary: "List manual reply qualifications (org-scoped audit history)",
+  description:
+    "Returns the caller-org's manual qualification history, sorted by `qualifiedAt` DESC. Optionally filter by " +
+    "`campaign_id` and/or `email`. Cross-org rows are blocked at the instantly-service layer. " +
+    "Transparent proxy to email-gateway → instantly-service; the response shape is owned upstream.",
+  security: authed,
+  request: {
+    query: z.object({
+      campaign_id: z.string().min(1).optional().describe("Filter by logical campaign id"),
+      email: z.string().email().optional().describe("Filter by lead email"),
+      limit: z.coerce.number().int().optional().describe("Max rows to return (upstream default 200, max 500)"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "List of manual qualifications",
+      content: {
+        "application/json": {
+          schema: z.object({}).passthrough().openapi("ManualQualificationListResponse"),
         },
       },
     },

--- a/tests/unit/manual-qualifications.test.ts
+++ b/tests/unit/manual-qualifications.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock auth middleware — full identity present by default.
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.authType = "user_key";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import emailsRoutes from "../../src/routes/emails.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", emailsRoutes);
+  return app;
+}
+
+const QUALIFICATION_FIXTURE = {
+  id: "00000000-0000-0000-0000-000000000001",
+  orgId: "org_test456",
+  campaignId: "c1a2b3c4-0000-0000-0000-000000000001",
+  instantlyCampaignId: "instantly-camp-1",
+  email: "alice@media.com",
+  status: "lead_interested",
+  qualifiedBy: "user_test123",
+  notes: "Reply received on Gmail — Instantly missed it",
+  qualifiedAt: "2026-05-24T10:00:00.000Z",
+};
+
+function mockFetchOk(payload: any) {
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+    fetchCalls.push({ url, method: init?.method, body, headers });
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(payload),
+    };
+  });
+}
+
+function mockFetchError(status: number, errorBody: string) {
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+    fetchCalls.push({ url, method: init?.method, body, headers });
+    return {
+      ok: false,
+      status,
+      text: () => Promise.resolve(errorBody),
+      json: () => Promise.resolve(JSON.parse(errorBody)),
+    };
+  });
+}
+
+describe("POST /v1/emails/manual-qualifications", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    mockFetchOk({ idempotent: false, qualification: QUALIFICATION_FIXTURE });
+    app = createApp();
+  });
+
+  it("forwards body byte-identical to email-gateway with identity headers", async () => {
+    const body = {
+      campaign_id: "c1a2b3c4-0000-0000-0000-000000000001",
+      email: "alice@media.com",
+      status: "lead_interested",
+      notes: "Reply received on Gmail — Instantly missed it",
+    };
+    const res = await request(app).post("/v1/emails/manual-qualifications").send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ idempotent: false, qualification: QUALIFICATION_FIXTURE });
+
+    const call = fetchCalls.find((c) => c.url.includes("/orgs/manual-qualifications"));
+    expect(call).toBeDefined();
+    expect(call!.method).toBe("POST");
+    // AC#7 — URL contract: downstream call path must be /orgs/manual-qualifications byte-equal.
+    expect(call!.url.endsWith("/orgs/manual-qualifications")).toBe(true);
+    // AC — body byte-identical, no field injection.
+    expect(call!.body).toEqual(body);
+    expect(call!.body.orgId).toBeUndefined();
+    expect(call!.body.userId).toBeUndefined();
+    // Identity headers injected.
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-user-id"]).toBe("user_test123");
+    expect(call!.headers!["x-run-id"]).toBe("run_test789");
+  });
+
+  it("round-trips idempotent: true from upstream unchanged", async () => {
+    mockFetchOk({ idempotent: true, qualification: QUALIFICATION_FIXTURE });
+    app = createApp();
+
+    const res = await request(app)
+      .post("/v1/emails/manual-qualifications")
+      .send({
+        campaign_id: "c1a2b3c4-0000-0000-0000-000000000001",
+        email: "alice@media.com",
+        status: "lead_interested",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.idempotent).toBe(true);
+    expect(res.body.qualification).toEqual(QUALIFICATION_FIXTURE);
+  });
+
+  it("propagates upstream 400 (bad status enum) with body verbatim", async () => {
+    mockFetchError(400, '{"error":"Invalid request body","details":{"fieldErrors":{"status":["Invalid enum value"]}}}');
+    app = createApp();
+
+    const res = await request(app)
+      .post("/v1/emails/manual-qualifications")
+      .send({
+        campaign_id: "c1a2b3c4-0000-0000-0000-000000000001",
+        email: "alice@media.com",
+        status: "not_a_valid_status",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid request body");
+  });
+
+  it("propagates upstream 404 (campaign/email not in org)", async () => {
+    mockFetchError(404, '{"error":"Lead not found in campaign"}');
+    app = createApp();
+
+    const res = await request(app)
+      .post("/v1/emails/manual-qualifications")
+      .send({
+        campaign_id: "c1a2b3c4-0000-0000-0000-000000000001",
+        email: "ghost@nowhere.com",
+        status: "lead_interested",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("Lead not found");
+  });
+
+  it("returns 401 when userId is missing (requireUser)", async () => {
+    // Re-mount with a stripped auth that does NOT set userId.
+    vi.doMock("../../src/middleware/auth.js", () => ({
+      authenticate: (req: any, _res: any, next: any) => {
+        req.orgId = "org_test456";
+        next();
+      },
+      requireOrg: (req: any, res: any, next: any) => {
+        if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+        next();
+      },
+      requireUser: (req: any, res: any, next: any) => {
+        if (!req.userId) return res.status(401).json({ error: "User identity required" });
+        next();
+      },
+      AuthenticatedRequest: {},
+    }));
+    vi.resetModules();
+    const stripped = (await import("../../src/routes/emails.js")).default;
+    const noUserApp = express();
+    noUserApp.use(express.json());
+    noUserApp.use("/v1", stripped);
+
+    const res = await request(noUserApp)
+      .post("/v1/emails/manual-qualifications")
+      .send({
+        campaign_id: "c1a2b3c4-0000-0000-0000-000000000001",
+        email: "alice@media.com",
+        status: "lead_interested",
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("User identity required");
+
+    vi.doUnmock("../../src/middleware/auth.js");
+    vi.resetModules();
+  });
+});
+
+describe("GET /v1/emails/manual-qualifications", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    mockFetchOk({ qualifications: [QUALIFICATION_FIXTURE] });
+    app = createApp();
+  });
+
+  it("forwards all query params and identity headers to email-gateway", async () => {
+    const res = await request(app).get(
+      "/v1/emails/manual-qualifications?campaign_id=c1a2b3c4-0000-0000-0000-000000000001&email=alice@media.com&limit=50",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.qualifications).toEqual([QUALIFICATION_FIXTURE]);
+
+    const call = fetchCalls.find((c) => c.url.includes("/orgs/manual-qualifications"));
+    expect(call).toBeDefined();
+    expect(call!.method).toBe("GET");
+    expect(call!.url).toContain("campaign_id=c1a2b3c4-0000-0000-0000-000000000001");
+    expect(call!.url).toContain("email=alice%40media.com");
+    expect(call!.url).toContain("limit=50");
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-user-id"]).toBe("user_test123");
+    expect(call!.headers!["x-run-id"]).toBe("run_test789");
+  });
+
+  it("forwards with no query string when no filters given", async () => {
+    const res = await request(app).get("/v1/emails/manual-qualifications");
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.url.includes("/orgs/manual-qualifications"));
+    expect(call).toBeDefined();
+    // No query string appended.
+    expect(call!.url.endsWith("/orgs/manual-qualifications")).toBe(true);
+  });
+
+  it("propagates upstream error status", async () => {
+    mockFetchError(400, '{"error":"limit must be <= 500"}');
+    app = createApp();
+
+    const res = await request(app).get("/v1/emails/manual-qualifications?limit=9999");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("limit must be <= 500");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `POST /v1/emails/manual-qualifications` + `GET /v1/emails/manual-qualifications` on api-service.
- Bearer auth (`authenticate + requireOrg + requireUser`), identity headers (`x-org-id`, `x-user-id`, `x-run-id`) injected.
- Body forwarded byte-identical to email-gateway → instantly-service v0.31.1. Response + error round-tripped verbatim.
- No new env vars — reuses `EMAIL_GATEWAY_SERVICE_URL` + `EMAIL_GATEWAY_SERVICE_API_KEY`.

Refs DIS-30 (parent DIS-29).

## URL contract (byte-equal verified)

| Layer | Final URL string |
|---|---|
| api-service mount + handler | `/v1` + `/emails/manual-qualifications` → `/v1/emails/manual-qualifications` |
| Downstream call | `${EMAIL_GATEWAY_SERVICE_URL}/orgs/manual-qualifications` |
| email-gateway producer | `/orgs/manual-qualifications` (v0.16.1, PR #126) |
| instantly-service producer | `/orgs/manual-qualifications` (v0.31.1, PR #210) |

## Design notes

- **No local `safeParse`** on the request body — upstream strict status enum 400 round-trips per AC#3. Declaring `safeParse` would shadow the upstream error with api-service's Zod shape and leak coupling.
- **Response schemas declared as `z.object({}).passthrough()`** per CLAUDE.md rule #8. Downstream owns the shape.
- Status enum exposed in OpenAPI request schema so consumers see the 8 valid values without grepping upstream Zod.

## Test plan

- [x] AC1 POST happy → 200 `{ idempotent, qualification }`, downstream URL exact, body byte-identical, identity headers injected
- [x] AC2 POST without Bearer/userId → 401 (`requireUser`)
- [x] AC3 POST upstream 400 (bad enum) → 400 + body verbatim
- [x] AC4 POST upstream 404 (cross-org) → 404 + body verbatim
- [x] AC5 POST idempotent re-POST → `idempotent: true` round-tripped
- [x] AC6 GET happy with all query params (`campaign_id`, `email`, `limit`) forwarded; no params → no query string
- [x] AC7 URL contract: downstream call path `/orgs/manual-qualifications` byte-equal asserted in test
- [x] `npm test` 1254/1254 green
- [x] `npm run generate:openapi` regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)