### PR TITLE
feat(workflows): wire optional dag through /v1/workflows/upgrade proxy (DIS-34)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5893,17 +5893,41 @@
           "description": {
             "type": "string",
             "minLength": 10,
-            "description": "Natural language description of the upgrade. Describe what should change relative to the current workflow."
+            "description": "Natural language description of the upgrade. Required when `dag` is not provided (LLM regenerates the DAG from this description). Optional when `dag` is provided; if present, replaces the stored description on the resulting row."
+          },
+          "dag": {
+            "type": "object",
+            "properties": {
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "nullable": true
+                },
+                "minItems": 1,
+                "description": "DAG nodes — at least one required. Full shape owned by workflow-service."
+              },
+              "edges": {
+                "type": "array",
+                "items": {
+                  "nullable": true
+                },
+                "description": "DAG edges. Full shape owned by workflow-service."
+              }
+            },
+            "required": [
+              "nodes",
+              "edges"
+            ],
+            "description": "Optional client-supplied DAG. When provided, workflow-service skips the LLM and applies the same in-place / new-version branching as the LLM path. Full node/edge shape owned by workflow-service (see its OpenAPI). Use for surgical fixes (e.g. patch a single script node) without re-running generation."
           },
           "hints": {
             "type": "object",
             "properties": {},
-            "description": "Optional hints to guide the upgrade. Shape owned by workflow-service (see its OpenAPI for known keys)."
+            "description": "Optional hints to guide the upgrade. Shape owned by workflow-service (see its OpenAPI for known keys). Ignored when `dag` is provided."
           }
         },
         "required": [
-          "workflowSlug",
-          "description"
+          "workflowSlug"
         ]
       },
       "ProviderInfo": {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -596,7 +596,7 @@ router.post("/workflows/upgrade", authenticate, requireOrg, requireUser, async (
       });
     }
 
-    const { workflowSlug, description, hints } = parsed.data;
+    const { workflowSlug, description, hints, dag } = parsed.data;
 
     const result = await callExternalService(
       externalServices.workflow,
@@ -610,6 +610,7 @@ router.post("/workflows/upgrade", authenticate, requireOrg, requireUser, async (
           workflowSlug,
           description,
           hints,
+          dag,
         },
       }
     );

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3818,16 +3818,30 @@ export const UpgradeWorkflowRequestSchema = z
     description: z
       .string()
       .min(10)
+      .optional()
       .describe(
-        "Natural language description of the upgrade. Describe what should change relative to the current workflow."
+        "Natural language description of the upgrade. Required when `dag` is not provided (LLM regenerates the DAG from this description). Optional when `dag` is provided; if present, replaces the stored description on the resulting row."
+      ),
+    dag: z
+      .object({
+        nodes: z.array(z.unknown()).min(1).describe("DAG nodes — at least one required. Full shape owned by workflow-service."),
+        edges: z.array(z.unknown()).describe("DAG edges. Full shape owned by workflow-service."),
+      })
+      .passthrough()
+      .optional()
+      .describe(
+        "Optional client-supplied DAG. When provided, workflow-service skips the LLM and applies the same in-place / new-version branching as the LLM path. Full node/edge shape owned by workflow-service (see its OpenAPI). Use for surgical fixes (e.g. patch a single script node) without re-running generation."
       ),
     hints: z
       .object({})
       .passthrough()
       .optional()
       .describe(
-        "Optional hints to guide the upgrade. Shape owned by workflow-service (see its OpenAPI for known keys)."
+        "Optional hints to guide the upgrade. Shape owned by workflow-service (see its OpenAPI for known keys). Ignored when `dag` is provided."
       ),
+  })
+  .refine((data) => data.dag !== undefined || data.description !== undefined, {
+    message: "Either 'dag' or 'description' must be provided",
   })
   .openapi("UpgradeWorkflowRequest");
 

--- a/tests/unit/workflows-upgrade.test.ts
+++ b/tests/unit/workflows-upgrade.test.ts
@@ -44,12 +44,13 @@ describe("POST /v1/workflows/upgrade route", () => {
     expect(block).toContain("userId: req.userId");
   });
 
-  it("should forward workflowSlug, description, and hints from request body", () => {
+  it("should forward workflowSlug, description, hints, and dag from request body", () => {
     const upgradeIdx = content.indexOf('router.post("/workflows/upgrade"');
     const block = content.slice(upgradeIdx, upgradeIdx + 1000);
     expect(block).toContain("workflowSlug");
     expect(block).toContain("description");
     expect(block).toContain("hints");
+    expect(block).toContain("dag");
   });
 
   it("should return 400 on invalid request", () => {
@@ -76,11 +77,13 @@ describe("UpgradeWorkflowRequestSchema", () => {
     expect(schemaSection).toContain("workflowSlug");
   });
 
-  it("should require description", () => {
+  it("should declare description and dag fields (both optional, at least one required via refine)", () => {
     const start = content.indexOf("UpgradeWorkflowRequestSchema");
     const end = content.indexOf('.openapi("UpgradeWorkflowRequest")', start);
     const schemaSection = content.slice(start, end);
     expect(schemaSection).toContain("description");
+    expect(schemaSection).toContain("dag");
+    expect(schemaSection).toContain(".refine(");
   });
 
   it("should have optional hints", () => {
@@ -146,5 +149,74 @@ describe("UpgradeWorkflowRequestSchema parsing", () => {
     if (result.success) {
       expect(result.data.hints).toEqual({ futureKey: "value", services: ["x"] });
     }
+  });
+
+  it("accepts a dag-only body (no description, LLM is skipped downstream)", () => {
+    const result = UpgradeWorkflowRequestSchema.safeParse({
+      workflowSlug: "pr-cold-email-outreach",
+      dag: {
+        nodes: [{ id: "n1", type: "http.call", config: { service: "lead", method: "POST", path: "/x" } }],
+        edges: [],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dag).toBeDefined();
+      expect(result.data.dag?.nodes).toHaveLength(1);
+    }
+  });
+
+  it("accepts both dag and description in the same body", () => {
+    const result = UpgradeWorkflowRequestSchema.safeParse({
+      workflowSlug: "pr-cold-email-outreach",
+      description: "Patch the serialize-brand-fields script node",
+      dag: {
+        nodes: [{ id: "n1", type: "script", config: { code: "return {}" } }],
+        edges: [],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dag).toBeDefined();
+      expect(result.data.description).toBe("Patch the serialize-brand-fields script node");
+    }
+  });
+
+  it("rejects a body with neither dag nor description (refine)", () => {
+    const result = UpgradeWorkflowRequestSchema.safeParse({
+      workflowSlug: "pr-cold-email-outreach",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a dag with empty nodes array (downstream requires at least one node)", () => {
+    const result = UpgradeWorkflowRequestSchema.safeParse({
+      workflowSlug: "pr-cold-email-outreach",
+      dag: { nodes: [], edges: [] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("passes through unknown dag keys like onError (downstream owns the shape)", () => {
+    const result = UpgradeWorkflowRequestSchema.safeParse({
+      workflowSlug: "pr-cold-email-outreach",
+      dag: {
+        nodes: [{ id: "n1", type: "script", config: { code: "return {}" } }],
+        edges: [],
+        onError: "n1",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data.dag as { onError?: string }).onError).toBe("n1");
+    }
+  });
+
+  it("rejects description shorter than 10 chars when provided", () => {
+    const result = UpgradeWorkflowRequestSchema.safeParse({
+      workflowSlug: "pr-cold-email-outreach",
+      description: "short",
+    });
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `POST /v1/workflows/upgrade` now accepts optional `dag` field; forwarded verbatim to workflow-service v0.29.2+ (skips LLM regen, applies surgical patch).
- `description` flipped to optional; Zod refine enforces "at least one of `dag` / `description`".
- `hints` description updated to note "Ignored when `dag` is provided" (downstream contract).
- `openapi.json` regenerated; `dag` visible on `UpgradeWorkflowRequest`.

Linear: [DIS-34](https://linear.app/distribute-you/issue/DIS-34/multi-repo-feat-wire-client-supplied-dag-through-api-service-chat)
Upstream: [workflow-service PR #293](https://github.com/shamanic-technologies/workflow-service/pull/293) / [v0.29.2](https://github.com/shamanic-technologies/workflow-service/releases/tag/v0.29.2)

## Why this shape

- `dag` is `z.object({ nodes: z.array(z.unknown()).min(1), edges: z.array(z.unknown()) }).passthrough().optional()` — pins minimal top-level shape for an early 400 on obvious mistakes, leaves deep validation to workflow-service per transparent-proxy rule #4 (no body transforms) and the spirit of rule #8 (no re-declaration of downstream contract). Avoids re-encoding the full node-type enum here.
- `description` keeps `.min(10)` when present, mirrors downstream.
- Refine message: `"Either 'dag' or 'description' must be provided"`. Surfaces in the 400 response detail.

## Test plan

- [x] Schema parse: `{workflowSlug, dag}` → success, `dag` present
- [x] Schema parse: `{workflowSlug, description}` → success (existing LLM path)
- [x] Schema parse: `{workflowSlug, dag, description}` → success (both forwarded)
- [x] Schema parse: `{workflowSlug}` alone → refine fails (400)
- [x] Schema parse: empty `dag.nodes` → fails (min(1))
- [x] Schema parse: `dag` with passthrough extras (`onError`) → success
- [x] Schema parse: `description` <10 chars → fails
- [x] Route source contains `dag` in forwarded body destructure
- [x] `npm test` → 1260 / 1260 green (was 1254 on staging)
- [x] `npm run generate:openapi` → clean diff, `dag` field added
- [ ] Post-deploy curl on staging once auto-merged

## Non-goals (explicit cuts)

- `UpgradeWorkflowResponse` re-declaration at `src/schemas.ts:3906` (pre-existing rule #8 tech debt) — out of scope, separate cleanup.
- chat-service `upgrade_workflow` tool — parallel workspace per DIS-34.
- distribute.you dashboard surface — deferred per DIS-34 (no DAG-editor UI today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)