### PR TITLE
feat(quotes): proxy 2 HITL PR Expert Quote Opportunities routes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8917,6 +8917,22 @@
           "quotePitch"
         ]
       },
+      "OpportunitiesRankedResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "OpportunitiesRankedRequest": {
+        "type": "object",
+        "properties": {}
+      },
+      "QuoteRequestDraftResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "QuoteRequestDraftRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "VisibilityScoreWeights": {
         "type": "object",
         "properties": {
@@ -31220,6 +31236,250 @@
           },
           "404": {
             "description": "Quote pitch not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/opportunities/ranked": {
+      "post": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "RAG-ranked opportunities for the (campaign, brand)",
+        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/ranked. Body: { campaignId, brandId, limit?, offset? }. Response carries opportunities[] with score + whyRelevant. Body + response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunitiesRankedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ranked opportunities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunitiesRankedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (forwarded verbatim from downstream)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/orgs/quote-requests/{id}/draft": {
+      "post": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "Generate a pitch draft for the given quote request",
+        "description": "Pass-through to journalists-quotes-service POST /orgs/quote-requests/{id}/draft. Body: { brandId, campaignId, spokesperson, expertiseTopics, responseStyle, companyContext, valueProposition, additionalContext? }. Response: { pitch, charCount, attempts, tokensInput, tokensOutput }. Body + response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Quote request id"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuoteRequestDraftRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pitch draft",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuoteRequestDraftResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Content-generation length error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Quote request not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/quotes.ts
+++ b/src/routes/quotes.ts
@@ -94,4 +94,41 @@ router.get("/orgs/quote-pitches/:id", authenticate, requireOrg, requireUser, asy
   }
 });
 
+// POST /v1/orgs/opportunities/ranked — RAG-ranked opportunities for (campaign, brand)
+router.post("/orgs/opportunities/ranked", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      "/orgs/opportunities/ranked",
+      {
+        method: "POST",
+        body: req.body,
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch ranked opportunities" });
+  }
+});
+
+// POST /v1/orgs/quote-requests/:id/draft — generate a pitch draft for the given quote request
+router.post("/orgs/quote-requests/:id/draft", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const id = req.params.id;
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      `/orgs/quote-requests/${encodeURIComponent(id)}/draft`,
+      {
+        method: "POST",
+        body: req.body,
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to generate quote draft" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6919,6 +6919,13 @@ const QuotePitchResponseSchema = z
   .object({ quotePitch: QuotePitchSchema })
   .openapi("QuotePitchResponse");
 
+// Passthrough schemas for new HITL PR Expert Quote Opportunities routes.
+// Downstream (journalists-quotes-service) owns body + response shapes — api-service forwards bytes.
+const OpportunitiesRankedRequestSchema = z.object({}).passthrough().openapi("OpportunitiesRankedRequest");
+const OpportunitiesRankedResponseSchema = z.object({}).passthrough().openapi("OpportunitiesRankedResponse");
+const QuoteRequestDraftRequestSchema = z.object({}).passthrough().openapi("QuoteRequestDraftRequest");
+const QuoteRequestDraftResponseSchema = z.object({}).passthrough().openapi("QuoteRequestDraftResponse");
+
 registry.registerPath({
   method: "get",
   path: "/v1/orgs/quote-requests",
@@ -7018,6 +7025,51 @@ registry.registerPath({
     200: { description: "Quote pitch", content: { "application/json": { schema: QuotePitchResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Quote pitch not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/orgs/opportunities/ranked",
+  tags: ["Expert Quotes"],
+  summary: "RAG-ranked opportunities for the (campaign, brand)",
+  description:
+    "Pass-through to journalists-quotes-service POST /orgs/opportunities/ranked. " +
+    "Body: { campaignId, brandId, limit?, offset? }. Response carries opportunities[] with score + whyRelevant. " +
+    "Body + response shapes are owned by the downstream service.",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: OpportunitiesRankedRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Ranked opportunities", content: { "application/json": { schema: OpportunitiesRankedResponseSchema } } },
+    400: { description: "Bad request (forwarded verbatim from downstream)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/orgs/quote-requests/{id}/draft",
+  tags: ["Expert Quotes"],
+  summary: "Generate a pitch draft for the given quote request",
+  description:
+    "Pass-through to journalists-quotes-service POST /orgs/quote-requests/{id}/draft. " +
+    "Body: { brandId, campaignId, spokesperson, expertiseTopics, responseStyle, companyContext, valueProposition, additionalContext? }. " +
+    "Response: { pitch, charCount, attempts, tokensInput, tokensOutput }. " +
+    "Body + response shapes are owned by the downstream service.",
+  security: authed,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: "Quote request id" }),
+    }),
+    body: { content: { "application/json": { schema: QuoteRequestDraftRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Pitch draft", content: { "application/json": { schema: QuoteRequestDraftResponseSchema } } },
+    400: { description: "Content-generation length error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Quote request not found", content: errorContent },
   },
 });
 

--- a/tests/unit/quotes-proxy.test.ts
+++ b/tests/unit/quotes-proxy.test.ts
@@ -109,16 +109,16 @@ describe("Expert quotes proxy routes", () => {
     }
   });
 
-  it("should call externalServices.journalistsQuotes for every endpoint (5x)", () => {
+  it("should call externalServices.journalistsQuotes for every endpoint (7x)", () => {
     const matches = content.match(/externalServices\.journalistsQuotes/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(5);
+    expect(matches!.length).toBe(7);
   });
 
-  it("should use buildInternalHeaders for every endpoint (5x)", () => {
+  it("should use buildInternalHeaders for every endpoint (7x)", () => {
     const matches = content.match(/buildInternalHeaders\(req\)/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(5);
+    expect(matches!.length).toBe(7);
   });
 
   it("should preserve downstream paths (no path renaming)", () => {
@@ -127,6 +127,44 @@ describe("Expert quotes proxy routes", () => {
     expect(content).toContain('"/orgs/quote-requests/:id"');
     expect(content).toContain('"/orgs/quote-pitches"');
     expect(content).toContain('"/orgs/quote-pitches/:id"');
+    expect(content).toContain('"/orgs/opportunities/ranked"');
+    expect(content).toContain('"/orgs/quote-requests/:id/draft"');
+  });
+
+  it("should have POST /orgs/opportunities/ranked with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/orgs/opportunities/ranked"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward body verbatim on POST /orgs/opportunities/ranked", () => {
+    const idx = content.indexOf('"/orgs/opportunities/ranked"');
+    const section = content.slice(idx, idx + 800);
+    expect(section).toMatch(/method:\s*"POST"/);
+    expect(section).toContain("body: req.body");
+  });
+
+  it("should have POST /orgs/quote-requests/:id/draft with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/orgs/quote-requests/:id/draft"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should URL-encode :id and forward body verbatim on POST /orgs/quote-requests/:id/draft", () => {
+    const idx = content.indexOf('"/orgs/quote-requests/:id/draft"');
+    const section = content.slice(idx, idx + 800);
+    expect(section).toContain("req.params.id");
+    expect(section).toMatch(/\/orgs\/quote-requests\/\$\{[^}]*encodeURIComponent[^}]*\}\/draft/);
+    expect(section).toMatch(/method:\s*"POST"/);
+    expect(section).toContain("body: req.body");
   });
 });
 
@@ -197,6 +235,18 @@ describe("Expert quotes OpenAPI schemas", () => {
   it("should use Expert Quotes tag", () => {
     expect(schemaContent).toContain('tags: ["Expert Quotes"]');
   });
+
+  it("should register POST /v1/orgs/opportunities/ranked with passthrough body + response", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/opportunities/ranked"');
+    expect(schemaContent).toContain("OpportunitiesRankedRequest");
+    expect(schemaContent).toContain("OpportunitiesRankedResponse");
+  });
+
+  it("should register POST /v1/orgs/quote-requests/{id}/draft with passthrough body + response", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/quote-requests/{id}/draft"');
+    expect(schemaContent).toContain("QuoteRequestDraftRequest");
+    expect(schemaContent).toContain("QuoteRequestDraftResponse");
+  });
 });
 
 describe("Expert quotes endpoints in openapi.json", () => {
@@ -226,6 +276,16 @@ describe("Expert quotes endpoints in openapi.json", () => {
   it("should include /v1/orgs/quote-pitches/{id} GET in committed openapi.json", () => {
     expect(openapi.paths["/v1/orgs/quote-pitches/{id}"]).toBeDefined();
     expect(openapi.paths["/v1/orgs/quote-pitches/{id}"].get).toBeDefined();
+  });
+
+  it("should include /v1/orgs/opportunities/ranked POST in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/opportunities/ranked"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/opportunities/ranked"].post).toBeDefined();
+  });
+
+  it("should include /v1/orgs/quote-requests/{id}/draft POST in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/quote-requests/{id}/draft"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/quote-requests/{id}/draft"].post).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Add 2 new proxy routes to support the dashboard HITL surface for the `pr-expert-quote-opportunities` feature. Both mirror the existing journalists-quotes proxy idiom in `src/routes/quotes.ts`.

- `POST /v1/orgs/opportunities/ranked` → journalists-quotes-service `POST /orgs/opportunities/ranked`
- `POST /v1/orgs/quote-requests/:id/draft` → journalists-quotes-service `POST /orgs/quote-requests/:id/draft`

### Convention

- Middleware: `authenticate + requireOrg + requireUser` (matches the existing 5 GET routes — same `/orgs/*` tier per CLAUDE.md rule #3).
- Body forwarded verbatim — no transform, no field stripping (rule #4).
- Identity headers via `buildInternalHeaders(req)` — `x-org-id`, `x-user-id`, `x-run-id`, plus any `x-brand-id` / `x-campaign-id` / `x-feature-slug` resolved from header or query.
- Downstream paths preserved byte-equal (rule #1).
- Request + response schemas declared as `z.object({}).passthrough().openapi(...)` per CLAUDE.md rule #8 — journalists-quotes-service owns the shape.
- Upstream error bodies passed through verbatim via `error.message` (rule #7).

### URL contract (3 sides)

| Side | Final URL |
|------|-----------|
| Producer (journalists-quotes-service) | `POST /orgs/opportunities/ranked`, `POST /orgs/quote-requests/:id/draft` |
| Gateway (this service) | `POST /v1/orgs/opportunities/ranked`, `POST /v1/orgs/quote-requests/:id/draft` |
| Consumer (dashboard) | `apiCall("/orgs/opportunities/ranked")`, `apiCall("/orgs/quote-requests/{id}/draft")` |

Byte-equal verified.

### Files

- `src/routes/quotes.ts` — 2 new POST handlers
- `src/schemas.ts` — 2 new `registry.registerPath` entries + 4 passthrough schemas
- `openapi.json` — regenerated via `pnpm build`
- `tests/unit/quotes-proxy.test.ts` — bump 5x → 7x literal counts, add POST-handler assertions + openapi.json assertions

### Deployment ordering

Downstream `journalists-quotes-service` is shipping the producer endpoints in a parallel workspace. Until that lands on staging the proxy will pass through whatever the downstream returns (likely 404 on the new paths). No data-corruption risk — proxy is transparent.

## Test plan

- [x] `pnpm build` (tsc + openapi regen) green
- [x] `pnpm test` — 1270/1270 green locally
- [ ] After staging deploy + journalists-quotes-service staging deploy: smoke via `curl` with a real Bearer

🤖 Generated with [Claude Code](https://claude.com/claude-code)