### PR TITLE
fix(platform-prompts): tighten variables schema to {name,description}[] (DIS-52)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6683,14 +6683,7 @@
       },
       "PlatformPromptResponse": {
         "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "message"
-        ]
+        "properties": {}
       },
       "PlatformPromptRequest": {
         "type": "object",
@@ -6708,9 +6701,23 @@
           "variables": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Variable name as referenced in the prompt body via {{name}}."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Free-form description of what the caller should put for this variable. Caller decides the JSON shape — string, array, object, whatever fits the template."
+                }
+              },
+              "required": [
+                "name",
+                "description"
+              ]
             },
-            "description": "Template variable names (e.g. ['leadFirstName', 'leadLastName'])"
+            "description": "Inputs the template expects. Each entry is { name, description }; the caller decides the JSON shape per name."
           }
         },
         "required": [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4765,7 +4765,20 @@ export const PlatformPromptRequestSchema = z
   .object({
     type: z.string().min(1).describe("Prompt type (e.g. 'cold-email')"),
     prompt: z.string().min(1).describe("The prompt template text"),
-    variables: z.array(z.string()).describe("Template variable names (e.g. ['leadFirstName', 'leadLastName'])"),
+    variables: z
+      .array(
+        z.object({
+          name: z.string().describe("Variable name as referenced in the prompt body via {{name}}."),
+          description: z
+            .string()
+            .describe(
+              "Free-form description of what the caller should put for this variable. Caller decides the JSON shape — string, array, object, whatever fits the template."
+            ),
+        })
+      )
+      .describe(
+        "Inputs the template expects. Each entry is { name, description }; the caller decides the JSON shape per name."
+      ),
   })
   .openapi("PlatformPromptRequest");
 
@@ -4789,7 +4802,7 @@ registry.registerPath({
       description: "Prompt deployed",
       content: {
         "application/json": {
-          schema: z.object({ message: z.string() }).openapi("PlatformPromptResponse"),
+          schema: z.object({}).passthrough().openapi("PlatformPromptResponse"),
         },
       },
     },

--- a/tests/unit/platform-prompts.test.ts
+++ b/tests/unit/platform-prompts.test.ts
@@ -59,13 +59,17 @@ describe("PUT /platform-prompts", () => {
   });
 
   it("should deploy a platform prompt with valid API key and no identity headers", async () => {
+    const variables = [
+      { name: "leadFirstName", description: "Lead first name (string)." },
+      { name: "leadLastName", description: "Lead last name (string)." },
+    ];
     const res = await request(app)
       .put("/platform-prompts")
       .set("X-API-Key", VALID_API_KEY)
       .send({
         type: "cold-email",
         prompt: "You are writing cold emails...",
-        variables: ["leadFirstName", "leadLastName"],
+        variables,
       });
 
     expect(res.status).toBe(200);
@@ -77,12 +81,56 @@ describe("PUT /platform-prompts", () => {
     expect(call!.body).toMatchObject({
       type: "cold-email",
       prompt: "You are writing cold emails...",
-      variables: ["leadFirstName", "leadLastName"],
+      variables,
     });
     // No identity headers forwarded
     expect(call!.headers!["x-org-id"]).toBeUndefined();
     expect(call!.headers!["x-user-id"]).toBeUndefined();
     expect(call!.headers!["x-run-id"]).toBeUndefined();
+  });
+
+  it("should return 400 when variables is a string array (legacy shape)", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        type: "cold-email",
+        prompt: "test",
+        variables: ["leadFirstName", "leadLastName"],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+    // Downstream MUST NOT be called
+    expect(fetchCalls.find((c) => c.url.includes("/platform-prompts"))).toBeUndefined();
+  });
+
+  it("should return 400 when a variable entry is missing description", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        type: "cold-email",
+        prompt: "test",
+        variables: [{ name: "leadFirstName" }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
+  });
+
+  it("should return 400 when a variable entry is missing name", async () => {
+    const res = await request(app)
+      .put("/platform-prompts")
+      .set("X-API-Key", VALID_API_KEY)
+      .send({
+        type: "cold-email",
+        prompt: "test",
+        variables: [{ description: "Lead first name." }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid request");
   });
 
   it("should return 401 without API key", async () => {


### PR DESCRIPTION
## Summary

- Tighten `PUT /platform-prompts` request schema: `variables` is now `Array<{name: string, description: string}>` (was `string[]`).
- String-array payloads now return **400 at api-service** instead of passing through to content-gen and 400-ing at the downstream Zod boundary with an opaque error.
- Collapse `PlatformPromptResponse` to `z.object({}).passthrough()` per `CLAUDE.md` rule #8 (response was declared as `{message: string}`, downstream actually returns the full prompt object).
- Regenerate `openapi.json` via `pnpm generate:openapi`.

## Context

Content-generation-service shipped DIS-52 (2026-05-26 → main) requiring the new variable shape. Distribute.you dashboard PR for DIS-54 ships the consumer-side rename in parallel. This PR is the gateway-side gate so:

1. Clients still on `string[]` get a clear 400 from api-service before the request fans out.
2. The OpenAPI spec on the public gateway advertises the real contract.

Registry confirms the deployed downstream shape:
```
mcp__api-registry__get_endpoint_details(content-generation POST /platform-prompts)
→ variables: array<{name: string, description: string}>
```

## Test plan

- [x] `pnpm test` — 1273/1273 green
- [x] `pnpm build` — tsc + openapi regen green
- [x] New negative test: `variables: ["leadFirstName"]` → 400 without downstream call
- [x] New negative tests: missing `name` / missing `description` → 400
- [x] `jq '.components.schemas.PlatformPromptRequest.properties.variables' openapi.json` shows `items.properties.{name,description}` both required

## Related

- DIS-52 — content-generation-service (Done, merged 2026-05-26)
- DIS-54 — distribute.you cold-email template registration (In Progress, parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)