### PR TITLE
feat(invites,waitlist): proxy 5 client-service routes for Wave 0.5 (DIS-64)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -86,6 +86,14 @@
     {
       "name": "AI Visibility",
       "description": "AI visibility-score audits (ai-visibility-score-service proxy)"
+    },
+    {
+      "name": "Invites",
+      "description": "Invite-only gate (Wave 0.5): validate codes, query org quota, claim rewards"
+    },
+    {
+      "name": "Waitlist",
+      "description": "Waitlist for users without an invite code"
     }
   ],
   "components": {
@@ -9444,6 +9452,38 @@
           "top_competitors",
           "citation_opportunities"
         ]
+      },
+      "InviteValidateResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "InviteValidateRequest": {
+        "type": "object",
+        "properties": {}
+      },
+      "WaitlistRequestAccessResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "WaitlistRequestAccessRequest": {
+        "type": "object",
+        "properties": {}
+      },
+      "WaitlistPositionResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "OrgInvitesStatusResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "OrgInvitesClaimResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "OrgInvitesClaimRequest": {
+        "type": "object",
+        "properties": {}
       }
     },
     "parameters": {}
@@ -31853,6 +31893,404 @@
           },
           "404": {
             "description": "Run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/invites/validate": {
+      "post": {
+        "tags": [
+          "Invites"
+        ],
+        "summary": "Validate an invite code (no auth)",
+        "description": "Public pass-through to client-service POST /public/invites/validate. Returns whether the supplied invite code is currently redeemable. Body + response shapes are owned by the downstream service.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteValidateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteValidateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (forwarded verbatim from downstream)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/waitlist/request-access": {
+      "post": {
+        "tags": [
+          "Waitlist"
+        ],
+        "summary": "Request waitlist access (no auth)",
+        "description": "Public pass-through to client-service POST /public/waitlist/request-access. Downstream inserts the waitlist row and fires the confirmation email. Body + response shapes are owned by the downstream service.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WaitlistRequestAccessRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Waitlist position",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WaitlistRequestAccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (forwarded verbatim from downstream)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/waitlist/position": {
+      "get": {
+        "tags": [
+          "Waitlist"
+        ],
+        "summary": "Look up waitlist position by email (no auth)",
+        "description": "Public pass-through to client-service GET /public/waitlist/position. Response shape is owned by the downstream service.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "email",
+              "description": "Email that signed up to the waitlist"
+            },
+            "required": true,
+            "name": "email",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Waitlist position",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WaitlistPositionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Email not on waitlist (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/{orgId}/invites/status": {
+      "get": {
+        "tags": [
+          "Invites"
+        ],
+        "summary": "Get invite quota status for an org",
+        "description": "Pass-through to client-service GET /internal/orgs/{orgId}/invites/status. Returns used / total quota and the org's invite code. The {orgId} path segment MUST match the authenticated x-org-id; mismatch returns 403. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Org UUID (must match authenticated org)"
+            },
+            "required": true,
+            "name": "orgId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Invite status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgInvitesStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "orgId path does not match authenticated org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/{orgId}/invites/claim": {
+      "post": {
+        "tags": [
+          "Invites"
+        ],
+        "summary": "Claim an invite code for the authenticated org",
+        "description": "Pass-through to client-service POST /internal/orgs/{orgId}/invites/claim. Downstream orchestrates: record claim row -> grant $25 to inviter + $25 to invitee via billing-service -> send invite-claimed-welcome + invite-success-notification via transactional-email-service. Idempotent on (code, inviteeOrgId). The {orgId} path segment MUST match the authenticated x-org-id; mismatch returns 403. Body + response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Org UUID (must match authenticated org)"
+            },
+            "required": true,
+            "name": "orgId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrgInvitesClaimRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Claim result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgInvitesClaimResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid code (forwarded verbatim from downstream)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "orgId path does not match authenticated org",
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -74,6 +74,8 @@ Authorization: Bearer distrib.usr_abc123...
     { name: "Google CRM", description: "Google CRM (Gmail + People bronze) ingestion" },
     { name: "Expert Quotes", description: "Expert quote outreach (journalists-quotes-service proxy)" },
     { name: "AI Visibility", description: "AI visibility-score audits (ai-visibility-score-service proxy)" },
+    { name: "Invites", description: "Invite-only gate (Wave 0.5): validate codes, query org quota, claim rewards" },
+    { name: "Waitlist", description: "Waitlist for users without an invite code" },
   ],
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ import featuresRoutes from "./routes/features.js";
 import googleRoutes from "./routes/google.js";
 import quotesRoutes from "./routes/quotes.js";
 import visibilityRoutes from "./routes/visibility.js";
+import invitesRoutes from "./routes/invites.js";
+import waitlistRoutes from "./routes/waitlist.js";
 import publicStatsRoutes from "./routes/public-stats.js";
 import costsRoutes from "./routes/costs.js";
 import adminRoutes from "./routes/admin.js";
@@ -210,6 +212,8 @@ app.use("/v1", featuresRoutes);
 app.use("/v1", googleRoutes);
 app.use("/v1", quotesRoutes);
 app.use("/v1", visibilityRoutes);
+app.use("/v1", invitesRoutes);
+app.use("/v1", waitlistRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/src/routes/invites.ts
+++ b/src/routes/invites.ts
@@ -1,0 +1,90 @@
+import { Router } from "express";
+import {
+  authenticate,
+  requireOrg,
+  requireUser,
+  AuthenticatedRequest,
+} from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+// POST /v1/invites/validate — public lookup of an invite code (Wave 0.5)
+router.post("/invites/validate", async (req, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.client,
+      "/public/invites/validate",
+      { method: "POST", body: req.body },
+    );
+    res.json(result);
+  } catch (error: any) {
+    res
+      .status(error.statusCode || 500)
+      .json({ error: error.message || "Failed to validate invite" });
+  }
+});
+
+// GET /v1/orgs/:orgId/invites/status — authed quota lookup for the org
+router.get(
+  "/orgs/:orgId/invites/status",
+  authenticate,
+  requireOrg,
+  requireUser,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      if (req.params.orgId !== req.orgId) {
+        return res.status(403).json({
+          error: "orgId path parameter does not match authenticated org",
+        });
+      }
+      const result = await callExternalService(
+        externalServices.client,
+        `/internal/orgs/${encodeURIComponent(req.params.orgId)}/invites/status`,
+        { headers: buildInternalHeaders(req) },
+      );
+      res.json(result);
+    } catch (error: any) {
+      res
+        .status(error.statusCode || 500)
+        .json({ error: error.message || "Failed to fetch invite status" });
+    }
+  },
+);
+
+// POST /v1/orgs/:orgId/invites/claim — authed claim. Downstream client-service
+// orchestrates: record claim row → grant $25 to inviter + $25 to invitee via
+// billing-service → send invite-claimed-welcome + invite-success-notification
+// via transactional-email-service. api-service stays a transparent proxy.
+router.post(
+  "/orgs/:orgId/invites/claim",
+  authenticate,
+  requireOrg,
+  requireUser,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      if (req.params.orgId !== req.orgId) {
+        return res.status(403).json({
+          error: "orgId path parameter does not match authenticated org",
+        });
+      }
+      const result = await callExternalService(
+        externalServices.client,
+        `/internal/orgs/${encodeURIComponent(req.params.orgId)}/invites/claim`,
+        {
+          method: "POST",
+          body: req.body,
+          headers: buildInternalHeaders(req),
+        },
+      );
+      res.json(result);
+    } catch (error: any) {
+      res
+        .status(error.statusCode || 500)
+        .json({ error: error.message || "Failed to claim invite" });
+    }
+  },
+);
+
+export default router;

--- a/src/routes/waitlist.ts
+++ b/src/routes/waitlist.ts
@@ -1,0 +1,44 @@
+import { Router } from "express";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+
+const router = Router();
+
+// POST /v1/waitlist/request-access — public waitlist signup. Downstream
+// client-service inserts the row and fires the confirmation email; api-service
+// stays a transparent proxy.
+router.post("/waitlist/request-access", async (req, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.client,
+      "/public/waitlist/request-access",
+      { method: "POST", body: req.body },
+    );
+    res.json(result);
+  } catch (error: any) {
+    res
+      .status(error.statusCode || 500)
+      .json({ error: error.message || "Failed to request waitlist access" });
+  }
+});
+
+// GET /v1/waitlist/position?email=<email> — public position lookup
+router.get("/waitlist/position", async (req, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query["email"]) {
+      params.set("email", req.query["email"] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.client,
+      `/public/waitlist/position${qs}`,
+    );
+    res.json(result);
+  } catch (error: any) {
+    res
+      .status(error.statusCode || 500)
+      .json({ error: error.message || "Failed to fetch waitlist position" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7314,3 +7314,139 @@ registry.registerPath({
     404: { description: "Run not found", content: errorContent },
   },
 });
+
+// ===================================================================
+// INVITES + WAITLIST (Wave 0.5 — DIS-64)
+// ===================================================================
+// api-service is a transparent proxy here per CLAUDE.md #2. The downstream
+// client-service owns the entire invite/waitlist domain, including the
+// claim orchestration (billing-service credit grants + transactional-email
+// confirmations). All response shapes collapse to passthrough so downstream
+// renames flow through without coordinated api-service edits (CLAUDE.md #8).
+// ===================================================================
+
+const InviteValidateRequestSchema = z.object({}).passthrough().openapi("InviteValidateRequest");
+const InviteValidateResponseSchema = z.object({}).passthrough().openapi("InviteValidateResponse");
+const WaitlistRequestAccessRequestSchema = z.object({}).passthrough().openapi("WaitlistRequestAccessRequest");
+const WaitlistRequestAccessResponseSchema = z.object({}).passthrough().openapi("WaitlistRequestAccessResponse");
+const WaitlistPositionResponseSchema = z.object({}).passthrough().openapi("WaitlistPositionResponse");
+const OrgInvitesStatusResponseSchema = z.object({}).passthrough().openapi("OrgInvitesStatusResponse");
+const OrgInvitesClaimRequestSchema = z.object({}).passthrough().openapi("OrgInvitesClaimRequest");
+const OrgInvitesClaimResponseSchema = z.object({}).passthrough().openapi("OrgInvitesClaimResponse");
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/invites/validate",
+  tags: ["Invites"],
+  summary: "Validate an invite code (no auth)",
+  description:
+    "Public pass-through to client-service POST /public/invites/validate. " +
+    "Returns whether the supplied invite code is currently redeemable. " +
+    "Body + response shapes are owned by the downstream service.",
+  request: {
+    body: { content: { "application/json": { schema: InviteValidateRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Validation result", content: { "application/json": { schema: InviteValidateResponseSchema } } },
+    400: { description: "Bad request (forwarded verbatim from downstream)", content: errorContent },
+    502: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/waitlist/request-access",
+  tags: ["Waitlist"],
+  summary: "Request waitlist access (no auth)",
+  description:
+    "Public pass-through to client-service POST /public/waitlist/request-access. " +
+    "Downstream inserts the waitlist row and fires the confirmation email. " +
+    "Body + response shapes are owned by the downstream service.",
+  request: {
+    body: { content: { "application/json": { schema: WaitlistRequestAccessRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Waitlist position", content: { "application/json": { schema: WaitlistRequestAccessResponseSchema } } },
+    400: { description: "Bad request (forwarded verbatim from downstream)", content: errorContent },
+    502: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/waitlist/position",
+  tags: ["Waitlist"],
+  summary: "Look up waitlist position by email (no auth)",
+  description:
+    "Public pass-through to client-service GET /public/waitlist/position. " +
+    "Response shape is owned by the downstream service.",
+  request: {
+    query: z.object({
+      email: z
+        .string()
+        .email()
+        .openapi({ description: "Email that signed up to the waitlist" }),
+    }),
+  },
+  responses: {
+    200: { description: "Waitlist position", content: { "application/json": { schema: WaitlistPositionResponseSchema } } },
+    404: { description: "Email not on waitlist (forwarded verbatim)", content: errorContent },
+    502: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/{orgId}/invites/status",
+  tags: ["Invites"],
+  summary: "Get invite quota status for an org",
+  description:
+    "Pass-through to client-service GET /internal/orgs/{orgId}/invites/status. " +
+    "Returns used / total quota and the org's invite code. " +
+    "The {orgId} path segment MUST match the authenticated x-org-id; mismatch returns 403. " +
+    "Response shape is owned by the downstream service.",
+  security: authed,
+  request: {
+    params: z.object({
+      orgId: z
+        .string()
+        .uuid()
+        .openapi({ description: "Org UUID (must match authenticated org)" }),
+    }),
+  },
+  responses: {
+    200: { description: "Invite status", content: { "application/json": { schema: OrgInvitesStatusResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "orgId path does not match authenticated org", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/orgs/{orgId}/invites/claim",
+  tags: ["Invites"],
+  summary: "Claim an invite code for the authenticated org",
+  description:
+    "Pass-through to client-service POST /internal/orgs/{orgId}/invites/claim. " +
+    "Downstream orchestrates: record claim row -> grant $25 to inviter + $25 to invitee via " +
+    "billing-service -> send invite-claimed-welcome + invite-success-notification via " +
+    "transactional-email-service. Idempotent on (code, inviteeOrgId). " +
+    "The {orgId} path segment MUST match the authenticated x-org-id; mismatch returns 403. " +
+    "Body + response shapes are owned by the downstream service.",
+  security: authed,
+  request: {
+    params: z.object({
+      orgId: z
+        .string()
+        .uuid()
+        .openapi({ description: "Org UUID (must match authenticated org)" }),
+    }),
+    body: { content: { "application/json": { schema: OrgInvitesClaimRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Claim result", content: { "application/json": { schema: OrgInvitesClaimResponseSchema } } },
+    400: { description: "Invalid code (forwarded verbatim from downstream)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "orgId path does not match authenticated org", content: errorContent },
+  },
+});

--- a/tests/unit/invites-waitlist-proxy.test.ts
+++ b/tests/unit/invites-waitlist-proxy.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const invitesRoutePath = path.join(__dirname, "../../src/routes/invites.ts");
+const invitesContent = fs.readFileSync(invitesRoutePath, "utf-8");
+
+const waitlistRoutePath = path.join(__dirname, "../../src/routes/waitlist.ts");
+const waitlistContent = fs.readFileSync(waitlistRoutePath, "utf-8");
+
+const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+
+const indexPath = path.join(__dirname, "../../src/index.ts");
+const indexContent = fs.readFileSync(indexPath, "utf-8");
+
+function blockFor(file: string, method: string, routePath: string): string {
+  const escPath = routePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const sigRe = new RegExp(`router\\.${method}\\(\\s*"${escPath}"`);
+  const m = sigRe.exec(file);
+  if (!m) return "";
+  const start = m.index;
+  const rest = file.slice(start + m[0].length);
+  const nextRouter = rest.search(/\nrouter\.[a-z]+\(/);
+  const nextExport = rest.search(/\nexport default/);
+  const ends = [nextRouter, nextExport].filter((n) => n >= 0);
+  const end = ends.length > 0 ? Math.min(...ends) : rest.length;
+  return file.substring(start, start + m[0].length + end);
+}
+
+describe("Invites proxy routes", () => {
+  it("POST /invites/validate is public (no authenticate middleware)", () => {
+    const block = blockFor(invitesContent, "post", "/invites/validate");
+    expect(block).not.toBe("");
+    expect(block).not.toContain("authenticate");
+    expect(block).toContain("/public/invites/validate");
+  });
+
+  it("GET /orgs/:orgId/invites/status uses authenticate + requireOrg + requireUser", () => {
+    const block = blockFor(invitesContent, "get", "/orgs/:orgId/invites/status");
+    expect(block).not.toBe("");
+    expect(block).toContain("authenticate");
+    expect(block).toContain("requireOrg");
+    expect(block).toContain("requireUser");
+    expect(block).toContain("/internal/orgs/");
+    expect(block).toContain("/invites/status");
+  });
+
+  it("POST /orgs/:orgId/invites/claim uses authenticate + requireOrg + requireUser", () => {
+    const block = blockFor(invitesContent, "post", "/orgs/:orgId/invites/claim");
+    expect(block).not.toBe("");
+    expect(block).toContain("authenticate");
+    expect(block).toContain("requireOrg");
+    expect(block).toContain("requireUser");
+    expect(block).toContain("/internal/orgs/");
+    expect(block).toContain("/invites/claim");
+  });
+
+  it("authed routes guard params.orgId !== req.orgId with 403", () => {
+    expect(invitesContent).toContain("req.params.orgId");
+    expect(invitesContent).toContain("!== req.orgId");
+    expect(invitesContent).toContain("res.status(403)");
+  });
+
+  it("uses callExternalService(externalServices.client, ...)", () => {
+    expect(invitesContent).toContain("externalServices.client");
+    expect(invitesContent).toContain("callExternalService");
+  });
+
+  it("does NOT call billing or transactional-email (no aggregation per CLAUDE.md #2)", () => {
+    expect(invitesContent).not.toContain("externalServices.billing");
+    expect(invitesContent).not.toContain("externalServices.transactionalEmail");
+  });
+
+  it("forwards identity headers via buildInternalHeaders on authed routes", () => {
+    expect(invitesContent).toContain("buildInternalHeaders(req)");
+  });
+
+  it("propagates upstream status + error message verbatim (CLAUDE.md #7)", () => {
+    expect(invitesContent).toContain("error.statusCode");
+    expect(invitesContent).toContain("error.message");
+  });
+});
+
+describe("Waitlist proxy routes", () => {
+  it("POST /waitlist/request-access is public (no authenticate middleware)", () => {
+    const block = blockFor(waitlistContent, "post", "/waitlist/request-access");
+    expect(block).not.toBe("");
+    expect(block).not.toContain("authenticate");
+    expect(block).toContain("/public/waitlist/request-access");
+  });
+
+  it("GET /waitlist/position is public (no authenticate middleware)", () => {
+    const block = blockFor(waitlistContent, "get", "/waitlist/position");
+    expect(block).not.toBe("");
+    expect(block).not.toContain("authenticate");
+    expect(block).toContain("/public/waitlist/position");
+  });
+
+  it("forwards email query param to downstream", () => {
+    expect(waitlistContent).toContain("req.query");
+    expect(waitlistContent).toContain('"email"');
+  });
+
+  it("uses callExternalService(externalServices.client, ...)", () => {
+    expect(waitlistContent).toContain("externalServices.client");
+    expect(waitlistContent).toContain("callExternalService");
+  });
+
+  it("does NOT call transactional-email (orchestration is client-service's job)", () => {
+    expect(waitlistContent).not.toContain("externalServices.transactionalEmail");
+  });
+
+  it("propagates upstream status + error message verbatim (CLAUDE.md #7)", () => {
+    expect(waitlistContent).toContain("error.statusCode");
+    expect(waitlistContent).toContain("error.message");
+  });
+});
+
+describe("Invites + Waitlist OpenAPI schemas", () => {
+  it("registers all five paths in src/schemas.ts", () => {
+    expect(schemaContent).toContain('path: "/v1/invites/validate"');
+    expect(schemaContent).toContain('path: "/v1/waitlist/request-access"');
+    expect(schemaContent).toContain('path: "/v1/waitlist/position"');
+    expect(schemaContent).toContain('path: "/v1/orgs/{orgId}/invites/status"');
+    expect(schemaContent).toContain('path: "/v1/orgs/{orgId}/invites/claim"');
+  });
+
+  it("all response schemas are passthrough (CLAUDE.md #8)", () => {
+    expect(schemaContent).toContain(
+      'z.object({}).passthrough().openapi("InviteValidateResponse")',
+    );
+    expect(schemaContent).toContain(
+      'z.object({}).passthrough().openapi("WaitlistRequestAccessResponse")',
+    );
+    expect(schemaContent).toContain(
+      'z.object({}).passthrough().openapi("WaitlistPositionResponse")',
+    );
+    expect(schemaContent).toContain(
+      'z.object({}).passthrough().openapi("OrgInvitesStatusResponse")',
+    );
+    expect(schemaContent).toContain(
+      'z.object({}).passthrough().openapi("OrgInvitesClaimResponse")',
+    );
+  });
+
+  it("uses Invites + Waitlist tags", () => {
+    expect(schemaContent).toContain('tags: ["Invites"]');
+    expect(schemaContent).toContain('tags: ["Waitlist"]');
+  });
+
+  it("authed paths declare security: authed", () => {
+    const statusBlock = schemaContent.match(
+      /path: "\/v1\/orgs\/\{orgId\}\/invites\/status"[\s\S]*?\}\);/,
+    );
+    const claimBlock = schemaContent.match(
+      /path: "\/v1\/orgs\/\{orgId\}\/invites\/claim"[\s\S]*?\}\);/,
+    );
+    expect(statusBlock).not.toBeNull();
+    expect(claimBlock).not.toBeNull();
+    expect(statusBlock![0]).toContain("security: authed");
+    expect(claimBlock![0]).toContain("security: authed");
+  });
+
+  it("public paths do NOT declare security", () => {
+    const validateBlock = schemaContent.match(
+      /path: "\/v1\/invites\/validate"[\s\S]*?\}\);/,
+    );
+    const reqAccessBlock = schemaContent.match(
+      /path: "\/v1\/waitlist\/request-access"[\s\S]*?\}\);/,
+    );
+    const positionBlock = schemaContent.match(
+      /path: "\/v1\/waitlist\/position"[\s\S]*?\}\);/,
+    );
+    expect(validateBlock).not.toBeNull();
+    expect(reqAccessBlock).not.toBeNull();
+    expect(positionBlock).not.toBeNull();
+    expect(validateBlock![0]).not.toContain("security: authed");
+    expect(reqAccessBlock![0]).not.toContain("security: authed");
+    expect(positionBlock![0]).not.toContain("security: authed");
+  });
+});
+
+describe("Invites + Waitlist routes wired in index.ts", () => {
+  it("imports both routers from ./routes/invites and ./routes/waitlist", () => {
+    expect(indexContent).toContain("invitesRoutes");
+    expect(indexContent).toContain("./routes/invites");
+    expect(indexContent).toContain("waitlistRoutes");
+    expect(indexContent).toContain("./routes/waitlist");
+  });
+
+  it("mounts both under /v1", () => {
+    expect(indexContent).toMatch(/app\.use\("\/v1",\s*invitesRoutes\)/);
+    expect(indexContent).toMatch(/app\.use\("\/v1",\s*waitlistRoutes\)/);
+  });
+});


### PR DESCRIPTION
## Summary

api-service slice of [DIS-64](https://linear.app/distribute-you/issue/DIS-64/multi-repo-feat-wave-05-invite-only-gate-dollar25-referral-reward) (Wave 0.5 — invite-only gate + waitlist).

Adds 5 transparent proxy routes; api-service stays a pure proxy per `CLAUDE.md` rules #2 (no aggregation), #7 (verbatim upstream errors), #8 (passthrough response shapes).

### Public (no auth)
| api-service | client-service |
|-------------|----------------|
| `POST /v1/invites/validate` | `POST /public/invites/validate` |
| `POST /v1/waitlist/request-access` | `POST /public/waitlist/request-access` |
| `GET /v1/waitlist/position` | `GET /public/waitlist/position` |

### Authed (`authenticate + requireOrg + requireUser`)
| api-service | client-service |
|-------------|----------------|
| `GET /v1/orgs/:orgId/invites/status` | `GET /internal/orgs/{orgId}/invites/status` |
| `POST /v1/orgs/:orgId/invites/claim` | `POST /internal/orgs/{orgId}/invites/claim` |

### Architectural notes

- **No orchestration in api-service.** The DIS-64 brief proposed an in-gateway orchestrator (validate → claim → 2× billing grant → 2× transactional-email send). That violates `CLAUDE.md` #2. Orchestration lives in **client-service**, which owns the invite/waitlist domain. api-service forwards bytes.
- **Identity guard.** Authed routes reject `params.orgId !== req.orgId` with 403 before any downstream call.
- **No new env vars.** Reuses existing `CLIENT_SERVICE_URL` / `CLIENT_SERVICE_API_KEY`.
- **Idempotency.** Downstream-enforced. Dashboard retries replay the same calls; client-service dedupes on `(code, inviteeOrgId)`.

### Deployment ordering

⚠️ Routes will 404 at runtime until **client-service** ships the 5 downstream endpoints (separate workspace per Wave 0.5). URL contract is locked across both sides per DIS-64 — this PR is mergeable independently. Unit tests do not require the downstream to exist.

## Test plan

- [x] `pnpm test` → 1294/1294 green (115 files), including 21 new tests in `tests/unit/invites-waitlist-proxy.test.ts`
- [x] `npx tsc --noEmit` → no errors
- [x] `pnpm generate:openapi` → regenerated `openapi.json` with 5 new paths under `Invites` + `Waitlist` tags
- [ ] Post-deploy staging smoke once client-service Wave 0.5 PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)