### PR TITLE
feat(quotes): proxy POST /v1/orgs/opportunities/:id/reply

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8940,6 +8940,14 @@
         "type": "object",
         "properties": {}
       },
+      "OpportunityReplyResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "OpportunityReplyRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "VisibilityScoreWeights": {
         "type": "object",
         "properties": {
@@ -31487,6 +31495,138 @@
           },
           "404": {
             "description": "Quote request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/orgs/opportunities/{id}/reply": {
+      "post": {
+        "tags": [
+          "Expert Quotes"
+        ],
+        "summary": "Submit a HITL pitch reply for the given opportunity",
+        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/{id}/reply. Dispatches via Featured submitAnswer (provider=featured) or email-gateway-service /orgs/send (other providers, e.g. haro). Body + response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Opportunity id"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityReplyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Reply submitted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityReplyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (forwarded verbatim from downstream)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Opportunity not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/quotes.ts
+++ b/src/routes/quotes.ts
@@ -131,4 +131,23 @@ router.post("/orgs/quote-requests/:id/draft", authenticate, requireOrg, requireU
   }
 });
 
+// POST /v1/orgs/opportunities/:id/reply — submit a HITL pitch reply for the given opportunity
+router.post("/orgs/opportunities/:id/reply", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const id = req.params.id;
+    const result = await callExternalService(
+      externalServices.journalistsQuotes,
+      `/orgs/opportunities/${encodeURIComponent(id)}/reply`,
+      {
+        method: "POST",
+        body: req.body,
+        headers: buildInternalHeaders(req),
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to submit opportunity reply" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6938,6 +6938,8 @@ const OpportunitiesRankedRequestSchema = z.object({}).passthrough().openapi("Opp
 const OpportunitiesRankedResponseSchema = z.object({}).passthrough().openapi("OpportunitiesRankedResponse");
 const QuoteRequestDraftRequestSchema = z.object({}).passthrough().openapi("QuoteRequestDraftRequest");
 const QuoteRequestDraftResponseSchema = z.object({}).passthrough().openapi("QuoteRequestDraftResponse");
+const OpportunityReplyRequestSchema = z.object({}).passthrough().openapi("OpportunityReplyRequest");
+const OpportunityReplyResponseSchema = z.object({}).passthrough().openapi("OpportunityReplyResponse");
 
 registry.registerPath({
   method: "get",
@@ -7083,6 +7085,30 @@ registry.registerPath({
     400: { description: "Content-generation length error (forwarded verbatim)", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Quote request not found", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/orgs/opportunities/{id}/reply",
+  tags: ["Expert Quotes"],
+  summary: "Submit a HITL pitch reply for the given opportunity",
+  description:
+    "Pass-through to journalists-quotes-service POST /orgs/opportunities/{id}/reply. " +
+    "Dispatches via Featured submitAnswer (provider=featured) or email-gateway-service /orgs/send (other providers, e.g. haro). " +
+    "Body + response shapes are owned by the downstream service.",
+  security: authed,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ description: "Opportunity id" }),
+    }),
+    body: { content: { "application/json": { schema: OpportunityReplyRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Reply submitted", content: { "application/json": { schema: OpportunityReplyResponseSchema } } },
+    400: { description: "Bad request (forwarded verbatim from downstream)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Opportunity not found", content: errorContent },
   },
 });
 

--- a/tests/unit/quotes-proxy.test.ts
+++ b/tests/unit/quotes-proxy.test.ts
@@ -109,16 +109,16 @@ describe("Expert quotes proxy routes", () => {
     }
   });
 
-  it("should call externalServices.journalistsQuotes for every endpoint (7x)", () => {
+  it("should call externalServices.journalistsQuotes for every endpoint (8x)", () => {
     const matches = content.match(/externalServices\.journalistsQuotes/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(7);
+    expect(matches!.length).toBe(8);
   });
 
-  it("should use buildInternalHeaders for every endpoint (7x)", () => {
+  it("should use buildInternalHeaders for every endpoint (8x)", () => {
     const matches = content.match(/buildInternalHeaders\(req\)/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(7);
+    expect(matches!.length).toBe(8);
   });
 
   it("should preserve downstream paths (no path renaming)", () => {
@@ -129,6 +129,7 @@ describe("Expert quotes proxy routes", () => {
     expect(content).toContain('"/orgs/quote-pitches/:id"');
     expect(content).toContain('"/orgs/opportunities/ranked"');
     expect(content).toContain('"/orgs/quote-requests/:id/draft"');
+    expect(content).toContain('"/orgs/opportunities/:id/reply"');
   });
 
   it("should have POST /orgs/opportunities/ranked with auth + requireOrg + requireUser", () => {
@@ -163,6 +164,25 @@ describe("Expert quotes proxy routes", () => {
     const section = content.slice(idx, idx + 800);
     expect(section).toContain("req.params.id");
     expect(section).toMatch(/\/orgs\/quote-requests\/\$\{[^}]*encodeURIComponent[^}]*\}\/draft/);
+    expect(section).toMatch(/method:\s*"POST"/);
+    expect(section).toContain("body: req.body");
+  });
+
+  it("should have POST /orgs/opportunities/:id/reply with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/orgs/opportunities/:id/reply"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should URL-encode :id and forward body verbatim on POST /orgs/opportunities/:id/reply", () => {
+    const idx = content.indexOf('"/orgs/opportunities/:id/reply"');
+    const section = content.slice(idx, idx + 800);
+    expect(section).toContain("req.params.id");
+    expect(section).toMatch(/\/orgs\/opportunities\/\$\{[^}]*encodeURIComponent[^}]*\}\/reply/);
     expect(section).toMatch(/method:\s*"POST"/);
     expect(section).toContain("body: req.body");
   });
@@ -247,6 +267,12 @@ describe("Expert quotes OpenAPI schemas", () => {
     expect(schemaContent).toContain("QuoteRequestDraftRequest");
     expect(schemaContent).toContain("QuoteRequestDraftResponse");
   });
+
+  it("should register POST /v1/orgs/opportunities/{id}/reply with passthrough body + response", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/opportunities/{id}/reply"');
+    expect(schemaContent).toContain("OpportunityReplyRequest");
+    expect(schemaContent).toContain("OpportunityReplyResponse");
+  });
 });
 
 describe("Expert quotes endpoints in openapi.json", () => {
@@ -286,6 +312,11 @@ describe("Expert quotes endpoints in openapi.json", () => {
   it("should include /v1/orgs/quote-requests/{id}/draft POST in committed openapi.json", () => {
     expect(openapi.paths["/v1/orgs/quote-requests/{id}/draft"]).toBeDefined();
     expect(openapi.paths["/v1/orgs/quote-requests/{id}/draft"].post).toBeDefined();
+  });
+
+  it("should include /v1/orgs/opportunities/{id}/reply POST in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/opportunities/{id}/reply"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/opportunities/{id}/reply"].post).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds the transparent api-service hop for `POST /v1/orgs/opportunities/:id/reply` → journalists-quotes-service `POST /orgs/opportunities/:id/reply`.
- Mirrors the sibling `/draft` proxy: `authenticate + requireOrg + requireUser`, URI-encoded `:id`, body forwarded verbatim, identity headers via `buildInternalHeaders(req)`.
- Body/response schemas registered as `z.object({}).passthrough()` per CLAUDE.md rule #8 — the upcoming brand-only variant (campaignId optional) ships without further gateway edits.

Fixes the 404 hit by dashboard `submitQuoteOpportunityReply` (apps/dashboard/src/lib/api.ts), which already calls this gateway path.

## Test plan
- [x] `pnpm test` — 114 files / 1277 tests green
- [x] `pnpm build` — tsc + OpenAPI regen green; `openapi.json` includes `/v1/orgs/opportunities/{id}/reply`
- [x] Unit tests assert: route has correct middleware, body forwarded verbatim, `:id` URI-encoded, schemas registered, openapi.json contains the path
- [ ] Smoke: curl POST against staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)