### PR TITLE
feat(quotes,content): drop /draft, add /next + /generate-expert-quote-pitch (DIS-66)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8053,6 +8053,14 @@
           "outputBlobToken"
         ]
       },
+      "GenerateExpertQuotePitchResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "GenerateExpertQuotePitchRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "LlmServiceOverview": {
         "type": "object",
         "properties": {
@@ -8940,11 +8948,11 @@
         "type": "object",
         "properties": {}
       },
-      "QuoteRequestDraftResponse": {
+      "OpportunityNextResponse": {
         "type": "object",
         "properties": {}
       },
-      "QuoteRequestDraftRequest": {
+      "OpportunityNextRequest": {
         "type": "object",
         "properties": {}
       },
@@ -28586,6 +28594,128 @@
         ]
       }
     },
+    "/v1/content/generate-expert-quote-pitch": {
+      "post": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Generate a journalist-quote pitch",
+        "description": "Proxy to content-generation-service POST /generate-expert-quote-pitch. Generates a Featured.com-compliant pitch (100-2500 char constraint) for an expert journalist quote opportunity. Body + response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateExpertQuotePitchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pitch generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateExpertQuotePitchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Content-generation length error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
     "/v1/platform/llm-context": {
       "get": {
         "tags": [
@@ -31307,8 +31437,8 @@
         "tags": [
           "Expert Quotes"
         ],
-        "summary": "RAG-ranked opportunities for the (campaign, brand)",
-        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/ranked. Body: { campaignId, brandId, limit?, offset? }. Response carries opportunities[] with score + whyRelevant. Body + response shapes are owned by the downstream service.",
+        "summary": "RAG-ranked opportunities for the (campaign, brand-set)",
+        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/ranked. Brand identity flows via the x-brand-id header (CSV when plural). Returns Gold-cluster opportunity IDs with score + latest pitchStatus annotation. Body + response shapes are owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
@@ -31414,29 +31544,60 @@
         ]
       }
     },
-    "/v1/orgs/quote-requests/{id}/draft": {
+    "/v1/orgs/opportunities/next": {
       "post": {
         "tags": [
           "Expert Quotes"
         ],
-        "summary": "Generate a pitch draft for the given quote request",
-        "description": "Pass-through to journalists-quotes-service POST /orgs/quote-requests/{id}/draft. Body: { brandId, campaignId, spokesperson, expertiseTopics, responseStyle, companyContext, valueProposition, additionalContext? }. Response: { pitch, charCount, attempts, tokensInput, tokensOutput }. Body + response shapes are owned by the downstream service.",
+        "summary": "Single highest-scored Gold-cluster opportunity for the brand-set",
+        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/next. Mirrors lead-service POST /orgs/buffer/next semantics. Brand identity via x-brand-id header (CSV when plural). Excludes opportunities with a non-retryable pitch (drafted/submitted/selected/published/not_selected) on the exact brand-set. Returns { found: false } when nothing eligible remains. Body + response shapes are owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "Quote request id"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpportunityNextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Next opportunity (or { found: false })",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpportunityNextResponse"
+                }
+              }
+            }
           },
+          "400": {
+            "description": "Bad request (forwarded verbatim from downstream)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
           {
             "name": "x-org-id",
             "in": "header",
@@ -31492,58 +31653,7 @@
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QuoteRequestDraftRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Pitch draft",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QuoteRequestDraftResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Content-generation length error (forwarded verbatim)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Quote request not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
+        ]
       }
     },
     "/v1/orgs/opportunities/{id}/reply": {
@@ -31551,8 +31661,8 @@
         "tags": [
           "Expert Quotes"
         ],
-        "summary": "Submit a HITL pitch reply for the given opportunity",
-        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/{id}/reply. Dispatches via Featured submitAnswer (provider=featured) or email-gateway-service /orgs/send (other providers, e.g. haro). Body + response shapes are owned by the downstream service.",
+        "summary": "Submit a HITL pitch reply for the given Gold-cluster opportunity",
+        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/{id}/reply. `id` = quote_opportunities.id (Gold cluster). Brand identity via x-brand-id header (CSV when plural). The downstream service picks a representative silver row (Featured-API preferred, else most recent email) and dispatches via Featured submitAnswer or email-gateway-service /orgs/send. Idempotency: exact-match on (quote_opportunity_id, sorted brand_ids[]) — co-branded [A,B] is distinct from solo [A]. Body + response shapes are owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
@@ -31563,7 +31673,7 @@
             "schema": {
               "type": "string",
               "format": "uuid",
-              "description": "Opportunity id"
+              "description": "Gold-cluster opportunity id (quote_opportunities.id)"
             },
             "required": true,
             "name": "id",

--- a/src/routes/content.ts
+++ b/src/routes/content.ts
@@ -29,8 +29,30 @@ router.post("/content/compose", authenticate, requireOrg, requireUser, async (re
 
     res.json(result);
   } catch (error: any) {
-    console.error("Content compose error:", error.message);
+    console.error("[api-service] Content compose error:", error.message);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to compose content" });
+  }
+});
+
+/**
+ * POST /v1/content/generate-expert-quote-pitch
+ * Proxy to content-generation-service POST /generate-expert-quote-pitch.
+ * Body + response shapes are owned by the downstream service — passthrough only.
+ */
+router.post("/content/generate-expert-quote-pitch", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.emailgen,
+      "/generate-expert-quote-pitch",
+      {
+        method: "POST",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to generate expert quote pitch" });
   }
 });
 

--- a/src/routes/quotes.ts
+++ b/src/routes/quotes.ts
@@ -94,7 +94,7 @@ router.get("/orgs/quote-pitches/:id", authenticate, requireOrg, requireUser, asy
   }
 });
 
-// POST /v1/orgs/opportunities/ranked — RAG-ranked opportunities for (campaign, brand)
+// POST /v1/orgs/opportunities/ranked — RAG-ranked opportunities for (campaign, brand-set)
 router.post("/orgs/opportunities/ranked", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
@@ -112,13 +112,12 @@ router.post("/orgs/opportunities/ranked", authenticate, requireOrg, requireUser,
   }
 });
 
-// POST /v1/orgs/quote-requests/:id/draft — generate a pitch draft for the given quote request
-router.post("/orgs/quote-requests/:id/draft", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+// POST /v1/orgs/opportunities/next — single highest-scored Gold-cluster opportunity for the brand-set
+router.post("/orgs/opportunities/next", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const id = req.params.id;
     const result = await callExternalService(
       externalServices.journalistsQuotes,
-      `/orgs/quote-requests/${encodeURIComponent(id)}/draft`,
+      "/orgs/opportunities/next",
       {
         method: "POST",
         body: req.body,
@@ -127,7 +126,7 @@ router.post("/orgs/quote-requests/:id/draft", authenticate, requireOrg, requireU
     );
     res.json(result);
   } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to generate quote draft" });
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch next opportunity" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6261,6 +6261,32 @@ registry.registerPath({
   },
 });
 
+// Content – Generate Expert Quote Pitch (proxy to content-generation-service)
+// Downstream owns body + response shapes — passthrough only.
+const GenerateExpertQuotePitchRequestSchema = z.object({}).passthrough().openapi("GenerateExpertQuotePitchRequest");
+const GenerateExpertQuotePitchResponseSchema = z.object({}).passthrough().openapi("GenerateExpertQuotePitchResponse");
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/content/generate-expert-quote-pitch",
+  tags: ["Content"],
+  summary: "Generate a journalist-quote pitch",
+  description:
+    "Proxy to content-generation-service POST /generate-expert-quote-pitch. " +
+    "Generates a Featured.com-compliant pitch (100-2500 char constraint) for an expert journalist quote opportunity. " +
+    "Body + response shapes are owned by the downstream service.",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: GenerateExpertQuotePitchRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Pitch generated", content: { "application/json": { schema: GenerateExpertQuotePitchResponseSchema } } },
+    400: { description: "Content-generation length error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/v1/platform/llm-context",
@@ -6932,12 +6958,12 @@ const QuotePitchResponseSchema = z
   .object({ quotePitch: QuotePitchSchema })
   .openapi("QuotePitchResponse");
 
-// Passthrough schemas for new HITL PR Expert Quote Opportunities routes.
+// Passthrough schemas for HITL PR Expert Quote Opportunities routes.
 // Downstream (journalists-quotes-service) owns body + response shapes — api-service forwards bytes.
 const OpportunitiesRankedRequestSchema = z.object({}).passthrough().openapi("OpportunitiesRankedRequest");
 const OpportunitiesRankedResponseSchema = z.object({}).passthrough().openapi("OpportunitiesRankedResponse");
-const QuoteRequestDraftRequestSchema = z.object({}).passthrough().openapi("QuoteRequestDraftRequest");
-const QuoteRequestDraftResponseSchema = z.object({}).passthrough().openapi("QuoteRequestDraftResponse");
+const OpportunityNextRequestSchema = z.object({}).passthrough().openapi("OpportunityNextRequest");
+const OpportunityNextResponseSchema = z.object({}).passthrough().openapi("OpportunityNextResponse");
 const OpportunityReplyRequestSchema = z.object({}).passthrough().openapi("OpportunityReplyRequest");
 const OpportunityReplyResponseSchema = z.object({}).passthrough().openapi("OpportunityReplyResponse");
 
@@ -7047,10 +7073,11 @@ registry.registerPath({
   method: "post",
   path: "/v1/orgs/opportunities/ranked",
   tags: ["Expert Quotes"],
-  summary: "RAG-ranked opportunities for the (campaign, brand)",
+  summary: "RAG-ranked opportunities for the (campaign, brand-set)",
   description:
     "Pass-through to journalists-quotes-service POST /orgs/opportunities/ranked. " +
-    "Body: { campaignId, brandId, limit?, offset? }. Response carries opportunities[] with score + whyRelevant. " +
+    "Brand identity flows via the x-brand-id header (CSV when plural). " +
+    "Returns Gold-cluster opportunity IDs with score + latest pitchStatus annotation. " +
     "Body + response shapes are owned by the downstream service.",
   security: authed,
   request: {
@@ -7065,26 +7092,24 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/orgs/quote-requests/{id}/draft",
+  path: "/v1/orgs/opportunities/next",
   tags: ["Expert Quotes"],
-  summary: "Generate a pitch draft for the given quote request",
+  summary: "Single highest-scored Gold-cluster opportunity for the brand-set",
   description:
-    "Pass-through to journalists-quotes-service POST /orgs/quote-requests/{id}/draft. " +
-    "Body: { brandId, campaignId, spokesperson, expertiseTopics, responseStyle, companyContext, valueProposition, additionalContext? }. " +
-    "Response: { pitch, charCount, attempts, tokensInput, tokensOutput }. " +
+    "Pass-through to journalists-quotes-service POST /orgs/opportunities/next. " +
+    "Mirrors lead-service POST /orgs/buffer/next semantics. " +
+    "Brand identity via x-brand-id header (CSV when plural). " +
+    "Excludes opportunities with a non-retryable pitch (drafted/submitted/selected/published/not_selected) on the exact brand-set. " +
+    "Returns { found: false } when nothing eligible remains. " +
     "Body + response shapes are owned by the downstream service.",
   security: authed,
   request: {
-    params: z.object({
-      id: z.string().uuid().openapi({ description: "Quote request id" }),
-    }),
-    body: { content: { "application/json": { schema: QuoteRequestDraftRequestSchema } } },
+    body: { content: { "application/json": { schema: OpportunityNextRequestSchema } } },
   },
   responses: {
-    200: { description: "Pitch draft", content: { "application/json": { schema: QuoteRequestDraftResponseSchema } } },
-    400: { description: "Content-generation length error (forwarded verbatim)", content: errorContent },
+    200: { description: "Next opportunity (or { found: false })", content: { "application/json": { schema: OpportunityNextResponseSchema } } },
+    400: { description: "Bad request (forwarded verbatim from downstream)", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
-    404: { description: "Quote request not found", content: errorContent },
   },
 });
 
@@ -7092,15 +7117,18 @@ registry.registerPath({
   method: "post",
   path: "/v1/orgs/opportunities/{id}/reply",
   tags: ["Expert Quotes"],
-  summary: "Submit a HITL pitch reply for the given opportunity",
+  summary: "Submit a HITL pitch reply for the given Gold-cluster opportunity",
   description:
     "Pass-through to journalists-quotes-service POST /orgs/opportunities/{id}/reply. " +
-    "Dispatches via Featured submitAnswer (provider=featured) or email-gateway-service /orgs/send (other providers, e.g. haro). " +
+    "`id` = quote_opportunities.id (Gold cluster). Brand identity via x-brand-id header (CSV when plural). " +
+    "The downstream service picks a representative silver row (Featured-API preferred, else most recent email) and " +
+    "dispatches via Featured submitAnswer or email-gateway-service /orgs/send. " +
+    "Idempotency: exact-match on (quote_opportunity_id, sorted brand_ids[]) — co-branded [A,B] is distinct from solo [A]. " +
     "Body + response shapes are owned by the downstream service.",
   security: authed,
   request: {
     params: z.object({
-      id: z.string().uuid().openapi({ description: "Opportunity id" }),
+      id: z.string().uuid().openapi({ description: "Gold-cluster opportunity id (quote_opportunities.id)" }),
     }),
     body: { content: { "application/json": { schema: OpportunityReplyRequestSchema } } },
   },

--- a/tests/unit/content-quote-pitch.test.ts
+++ b/tests/unit/content-quote-pitch.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.brandId = "brand_testabc";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import contentRouter from "../../src/routes/content.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", contentRouter);
+  return app;
+}
+
+const validBody = {
+  quoteRequestId: "11111111-1111-4111-8111-111111111111",
+  brandId: "22222222-2222-4222-8222-222222222222",
+  campaignId: "33333333-3333-4333-8333-333333333333",
+  spokesperson: "Sophie",
+  expertiseTopics: ["growth", "retention"],
+  responseStyle: "concise",
+  companyContext: "B2B SaaS",
+  valueProposition: "Predictable revenue.",
+};
+
+const upstreamResponse = {
+  pitch: "Sophie is a B2B SaaS growth expert ...",
+  charCount: 1234,
+  attempts: 1,
+  tokensInput: 567,
+  tokensOutput: 890,
+};
+
+describe("POST /v1/content/generate-expert-quote-pitch", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(upstreamResponse),
+      };
+    });
+  });
+
+  it("should return the downstream payload verbatim on success", async () => {
+    const res = await request(app)
+      .post("/v1/content/generate-expert-quote-pitch")
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstreamResponse);
+  });
+
+  it("should forward body verbatim to content-generation-service /generate-expert-quote-pitch", async () => {
+    await request(app)
+      .post("/v1/content/generate-expert-quote-pitch")
+      .send(validBody);
+
+    expect(capturedUrl).toContain("/generate-expert-quote-pitch");
+    const body = JSON.parse(capturedInit?.body as string);
+    expect(body).toEqual(validBody);
+  });
+
+  it("should forward identity headers (x-org-id, x-user-id, x-run-id, x-brand-id)", async () => {
+    await request(app)
+      .post("/v1/content/generate-expert-quote-pitch")
+      .send(validBody);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+    expect(headers["x-brand-id"]).toBe("brand_testabc");
+  });
+
+  it("should send X-API-Key to downstream service", async () => {
+    await request(app)
+      .post("/v1/content/generate-expert-quote-pitch")
+      .send(validBody);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["X-API-Key"]).toBeDefined();
+  });
+
+  it("should forward upstream error status verbatim (400 length error)", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"error":"Pitch exceeded 2500 chars after 3 attempts"}'),
+    }));
+
+    const res = await request(app)
+      .post("/v1/content/generate-expert-quote-pitch")
+      .send(validBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Pitch exceeded 2500 chars");
+  });
+
+  it("should forward upstream 503 status verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve("Service unavailable"),
+    }));
+
+    const res = await request(app)
+      .post("/v1/content/generate-expert-quote-pitch")
+      .send(validBody);
+
+    expect(res.status).toBe(503);
+  });
+});

--- a/tests/unit/quotes-proxy.test.ts
+++ b/tests/unit/quotes-proxy.test.ts
@@ -128,8 +128,12 @@ describe("Expert quotes proxy routes", () => {
     expect(content).toContain('"/orgs/quote-pitches"');
     expect(content).toContain('"/orgs/quote-pitches/:id"');
     expect(content).toContain('"/orgs/opportunities/ranked"');
-    expect(content).toContain('"/orgs/quote-requests/:id/draft"');
+    expect(content).toContain('"/orgs/opportunities/next"');
     expect(content).toContain('"/orgs/opportunities/:id/reply"');
+  });
+
+  it("should NOT define the legacy POST /orgs/quote-requests/:id/draft proxy (removed in DIS-66)", () => {
+    expect(content).not.toContain('"/orgs/quote-requests/:id/draft"');
   });
 
   it("should have POST /orgs/opportunities/ranked with auth + requireOrg + requireUser", () => {
@@ -149,9 +153,9 @@ describe("Expert quotes proxy routes", () => {
     expect(section).toContain("body: req.body");
   });
 
-  it("should have POST /orgs/quote-requests/:id/draft with auth + requireOrg + requireUser", () => {
+  it("should have POST /orgs/opportunities/next with auth + requireOrg + requireUser", () => {
     const line = content.split("\n").find((l) =>
-      l.includes("router.post") && l.includes('"/orgs/quote-requests/:id/draft"')
+      l.includes("router.post") && l.includes('"/orgs/opportunities/next"')
     );
     expect(line).toBeDefined();
     expect(line).toContain("authenticate");
@@ -159,11 +163,9 @@ describe("Expert quotes proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
-  it("should URL-encode :id and forward body verbatim on POST /orgs/quote-requests/:id/draft", () => {
-    const idx = content.indexOf('"/orgs/quote-requests/:id/draft"');
+  it("should forward body verbatim on POST /orgs/opportunities/next", () => {
+    const idx = content.indexOf('"/orgs/opportunities/next"');
     const section = content.slice(idx, idx + 800);
-    expect(section).toContain("req.params.id");
-    expect(section).toMatch(/\/orgs\/quote-requests\/\$\{[^}]*encodeURIComponent[^}]*\}\/draft/);
     expect(section).toMatch(/method:\s*"POST"/);
     expect(section).toContain("body: req.body");
   });
@@ -262,10 +264,16 @@ describe("Expert quotes OpenAPI schemas", () => {
     expect(schemaContent).toContain("OpportunitiesRankedResponse");
   });
 
-  it("should register POST /v1/orgs/quote-requests/{id}/draft with passthrough body + response", () => {
-    expect(schemaContent).toContain('path: "/v1/orgs/quote-requests/{id}/draft"');
-    expect(schemaContent).toContain("QuoteRequestDraftRequest");
-    expect(schemaContent).toContain("QuoteRequestDraftResponse");
+  it("should register POST /v1/orgs/opportunities/next with passthrough body + response", () => {
+    expect(schemaContent).toContain('path: "/v1/orgs/opportunities/next"');
+    expect(schemaContent).toContain("OpportunityNextRequest");
+    expect(schemaContent).toContain("OpportunityNextResponse");
+  });
+
+  it("should NOT register the legacy POST /v1/orgs/quote-requests/{id}/draft path (removed in DIS-66)", () => {
+    expect(schemaContent).not.toContain('path: "/v1/orgs/quote-requests/{id}/draft"');
+    expect(schemaContent).not.toContain("QuoteRequestDraftRequest");
+    expect(schemaContent).not.toContain("QuoteRequestDraftResponse");
   });
 
   it("should register POST /v1/orgs/opportunities/{id}/reply with passthrough body + response", () => {
@@ -309,9 +317,13 @@ describe("Expert quotes endpoints in openapi.json", () => {
     expect(openapi.paths["/v1/orgs/opportunities/ranked"].post).toBeDefined();
   });
 
-  it("should include /v1/orgs/quote-requests/{id}/draft POST in committed openapi.json", () => {
-    expect(openapi.paths["/v1/orgs/quote-requests/{id}/draft"]).toBeDefined();
-    expect(openapi.paths["/v1/orgs/quote-requests/{id}/draft"].post).toBeDefined();
+  it("should include /v1/orgs/opportunities/next POST in committed openapi.json", () => {
+    expect(openapi.paths["/v1/orgs/opportunities/next"]).toBeDefined();
+    expect(openapi.paths["/v1/orgs/opportunities/next"].post).toBeDefined();
+  });
+
+  it("should NOT include the legacy /v1/orgs/quote-requests/{id}/draft POST (removed in DIS-66)", () => {
+    expect(openapi.paths["/v1/orgs/quote-requests/{id}/draft"]).toBeUndefined();
   });
 
   it("should include /v1/orgs/opportunities/{id}/reply POST in committed openapi.json", () => {


### PR DESCRIPTION
## Summary

api-service follow-up to [journalists-quotes-service v0.8.1](https://github.com/shamanic-technologies/journalists-quotes-service/pull/41) (DIS-66 opportunity-catalog refactor).

- **Drop** `POST /v1/orgs/quote-requests/:id/draft` proxy — downstream route was removed; existing proxy 404s. No facade.
- **Add** `POST /v1/orgs/opportunities/next` proxy — single highest-scored Gold-cluster opportunity for the brand-set, mirrors `lead-service /orgs/buffer/next`.
- **Add** `POST /v1/content/generate-expert-quote-pitch` proxy — content-generation-service direct call needed by dashboard W2 (replaces the dropped journalists-quotes `/draft` path).
- `/v1/orgs/opportunities/ranked` + `/:id/reply` already forward `x-brand-id` via `buildInternalHeaders` (no code change). OpenAPI descriptions updated to reflect Gold-cluster IDs + CSV brand-set semantics.

All routes are passthrough per CLAUDE.md rule #8: `z.object({}).passthrough()` request + response, identity headers forwarded by `buildInternalHeaders`, upstream errors propagated verbatim.

## URL contract

| Route | Gateway → Downstream |
|---|---|
| `POST /v1/orgs/opportunities/next` | `journalists-quotes POST /orgs/opportunities/next` |
| `POST /v1/orgs/opportunities/ranked` | `journalists-quotes POST /orgs/opportunities/ranked` |
| `POST /v1/orgs/opportunities/{id}/reply` | `journalists-quotes POST /orgs/opportunities/{id}/reply` |
| `POST /v1/content/generate-expert-quote-pitch` | `content-generation POST /generate-expert-quote-pitch` |

## Test plan

- [x] `pnpm test` — 1307 passed (116 files)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm generate:openapi` — regenerated + committed
- [x] `openapi.json` paths: `/v1/orgs/opportunities/next` present, `/v1/orgs/quote-requests/{id}/draft` absent
- [ ] Post-deploy smoke against staging: `curl POST /v1/orgs/opportunities/next` returns downstream payload; `curl POST /v1/orgs/quote-requests/{id}/draft` returns 404
- [ ] Dashboard W2 PR (separate workspace) consumes `/v1/content/generate-expert-quote-pitch`

## Linear

DIS-66 — refactor Opportunity-catalog pattern (this PR = W3 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)