### PR TITLE
feat(content): proxy GET /v1/content/platform-prompts (DIS-66 follow-up)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -28716,6 +28716,128 @@
         ]
       }
     },
+    "/v1/content/platform-prompts": {
+      "get": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Get a prompt template by type",
+        "description": "Proxy to content-generation-service GET /platform-prompts?type=<type>. Returns the stored prompt template + its variable metadata so callers can collect inputs before invoking POST /v1/content/generate-expert-quote-pitch. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Prompt type to look up (e.g. expert-quote-pitch)"
+            },
+            "required": true,
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompt template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformPromptResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Prompt type not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/platform/llm-context": {
       "get": {
         "tags": [

--- a/src/routes/content.ts
+++ b/src/routes/content.ts
@@ -56,4 +56,28 @@ router.post("/content/generate-expert-quote-pitch", authenticate, requireOrg, re
   }
 });
 
+/**
+ * GET /v1/content/platform-prompts?type=<string>
+ * Proxy to content-generation-service GET /platform-prompts?type=<string>.
+ * Returns the stored prompt template + its variable metadata so callers can
+ * collect inputs before invoking POST /v1/content/generate-expert-quote-pitch.
+ * Response shape is owned by the downstream service — passthrough only.
+ */
+router.get("/content/platform-prompts", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query["type"]) params.set("type", req.query["type"] as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.emailgen,
+      `/platform-prompts${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch platform prompt" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6287,6 +6287,32 @@ registry.registerPath({
   },
 });
 
+// Content – Get Platform Prompt (proxy to content-generation-service)
+// Downstream owns response shape — passthrough only.
+const PlatformPromptResponseSchema = z.object({}).passthrough().openapi("PlatformPromptResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/content/platform-prompts",
+  tags: ["Content"],
+  summary: "Get a prompt template by type",
+  description:
+    "Proxy to content-generation-service GET /platform-prompts?type=<type>. " +
+    "Returns the stored prompt template + its variable metadata so callers can collect inputs " +
+    "before invoking POST /v1/content/generate-expert-quote-pitch. " +
+    "Response shape is owned by the downstream service.",
+  security: authed,
+  request: {
+    query: z.object({ type: z.string().openapi({ description: "Prompt type to look up (e.g. expert-quote-pitch)" }) }),
+  },
+  responses: {
+    200: { description: "Prompt template", content: { "application/json": { schema: PlatformPromptResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Prompt type not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/v1/platform/llm-context",

--- a/tests/unit/content-platform-prompts.test.ts
+++ b/tests/unit/content-platform-prompts.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.brandId = "brand_testabc";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import contentRouter from "../../src/routes/content.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", contentRouter);
+  return app;
+}
+
+const upstreamResponse = {
+  id: "prompt_abc123",
+  type: "expert-quote-pitch",
+  prompt: "You are an expert at writing pitches...",
+  variables: [
+    { name: "brands", description: "Array of brand profiles" },
+    { name: "request", description: "Quote request details" },
+  ],
+  createdAt: "2026-05-27T10:00:00Z",
+  updatedAt: "2026-05-27T10:00:00Z",
+};
+
+describe("GET /v1/content/platform-prompts", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(upstreamResponse),
+      };
+    });
+  });
+
+  it("should return the downstream payload verbatim on success", async () => {
+    const res = await request(app)
+      .get("/v1/content/platform-prompts")
+      .query({ type: "expert-quote-pitch" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstreamResponse);
+  });
+
+  it("should forward ?type= query param to content-generation-service /platform-prompts", async () => {
+    await request(app)
+      .get("/v1/content/platform-prompts")
+      .query({ type: "expert-quote-pitch" });
+
+    expect(capturedUrl).toContain("/platform-prompts");
+    expect(capturedUrl).toContain("type=expert-quote-pitch");
+  });
+
+  it("should forward identity headers (x-org-id, x-user-id, x-run-id, x-brand-id)", async () => {
+    await request(app)
+      .get("/v1/content/platform-prompts")
+      .query({ type: "expert-quote-pitch" });
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+    expect(headers["x-brand-id"]).toBe("brand_testabc");
+  });
+
+  it("should send X-API-Key to downstream service", async () => {
+    await request(app)
+      .get("/v1/content/platform-prompts")
+      .query({ type: "expert-quote-pitch" });
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["X-API-Key"]).toBeDefined();
+  });
+
+  it("should forward upstream 404 verbatim when prompt type does not exist", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"Prompt type \\"missing\\" not found"}'),
+    }));
+
+    const res = await request(app)
+      .get("/v1/content/platform-prompts")
+      .query({ type: "missing" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("not found");
+  });
+
+  it("should forward upstream 500 status verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal upstream error"),
+    }));
+
+    const res = await request(app)
+      .get("/v1/content/platform-prompts")
+      .query({ type: "expert-quote-pitch" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Internal upstream error");
+  });
+
+  it("should still proxy when ?type is missing (downstream owns validation)", async () => {
+    await request(app).get("/v1/content/platform-prompts");
+
+    expect(capturedUrl).toContain("/platform-prompts");
+    // Express stringifies an empty query as "" — gateway must not invent ?type=
+    expect(capturedUrl).not.toContain("type=");
+  });
+});


### PR DESCRIPTION
## Summary

Dashboard public-report HITL queue (`pr-expert-quote-opportunities`) needs to fetch the stored prompt template + its variable metadata so the user can collect inputs before invoking `POST /v1/content/generate-expert-quote-pitch` (shipped in #490).

This PR adds the missing **`GET /v1/content/platform-prompts`** transparent proxy → content-generation-service `GET /platform-prompts?type=<type>`. Follows the sibling `/v1/content/{compose,generate-expert-quote-pitch}` convention per CLAUDE.md "Future direction" (`/v1/{service-name}/{downstream-path}`).

## URL contract

| Gateway | → Downstream |
|---|---|
| `GET /v1/content/platform-prompts?type=<type>` | `GET /platform-prompts?type=<type>` |

- Auth: `authenticate + requireOrg + requireUser` (mirrors POST sibling).
- Headers: `buildInternalHeaders(req)` forwards `x-org-id`, `x-user-id`, `x-run-id`, `x-brand-id` + `X-API-Key`.
- Response: `z.object({}).passthrough().openapi("PlatformPromptResponse")` per CLAUDE.md rule #8.
- Errors: propagated verbatim (statusCode + body) per CLAUDE.md rule #7.

## DIS-66 context

DIS-66 W3 (api-service) shipped in #490: dropped `POST /v1/orgs/quote-requests/:id/draft`, added `POST /v1/content/generate-expert-quote-pitch` + `POST /v1/orgs/opportunities/next`.

W3 plan did NOT include the GET prompt-template proxy — dashboard W2 needs it to render the input form for the HITL queue. This PR closes that gap.

## Test plan

- [x] `pnpm test` — 1314 passed (117 files; +7 new)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm generate:openapi` — regenerated + committed
- [x] `openapi.json` paths: `/v1/content/platform-prompts` present
- [ ] Post-staging deploy: `curl https://api.staging.distribute.you/v1/content/platform-prompts?type=expert-quote-pitch` returns downstream prompt template JSON
- [ ] api-registry-staging MCP picks up new openapi within ~5min of Railway redeploy
- [ ] Dashboard W2 PR (separate workspace) consumes `/v1/content/platform-prompts` + `/v1/content/generate-expert-quote-pitch`

## Linear

DIS-66 (Done) — refactor Opportunity-catalog pattern. This PR = gap-fix for dashboard W2 wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)