### PR TITLE
feat(content): proxy GET + PUT /v1/content/prompt-assignments

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8061,6 +8061,14 @@
         "type": "object",
         "properties": {}
       },
+      "PromptAssignmentResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PromptAssignmentRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "LlmServiceOverview": {
         "type": "object",
         "properties": {
@@ -28836,6 +28844,248 @@
             }
           }
         }
+      }
+    },
+    "/v1/content/prompt-assignments": {
+      "get": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Get a feature's assigned generation prompt",
+        "description": "Proxy to content-generation-service GET /prompt-assignments?featureSlug=<slug>. Returns the prompt currently assigned to a feature + its variable metadata so the dashboard prompt editor can read the prompt the feature's GENERATE step uses. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug whose assigned prompt to fetch (e.g. pr-expert-quote-opportunities)"
+            },
+            "required": true,
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Assigned prompt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptAssignmentResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No assignment for featureSlug (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Content"
+        ],
+        "summary": "Save a feature's generation prompt",
+        "description": "Proxy to content-generation-service PUT /prompt-assignments. Saves the feature's generation prompt (forks + reassigns downstream). Body + response shapes are owned by the downstream service; its 400 variable-integrity errors propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptAssignmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Prompt saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptAssignmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Variable-integrity error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/platform/llm-context": {

--- a/src/routes/content.ts
+++ b/src/routes/content.ts
@@ -80,4 +80,52 @@ router.get("/content/platform-prompts", authenticate, requireOrg, requireUser, a
   }
 });
 
+/**
+ * GET /v1/content/prompt-assignments?featureSlug=<slug>
+ * Proxy to content-generation-service GET /prompt-assignments?featureSlug=<slug>.
+ * Returns the prompt currently assigned to a feature + its variable metadata so the
+ * dashboard prompt editor can read the prompt the feature's GENERATE step uses.
+ * Response shape is owned by the downstream service — passthrough only.
+ */
+router.get("/content/prompt-assignments", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query["featureSlug"]) params.set("featureSlug", req.query["featureSlug"] as string);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.emailgen,
+      `/prompt-assignments${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch prompt assignment" });
+  }
+});
+
+/**
+ * PUT /v1/content/prompt-assignments
+ * Proxy to content-generation-service PUT /prompt-assignments.
+ * Saves the feature's generation prompt (forks + reassigns downstream).
+ * Body + response shapes are owned by the downstream service — passthrough only.
+ * Downstream owns validation: its 400 variable-integrity errors propagate verbatim.
+ */
+router.put("/content/prompt-assignments", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.emailgen,
+      "/prompt-assignments",
+      {
+        method: "PUT",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to save prompt assignment" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6313,6 +6313,55 @@ registry.registerPath({
   },
 });
 
+// Content – Prompt Assignments (proxy to content-generation-service)
+// Downstream owns body + response shapes — passthrough only. No gateway re-validation.
+const PromptAssignmentResponseSchema = z.object({}).passthrough().openapi("PromptAssignmentResponse");
+const PromptAssignmentRequestSchema = z.object({}).passthrough().openapi("PromptAssignmentRequest");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/content/prompt-assignments",
+  tags: ["Content"],
+  summary: "Get a feature's assigned generation prompt",
+  description:
+    "Proxy to content-generation-service GET /prompt-assignments?featureSlug=<slug>. " +
+    "Returns the prompt currently assigned to a feature + its variable metadata so the " +
+    "dashboard prompt editor can read the prompt the feature's GENERATE step uses. " +
+    "Response shape is owned by the downstream service.",
+  security: authed,
+  request: {
+    query: z.object({ featureSlug: z.string().openapi({ description: "Feature slug whose assigned prompt to fetch (e.g. pr-expert-quote-opportunities)" }) }),
+  },
+  responses: {
+    200: { description: "Assigned prompt", content: { "application/json": { schema: PromptAssignmentResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "No assignment for featureSlug (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/content/prompt-assignments",
+  tags: ["Content"],
+  summary: "Save a feature's generation prompt",
+  description:
+    "Proxy to content-generation-service PUT /prompt-assignments. " +
+    "Saves the feature's generation prompt (forks + reassigns downstream). " +
+    "Body + response shapes are owned by the downstream service; its 400 variable-integrity " +
+    "errors propagate verbatim.",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: PromptAssignmentRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Prompt saved", content: { "application/json": { schema: PromptAssignmentResponseSchema } } },
+    400: { description: "Variable-integrity error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/v1/platform/llm-context",

--- a/tests/unit/content-prompt-assignments.test.ts
+++ b/tests/unit/content-prompt-assignments.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.brandId = "brand_testabc";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import contentRouter from "../../src/routes/content.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", contentRouter);
+  return app;
+}
+
+const getResponse = {
+  featureSlug: "pr-expert-quote-opportunities",
+  promptType: "expert-quote-pitch",
+  prompt: "You are an expert at writing pitches for {{brands}}...",
+  variables: [
+    { name: "brands", description: "Array of brand profiles" },
+    { name: "request", description: "Quote request details" },
+  ],
+  isDefault: false,
+};
+
+const putBody = {
+  featureSlug: "pr-expert-quote-opportunities",
+  prompt: "You are an expert at writing pitches for {{brands}}...",
+  variables: [
+    { name: "brands", description: "Array of brand profiles" },
+    { name: "request", description: "Quote request details" },
+  ],
+};
+
+describe("GET /v1/content/prompt-assignments", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(getResponse),
+      };
+    });
+  });
+
+  it("should return the downstream payload verbatim on success", async () => {
+    const res = await request(app)
+      .get("/v1/content/prompt-assignments")
+      .query({ featureSlug: "pr-expert-quote-opportunities" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(getResponse);
+  });
+
+  it("should forward ?featureSlug= query param to content-generation-service /prompt-assignments", async () => {
+    await request(app)
+      .get("/v1/content/prompt-assignments")
+      .query({ featureSlug: "pr-expert-quote-opportunities" });
+
+    expect(capturedUrl).toContain("/prompt-assignments");
+    expect(capturedUrl).toContain("featureSlug=pr-expert-quote-opportunities");
+  });
+
+  it("should forward identity headers (x-org-id, x-user-id, x-run-id, x-brand-id)", async () => {
+    await request(app)
+      .get("/v1/content/prompt-assignments")
+      .query({ featureSlug: "pr-expert-quote-opportunities" });
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+    expect(headers["x-brand-id"]).toBe("brand_testabc");
+  });
+
+  it("should send X-API-Key to downstream service", async () => {
+    await request(app)
+      .get("/v1/content/prompt-assignments")
+      .query({ featureSlug: "pr-expert-quote-opportunities" });
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["X-API-Key"]).toBeDefined();
+  });
+
+  it("should forward upstream 404 verbatim when featureSlug has no assignment", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"No prompt assignment for featureSlug \\"missing\\""}'),
+    }));
+
+    const res = await request(app)
+      .get("/v1/content/prompt-assignments")
+      .query({ featureSlug: "missing" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("No prompt assignment");
+  });
+
+  it("should forward upstream 500 status verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal upstream error"),
+    }));
+
+    const res = await request(app)
+      .get("/v1/content/prompt-assignments")
+      .query({ featureSlug: "pr-expert-quote-opportunities" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Internal upstream error");
+  });
+});
+
+describe("PUT /v1/content/prompt-assignments", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(getResponse),
+      };
+    });
+  });
+
+  it("should return the downstream response verbatim on success", async () => {
+    const res = await request(app)
+      .put("/v1/content/prompt-assignments")
+      .send(putBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(getResponse);
+  });
+
+  it("should forward the body verbatim (PUT) to content-generation-service /prompt-assignments", async () => {
+    await request(app)
+      .put("/v1/content/prompt-assignments")
+      .send(putBody);
+
+    expect(capturedUrl).toContain("/prompt-assignments");
+    expect(capturedInit?.method).toBe("PUT");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual(putBody);
+  });
+
+  it("should forward identity headers (x-org-id, x-user-id, x-run-id, x-brand-id)", async () => {
+    await request(app)
+      .put("/v1/content/prompt-assignments")
+      .send(putBody);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+    expect(headers["x-brand-id"]).toBe("brand_testabc");
+  });
+
+  it("should propagate a 400 variable-integrity error verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      text: () =>
+        Promise.resolve(
+          '{"error":"Variable integrity violation: prompt references {{founders}} not declared in variables"}',
+        ),
+    }));
+
+    const res = await request(app)
+      .put("/v1/content/prompt-assignments")
+      .send(putBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Variable integrity violation");
+  });
+
+  it("should forward upstream 500 status verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal upstream error"),
+    }));
+
+    const res = await request(app)
+      .put("/v1/content/prompt-assignments")
+      .send(putBody);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Internal upstream error");
+  });
+});


### PR DESCRIPTION
## What

Expose content-generation-service's two new **prompt-assignment** operations through the gateway so the dashboard **quote-prompt editor** (PR Expert quote-opportunities) can read + save a feature's GENERATE prompt.

| Gateway | Downstream (content-generation) | Middleware |
|---|---|---|
| `GET /v1/content/prompt-assignments?featureSlug=<slug>` | `GET /prompt-assignments?featureSlug=` | `authenticate + requireOrg + requireUser` |
| `PUT /v1/content/prompt-assignments` | `PUT /prompt-assignments` | `authenticate + requireOrg + requireUser` |

## How

Pure transparent proxy via `externalServices.emailgen` (content-generation), mirroring the existing `/v1/content/generate-expert-quote-pitch` + `/v1/content/platform-prompts` handlers in the same router.

- No gateway body re-validation — content-generation owns validation. Its **400 variable-integrity errors propagate verbatim** (no mask, no truncation — CLAUDE.md rule #7).
- Passthrough response schemas (`z.object({}).passthrough()`) per CLAUDE.md rule #8.
- `openapi.json` regenerated.

## Tests

`tests/unit/content-prompt-assignments.test.ts` (11 cases) mirrors `content-platform-prompts.test.ts`: success passthrough, `featureSlug` forward, identity-header forward, `X-API-Key`, PUT body byte-equal, **400 var-integrity verbatim**, 404/500 verbatim. Full suite: **1329 pass / 0 fail**.

## Deployment ordering

Downstream content-generation prompt-assignment routes are in flight (separate workspace). Contract is **LOCKED byte-equal** with the dashboard consumer. This proxy 404s until content-generation deploys those routes — expected; gateway path + downstream path are identical so it lights up the moment downstream lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)