### PR TITLE
feat(admin): proxy DELETE /internal/admin/orgs/:orgId org cascade teardown

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { authenticatePlatform } from "../middleware/auth.js";
+import { callExternalServiceWithStatus, externalServices } from "../lib/service-client.js";
 import pg from "pg";
 
 const { Pool } = pg;
@@ -251,6 +252,27 @@ router.get("/admin/services/:name/tables/:table/rows", authenticatePlatform, asy
     limit,
     offset,
   });
+});
+
+// ── DELETE /admin/orgs/:orgId ───────────────────────────────────────────────
+// Staff-only org cascade teardown. Pure proxy to client-service, which owns the
+// org-lifecycle orchestration: it deletes its own org data, the Clerk org
+// (online), and — via stripe-service — the org's Stripe customer (online).
+// The gateway adds no logic: it forwards the result + status and propagates any
+// upstream error body verbatim so a partial teardown fails loud (CLAUDE.md #7).
+router.delete("/admin/orgs/:orgId", authenticatePlatform, async (req: Request, res: Response) => {
+  const { orgId } = req.params;
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.client,
+      `/internal/orgs/${encodeURIComponent(orgId)}`,
+      { method: "DELETE" },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error(`[api-service] org teardown failed for ${orgId}:`, error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to tear down org" });
+  }
 });
 
 export default router;

--- a/tests/unit/admin-org-teardown.test.ts
+++ b/tests/unit/admin-org-teardown.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Keep authenticatePlatform real — this is a staff-only platform route.
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return { ...actual };
+});
+
+import adminRoutes from "../../src/routes/admin.js";
+
+const VALID_API_KEY = "test-admin-distribute-key";
+const ORG_ID = "org_test_teardown_123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/internal", adminRoutes);
+  return app;
+}
+
+const downstreamBody = { deleted: true, orgId: ORG_ID, clerk: "deleted", stripe: "deleted" };
+
+describe("DELETE /internal/admin/orgs/:orgId", () => {
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(downstreamBody),
+      };
+    });
+  });
+
+  it("forwards to client-service DELETE /internal/orgs/:orgId", async () => {
+    const app = createApp();
+    await request(app).delete(`/internal/admin/orgs/${ORG_ID}`).set("X-API-Key", VALID_API_KEY);
+
+    expect(capturedUrl).toContain(`/internal/orgs/${ORG_ID}`);
+    expect(capturedInit?.method).toBe("DELETE");
+  });
+
+  it("returns the downstream JSON body + status verbatim on success", async () => {
+    const app = createApp();
+    const res = await request(app).delete(`/internal/admin/orgs/${ORG_ID}`).set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(downstreamBody);
+  });
+
+  it("sends X-API-Key to client-service", async () => {
+    const app = createApp();
+    await request(app).delete(`/internal/admin/orgs/${ORG_ID}`).set("X-API-Key", VALID_API_KEY);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["X-API-Key"]).toBeDefined();
+  });
+
+  it("rejects requests without platform API key (401)", async () => {
+    const app = createApp();
+    const res = await request(app).delete(`/internal/admin/orgs/${ORG_ID}`);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("propagates an upstream 404 verbatim", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"org not found"}'),
+    });
+
+    const app = createApp();
+    const res = await request(app).delete(`/internal/admin/orgs/${ORG_ID}`).set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("org not found");
+  });
+
+  it("propagates an upstream 500 verbatim (fail loud on partial teardown)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Clerk org deletion failed"),
+    });
+
+    const app = createApp();
+    const res = await request(app).delete(`/internal/admin/orgs/${ORG_ID}`).set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Clerk org deletion failed");
+  });
+});


### PR DESCRIPTION
## What
Staff-only org cascade teardown route on the admin console:

`DELETE /internal/admin/orgs/:orgId` (auth: `authenticatePlatform` / X-API-Key, staff only)
→ proxies to client-service `DELETE /internal/orgs/:orgId`.

Pure proxy — gateway adds no logic. Forwards downstream status + JSON body, propagates upstream error body verbatim so a partial teardown fails loud (CLAUDE.md #7). Not client/Bearer-exposed, not in OpenAPI (consistent with existing `/internal/admin/*` console routes).

## Architecture (A)
client-service owns the cascade orchestration: deletes its own org data + the Clerk org (online) + the org's Stripe customer (online, via stripe-service). Orchestration lives in the org-lifecycle owner, not the gateway (CLAUDE.md rule #2). Scope this round: client-service + Stripe + Clerk only — NOT the other ~30 service DBs.

## LOCKED contract
| Side | String |
|------|--------|
| Gateway | `DELETE /internal/admin/orgs/:orgId` |
| Downstream (client-service) | `DELETE /internal/orgs/:orgId` |

## ⚠️ Deployment ordering
**Do NOT merge before client-service ships `DELETE /internal/orgs/:orgId` to staging.** This route 404s downstream until then. Sister PRs:
- client-service: org teardown endpoint (+ Clerk online + calls stripe-service) — spawned
- stripe-service: delete org Stripe customer online (`DELETE /internal/customers/by-org/:orgId`) — spawned

## Tests
`tests/unit/admin-org-teardown.test.ts` — 6 cases: downstream path/method forward, status+body verbatim, X-API-Key sent, 401 without platform key, upstream 404/500 propagated verbatim. Full suite: 1335 passed. openapi.json unchanged.

## Triage
Feature → staging.