### PR TITLE
refactor(quotes): remove deprecated POST /orgs/opportunities/ranked proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8960,14 +8960,6 @@
         "type": "object",
         "properties": {}
       },
-      "OpportunitiesRankedResponse": {
-        "type": "object",
-        "properties": {}
-      },
-      "OpportunitiesRankedRequest": {
-        "type": "object",
-        "properties": {}
-      },
       "OpportunityNextResponse": {
         "type": "object",
         "properties": {}
@@ -32203,118 +32195,6 @@
             }
           }
         }
-      }
-    },
-    "/v1/orgs/opportunities/ranked": {
-      "post": {
-        "tags": [
-          "Expert Quotes"
-        ],
-        "summary": "RAG-ranked opportunities for the (campaign, brand-set)",
-        "description": "Pass-through to journalists-quotes-service POST /orgs/opportunities/ranked. Brand identity flows via the x-brand-id header (CSV when plural). Returns Gold-cluster opportunity IDs with score + latest pitchStatus annotation. Body + response shapes are owned by the downstream service.",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OpportunitiesRankedRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Ranked opportunities",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OpportunitiesRankedResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request (forwarded verbatim from downstream)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "example": "uuid1,uuid2,uuid3"
-            },
-            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ]
       }
     },
     "/v1/orgs/opportunities/next": {

--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -5,10 +5,10 @@
 import { Agent, type Dispatcher } from "undici";
 
 // Shared undici dispatcher for journalists-quotes-service.
-// /orgs/opportunities/ranked runs heavy RAG ranking on large brand-sets and can
-// legitimately take 5–10 minutes. Node's default undici headersTimeout (300s)
-// surfaces as UND_ERR_HEADERS_TIMEOUT before the downstream finishes; this bumps
-// headers + body timeout to 10 minutes for that one service only.
+// /orgs/opportunities/discover (batch scorer) and /next run heavy RAG scoring on
+// large brand-sets and can legitimately take 5–10 minutes. Node's default undici
+// headersTimeout (300s) surfaces as UND_ERR_HEADERS_TIMEOUT before the downstream
+// finishes; this bumps headers + body timeout to 10 minutes for that one service only.
 const JOURNALISTS_QUOTES_DISPATCHER: Dispatcher = new Agent({
   headersTimeout: 600_000,
   bodyTimeout: 600_000,

--- a/src/routes/quotes.ts
+++ b/src/routes/quotes.ts
@@ -114,24 +114,6 @@ router.get("/orgs/opportunities", authenticate, requireOrg, requireUser, async (
   }
 });
 
-// POST /v1/orgs/opportunities/ranked — RAG-ranked opportunities for (campaign, brand-set)
-router.post("/orgs/opportunities/ranked", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const result = await callExternalService(
-      externalServices.journalistsQuotes,
-      "/orgs/opportunities/ranked",
-      {
-        method: "POST",
-        body: req.body,
-        headers: buildInternalHeaders(req),
-      }
-    );
-    res.json(result);
-  } catch (error: any) {
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to fetch ranked opportunities" });
-  }
-});
-
 // POST /v1/orgs/opportunities/next — single highest-scored Gold-cluster opportunity for the brand-set
 router.post("/orgs/opportunities/next", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7090,8 +7090,6 @@ const QuotePitchResponseSchema = z
 
 // Passthrough schemas for HITL PR Expert Quote Opportunities routes.
 // Downstream (journalists-quotes-service) owns body + response shapes — api-service forwards bytes.
-const OpportunitiesRankedRequestSchema = z.object({}).passthrough().openapi("OpportunitiesRankedRequest");
-const OpportunitiesRankedResponseSchema = z.object({}).passthrough().openapi("OpportunitiesRankedResponse");
 const OpportunityNextRequestSchema = z.object({}).passthrough().openapi("OpportunityNextRequest");
 const OpportunityNextResponseSchema = z.object({}).passthrough().openapi("OpportunityNextResponse");
 const OpportunityReplyRequestSchema = z.object({}).passthrough().openapi("OpportunityReplyRequest");
@@ -7222,27 +7220,6 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Scored opportunities", content: { "application/json": { schema: OpportunitiesListResponseSchema } } },
-    401: { description: "Unauthorized", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "post",
-  path: "/v1/orgs/opportunities/ranked",
-  tags: ["Expert Quotes"],
-  summary: "RAG-ranked opportunities for the (campaign, brand-set)",
-  description:
-    "Pass-through to journalists-quotes-service POST /orgs/opportunities/ranked. " +
-    "Brand identity flows via the x-brand-id header (CSV when plural). " +
-    "Returns Gold-cluster opportunity IDs with score + latest pitchStatus annotation. " +
-    "Body + response shapes are owned by the downstream service.",
-  security: authed,
-  request: {
-    body: { content: { "application/json": { schema: OpportunitiesRankedRequestSchema } } },
-  },
-  responses: {
-    200: { description: "Ranked opportunities", content: { "application/json": { schema: OpportunitiesRankedResponseSchema } } },
-    400: { description: "Bad request (forwarded verbatim from downstream)", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
   },
 });

--- a/tests/unit/journalists-quotes-dispatcher.regression.test.ts
+++ b/tests/unit/journalists-quotes-dispatcher.regression.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Agent } from "undici";
 
 /**
- * Regression test: journalists-quotes-service /orgs/opportunities/ranked runs
- * heavy RAG ranking that legitimately takes 5–10 minutes on large brand-sets.
+ * Regression test: journalists-quotes-service /orgs/opportunities/discover (batch
+ * scorer) and /next run heavy RAG scoring that legitimately takes 5–10 minutes on
+ * large brand-sets.
  *
  * `externalServices.journalistsQuotes` MUST carry a `dispatcher` (undici Agent
  * with bumped headers + body timeouts) and `callExternalServiceWithStatus`
@@ -53,7 +54,7 @@ describe("journalists-quotes dispatcher", () => {
 
     await callExternalServiceWithStatus(
       externalServices.journalistsQuotes,
-      "/orgs/opportunities/ranked",
+      "/orgs/opportunities/discover",
       { method: "POST", body: { brandIds: ["b1"] } }
     );
 

--- a/tests/unit/quotes-proxy.test.ts
+++ b/tests/unit/quotes-proxy.test.ts
@@ -109,16 +109,16 @@ describe("Expert quotes proxy routes", () => {
     }
   });
 
-  it("should call externalServices.journalistsQuotes for every endpoint (10x)", () => {
+  it("should call externalServices.journalistsQuotes for every endpoint (9x)", () => {
     const matches = content.match(/externalServices\.journalistsQuotes/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(10);
+    expect(matches!.length).toBe(9);
   });
 
-  it("should use buildInternalHeaders for every endpoint (10x)", () => {
+  it("should use buildInternalHeaders for every endpoint (9x)", () => {
     const matches = content.match(/buildInternalHeaders\(req\)/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(10);
+    expect(matches!.length).toBe(9);
   });
 
   it("should preserve downstream paths (no path renaming)", () => {
@@ -129,7 +129,6 @@ describe("Expert quotes proxy routes", () => {
     expect(content).toContain('"/orgs/quote-pitches/:id"');
     expect(content).toContain('"/orgs/opportunities"');
     expect(content).toContain('"/orgs/opportunities/discover"');
-    expect(content).toContain('"/orgs/opportunities/ranked"');
     expect(content).toContain('"/orgs/opportunities/next"');
     expect(content).toContain('"/orgs/opportunities/:id/reply"');
   });
@@ -138,21 +137,8 @@ describe("Expert quotes proxy routes", () => {
     expect(content).not.toContain('"/orgs/quote-requests/:id/draft"');
   });
 
-  it("should have POST /orgs/opportunities/ranked with auth + requireOrg + requireUser", () => {
-    const line = content.split("\n").find((l) =>
-      l.includes("router.post") && l.includes('"/orgs/opportunities/ranked"')
-    );
-    expect(line).toBeDefined();
-    expect(line).toContain("authenticate");
-    expect(line).toContain("requireOrg");
-    expect(line).toContain("requireUser");
-  });
-
-  it("should forward body verbatim on POST /orgs/opportunities/ranked", () => {
-    const idx = content.indexOf('"/orgs/opportunities/ranked"');
-    const section = content.slice(idx, idx + 800);
-    expect(section).toMatch(/method:\s*"POST"/);
-    expect(section).toContain("body: req.body");
+  it("should NOT define POST /orgs/opportunities/ranked (deprecated, removed — replaced by /discover + /next)", () => {
+    expect(content).not.toContain('"/orgs/opportunities/ranked"');
   });
 
   it("should have POST /orgs/opportunities/next with auth + requireOrg + requireUser", () => {
@@ -295,10 +281,10 @@ describe("Expert quotes OpenAPI schemas", () => {
     expect(schemaContent).toContain('tags: ["Expert Quotes"]');
   });
 
-  it("should register POST /v1/orgs/opportunities/ranked with passthrough body + response", () => {
-    expect(schemaContent).toContain('path: "/v1/orgs/opportunities/ranked"');
-    expect(schemaContent).toContain("OpportunitiesRankedRequest");
-    expect(schemaContent).toContain("OpportunitiesRankedResponse");
+  it("should NOT register POST /v1/orgs/opportunities/ranked (deprecated, removed)", () => {
+    expect(schemaContent).not.toContain('path: "/v1/orgs/opportunities/ranked"');
+    expect(schemaContent).not.toContain("OpportunitiesRankedRequest");
+    expect(schemaContent).not.toContain("OpportunitiesRankedResponse");
   });
 
   it("should register POST /v1/orgs/opportunities/next with passthrough body + response", () => {
@@ -360,9 +346,8 @@ describe("Expert quotes endpoints in openapi.json", () => {
     expect(openapi.paths["/v1/orgs/quote-pitches/{id}"].get).toBeDefined();
   });
 
-  it("should include /v1/orgs/opportunities/ranked POST in committed openapi.json", () => {
-    expect(openapi.paths["/v1/orgs/opportunities/ranked"]).toBeDefined();
-    expect(openapi.paths["/v1/orgs/opportunities/ranked"].post).toBeDefined();
+  it("should NOT include /v1/orgs/opportunities/ranked POST in committed openapi.json (deprecated, removed)", () => {
+    expect(openapi.paths["/v1/orgs/opportunities/ranked"]).toBeUndefined();
   });
 
   it("should include /v1/orgs/opportunities/next POST in committed openapi.json", () => {


### PR DESCRIPTION
## What

Removes the deprecated `POST /v1/orgs/opportunities/ranked` proxy from api-service. The dashboard has already cut all `/orgs/opportunities/ranked` calls in favor of the opportunity-catalog pattern (`POST /orgs/opportunities/discover` + `POST /orgs/opportunities/next` + `GET /orgs/opportunities`). This removes the gateway proxy in lockstep (CLAUDE.md rule #5).

## Changes
- `src/routes/quotes.ts` — drop the `/orgs/opportunities/ranked` route.
- `src/schemas.ts` — drop `OpportunitiesRanked{Request,Response}` schemas + the `registerPath` entry.
- `openapi.json` — regenerated (no `/ranked` path).
- `tests/unit/quotes-proxy.test.ts` — ranked assertions inverted to clean-cut removal guards; endpoint counts 10 → 9.
- `tests/unit/journalists-quotes-dispatcher.regression.test.ts` — re-pointed example path to `/discover`; comment updated.

## Kept on purpose
The journalists-quotes **600s undici dispatcher stays** — `/discover` (batch scorer) and `/next` still run heavy RAG scoring and need the bumped headers/body timeout. Only the comment was re-pointed off `/ranked`.

## ⚠️ Deployment ordering (promote gate)
Safe to merge to **staging** now. Do **NOT promote to prod** until the **dashboard prod deploy is on the catalog-pattern build** (already cut on `main`). Prod logs still show a live `/ranked` caller — almost certainly a stale Vercel deploy; promoting this proxy removal before the dashboard promotes would 404 that caller. This mirrors the jqs v0.9.0 → v0.9.1 premature-drop incident.

## Cross-repo
- **jqs** removal of the upstream `/orgs/opportunities/ranked` route — spawned in parallel (separate PR → staging).
- **dashboard** — already cut on `main`.

Tests: full unit suite green (1348 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)