### PR TITLE
feat(mentions): proxy GET+POST /v1/mentions to articles-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3888,6 +3888,18 @@
           "discoveries"
         ]
       },
+      "ListMentionsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "MentionResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "CreateMentionRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "DiscoveryStats": {
         "type": "object",
         "properties": {
@@ -16062,6 +16074,267 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BulkCreateDiscoveriesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/mentions": {
+      "get": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "List recorded journalist mentions, joined with article data",
+        "description": "Lists mentions for the org (from x-org-id), optionally filtered by brandId, campaignId, outletId, journalistId. Each row includes the joined article (title, author, published date, word count). Proxied to articles-service GET /v1/mentions.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by brand ID"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by campaign ID"
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by outlet ID"
+            },
+            "required": false,
+            "name": "outletId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by journalist ID"
+            },
+            "required": false,
+            "name": "journalistId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mentions with joined article data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMentionsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Articles"
+        ],
+        "summary": "Record a journalist mention (earned-media placement) after outreach",
+        "description": "Logs that a journalist published an article mentioning a brand, with the placement's characteristics (mention/quote/link/dofollow, organic vs sponsored, paid vs free + spend). org/brand/campaign come from identity headers (x-org-id, x-brand-id, x-campaign-id required). Provide either articleId (already indexed) or articleUrl (scraped + extracted + upserted). Proxied to articles-service POST /v1/mentions.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMentionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Mention recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MentionResponse"
                 }
               }
             }

--- a/src/routes/articles.ts
+++ b/src/routes/articles.ts
@@ -246,4 +246,40 @@ router.post("/discover/journalist-publications", authenticate, requireOrg, requi
   }
 });
 
+// ── Mentions ──────────────────────────────────────────────────────────────────
+
+// GET /v1/mentions — list recorded journalist mentions, joined with article data
+router.get("/mentions", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "campaignId", "outletId", "journalistId", "limit", "offset"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+
+    const result = await callExternalService(
+      externalServices.articles,
+      `/v1/mentions${qs}`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to list mentions" });
+  }
+});
+
+// POST /v1/mentions — record a journalist mention (earned-media placement) after outreach
+router.post("/mentions", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.articles,
+      "/v1/mentions",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to create mention" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2281,6 +2281,68 @@ registry.registerPath({
   },
 });
 
+// ── Mentions ────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/mentions",
+  tags: ["Articles"],
+  summary: "List recorded journalist mentions, joined with article data",
+  description: "Lists mentions for the org (from x-org-id), optionally filtered by brandId, campaignId, outletId, journalistId. Each row includes the joined article (title, author, published date, word count). Proxied to articles-service GET /v1/mentions.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().optional().openapi({ description: "Filter by brand ID" }),
+      campaignId: z.string().uuid().optional().openapi({ description: "Filter by campaign ID" }),
+      outletId: z.string().uuid().optional().openapi({ description: "Filter by outlet ID" }),
+      journalistId: z.string().uuid().optional().openapi({ description: "Filter by journalist ID" }),
+      limit: z.coerce.number().int().optional(),
+      offset: z.coerce.number().int().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Mentions with joined article data",
+      content: {
+        "application/json": {
+          schema: z.object({}).passthrough().openapi("ListMentionsResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/mentions",
+  tags: ["Articles"],
+  summary: "Record a journalist mention (earned-media placement) after outreach",
+  description: "Logs that a journalist published an article mentioning a brand, with the placement's characteristics (mention/quote/link/dofollow, organic vs sponsored, paid vs free + spend). org/brand/campaign come from identity headers (x-org-id, x-brand-id, x-campaign-id required). Provide either articleId (already indexed) or articleUrl (scraped + extracted + upserted). Proxied to articles-service POST /v1/mentions.",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({}).passthrough().openapi("CreateMentionRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Mention recorded",
+      content: {
+        "application/json": {
+          schema: z.object({}).passthrough().openapi("MentionResponse"),
+        },
+      },
+    },
+    400: { description: "Validation error", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+  },
+});
+
 // ── Article stats ───────────────────────────────────────────────────────────
 
 registry.registerPath({

--- a/tests/unit/articles-proxy.test.ts
+++ b/tests/unit/articles-proxy.test.ts
@@ -167,6 +167,44 @@ describe("Articles proxy routes", () => {
     expect(content).toContain('"/discover/journalist-publications"');
   });
 
+  // ── Mentions ──────────────────────────────────────────────────────────
+
+  it("should have GET /mentions with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/mentions"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward filter params on GET /mentions", () => {
+    const section = content.slice(
+      content.indexOf('router.get("/mentions"'),
+      content.indexOf('router.post("/mentions"')
+    );
+    for (const param of ["brandId", "campaignId", "outletId", "journalistId", "limit", "offset"]) {
+      expect(section).toContain(`"${param}"`);
+    }
+  });
+
+  it("should have POST /mentions with auth + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.post") && l.includes('"/mentions"')
+    );
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should proxy /mentions path-preserving to /v1/mentions on articles-service", () => {
+    // POST forwards to bare /v1/mentions; GET forwards with query string
+    expect(content).toContain('"/v1/mentions"');
+    expect(content).toContain('`/v1/mentions${qs}`');
+  });
+
   // ── General checks ────────────────────────────────────────────────────
 
   it("should proxy to articles-service at /v1/ paths (articles-service uses /v1 prefix)", () => {
@@ -181,7 +219,7 @@ describe("Articles proxy routes", () => {
   it("should use buildInternalHeaders for all endpoints", () => {
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(15);
+    expect(headerMatches!.length).toBe(17);
   });
 
   it("should enforce requireOrg + requireUser on ALL article routes", () => {
@@ -296,8 +334,44 @@ describe("Articles OpenAPI schemas", () => {
     expect(schemaContent).toContain("ArticleStatsResponse");
   });
 
+  it("should register GET + POST /v1/mentions", () => {
+    expect(schemaContent).toContain('path: "/v1/mentions"');
+    expect(schemaContent).toContain("CreateMentionRequest");
+    expect(schemaContent).toContain("ListMentionsResponse");
+    expect(schemaContent).toContain("MentionResponse");
+  });
+
+  it("should keep /v1/mentions request + response schemas passthrough (no field re-declaration)", () => {
+    const start = schemaContent.indexOf("CreateMentionRequest");
+    const block = schemaContent.slice(start - 200, start);
+    expect(block).toContain("z.object({}).passthrough()");
+  });
+
+  it("should not cap limit/offset on GET /v1/mentions", () => {
+    const block = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/mentions"'),
+      schemaContent.indexOf("CreateMentionRequest")
+    );
+    expect(block).toContain("limit: z.coerce.number().int().optional()");
+    expect(block).not.toContain(".max(");
+    expect(block).not.toContain(".default(");
+  });
+
   it("should use Articles tag", () => {
     expect(schemaContent).toContain('tags: ["Articles"]');
+  });
+});
+
+describe("Mentions paths in generated openapi.json", () => {
+  const openapiPath = path.join(__dirname, "../../openapi.json");
+  const openapi = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+
+  it("should expose GET /v1/mentions", () => {
+    expect(openapi.paths["/v1/mentions"]?.get).toBeDefined();
+  });
+
+  it("should expose POST /v1/mentions", () => {
+    expect(openapi.paths["/v1/mentions"]?.post).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## TL;DR

articles-service shipped earned-media **journalist mentions** (PR [#50](https://github.com/shamanic-technologies/articles-service/pull/50), DIS-228). Add transparent path-preserving proxies so the dashboard can record/list mentions through the gateway. Pure-additive, zero blast radius.

## Routes (byte-equal, path-preserving — no service-name prefix)

| Gateway | Downstream (articles-service) |
| -- | -- |
| `POST /v1/mentions` | `POST /v1/mentions` |
| `GET /v1/mentions` | `GET /v1/mentions` |

Mirrors the existing `/v1/discoveries` GET+POST idiom in `src/routes/articles.ts`: `authenticate + requireOrg + requireUser`, identity headers (`x-org-id`, `x-user-id`, `x-run-id`, `x-brand-id`, `x-campaign-id`) via `buildInternalHeaders`, articles-service API key injected by `callExternalService`.

## Conventions

- Request + response schemas are `z.object({}).passthrough()` — no downstream field re-declaration (CLAUDE.md #8; mirrors `PriceRequestOutletsResponse`).
- GET filters `brandId / campaignId / outletId / journalistId / limit / offset` forwarded **uncapped** (no `.default()` / `.max()` — no-limit-defaults regression).
- No new env var — `ARTICLES_SERVICE_URL` / `ARTICLES_SERVICE_API_KEY` already power the existing articles proxies in prod.

## Tests

- Route + schema + openapi.json assertions added to `tests/unit/articles-proxy.test.ts` (mirrors discoveries tests; `buildInternalHeaders` count 15 → 17).
- Full suite green (1390 passed). `openapi.json` regenerated, both `/v1/mentions` paths present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)