### PR TITLE
feat(features): proxy GET /v1/features/{featureSlug}/revenue to features-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8297,6 +8297,10 @@
         "type": "object",
         "properties": {}
       },
+      "FeatureRevenueResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "PublicUserStatsResponse": {
         "type": "object",
         "properties": {}
@@ -30653,6 +30657,152 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FeatureStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/{featureSlug}/revenue": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Feature revenue overview",
+        "description": "Expected-pipeline-revenue overview for a specific feature: headline pipeline $, organizations, and leads. Scoped by brandId (+ optional campaignId). Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "featureSlug",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand UUID (required) — scopes the revenue view to one brand",
+              "example": "brand-uuid-123"
+            },
+            "required": true,
+            "description": "Brand UUID (required) — scopes the revenue view to one brand",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by campaign UUID",
+              "example": "campaign-uuid-456"
+            },
+            "required": false,
+            "description": "Filter by campaign UUID",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature revenue overview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureRevenueResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -234,4 +234,27 @@ router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async
   }
 });
 
+/**
+ * GET /v1/features/:slug/revenue
+ * Expected-pipeline-revenue overview for a specific feature, scoped by brandId (+ optional campaignId).
+ */
+router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "campaignId"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}/revenue${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Feature revenue error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature revenue" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6678,6 +6678,29 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/{featureSlug}/revenue",
+  tags: ["Features"],
+  summary: "Feature revenue overview",
+  description:
+    "Expected-pipeline-revenue overview for a specific feature: headline pipeline $, organizations, and leads. Scoped by brandId (+ optional campaignId). Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug") }),
+    query: z.object({
+      brandId: z.string().openapi({ example: "brand-uuid-123" }).describe("Brand UUID (required) — scopes the revenue view to one brand"),
+      campaignId: z.string().optional().openapi({ example: "campaign-uuid-456" }).describe("Filter by campaign UUID"),
+    }),
+  },
+  responses: {
+    200: { description: "Feature revenue overview", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureRevenueResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ---------------------------------------------------------------------------
 // PUBLIC STATS (no auth — landing page endpoints)
 // ---------------------------------------------------------------------------

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -110,6 +110,24 @@ describe("Features proxy routes", () => {
     expect(content).toContain('"workflowDynastySlug"');
   });
 
+  it("should have GET /features/:slug/revenue with auth + requireOrg + requireUser", () => {
+    expect(content).toContain('"/features/:slug/revenue"');
+    const line = content.split("\n").find((l) =>
+      l.includes('"/features/:slug/revenue"')
+    );
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward brandId and campaignId on GET /features/:slug/revenue", () => {
+    const revenueIdx = content.indexOf('"/features/:slug/revenue"');
+    const revenueBlock = content.slice(revenueIdx, revenueIdx + 400);
+    expect(revenueBlock).toContain('"brandId"');
+    expect(revenueBlock).toContain('"campaignId"');
+    expect(revenueBlock).toContain("/revenue");
+  });
+
   it("should enforce requireOrg + requireUser on ALL authenticated feature routes", () => {
     const routeLines = content.split("\n").filter((l) =>
       /router\.(get|post|put)\(/.test(l) && l.includes('"/') && !l.includes("/public/")
@@ -204,6 +222,10 @@ describe("Features OpenAPI schemas", () => {
 
   it("should register GET /v1/features/{featureSlug}/stats", () => {
     expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/stats"');
+  });
+
+  it("should register GET /v1/features/{featureSlug}/revenue", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/revenue"');
   });
 
   it("should document groupBy query param on stats endpoints", () => {

--- a/tests/unit/features-stats.test.ts
+++ b/tests/unit/features-stats.test.ts
@@ -148,3 +148,51 @@ describe("GET /v1/public/features/best", () => {
     expect(url).not.toContain("by=");
   });
 });
+
+const MOCK_REVENUE = {
+  pipelineRevenueUsdCents: 1234500,
+  organizations: [{ orgId: "o-1", name: "Acme", revenueUsdCents: 1000000 }],
+  leads: [{ leadId: "l-1", stage: "qualified", expectedRevenueUsdCents: 234500 }],
+};
+
+describe("GET /v1/features/:slug/revenue", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("proxies to features-service /features/:slug/revenue and returns the body verbatim", async () => {
+    const app = createApp();
+    mockCallExternalService.mockImplementation((service: any, path: string) => {
+      if (service.url === "http://mock-features" && path.startsWith("/features/sales-cold-email-outreach/revenue")) {
+        return Promise.resolve(MOCK_REVENUE);
+      }
+      return Promise.resolve({});
+    });
+
+    const res = await request(app).get("/v1/features/sales-cold-email-outreach/revenue?brandId=brand-uuid-123&campaignId=campaign-uuid-456");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_REVENUE);
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/features/sales-cold-email-outreach/revenue"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).toContain("brandId=brand-uuid-123");
+    expect(url).toContain("campaignId=campaign-uuid-456");
+  });
+
+  it("forwards only brandId when campaignId is absent", async () => {
+    const app = createApp();
+    mockCallExternalService.mockResolvedValue(MOCK_REVENUE);
+
+    await request(app).get("/v1/features/sales-cold-email-outreach/revenue?brandId=brand-uuid-123");
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/features/sales-cold-email-outreach/revenue"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).toContain("brandId=brand-uuid-123");
+    expect(url).not.toContain("campaignId=");
+  });
+});


### PR DESCRIPTION
## Job (JTBD)
When the dashboard requests a feature's revenue overview, the gateway forwards to features-service and returns the payload unchanged.

## What
Thin passthrough proxy mirroring the sibling `GET /v1/features/{featureSlug}/stats`.

- **Gateway route:** `GET /v1/features/{featureSlug}/revenue`
- **Downstream:** features-service `GET /features/{featureSlug}/revenue`
- **Query forwarded:** `brandId` (required per contract), `campaignId` (optional) — only-if-present
- **Middleware:** `authenticate + requireOrg + requireUser` (org-scoped, matches stats)
- **Response:** `z.object({}).passthrough()` per CLAUDE.md #8 — no reshape, no field strip, no aggregation

## Files
- `src/routes/features.ts` — handler (mirror of `:slug/stats`)
- `src/schemas.ts` — OpenAPI registration
- `openapi.json` — regenerated
- `tests/unit/features-proxy.test.ts` + `features-stats.test.ts` — route/middleware/passthrough coverage

## Verify
- `pnpm build` ✅ (tsc + openapi regen)
- `pnpm test` ✅ 1386/1386
- `GET /v1/features/sales-cold-email-outreach/revenue?brandId=<uuid>` → forwarded verbatim, identity headers attached

## Notes
- Transparent proxy: handler does NOT 400 on missing `brandId` (features-service owns validation, rule #4); OpenAPI documents it as required per locked contract.
- features-service `/revenue` not yet in prod registry — route ships dormant, lights up on features-service deploy (zero blast radius, additive).
- Triage: **hotfix → main** (additive passthrough, zero blast radius).
- Part of DIS-229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)