### PR TITLE
feat(features): proxy GET /features/:slug/workflow-projection to features-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8313,6 +8313,10 @@
         "type": "object",
         "properties": {}
       },
+      "WorkflowProjectionResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "PublicUserStatsResponse": {
         "type": "object",
         "properties": {}
@@ -31104,6 +31108,163 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FeatureRevenueResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/{featureSlug}/workflow-projection": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Feature workflow projection",
+        "description": "Ranks a brand's workflows by cost-per-close and projects a budget through the sales funnel for a specific feature. Scoped by brandId (+ objective, budgetUsd). Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "featureSlug",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand UUID (required) — scopes the projection to one brand",
+              "example": "brand-uuid-123"
+            },
+            "required": true,
+            "description": "Brand UUID (required) — scopes the projection to one brand",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Sales-funnel objective to project toward",
+              "example": "meeting-booked"
+            },
+            "required": false,
+            "description": "Sales-funnel objective to project toward",
+            "name": "objective",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Budget in USD to project through the funnel",
+              "example": "1000"
+            },
+            "required": false,
+            "description": "Budget in USD to project through the funnel",
+            "name": "budgetUsd",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature workflow projection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowProjectionResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -257,4 +257,28 @@ router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, asy
   }
 });
 
+/**
+ * GET /v1/features/:slug/workflow-projection
+ * Ranks a brand's workflows by cost-per-close and projects a budget through the sales funnel,
+ * scoped by brandId. Proxied to features-service GET /features/:slug/workflow-projection.
+ */
+router.get("/features/:slug/workflow-projection", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "objective", "budgetUsd"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}/workflow-projection${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Feature workflow-projection error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature workflow projection" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6763,6 +6763,30 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/{featureSlug}/workflow-projection",
+  tags: ["Features"],
+  summary: "Feature workflow projection",
+  description:
+    "Ranks a brand's workflows by cost-per-close and projects a budget through the sales funnel for a specific feature. Scoped by brandId (+ objective, budgetUsd). Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug") }),
+    query: z.object({
+      brandId: z.string().openapi({ example: "brand-uuid-123" }).describe("Brand UUID (required) — scopes the projection to one brand"),
+      objective: z.string().optional().openapi({ example: "meeting-booked" }).describe("Sales-funnel objective to project toward"),
+      budgetUsd: z.string().optional().openapi({ example: "1000" }).describe("Budget in USD to project through the funnel"),
+    }),
+  },
+  responses: {
+    200: { description: "Feature workflow projection", content: { "application/json": { schema: z.object({}).passthrough().openapi("WorkflowProjectionResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ---------------------------------------------------------------------------
 // PUBLIC STATS (no auth — landing page endpoints)
 // ---------------------------------------------------------------------------

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -128,6 +128,25 @@ describe("Features proxy routes", () => {
     expect(revenueBlock).toContain("/revenue");
   });
 
+  it("should have GET /features/:slug/workflow-projection with auth + requireOrg + requireUser", () => {
+    expect(content).toContain('"/features/:slug/workflow-projection"');
+    const line = content.split("\n").find((l) =>
+      l.includes('"/features/:slug/workflow-projection"')
+    );
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward brandId, objective and budgetUsd on GET /features/:slug/workflow-projection", () => {
+    const projectionIdx = content.indexOf('"/features/:slug/workflow-projection"');
+    const projectionBlock = content.slice(projectionIdx, projectionIdx + 400);
+    expect(projectionBlock).toContain('"brandId"');
+    expect(projectionBlock).toContain('"objective"');
+    expect(projectionBlock).toContain('"budgetUsd"');
+    expect(projectionBlock).toContain("/workflow-projection");
+  });
+
   it("should enforce requireOrg + requireUser on ALL authenticated feature routes", () => {
     const routeLines = content.split("\n").filter((l) =>
       /router\.(get|post|put)\(/.test(l) && l.includes('"/') && !l.includes("/public/")
@@ -226,6 +245,10 @@ describe("Features OpenAPI schemas", () => {
 
   it("should register GET /v1/features/{featureSlug}/revenue", () => {
     expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/revenue"');
+  });
+
+  it("should register GET /v1/features/{featureSlug}/workflow-projection", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/workflow-projection"');
   });
 
   it("should document groupBy query param on stats endpoints", () => {


### PR DESCRIPTION
## What
Transparent proxy for the new features-service endpoint `GET /features/:slug/workflow-projection`. The dashboard reaches features-service only through api-service, so this route is required for the campaign-create page to read the cost-per-close workflow ranking + budget-through-funnel projection that features-service now computes server-side.

## Contract (byte-equal)
- Gateway: `GET /v1/features/:slug/workflow-projection?brandId=&objective=&budgetUsd=`
- Forwards to features-service `GET /features/:slug/workflow-projection` with the same query string + identity headers.

## Implementation
Mirrors the existing `/features/:slug/revenue` proxy exactly:
- middleware `authenticate + requireOrg + requireUser`
- query allowlist `[brandId, objective, budgetUsd]`
- passthrough response schema (CLAUDE.md convention #8 — no field re-declaration)
- regenerated `openapi.json`

## Tests
- `tests/unit/features-proxy.test.ts`: route shape (3 middlewares), param forwarding, schema registration. Full unit suite green (1407 pass).

## Heads-up
Downstream `workflow-projection` is in-flight on features-service (not yet in prod registry). This proxy returns 5xx until features-service deploys its endpoint. Pure-additive, zero blast radius on existing routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)