### PR TITLE
feat(emails): proxy GET /v1/workflow-examples to content-generation /generations/examples

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7009,6 +7009,21 @@
           "emails"
         ]
       },
+      "WorkflowExamplesResponse": {
+        "type": "object",
+        "properties": {
+          "examples": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "required": [
+          "examples"
+        ]
+      },
       "SendEmailResponse": {
         "type": "object",
         "properties": {
@@ -25035,6 +25050,148 @@
           },
           "400": {
             "description": "Missing brandId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflow-examples": {
+      "get": {
+        "tags": [
+          "Emails"
+        ],
+        "summary": "List example emails for a workflow",
+        "description": "Example emails per workflow for the workflow picker — a brand→org→global cascade of past generations. Transparent proxy to content-generation-service GET /generations/examples; body forwarded verbatim. Each example carries the email fields plus scope ('brand'|'org'|'global') and brandName.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug (required)"
+            },
+            "required": true,
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Optional brand ID for the brand-scoped cascade tier"
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Max examples to return"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Example emails (passthrough — owned by content-generation-service)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowExamplesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing workflowSlug",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -232,4 +232,39 @@ router.put("/emails/templates", authenticate, requireOrg, async (req: Authentica
   }
 });
 
+/**
+ * GET /v1/workflow-examples — example emails per workflow for the workflow picker.
+ * Transparent proxy to content-generation-service GET /generations/examples (a brand→org→global
+ * cascade of past generations). Returns content-gen's body verbatim:
+ * { examples: Array<ExampleEmail> } where each carries the email fields + scope
+ * ("brand"|"org"|"global") + brandName. No enrichment / no field re-declaration (CLAUDE.md #8).
+ */
+router.get("/workflow-examples", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { workflowSlug, brandId, limit } = req.query as {
+      workflowSlug?: string;
+      brandId?: string;
+      limit?: string;
+    };
+    if (!workflowSlug) {
+      return res.status(400).json({ error: "Missing required query parameter: workflowSlug" });
+    }
+
+    const params = new URLSearchParams();
+    params.set("workflowSlug", workflowSlug);
+    if (brandId) params.set("brandId", brandId);
+    if (limit) params.set("limit", limit);
+
+    const result = await callExternalService(
+      externalServices.emailgen,
+      `/generations/examples?${params}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Get workflow examples error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get workflow examples" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5329,6 +5329,42 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/v1/workflow-examples",
+  tags: ["Emails"],
+  summary: "List example emails for a workflow",
+  description:
+    "Example emails per workflow for the workflow picker — a brand→org→global cascade of past generations. " +
+    "Transparent proxy to content-generation-service GET /generations/examples; body forwarded verbatim. " +
+    "Each example carries the email fields plus scope ('brand'|'org'|'global') and brandName.",
+  security: authed,
+  request: {
+    query: z.object({
+      workflowSlug: z.string().openapi({ description: "Workflow slug (required)" }),
+      brandId: z.string().uuid().optional().openapi({ description: "Optional brand ID for the brand-scoped cascade tier" }),
+      limit: z.coerce.number().int().optional().openapi({ description: "Max examples to return" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Example emails (passthrough — owned by content-generation-service)",
+      content: {
+        "application/json": {
+          // Passthrough per CLAUDE.md #8 — downstream owns the ExampleEmail shape; do NOT re-declare fields.
+          schema: z
+            .object({ examples: z.array(z.object({}).passthrough()) })
+            .passthrough()
+            .openapi("WorkflowExamplesResponse"),
+        },
+      },
+    },
+    400: { description: "Missing workflowSlug", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "post",
   path: "/v1/emails/send",
   tags: ["Emails"],

--- a/tests/unit/workflow-examples-proxy.test.ts
+++ b/tests/unit/workflow-examples-proxy.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import * as fs from "fs";
+import * as path from "path";
+
+// Mock auth middleware — mirrors emails.test.ts
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "user_key";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+interface FetchCall {
+  url: string;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+let fetchCalls: FetchCall[] = [];
+
+import emailsRoutes from "../../src/routes/emails.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", emailsRoutes);
+  return app;
+}
+
+// Passthrough body content-gen would return — email fields + scope + brandName
+const UPSTREAM_BODY = {
+  examples: [
+    {
+      id: "gen_1",
+      subject: "Intro to Polarity",
+      bodyHtml: "<p>Hi {{name}}</p>",
+      bodyText: "Hi {{name}}",
+      scope: "brand",
+      brandName: "Polarity",
+    },
+    {
+      id: "gen_2",
+      subject: "Org-level example",
+      bodyHtml: "<p>Hello</p>",
+      bodyText: "Hello",
+      scope: "org",
+      brandName: null,
+    },
+    {
+      id: "gen_3",
+      subject: "Global example",
+      bodyHtml: "<p>Generic</p>",
+      bodyText: "Generic",
+      scope: "global",
+      brandName: null,
+    },
+  ],
+};
+
+describe("GET /v1/workflow-examples (runtime proxy)", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
+      return {
+        ok: true,
+        json: () => Promise.resolve(UPSTREAM_BODY),
+      };
+    });
+    app = createApp();
+  });
+
+  it("forwards workflowSlug + brandId + limit to content-gen /generations/examples", async () => {
+    const res = await request(app).get(
+      "/v1/workflow-examples?workflowSlug=sales-cold-email&brandId=11111111-1111-4111-8111-111111111111&limit=3",
+    );
+
+    expect(res.status).toBe(200);
+
+    const call = fetchCalls.find((c) => c.url.includes("/generations/examples"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("workflowSlug=sales-cold-email");
+    expect(call!.url).toContain("brandId=11111111-1111-4111-8111-111111111111");
+    expect(call!.url).toContain("limit=3");
+  });
+
+  it("forwards identity via buildInternalHeaders (x-org-id reaches content-gen)", async () => {
+    await request(app).get("/v1/workflow-examples?workflowSlug=sales-cold-email");
+
+    const call = fetchCalls.find((c) => c.url.includes("/generations/examples"));
+    expect(call).toBeDefined();
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-user-id"]).toBe("user_test123");
+  });
+
+  it("returns content-gen body verbatim (passthrough, scope + brandName preserved)", async () => {
+    const res = await request(app).get("/v1/workflow-examples?workflowSlug=sales-cold-email");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(UPSTREAM_BODY);
+    expect(res.body.examples[0].scope).toBe("brand");
+    expect(res.body.examples[0].brandName).toBe("Polarity");
+    expect(res.body.examples[2].scope).toBe("global");
+  });
+
+  it("works with only workflowSlug (brandId + limit optional → not forwarded)", async () => {
+    const res = await request(app).get("/v1/workflow-examples?workflowSlug=sales-cold-email");
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.url.includes("/generations/examples"));
+    expect(call!.url).toContain("workflowSlug=sales-cold-email");
+    expect(call!.url).not.toContain("brandId=");
+    expect(call!.url).not.toContain("limit=");
+  });
+
+  it("returns 400 when workflowSlug is missing", async () => {
+    const res = await request(app).get("/v1/workflow-examples?brandId=11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("workflowSlug");
+    // Must not call downstream
+    expect(fetchCalls.find((c) => c.url.includes("/generations/examples"))).toBeUndefined();
+  });
+
+  it("surfaces upstream error status + body verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 502,
+      json: () => Promise.resolve({ error: "content-gen down" }),
+      text: () => Promise.resolve('{"error":"content-gen down"}'),
+    }));
+    app = createApp();
+
+    const res = await request(app).get("/v1/workflow-examples?workflowSlug=sales-cold-email");
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("GET /v1/workflow-examples (source + OpenAPI)", () => {
+  const routePath = path.join(__dirname, "../../src/routes/emails.ts");
+  const content = fs.readFileSync(routePath, "utf-8");
+  const schemaPath = path.join(__dirname, "../../src/schemas.ts");
+  const schemaContent = fs.readFileSync(schemaPath, "utf-8");
+  const openapi = JSON.parse(fs.readFileSync(path.join(__dirname, "../../openapi.json"), "utf-8"));
+
+  it("route has authenticate + requireOrg + requireUser", () => {
+    const line = content.split("\n").find((l) => l.includes("router.get") && l.includes('"/workflow-examples"'));
+    expect(line).toBeDefined();
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("proxies to content-gen /generations/examples via emailgen", () => {
+    expect(content).toContain("externalServices.emailgen");
+    expect(content).toContain("`/generations/examples?${params}`");
+  });
+
+  it("uses buildInternalHeaders", () => {
+    expect(content).toContain("buildInternalHeaders(req)");
+  });
+
+  it("does NOT enrich with getRunsBatch (pure passthrough)", () => {
+    const section = content.slice(content.indexOf('router.get("/workflow-examples"'));
+    expect(section).not.toContain("getRunsBatch");
+  });
+
+  it("registers /v1/workflow-examples in schemas.ts with passthrough response", () => {
+    expect(schemaContent).toContain('path: "/v1/workflow-examples"');
+    expect(schemaContent).toContain("WorkflowExamplesResponse");
+  });
+
+  it("OpenAPI has /v1/workflow-examples GET with required workflowSlug query param", () => {
+    const op = openapi.paths["/v1/workflow-examples"]?.get;
+    expect(op).toBeDefined();
+    const params = op.parameters || [];
+    const slug = params.find((p: { name: string; in: string }) => p.name === "workflowSlug" && p.in === "query");
+    expect(slug).toBeDefined();
+    expect(slug.required).toBe(true);
+  });
+
+  it("OpenAPI has 200/400/401/500 responses", () => {
+    const op = openapi.paths["/v1/workflow-examples"]?.get;
+    expect(op).toBeDefined();
+    expect(op.responses["200"]).toBeDefined();
+    expect(op.responses["400"]).toBeDefined();
+    expect(op.responses["401"]).toBeDefined();
+    expect(op.responses["500"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

New transparent-proxy route `GET /v1/workflow-examples` so the authed dashboard's workflow picker can show example emails per workflow (a brand→org→global cascade of past generations) without running a real test.

Mirrors the `GET /v1/emails` pattern:
- Guards: `authenticate + requireOrg + requireUser`
- Forwards `workflowSlug` (required) + `brandId` + `limit` and identity via `buildInternalHeaders(req)` to content-generation-service `GET /generations/examples`
- Reuses existing `CONTENT_GENERATION_SERVICE_URL` / `_API_KEY` (the `emailgen` client) — **no new env var**

## Passthrough (CLAUDE.md #8)

Pure proxy — no run-cost enrichment, no field re-declaration. Response schema is `z.object({ examples: [...] }).passthrough()`; content-generation owns the `ExampleEmail` shape (email fields + `scope: "brand"|"org"|"global"` + `brandName: string|null`), body forwarded byte-verbatim.

## Tests

`tests/unit/workflow-examples-proxy.test.ts` (13 cases): downstream path `/generations/examples`, param forwarding, identity headers, passthrough body (scope + brandName), 400 on missing `workflowSlug`, upstream-error passthrough, + source/OpenAPI assertions. Full suite green (1423 pass).

## ⚠️ Deployment ordering

Depends on **content-generation-service** shipping `GET /generations/examples` first. Until then the route 502s **if called** — but it is additive and dormant: no existing handler/response/middleware touched, and no client calls it until the dashboard ships the picker. **Zero blast radius to existing traffic.** Safe to land ahead of the dashboard; harmless until content-gen is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)