### PR TITLE
feat(brands): proxy GET /v1/sales-economics-average to brand-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5052,6 +5052,10 @@
           "runs"
         ]
       },
+      "SalesEconomicsAverageResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "SalesEconomicsResponse": {
         "type": "object",
         "properties": {}
@@ -19976,6 +19980,109 @@
             }
           }
         }
+      }
+    },
+    "/v1/sales-economics-average": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get the org's cross-brand average sales conversion-economics",
+        "description": "Proxy to brand-service GET /orgs/sales-economics-average. Returns the average of the org's saved sales conversion-economics across all brands (lifetimeRevenueUsd, replyToMeetingPct, visitToMeetingPct, meetingToClosePct, visitToClosePct), or { averages: null } when no brand has saved any. Used to prefill the new-campaign sales-economics inputs. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cross-brand average sales economics (or null)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalesEconomicsAverageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/brands/{id}/sales-economics": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -313,6 +313,28 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
 });
 
 /**
+ * GET /v1/sales-economics-average
+ * Proxy to brand-service GET /orgs/sales-economics-average.
+ * Returns the cross-brand average sales conversion-economics for the org
+ * ({ averages: { ...5 metrics } | null }). Used by the dashboard "new campaign"
+ * page to prefill inputs when a brand has saved nothing. Response shape is owned
+ * by the downstream service — passthrough only.
+ */
+router.get("/sales-economics-average", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.brand,
+      "/orgs/sales-economics-average",
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Get sales economics average error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get sales economics average" });
+  }
+});
+
+/**
  * GET /v1/brands/:id/sales-economics
  * Proxy to brand-service GET /orgs/brands/:id/sales-economics.
  * Returns the brand's sales conversion-economics metrics (5 numbers) or

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3460,6 +3460,31 @@ registry.registerPath({
   },
 });
 
+// Brand – Sales Economics Average (proxy to brand-service /orgs/sales-economics-average)
+// Cross-brand average of the org's saved sales economics. Downstream owns the
+// response shape — passthrough only. Response is { averages: { ...5 metrics } | null }.
+const SalesEconomicsAverageResponseSchema = z.object({}).passthrough().openapi("SalesEconomicsAverageResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/sales-economics-average",
+  tags: ["Brand"],
+  summary: "Get the org's cross-brand average sales conversion-economics",
+  description:
+    "Proxy to brand-service GET /orgs/sales-economics-average. " +
+    "Returns the average of the org's saved sales conversion-economics across all " +
+    "brands (lifetimeRevenueUsd, replyToMeetingPct, visitToMeetingPct, " +
+    "meetingToClosePct, visitToClosePct), or { averages: null } when no brand has " +
+    "saved any. Used to prefill the new-campaign sales-economics inputs. " +
+    "Response shape is owned by the downstream service.",
+  security: authed,
+  responses: {
+    200: { description: "Cross-brand average sales economics (or null)", content: { "application/json": { schema: SalesEconomicsAverageResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
 // Brand – Sales Economics (proxy to brand-service /orgs/brands/:id/sales-economics)
 // Downstream owns body + response shapes — passthrough only. No gateway re-validation,
 // so brand-service's 4xx validation errors propagate verbatim.

--- a/tests/unit/sales-economics-average.test.ts
+++ b/tests/unit/sales-economics-average.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.brandId = "brand_testabc";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+const populatedResponse = {
+  averages: {
+    lifetimeRevenueUsd: 42000,
+    replyToMeetingPct: 28,
+    visitToMeetingPct: 18,
+    meetingToClosePct: 22,
+    visitToClosePct: 4,
+  },
+};
+
+const nullResponse = { averages: null };
+
+describe("GET /v1/sales-economics-average", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(populatedResponse),
+      };
+    });
+  });
+
+  it("should return the downstream averages payload verbatim on success", async () => {
+    const res = await request(app).get("/v1/sales-economics-average");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(populatedResponse);
+  });
+
+  it("should return { averages: null } verbatim when no brand has saved economics", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(nullResponse),
+      };
+    });
+
+    const res = await request(app).get("/v1/sales-economics-average");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(nullResponse);
+  });
+
+  it("should forward to brand-service GET /orgs/sales-economics-average", async () => {
+    await request(app).get("/v1/sales-economics-average");
+
+    expect(capturedUrl).toContain("/orgs/sales-economics-average");
+    expect(capturedInit?.method ?? "GET").toBe("GET");
+  });
+
+  it("should forward identity headers (x-org-id, x-user-id, x-run-id)", async () => {
+    await request(app).get("/v1/sales-economics-average");
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+  });
+
+  it("should forward upstream error status + body verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('{"error":"downstream boom"}'),
+    }));
+
+    const res = await request(app).get("/v1/sales-economics-average");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("downstream boom");
+  });
+});


### PR DESCRIPTION
## What
Adds a passthrough proxy for brand-service's new cross-brand average sales-economics endpoint.

- `GET /v1/sales-economics-average` → brand-service `GET /orgs/sales-economics-average`
- Auth: same stack as the sibling per-brand routes (`authenticate + requireOrg + requireUser`)
- Response forwarded byte-identical: `{ averages: { lifetimeRevenueUsd, replyToMeetingPct, visitToMeetingPct, meetingToClosePct, visitToClosePct } | null }`
- Passthrough schema, no field re-declaration (CLAUDE.md #8)
- Mirrors existing `GET/PUT /v1/brands/:id/sales-economics` (#502)

## Why
The dashboard "new campaign" page calls this (via the gateway) to prefill the sales-economics inputs when a brand has saved nothing. The dashboard only talks to api-service; brand-service's new endpoint is unreachable until the gateway proxies it.

## ⚠️ Deployment ordering
brand-service `GET /orgs/sales-economics-average` is **not yet deployed to prod** (prod registry shows only the per-brand routes). This route is **dormant**: it is additive, touches no existing handler/response/middleware, and has no live caller yet (the dashboard consumer hasn't shipped). It 502s only IF called before brand-service ships, then starts working silently once brand-service deploys. Shipping ahead is safe (additive-gateway convention) — no merge gate.

## Tests
- 5 unit tests mirroring the sibling sales-economics proxy test (path forward, passthrough body incl. null, identity headers, upstream error verbatim).
- Full suite: 1427 passing, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)