### PR TITLE
feat(events): forward event query param on GET /v1/events proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -21269,6 +21269,16 @@
           {
             "schema": {
               "type": "string",
+              "description": "Filter by event slug(s) — comma-separated, e.g. send-start,generate-start"
+            },
+            "required": false,
+            "description": "Filter by event slug(s) — comma-separated, e.g. send-start,generate-start",
+            "name": "event",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "description": "Page size — forwarded as-is to runs-service"
             },
             "required": false,

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -77,7 +77,7 @@ router.get("/runs/stats/costs", authenticate, requireOrg, requireUser, async (re
  * Cross-run event listing from runs-service for the authenticated org.
  * orgId is injected from the auth context — never trusted from client query.
  * Whitelisted query params are forwarded: campaignId, brandId, level, limit,
- * offset, service, workflowSlug, featureSlug.
+ * offset, service, workflowSlug, featureSlug, event.
  */
 const EVENTS_QUERY_WHITELIST = [
   "campaignId",
@@ -88,6 +88,7 @@ const EVENTS_QUERY_WHITELIST = [
   "service",
   "workflowSlug",
   "featureSlug",
+  "event",
 ] as const;
 
 router.get("/events", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3838,6 +3838,7 @@ registry.registerPath({
       service: z.string().optional().describe("Filter by emitting service name"),
       workflowSlug: z.string().optional().describe("Filter by workflow slug"),
       featureSlug: z.string().optional().describe("Filter by feature slug"),
+      event: z.string().optional().describe("Filter by event slug(s) — comma-separated, e.g. send-start,generate-start"),
       limit: z.string().optional().describe("Page size — forwarded as-is to runs-service"),
       offset: z.string().optional().describe("Page offset — forwarded as-is to runs-service"),
     }).openapi("ListEventsQuery"),

--- a/tests/unit/events-proxy.test.ts
+++ b/tests/unit/events-proxy.test.ts
@@ -97,7 +97,7 @@ describe("GET /v1/events", () => {
     expect(call!.url).toContain("orgId=org_test456");
   });
 
-  it("forwards whitelisted query params: campaignId, brandId, level, limit, offset, service, workflowSlug, featureSlug", async () => {
+  it("forwards whitelisted query params: campaignId, brandId, level, limit, offset, service, workflowSlug, featureSlug, event", async () => {
     const app = createApp();
 
     await request(app)
@@ -111,6 +111,7 @@ describe("GET /v1/events", () => {
         service: "workflow-service",
         workflowSlug: "pr-outreach",
         featureSlug: "lead-serve",
+        event: "send-start",
       })
       .set("Authorization", "Bearer distrib.usr_xxx");
 
@@ -125,7 +126,35 @@ describe("GET /v1/events", () => {
     expect(url).toContain("service=workflow-service");
     expect(url).toContain("workflowSlug=pr-outreach");
     expect(url).toContain("featureSlug=lead-serve");
+    expect(url).toContain("event=send-start");
     expect(url).toContain("orgId=org_test456");
+  });
+
+  it("forwards comma-separated event slugs intact", async () => {
+    const app = createApp();
+
+    await request(app)
+      .get("/v1/events")
+      .query({ campaignId: "c-1", event: "send-start,generate-start" })
+      .set("Authorization", "Bearer distrib.usr_xxx");
+
+    const call = fetchCalls.find((c) => c.url.includes("/v1/events"));
+    expect(call).toBeDefined();
+    expect(decodeURIComponent(call!.url)).toContain("event=send-start,generate-start");
+    expect(call!.url).toContain("campaignId=c-1");
+    expect(call!.url).toContain("orgId=org_test456");
+  });
+
+  it("omits event from the forwarded URL when not supplied", async () => {
+    const app = createApp();
+
+    await request(app)
+      .get("/v1/events?campaignId=c-1")
+      .set("Authorization", "Bearer distrib.usr_xxx");
+
+    const call = fetchCalls.find((c) => c.url.includes("/v1/events"));
+    expect(call).toBeDefined();
+    expect(call!.url).not.toContain("event=");
   });
 
   it("ignores client-supplied orgId — auth orgId wins", async () => {
@@ -191,5 +220,7 @@ describe("OpenAPI spec", () => {
     const op = spec.paths["/v1/events"].get;
     expect(op.security).toBeDefined();
     expect(op.security.length).toBeGreaterThan(0);
+    const paramNames = (op.parameters ?? []).map((p: { name: string }) => p.name);
+    expect(paramNames).toContain("event");
   });
 });


### PR DESCRIPTION
## What

Adds `event` (comma-separated event slugs) to the `GET /v1/events` query-param whitelist so it forwards through to runs-service, same as the existing filters (`campaignId`, `brandId`, `level`, `limit`, `offset`, `service`, `workflowSlug`, `featureSlug`).

Enables the dashboard's campaign live-activity feed to filter `run_events` by event slug server-side.

## Contract (LOCKED — consumer ↔ gateway ↔ runs-service, byte-equal)

- Path: `GET /v1/events`
- Param: `event`, comma-separated, e.g. `?event=send-start,generate-start`
- Absent → behavior unchanged
- `orgId` still injected server-side from auth context — **never** trusted from client query

## Changes

- `src/routes/runs.ts` — `event` added to `EVENTS_QUERY_WHITELIST` + JSDoc
- `src/schemas.ts` — `event` added to `ListEventsQuery` OpenAPI schema
- `openapi.json` — regenerated (only the `event` param added)
- `tests/unit/events-proxy.test.ts` — comma-separated forward + omit + OpenAPI param assertions

Additive forward only. No response-shape change. orgId injection unchanged (existing "ignores client-supplied orgId" test stays green).

## ⚠️ Deployment ordering

Pairs with the runs-service `event` filter (shipping in parallel). **Not a blocker** — this route is dormant/additive: before runs-service supports `event`, the param is simply ignored downstream; no client calls `?event=` yet. Safe to ship ahead.

## Tests

`pnpm test` — 1432 passing. `pnpm build` — tsc + openapi regen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)