### PR TITLE
feat(brands): swap sales-economics proxy to per-brand effective endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5052,7 +5052,7 @@
           "runs"
         ]
       },
-      "SalesEconomicsAverageResponse": {
+      "SalesEconomicsEffectiveResponse": {
         "type": "object",
         "properties": {}
       },
@@ -19982,51 +19982,29 @@
         }
       }
     },
-    "/v1/sales-economics-average": {
+    "/v1/brands/{id}/sales-economics-effective": {
       "get": {
         "tags": [
           "Brand"
         ],
-        "summary": "Get the org's cross-brand average sales conversion-economics",
-        "description": "Proxy to brand-service GET /orgs/sales-economics-average. Returns the average of the org's saved sales conversion-economics across all brands (lifetimeRevenueUsd, replyToMeetingPct, visitToMeetingPct, meetingToClosePct, visitToClosePct), or { averages: null } when no brand has saved any. Used to prefill the new-campaign sales-economics inputs. Response shape is owned by the downstream service.",
+        "summary": "Get a brand's effective sales conversion-economics",
+        "description": "Proxy to brand-service GET /orgs/brands/{id}/sales-economics-effective. Returns the brand's effective sales conversion-economics (lifetimeRevenueUsd, replyToMeetingPct, visitToMeetingPct, meetingToClosePct, visitToClosePct): the brand's own saved economics, or the org's cross-brand average when the brand has saved nothing, plus a `source` field (\"user\" | \"cross-brand-average\" | null). Used to prefill the new-campaign sales-economics inputs. Response shape is owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Cross-brand average sales economics (or null)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SalesEconomicsAverageResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Upstream error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
         "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
           {
             "name": "x-org-id",
             "in": "header",
@@ -20082,7 +20060,49 @@
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
-        ]
+        ],
+        "responses": {
+          "200": {
+            "description": "Effective sales economics (or null)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalesEconomicsEffectiveResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/brands/{id}/sales-economics": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -313,24 +313,26 @@ router.get("/brands/:id/runs", authenticate, requireOrg, requireUser, async (req
 });
 
 /**
- * GET /v1/sales-economics-average
- * Proxy to brand-service GET /orgs/sales-economics-average.
- * Returns the cross-brand average sales conversion-economics for the org
- * ({ averages: { ...5 metrics } | null }). Used by the dashboard "new campaign"
- * page to prefill inputs when a brand has saved nothing. Response shape is owned
- * by the downstream service — passthrough only.
+ * GET /v1/brands/:id/sales-economics-effective
+ * Proxy to brand-service GET /orgs/brands/:id/sales-economics-effective.
+ * Returns the brand's "gold" effective sales conversion-economics: its own saved
+ * economics, or the org's cross-brand average when the brand has saved nothing,
+ * plus a `source` provenance field ({ economics: { ...5 metrics } | null,
+ * source: "user" | "cross-brand-average" | null }). Used by the dashboard
+ * "new campaign" page to prefill inputs. Response shape is owned by the
+ * downstream service — passthrough only.
  */
-router.get("/sales-economics-average", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/brands/:id/sales-economics-effective", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.brand,
-      "/orgs/sales-economics-average",
+      `/orgs/brands/${req.params.id}/sales-economics-effective`,
       { headers: buildInternalHeaders(req) },
     );
     res.json(result);
   } catch (error: any) {
-    console.error("[api-service] Get sales economics average error:", error.message);
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get sales economics average" });
+    console.error("[api-service] Get sales economics effective error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get effective sales economics" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3460,27 +3460,32 @@ registry.registerPath({
   },
 });
 
-// Brand – Sales Economics Average (proxy to brand-service /orgs/sales-economics-average)
-// Cross-brand average of the org's saved sales economics. Downstream owns the
-// response shape — passthrough only. Response is { averages: { ...5 metrics } | null }.
-const SalesEconomicsAverageResponseSchema = z.object({}).passthrough().openapi("SalesEconomicsAverageResponse");
+// Brand – Sales Economics Effective (proxy to brand-service /orgs/brands/:id/sales-economics-effective)
+// The brand's "gold" effective economics: its own saved economics, or the org's
+// cross-brand average when the brand has saved nothing, plus a `source` provenance
+// field. Downstream owns the response shape — passthrough only. Response is
+// { economics: { ...5 metrics } | null, source: "user" | "cross-brand-average" | null }.
+const SalesEconomicsEffectiveResponseSchema = z.object({}).passthrough().openapi("SalesEconomicsEffectiveResponse");
 
 registry.registerPath({
   method: "get",
-  path: "/v1/sales-economics-average",
+  path: "/v1/brands/{id}/sales-economics-effective",
   tags: ["Brand"],
-  summary: "Get the org's cross-brand average sales conversion-economics",
+  summary: "Get a brand's effective sales conversion-economics",
   description:
-    "Proxy to brand-service GET /orgs/sales-economics-average. " +
-    "Returns the average of the org's saved sales conversion-economics across all " +
-    "brands (lifetimeRevenueUsd, replyToMeetingPct, visitToMeetingPct, " +
-    "meetingToClosePct, visitToClosePct), or { averages: null } when no brand has " +
-    "saved any. Used to prefill the new-campaign sales-economics inputs. " +
+    "Proxy to brand-service GET /orgs/brands/{id}/sales-economics-effective. " +
+    "Returns the brand's effective sales conversion-economics (lifetimeRevenueUsd, " +
+    "replyToMeetingPct, visitToMeetingPct, meetingToClosePct, visitToClosePct): the " +
+    "brand's own saved economics, or the org's cross-brand average when the brand has " +
+    "saved nothing, plus a `source` field (\"user\" | \"cross-brand-average\" | null). " +
+    "Used to prefill the new-campaign sales-economics inputs. " +
     "Response shape is owned by the downstream service.",
   security: authed,
+  request: { params: BrandIdParam },
   responses: {
-    200: { description: "Cross-brand average sales economics (or null)", content: { "application/json": { schema: SalesEconomicsAverageResponseSchema } } },
+    200: { description: "Effective sales economics (or null)", content: { "application/json": { schema: SalesEconomicsEffectiveResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
     500: { description: "Upstream error", content: errorContent },
   },
 });

--- a/tests/unit/sales-economics-effective.test.ts
+++ b/tests/unit/sales-economics-effective.test.ts
@@ -22,6 +22,8 @@ vi.mock("@distribute/runs-client", () => ({
 
 import brandRouter from "../../src/routes/brand.js";
 
+const BRAND_ID = "11111111-1111-4111-8111-111111111111";
+
 function buildApp() {
   const app = express();
   app.use(express.json());
@@ -29,19 +31,31 @@ function buildApp() {
   return app;
 }
 
-const populatedResponse = {
-  averages: {
+const userSourceResponse = {
+  economics: {
+    lifetimeRevenueUsd: 50000,
+    replyToMeetingPct: 30,
+    visitToMeetingPct: 20,
+    meetingToClosePct: 25,
+    visitToClosePct: 5,
+  },
+  source: "user",
+};
+
+const averageSourceResponse = {
+  economics: {
     lifetimeRevenueUsd: 42000,
     replyToMeetingPct: 28,
     visitToMeetingPct: 18,
     meetingToClosePct: 22,
     visitToClosePct: 4,
   },
+  source: "cross-brand-average",
 };
 
-const nullResponse = { averages: null };
+const nullResponse = { economics: null, source: null };
 
-describe("GET /v1/sales-economics-average", () => {
+describe("GET /v1/brands/:id/sales-economics-effective", () => {
   let app: express.Express;
   let capturedUrl: string | undefined;
   let capturedInit: RequestInit | undefined;
@@ -58,19 +72,36 @@ describe("GET /v1/sales-economics-average", () => {
       return {
         ok: true,
         status: 200,
-        json: () => Promise.resolve(populatedResponse),
+        json: () => Promise.resolve(userSourceResponse),
       };
     });
   });
 
-  it("should return the downstream averages payload verbatim on success", async () => {
-    const res = await request(app).get("/v1/sales-economics-average");
+  it("should return the downstream { economics, source: 'user' } payload verbatim", async () => {
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/sales-economics-effective`);
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual(populatedResponse);
+    expect(res.body).toEqual(userSourceResponse);
   });
 
-  it("should return { averages: null } verbatim when no brand has saved economics", async () => {
+  it("should return { economics, source: 'cross-brand-average' } verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(averageSourceResponse),
+      };
+    });
+
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/sales-economics-effective`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(averageSourceResponse);
+  });
+
+  it("should return { economics: null, source: null } verbatim", async () => {
     global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       capturedUrl = url;
       capturedInit = init;
@@ -81,21 +112,21 @@ describe("GET /v1/sales-economics-average", () => {
       };
     });
 
-    const res = await request(app).get("/v1/sales-economics-average");
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/sales-economics-effective`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual(nullResponse);
   });
 
-  it("should forward to brand-service GET /orgs/sales-economics-average", async () => {
-    await request(app).get("/v1/sales-economics-average");
+  it("should forward to brand-service GET /orgs/brands/:id/sales-economics-effective", async () => {
+    await request(app).get(`/v1/brands/${BRAND_ID}/sales-economics-effective`);
 
-    expect(capturedUrl).toContain("/orgs/sales-economics-average");
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/sales-economics-effective`);
     expect(capturedInit?.method ?? "GET").toBe("GET");
   });
 
   it("should forward identity headers (x-org-id, x-user-id, x-run-id)", async () => {
-    await request(app).get("/v1/sales-economics-average");
+    await request(app).get(`/v1/brands/${BRAND_ID}/sales-economics-effective`);
 
     const headers = capturedInit?.headers as Record<string, string>;
     expect(headers["x-org-id"]).toBe("org_test456");
@@ -110,7 +141,7 @@ describe("GET /v1/sales-economics-average", () => {
       text: () => Promise.resolve('{"error":"downstream boom"}'),
     }));
 
-    const res = await request(app).get("/v1/sales-economics-average");
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/sales-economics-effective`);
 
     expect(res.status).toBe(500);
     expect(res.body.error).toContain("downstream boom");


### PR DESCRIPTION
## What

Swap the api-service sales-economics proxy to match brand-service's big-bang refactor.

- **ADD** `GET /v1/brands/:id/sales-economics-effective` → brand-service `GET /orgs/brands/:id/sales-economics-effective`. Passthrough; response shape owned by brand-service: `{ economics: { lifetimeRevenueUsd, replyToMeetingPct, visitToMeetingPct, meetingToClosePct, visitToClosePct } | null, source: "user" | "cross-brand-average" | null }`. Auth identical to the sibling `GET /v1/brands/:id/sales-economics` proxy (`authenticate + requireOrg + requireUser`, forwarded via `buildInternalHeaders`).
- **REMOVE** `GET /v1/sales-economics-average` (route + schema + test). No legacy, no alias.

brand-service deleted its global `/orgs/sales-economics-average` endpoint in favor of the per-brand "gold" endpoint (returns the brand's saved economics, or the org cross-brand average when unset, plus a `source` provenance tag).

## Tests

- New `tests/unit/sales-economics-effective.test.ts`: passthrough verbatim (`user` / `cross-brand-average` / null), forwards to `/orgs/brands/:id/sales-economics-effective`, identity headers, upstream error passthrough.
- Removed `tests/unit/sales-economics-average.test.ts`.
- Full suite green: 124 files / 1431 tests. `pnpm build` (tsc + openapi regen) green.

## ⚠️ Deployment ordering

Depends on brand-service shipping the `/orgs/brands/:id/sales-economics-effective` endpoint to staging.
- The new effective route is **dormant** until brand-service deploys (502-if-called; no client calls it yet).
- The removed `/v1/sales-economics-average` is a hard cutover (no alias) — the dashboard prefill 404s on the old path until the dashboard PR catches up. Coordinated big-bang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)