### PR TITLE
Add public workflow engagement latency proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -173,6 +173,10 @@
         "type": "object",
         "properties": {}
       },
+      "PublicWorkflowEngagementLatencyResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -9816,6 +9820,84 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicFeatureRevenueResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/features/workflow-engagement-latency": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Public workflow engagement latency",
+        "description": "Public average/median time to first link click and first positive reply for a feature, grouped by workflow. Proxied to features-service GET /public/stats/workflow-engagement-latency. Response is producer-owned. No authentication required.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug (required).",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug (required).",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "workflow"
+              ],
+              "description": "Group public workflow engagement latency results by workflow.",
+              "example": "workflow"
+            },
+            "required": true,
+            "description": "Group public workflow engagement latency results by workflow.",
+            "name": "groupBy",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public workflow engagement latency — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicWorkflowEngagementLatencyResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -18,6 +18,7 @@ function buildParams(query: Record<string, unknown>, keys: string[]): URLSearchP
 const PUBLIC_RANKED_PARAMS = ["featureSlug", "objective", "groupBy", "limit"];
 const PUBLIC_BEST_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_REVENUE_PARAMS = ["featureSlug", "groupBy"];
+const PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY_PARAMS = ["featureSlug", "groupBy"];
 
 // ── Public routes (no auth) ─────────────────────────────────────────────────
 
@@ -76,6 +77,26 @@ router.get("/public/features/revenue", async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error("[api-service] Public feature revenue error:", error.message);
     res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public feature revenue" });
+  }
+});
+
+/**
+ * GET /v1/public/features/workflow-engagement-latency
+ * Public average/median engagement latency grouped by workflow.
+ * Proxied to features-service GET /public/stats/workflow-engagement-latency.
+ */
+router.get("/public/features/workflow-engagement-latency", async (req: Request, res: Response) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY_PARAMS);
+    const result = await callExternalService(
+      externalServices.features,
+      `/public/stats/workflow-engagement-latency?${params}`,
+      {},
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public workflow engagement latency error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public workflow engagement latency" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -180,6 +180,11 @@ const publicRevenueQueryParams = z.object({
   groupBy: z.enum(["brand", "workflow"]).openapi({ example: "workflow" }).describe("Group public revenue results by brand or workflow."),
 });
 
+const publicWorkflowEngagementLatencyQueryParams = z.object({
+  featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
+  groupBy: z.enum(["workflow"]).openapi({ example: "workflow" }).describe("Group public workflow engagement latency results by workflow."),
+});
+
 const WorkflowMetadataSchema = z
   .object({
     id: z.string().describe("Workflow ID"),
@@ -262,6 +267,23 @@ registry.registerPath({
   request: { query: publicRevenueQueryParams },
   responses: {
     200: { description: "Public feature revenue — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicFeatureRevenueResponse") } } },
+    400: { description: "Bad request from features-service", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/public/features/workflow-engagement-latency",
+  tags: ["Features"],
+  summary: "Public workflow engagement latency",
+  description:
+    "Public average/median time to first link click and first positive reply for a feature, grouped by workflow. " +
+    "Proxied to features-service GET /public/stats/workflow-engagement-latency. Response is producer-owned. No authentication required.",
+  request: { query: publicWorkflowEngagementLatencyQueryParams },
+  responses: {
+    200: { description: "Public workflow engagement latency — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicWorkflowEngagementLatencyResponse") } } },
     400: { description: "Bad request from features-service", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -302,6 +302,20 @@ describe("Public features proxy routes", () => {
     expect(content).toContain("`/public/stats/revenue");
   });
 
+  it("should have GET /public/features/workflow-engagement-latency without auth middleware", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/public/features/workflow-engagement-latency"')
+    );
+    expect(line).toBeDefined();
+    expect(line).not.toContain("authenticate");
+    expect(line).not.toContain("requireOrg");
+  });
+
+  it("should proxy public workflow engagement latency to /public/stats/workflow-engagement-latency on features-service", () => {
+    expect(content).toContain('"/public/features/workflow-engagement-latency"');
+    expect(content).toContain("`/public/stats/workflow-engagement-latency");
+  });
+
   it("should not require auth on public feature endpoints", () => {
     const publicFeaturesBlock = schemaContent.slice(
       schemaContent.indexOf('path: "/public/features"'),
@@ -319,6 +333,11 @@ describe("Public features OpenAPI schemas", () => {
   it("should register GET /v1/public/features/revenue", () => {
     expect(schemaContent).toContain('path: "/v1/public/features/revenue"');
     expect(schemaContent).toContain("PublicFeatureRevenueResponse");
+  });
+
+  it("should register GET /v1/public/features/workflow-engagement-latency", () => {
+    expect(schemaContent).toContain('path: "/v1/public/features/workflow-engagement-latency"');
+    expect(schemaContent).toContain("PublicWorkflowEngagementLatencyResponse");
   });
 });
 

--- a/tests/unit/features-stats.test.ts
+++ b/tests/unit/features-stats.test.ts
@@ -233,6 +233,50 @@ describe("GET /v1/public/features/revenue", () => {
   });
 });
 
+describe("GET /v1/public/features/workflow-engagement-latency", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("proxies public workflow engagement latency to features-service without auth and returns the body verbatim", async () => {
+    const app = createApp();
+    mockCallExternalService.mockImplementation((service: any, path: string) => {
+      if (service.url === "http://mock-features" && path.startsWith("/public/stats/workflow-engagement-latency")) {
+        return Promise.resolve(MOCK_PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY);
+      }
+      return Promise.resolve({});
+    });
+
+    const res = await request(app).get("/v1/public/features/workflow-engagement-latency?featureSlug=sales-cold-email-outreach&groupBy=workflow");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY);
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/stats/workflow-engagement-latency"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).toContain("featureSlug=sales-cold-email-outreach");
+    expect(url).toContain("groupBy=workflow");
+  });
+
+  it("does not forward private dashboard filters to public workflow engagement latency", async () => {
+    const app = createApp();
+    mockCallExternalService.mockResolvedValue(MOCK_PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY);
+
+    await request(app).get("/v1/public/features/workflow-engagement-latency?featureSlug=sales-cold-email-outreach&groupBy=workflow&brandId=brand-1&campaignId=campaign-1&workflowSlug=workflow-1&objective=replied");
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/public/stats/workflow-engagement-latency"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    expect(url).not.toContain("brandId=");
+    expect(url).not.toContain("campaignId=");
+    expect(url).not.toContain("workflowSlug=");
+    expect(url).not.toContain("objective=");
+  });
+});
+
 const MOCK_REVENUE = {
   pipelineRevenueUsdCents: 1234500,
   organizations: [{ orgId: "o-1", name: "Acme", revenueUsdCents: 1000000 }],
@@ -280,6 +324,27 @@ const MOCK_PUBLIC_WORKFLOW_REVENUE = {
       },
       headline: { totalPipelineUsd: 42000 },
       costEconomics: { totalCostUsd: 210, costOfAcquisitionPct: 0.5, roiMultiple: 200 },
+    },
+  ],
+};
+
+const MOCK_PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY = {
+  featureSlug: "sales-cold-email-outreach",
+  groupBy: "workflow",
+  results: [
+    {
+      workflow: {
+        id: "workflow-1",
+        workflowSlug: "sales-email-cold-outreach-mintaka-v3",
+        workflowName: "Mintaka",
+        workflowDynastySlug: "sales-email-cold-outreach-mintaka",
+      },
+      latency: {
+        avgTimeToFirstClickMs: 86400000,
+        medianTimeToFirstClickMs: 43200000,
+        avgTimeToFirstPositiveReplyMs: 172800000,
+        medianTimeToFirstPositiveReplyMs: 129600000,
+      },
     },
   ],
 };


### PR DESCRIPTION
## Summary
- add GET /v1/public/features/workflow-engagement-latency as a public api-service proxy
- forward featureSlug and groupBy to features-service GET /public/stats/workflow-engagement-latency
- document the route as producer-owned passthrough and regenerate openapi.json

## Verification
- pnpm vitest run tests/unit/features-stats.test.ts tests/unit/features-proxy.test.ts
- pnpm build

## Contract
Gateway: GET /v1/public/features/workflow-engagement-latency?featureSlug=<slug>&groupBy=workflow
Downstream: GET /public/stats/workflow-engagement-latency?featureSlug=<slug>&groupBy=workflow