### PR TITLE
feat(features): proxy GET /public/features/cost-projection

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -177,6 +177,10 @@
         "type": "object",
         "properties": {}
       },
+      "PublicCostProjectionResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -9927,6 +9931,70 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicWorkflowEngagementLatencyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/features/cost-projection": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Public feature cost projection",
+        "description": "Public feature-wide expected cost per meeting-booked and per purchase. Proxied to features-service GET /public/stats/cost-projection. Response is producer-owned. No authentication required.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug (required).",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug (required).",
+            "name": "featureSlug",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public feature cost projection — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicCostProjectionResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -19,6 +19,7 @@ const PUBLIC_RANKED_PARAMS = ["featureSlug", "objective", "groupBy", "limit"];
 const PUBLIC_BEST_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_REVENUE_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY_PARAMS = ["featureSlug", "groupBy"];
+const PUBLIC_COST_PROJECTION_PARAMS = ["featureSlug"];
 
 // ── Public routes (no auth) ─────────────────────────────────────────────────
 
@@ -97,6 +98,26 @@ router.get("/public/features/workflow-engagement-latency", async (req: Request, 
   } catch (error: any) {
     console.error("[api-service] Public workflow engagement latency error:", error.message);
     res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public workflow engagement latency" });
+  }
+});
+
+/**
+ * GET /v1/public/features/cost-projection
+ * Public feature-wide expected cost per meeting-booked and per purchase.
+ * Proxied to features-service GET /public/stats/cost-projection.
+ */
+router.get("/public/features/cost-projection", async (req: Request, res: Response) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, PUBLIC_COST_PROJECTION_PARAMS);
+    const result = await callExternalService(
+      externalServices.features,
+      `/public/stats/cost-projection?${params}`,
+      {},
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public feature cost projection error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public feature cost projection" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -185,6 +185,10 @@ const publicWorkflowEngagementLatencyQueryParams = z.object({
   groupBy: z.enum(["workflow"]).openapi({ example: "workflow" }).describe("Group public workflow engagement latency results by workflow."),
 });
 
+const publicCostProjectionQueryParams = z.object({
+  featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
+});
+
 const WorkflowMetadataSchema = z
   .object({
     id: z.string().describe("Workflow ID"),
@@ -284,6 +288,23 @@ registry.registerPath({
   request: { query: publicWorkflowEngagementLatencyQueryParams },
   responses: {
     200: { description: "Public workflow engagement latency — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicWorkflowEngagementLatencyResponse") } } },
+    400: { description: "Bad request from features-service", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/public/features/cost-projection",
+  tags: ["Features"],
+  summary: "Public feature cost projection",
+  description:
+    "Public feature-wide expected cost per meeting-booked and per purchase. " +
+    "Proxied to features-service GET /public/stats/cost-projection. Response is producer-owned. No authentication required.",
+  request: { query: publicCostProjectionQueryParams },
+  responses: {
+    200: { description: "Public feature cost projection — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicCostProjectionResponse") } } },
     400: { description: "Bad request from features-service", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -316,6 +316,20 @@ describe("Public features proxy routes", () => {
     expect(content).toContain("`/public/stats/workflow-engagement-latency");
   });
 
+  it("should have GET /public/features/cost-projection without auth middleware", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/public/features/cost-projection"')
+    );
+    expect(line).toBeDefined();
+    expect(line).not.toContain("authenticate");
+    expect(line).not.toContain("requireOrg");
+  });
+
+  it("should proxy public feature cost projection to /public/stats/cost-projection on features-service", () => {
+    expect(content).toContain('"/public/features/cost-projection"');
+    expect(content).toContain("`/public/stats/cost-projection");
+  });
+
   it("should not require auth on public feature endpoints", () => {
     const publicFeaturesBlock = schemaContent.slice(
       schemaContent.indexOf('path: "/public/features"'),
@@ -338,6 +352,11 @@ describe("Public features OpenAPI schemas", () => {
   it("should register GET /v1/public/features/workflow-engagement-latency", () => {
     expect(schemaContent).toContain('path: "/v1/public/features/workflow-engagement-latency"');
     expect(schemaContent).toContain("PublicWorkflowEngagementLatencyResponse");
+  });
+
+  it("should register GET /v1/public/features/cost-projection", () => {
+    expect(schemaContent).toContain('path: "/v1/public/features/cost-projection"');
+    expect(schemaContent).toContain("PublicCostProjectionResponse");
   });
 });
 


### PR DESCRIPTION
## What

Adds public, no-auth proxy `GET /v1/public/features/cost-projection?featureSlug=<slug>` → features-service `GET /public/stats/cost-projection?featureSlug=<slug>`.

Powers the distribute.you landing "proof metrics" band (feature-wide expected cost per meeting-booked and per purchase). Mirrors the existing `/v1/public/features/*` proxies (best, ranked, revenue, workflow-engagement-latency, workflow-projection PR #518).

## Changes
- `src/routes/features.ts` — new public route, forwards `featureSlug`, no auth.
- `src/schemas.ts` — `registerPath` + passthrough `PublicCostProjectionResponse` (CLAUDE.md #8 — no downstream field re-declaration).
- `openapi.json` — regenerated.
- `tests/unit/features-proxy.test.ts` — proxy + OpenAPI assertions mirroring revenue/latency.

## Contract (LOCKED, byte-equal)
- Gateway: `GET /v1/public/features/cost-projection?featureSlug=<slug>`
- Downstream: features-service `GET /public/stats/cost-projection?featureSlug=<slug>`
- Transparent passthrough body.

## Verification
- `pnpm build` (tsc + openapi regen) green.
- `pnpm test:unit` — 1458 passed.
- Producer endpoint confirmed live on api-registry-staging.

## Deployment ordering
Producer `/public/stats/cost-projection` (features-service PR #275) is **already live on staging** (registry-confirmed), so this is callable on merge — not even dormant. Additive: no existing route/handler touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)