### PR TITLE
feat(features): forward ?lens query param on GET /v1/features/:slug/revenue

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -31874,6 +31874,17 @@
             "in": "query"
           },
           {
+            "schema": {
+              "type": "string",
+              "description": "Filter to a funnel lens (signups | booked-meetings | sales). Returns lens-filtered leads, each carrying conversionProbabilityPct. Absent/unknown → un-lensed overview",
+              "example": "signups"
+            },
+            "required": false,
+            "description": "Filter to a funnel lens (signups | booked-meetings | sales). Returns lens-filtered leads, each carrying conversionProbabilityPct. Absent/unknown → un-lensed overview",
+            "name": "lens",
+            "in": "query"
+          },
+          {
             "name": "x-org-id",
             "in": "header",
             "required": false,

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -304,7 +304,7 @@ router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async
 router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "campaignId", "workflowSlug", "groupBy"]) {
+    for (const key of ["brandId", "campaignId", "workflowSlug", "groupBy", "lens"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6955,6 +6955,7 @@ registry.registerPath({
       campaignId: z.string().optional().openapi({ example: "campaign-uuid-456" }).describe("Filter by campaign UUID"),
       workflowSlug: z.string().optional().openapi({ example: "sales-email-cold-outreach-mintaka-v3" }).describe("Filter by workflow slug"),
       groupBy: z.string().optional().openapi({ example: "workflowSlug" }).describe("Group the revenue view by a dimension: campaignId or workflowSlug. Returns one grouped entry per value instead of the scalar overview"),
+      lens: z.string().optional().openapi({ example: "signups" }).describe("Filter to a funnel lens (signups | booked-meetings | sales). Returns lens-filtered leads, each carrying conversionProbabilityPct. Absent/unknown → un-lensed overview"),
     }),
   },
   responses: {


### PR DESCRIPTION
## Problem
Dashboard Signups / Booked-Meetings / Sales pages call `GET /v1/features/:slug/revenue?brandId=...&lens=<lens>`. The gateway proxy forwarded only `brandId`/`campaignId`/`workflowSlug`/`groupBy` and **dropped `lens`** → features-service returned the un-lensed overview → per-lead `conversionProbabilityPct` absent → dashboard probability column showed "-".

## Fix
Add `lens` to the forwarded query-key list in `router.get("/features/:slug/revenue")` (`src/routes/features.ts`). features-service already validates `lens ∈ {signups, booked-meetings, sales}` and ignores unknown/absent — no extra validation needed. Also documented the param in the OpenAPI registration (`src/schemas.ts`) + regenerated `openapi.json`.

## Scope
Additive, zero-blast-radius: forwards an already-supported downstream param. No request/response shape change. No other proxy route touched.

## Verify
- `GET /v1/features/sales-cold-email-outreach/revenue?brandId=<b>&lens=signups` → lens-filtered leads, each carrying `conversionProbabilityPct`.
- Un-lensed call (no `lens`) unchanged.
- Full suite green: 1462 pass / 0 fail. `tsc` clean. `lens` present in `openapi.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)