### PR TITLE
feat(brand): proxy POST /v1/brands/:id/personas/suggest to brand-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -20896,6 +20896,148 @@
         }
       }
     },
+    "/v1/brands/{id}/personas/suggest": {
+      "post": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Suggest AI-generated customer personas for a brand",
+        "description": "Proxy to brand-service POST /orgs/brands/{id}/personas/suggest. Returns AI-generated persona drafts ({ personas: [{ name, filters }] }). Body + response shapes are owned by the downstream service — passthrough only.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PersonaRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Persona drafts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonasResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/brands/{id}/personas/{personaId}/duplicate": {
       "post": {
         "tags": [

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -571,6 +571,24 @@ router.post("/brands/:id/personas", authenticate, requireOrg, requireUser, async
 });
 
 /**
+ * POST /v1/brands/:id/personas/suggest
+ * Proxy to brand-service POST /orgs/brands/:id/personas/suggest. Returns AI-generated persona drafts verbatim.
+ */
+router.post("/brands/:id/personas/suggest", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/personas/suggest${rawQuery(req)}`,
+      { method: "POST", headers: buildInternalHeaders(req), body: req.body },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Suggest personas error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to suggest personas" });
+  }
+});
+
+/**
  * POST /v1/brands/:id/personas/:personaId/duplicate
  * Proxy to brand-service POST /orgs/brands/:id/personas/:personaId/duplicate. Returns 201 verbatim.
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3661,6 +3661,29 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
+  path: "/v1/brands/{id}/personas/suggest",
+  tags: ["Brand"],
+  summary: "Suggest AI-generated customer personas for a brand",
+  description:
+    "Proxy to brand-service POST /orgs/brands/{id}/personas/suggest. " +
+    "Returns AI-generated persona drafts ({ personas: [{ name, filters }] }). " +
+    "Body + response shapes are owned by the downstream service — passthrough only.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: { content: { "application/json": { schema: PersonaRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Persona drafts", content: { "application/json": { schema: PersonasResponseSchema } } },
+    400: { description: "Validation error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
   path: "/v1/brands/{id}/personas/{personaId}/duplicate",
   tags: ["Brand"],
   summary: "Duplicate a customer persona",

--- a/tests/unit/brand-personas-profile-proxy.test.ts
+++ b/tests/unit/brand-personas-profile-proxy.test.ts
@@ -121,6 +121,32 @@ describe("POST /v1/brands/:id/personas", () => {
   });
 });
 
+describe("POST /v1/brands/:id/personas/suggest", () => {
+  const body = { count: 3 };
+  const suggestPayload = { personas: [{ name: "Eco shopper", filters: { interest: "sustainability" } }] };
+
+  it("forwards body byte-identical to the suggest path and returns payload + status verbatim", async () => {
+    mockUpstream(200, suggestPayload);
+    const app = buildApp();
+    const res = await request(app).post(`/v1/brands/${BRAND_ID}/personas/suggest`).send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(suggestPayload);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/personas/suggest`);
+    expect(capturedInit?.method).toBe("POST");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual(body);
+  });
+
+  it("propagates an upstream error verbatim", async () => {
+    mockUpstream(404, { error: "brand not found" });
+    const app = buildApp();
+    const res = await request(app).post(`/v1/brands/${BRAND_ID}/personas/suggest`).send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("brand not found");
+  });
+});
+
 describe("POST /v1/brands/:id/personas/:personaId/duplicate", () => {
   it("forwards to the duplicate path and returns 201 verbatim", async () => {
     mockUpstream(201, personaPayload);


### PR DESCRIPTION
## What
Expose brand-service's new `POST /orgs/brands/:brandId/personas/suggest` (AI-generated persona drafts) through the gateway so the dashboard can call it. Mirrors the existing personas proxy routes.

## Contract (byte-equal)
- gateway: `POST /v1/brands/:id/personas/suggest`
- → brand-service: `POST /orgs/brands/:brandId/personas/suggest`
- auth + identity headers identical to sibling `/v1/brands/:id/personas` routes (`authenticate + requireOrg + requireUser`, `buildInternalHeaders`)
- passthrough request/response — no field re-declaration (CLAUDE.md #8)

## Changes
- `src/routes/brand.ts` — new handler, copy of `POST /brands/:id/personas`
- `src/schemas.ts` — `registerPath` for the new route (passthrough schemas)
- `openapi.json` — regenerated
- `tests/unit/brand-personas-profile-proxy.test.ts` — suggest case (forwards to correct path + body byte-identical + error verbatim)

## Test
- `npm test` → 1475 passed (126 files)
- typecheck clean

## Triage
Additive zero-blast-radius gateway route → main (prod-direct) per additive-gateway default.

⚠️ brand-service downstream endpoint ships separately; until it deploys this route 404s verbatim (no consumer yet, self-resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)