### PR TITLE
feat(billing): proxy GET/PATCH /v1/brands/:brandId/daily-budget to billing-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6905,6 +6905,14 @@
           "return_url"
         ]
       },
+      "DailyBudgetResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "DailyBudgetRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "BrandEmailsResponse": {
         "type": "object",
         "properties": {
@@ -26563,6 +26571,251 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/brands/{brandId}/daily-budget": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Get a brand's daily budget",
+        "description": "Proxy to billing-service GET /internal/brands/{brandId}/daily-budget. Returns the brand's current daily spend ceiling (per-day pacing/allocation value, separate from org credit balance/affordability). An unset brand returns { dailyBudgetCents: null }. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Brand daily budget (dailyBudgetCents null when unset)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyBudgetResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Set a brand's daily budget",
+        "description": "Proxy to billing-service PATCH /v1/brands/{brandId}/daily-budget. Sets the brand's daily spend ceiling. Body { dailyBudgetCents } (number or decimal string, >= 0; 0 = pause). Identity headers (x-org-id, x-user-id, x-run-id) are forwarded. Body + response shapes are owned by the downstream service; its 4xx validation errors propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DailyBudgetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated brand daily budget",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyBudgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/emails": {

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -95,4 +95,47 @@ router.post("/billing/portal-sessions", authenticate, requireOrg, async (req: Au
   }
 });
 
+/**
+ * GET /v1/brands/:brandId/daily-budget
+ * Proxy to billing-service GET /internal/brands/:brandId/daily-budget.
+ * Reads a brand's current daily budget (per-day spend ceiling), keyed by brandId.
+ * Downstream is a user-less internal read (x-api-key only, injected by
+ * callExternalService); the gateway route stays user-facing. An unset brand
+ * returns { dailyBudgetCents: null }. Response shape is owned by the downstream
+ * service — passthrough only.
+ */
+router.get("/brands/:brandId/daily-budget", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      `/internal/brands/${req.params.brandId}/daily-budget`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get daily budget" });
+  }
+});
+
+/**
+ * PATCH /v1/brands/:brandId/daily-budget
+ * Proxy to billing-service PATCH /v1/brands/:brandId/daily-budget.
+ * Sets a brand's daily budget. Body { dailyBudgetCents } (number or decimal
+ * string, >= 0; 0 = pause) and response shape are owned by the downstream
+ * service; identity headers (x-org-id, x-user-id, x-run-id) are forwarded via
+ * buildInternalHeaders. Downstream 4xx errors propagate verbatim — passthrough only.
+ */
+router.patch("/brands/:brandId/daily-budget", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      `/v1/brands/${req.params.brandId}/daily-budget`,
+      { method: "PATCH", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to set daily budget" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5542,6 +5542,60 @@ registry.registerPath({
   },
 });
 
+// Brand – Daily Budget (proxy to billing-service)
+// Per-brand daily spend ceiling (pacing/allocation), SEPARATE from org credit
+// balance/affordability. GET proxies billing /internal/brands/:brandId/daily-budget
+// (unset -> dailyBudgetCents null); PATCH proxies billing /v1/brands/:brandId/daily-budget.
+// Downstream owns body + response shapes — passthrough only (CLAUDE.md #8).
+const BrandDailyBudgetParam = z.object({
+  brandId: z.string().uuid().describe("Brand ID"),
+});
+const DailyBudgetResponseSchema = z.object({}).passthrough().openapi("DailyBudgetResponse");
+const DailyBudgetRequestSchema = z.object({}).passthrough().openapi("DailyBudgetRequest");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{brandId}/daily-budget",
+  tags: ["Billing"],
+  summary: "Get a brand's daily budget",
+  description:
+    "Proxy to billing-service GET /internal/brands/{brandId}/daily-budget. " +
+    "Returns the brand's current daily spend ceiling (per-day pacing/allocation " +
+    "value, separate from org credit balance/affordability). An unset brand returns " +
+    "{ dailyBudgetCents: null }. Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandDailyBudgetParam },
+  responses: {
+    200: { description: "Brand daily budget (dailyBudgetCents null when unset)", content: { "application/json": { schema: DailyBudgetResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/brands/{brandId}/daily-budget",
+  tags: ["Billing"],
+  summary: "Set a brand's daily budget",
+  description:
+    "Proxy to billing-service PATCH /v1/brands/{brandId}/daily-budget. " +
+    "Sets the brand's daily spend ceiling. Body { dailyBudgetCents } (number or " +
+    "decimal string, >= 0; 0 = pause). Identity headers (x-org-id, x-user-id, " +
+    "x-run-id) are forwarded. Body + response shapes are owned by the downstream " +
+    "service; its 4xx validation errors propagate verbatim.",
+  security: authed,
+  request: {
+    params: BrandDailyBudgetParam,
+    body: { content: { "application/json": { schema: DailyBudgetRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Updated brand daily budget", content: { "application/json": { schema: DailyBudgetResponseSchema } } },
+    400: { description: "Validation error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
 
 // ===================================================================
 // TRANSACTIONAL EMAILS

--- a/tests/unit/billing-proxy.test.ts
+++ b/tests/unit/billing-proxy.test.ts
@@ -55,10 +55,10 @@ describe("Billing proxy routes", () => {
   });
 
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
-    // 6 routes + 1 import = 7
+    // 8 routes + 1 import = 9
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    expect(authMatches!.length).toBe(7);
+    expect(authMatches!.length).toBe(9);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints (no x-key-source)", () => {
@@ -66,7 +66,14 @@ describe("Billing proxy routes", () => {
     expect(content).not.toContain('"x-key-source"');
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(6);
+    expect(headerMatches!.length).toBe(8);
+  });
+
+  it("should have GET + PATCH /brands/:brandId/daily-budget endpoints", () => {
+    expect(content).toContain('"/brands/:brandId/daily-budget"');
+    // GET proxies billing internal read; PATCH proxies billing /v1 write
+    expect(content).toContain("`/internal/brands/${req.params.brandId}/daily-budget`");
+    expect(content).toContain("`/v1/brands/${req.params.brandId}/daily-budget`");
   });
 
   it("should proxy to externalServices.billing", () => {
@@ -120,6 +127,12 @@ describe("Billing OpenAPI schemas", () => {
 
   it("should use Billing tag", () => {
     expect(schemaContent).toContain('tags: ["Billing"]');
+  });
+
+  it("should register brand daily-budget paths (passthrough)", () => {
+    expect(schemaContent).toContain('path: "/v1/brands/{brandId}/daily-budget"');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("DailyBudgetResponse")');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("DailyBudgetRequest")');
   });
 
   it("should define request schemas with new names", () => {


### PR DESCRIPTION
## What

Two transparent proxy routes so the dashboard can read + set a brand's **daily budget** (per-day spend ceiling, stored in billing-service v0.33.0) without talking to billing directly.

| Gateway (locked, byte-equal to dashboard) | Middleware | → billing-service |
|---|---|---|
| `GET /v1/brands/:brandId/daily-budget` | `authenticate, requireOrg` | `GET /internal/brands/:brandId/daily-budget` (x-api-key only, injected) |
| `PATCH /v1/brands/:brandId/daily-budget` body `{ dailyBudgetCents }` | `authenticate, requireOrg` | `PATCH /v1/brands/:brandId/daily-budget` (x-org-id + x-user-id + x-run-id via `buildInternalHeaders`) |

- Passthrough response schemas (`z.object({}).passthrough()`, CLAUDE.md #8) — no field re-declaration.
- Upstream errors propagate verbatim (`error.statusCode || 500`, rule #7). No body transforms, no caps, no aggregation.
- Unset brand → `{ dailyBudgetCents: null }`.
- Daily budget = pacing/allocation; **org credit affordability untouched**.

## AC
- ✅ authed user GETs current daily budget; unset → `dailyBudgetCents: null`
- ✅ authed user PATCHes daily budget; subsequent GET reflects latest write (downstream-owned, passthrough)
- ✅ existing routes/handlers unchanged

## Verify
- Contract confirmed on staging api-registry (both billing endpoints, exact shapes). Prod registry lagging v0.33.0 sync (expected).
- `npm run build` clean, openapi.json regenerated, **1474/1474 unit tests pass**.
- No new env vars: reuses `BILLING_SERVICE_URL` / `BILLING_SERVICE_API_KEY` (already live in prod for existing billing proxy routes).

## Triage
Pure-additive transparent proxy, zero blast radius → **prod-direct (hotfix → main)** per api-service convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)