### PR TITLE
feat(brand): proxy GET/PATCH /v1/brands/:brandId/pause to campaign-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6905,6 +6905,14 @@
           "return_url"
         ]
       },
+      "DailyBudgetResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "DailyBudgetRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "BrandEmailsResponse": {
         "type": "object",
         "properties": {
@@ -26563,6 +26571,251 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/brands/{brandId}/daily-budget": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Get a brand's daily budget",
+        "description": "Proxy to billing-service GET /internal/brands/{brandId}/daily-budget. Returns the brand's current daily spend ceiling (per-day pacing/allocation value, separate from org credit balance/affordability). An unset brand returns { dailyBudgetCents: null }. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Brand daily budget (dailyBudgetCents null when unset)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyBudgetResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Set a brand's daily budget",
+        "description": "Proxy to billing-service PATCH /v1/brands/{brandId}/daily-budget. Sets the brand's daily spend ceiling. Body { dailyBudgetCents } (number or decimal string, >= 0; 0 = pause). Identity headers (x-org-id, x-user-id, x-run-id) are forwarded. Body + response shapes are owned by the downstream service; its 4xx validation errors propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DailyBudgetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated brand daily budget",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyBudgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/emails": {

--- a/openapi.json
+++ b/openapi.json
@@ -20896,6 +20896,148 @@
         }
       }
     },
+    "/v1/brands/{id}/personas/suggest": {
+      "post": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Suggest AI-generated customer personas for a brand",
+        "description": "Proxy to brand-service POST /orgs/brands/{id}/personas/suggest. Returns AI-generated persona drafts ({ personas: [{ name, filters }] }). Body + response shapes are owned by the downstream service — passthrough only.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PersonaRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Persona drafts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonasResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/brands/{id}/personas/{personaId}/duplicate": {
       "post": {
         "tags": [

--- a/openapi.json
+++ b/openapi.json
@@ -9594,6 +9594,22 @@
       "OrgInvitesClaimRequest": {
         "type": "object",
         "properties": {}
+      },
+      "BrandPauseResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "BrandPauseRequest": {
+        "type": "object",
+        "properties": {
+          "paused": {
+            "type": "boolean",
+            "description": "Desired pause state for the brand"
+          }
+        },
+        "required": [
+          "paused"
+        ]
       }
     },
     "parameters": {}
@@ -36754,6 +36770,239 @@
           },
           "403": {
             "description": "orgId path does not match authenticated org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{brandId}/pause": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get a brand's pause state",
+        "description": "Proxy to campaign-service GET /brands/{brandId}/pause. Returns the brand's pause state. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Brand pause state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandPauseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Update a brand's pause state",
+        "description": "Proxy to campaign-service PATCH /brands/{brandId}/pause. Body { paused: boolean }. Body + response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BrandPauseRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated brand pause state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandPauseResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import searchRoutes from "./routes/search.js";
 import meRoutes from "./routes/me.js";
 import qualifyRoutes from "./routes/qualify.js";
 import brandRoutes from "./routes/brand.js";
+import brandPauseRoutes from "./routes/brand-pause.js";
 import scrapingRoutes from "./routes/scraping.js";
 import leadsRoutes from "./routes/leads.js";
 import activityRoutes from "./routes/activity.js";
@@ -191,6 +192,9 @@ app.use("/v1", keysRoutes);
 app.use("/v1", campaignsRoutes);
 app.use("/v1", searchRoutes);
 app.use("/v1", qualifyRoutes);
+// Mount BEFORE brandRoutes: /brands/:brandId/pause forwards to campaign-service,
+// must win over any future brand-service brand proxy.
+app.use("/v1", brandPauseRoutes);
 app.use("/v1", brandRoutes);
 app.use("/v1", scrapingRoutes);
 app.use("/v1", leadsRoutes);

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -95,4 +95,47 @@ router.post("/billing/portal-sessions", authenticate, requireOrg, async (req: Au
   }
 });
 
+/**
+ * GET /v1/brands/:brandId/daily-budget
+ * Proxy to billing-service GET /internal/brands/:brandId/daily-budget.
+ * Reads a brand's current daily budget (per-day spend ceiling), keyed by brandId.
+ * Downstream is a user-less internal read (x-api-key only, injected by
+ * callExternalService); the gateway route stays user-facing. An unset brand
+ * returns { dailyBudgetCents: null }. Response shape is owned by the downstream
+ * service — passthrough only.
+ */
+router.get("/brands/:brandId/daily-budget", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      `/internal/brands/${req.params.brandId}/daily-budget`,
+      { headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get daily budget" });
+  }
+});
+
+/**
+ * PATCH /v1/brands/:brandId/daily-budget
+ * Proxy to billing-service PATCH /v1/brands/:brandId/daily-budget.
+ * Sets a brand's daily budget. Body { dailyBudgetCents } (number or decimal
+ * string, >= 0; 0 = pause) and response shape are owned by the downstream
+ * service; identity headers (x-org-id, x-user-id, x-run-id) are forwarded via
+ * buildInternalHeaders. Downstream 4xx errors propagate verbatim — passthrough only.
+ */
+router.patch("/brands/:brandId/daily-budget", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      `/v1/brands/${req.params.brandId}/daily-budget`,
+      { method: "PATCH", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to set daily budget" });
+  }
+});
+
 export default router;

--- a/src/routes/brand-pause.ts
+++ b/src/routes/brand-pause.ts
@@ -1,0 +1,73 @@
+import { Router } from "express";
+import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
+import { callExternalService, externalServices } from "../lib/service-client.js";
+import { buildInternalHeaders } from "../lib/internal-headers.js";
+
+const router = Router();
+
+/**
+ * Brand-level pause state.
+ *
+ * NOTE: although the client-facing path lives under /v1/brands/*, the pause
+ * flag is owned by CAMPAIGN-SERVICE (it owns the scheduler that gates sending),
+ * NOT brand-service. These routes forward to campaign-service /brands/:brandId/pause.
+ *
+ * This router MUST be mounted BEFORE brandRoutes in src/index.ts so the specific
+ * /brands/:brandId/pause routes win over any future brand-service brand proxy.
+ */
+
+/**
+ * GET /v1/brands/:brandId/pause
+ * Read a brand's pause state from campaign-service.
+ */
+router.get(
+  "/brands/:brandId/pause",
+  authenticate,
+  requireOrg,
+  requireUser,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const { brandId } = req.params;
+      const result = await callExternalService(
+        externalServices.campaign,
+        `/brands/${brandId}/pause`,
+        { headers: buildInternalHeaders(req) },
+      );
+      res.json(result);
+    } catch (error: any) {
+      console.error("[api-service] Get brand pause error:", error, { brandId: req.params.brandId, orgId: req.orgId });
+      res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand pause state" });
+    }
+  },
+);
+
+/**
+ * PATCH /v1/brands/:brandId/pause
+ * Update a brand's pause state in campaign-service. Body: { paused: boolean }.
+ */
+router.patch(
+  "/brands/:brandId/pause",
+  authenticate,
+  requireOrg,
+  requireUser,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const { brandId } = req.params;
+      const result = await callExternalService(
+        externalServices.campaign,
+        `/brands/${brandId}/pause`,
+        {
+          method: "PATCH",
+          headers: buildInternalHeaders(req),
+          body: req.body,
+        },
+      );
+      res.json(result);
+    } catch (error: any) {
+      console.error("[api-service] Update brand pause error:", error, { brandId: req.params.brandId, orgId: req.orgId });
+      res.status(error.statusCode || 500).json({ error: error.message || "Failed to update brand pause state" });
+    }
+  },
+);
+
+export default router;

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -571,6 +571,24 @@ router.post("/brands/:id/personas", authenticate, requireOrg, requireUser, async
 });
 
 /**
+ * POST /v1/brands/:id/personas/suggest
+ * Proxy to brand-service POST /orgs/brands/:id/personas/suggest. Returns AI-generated persona drafts verbatim.
+ */
+router.post("/brands/:id/personas/suggest", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/personas/suggest${rawQuery(req)}`,
+      { method: "POST", headers: buildInternalHeaders(req), body: req.body },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Suggest personas error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to suggest personas" });
+  }
+});
+
+/**
  * POST /v1/brands/:id/personas/:personaId/duplicate
  * Proxy to brand-service POST /orgs/brands/:id/personas/:personaId/duplicate. Returns 201 verbatim.
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3661,6 +3661,29 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
+  path: "/v1/brands/{id}/personas/suggest",
+  tags: ["Brand"],
+  summary: "Suggest AI-generated customer personas for a brand",
+  description:
+    "Proxy to brand-service POST /orgs/brands/{id}/personas/suggest. " +
+    "Returns AI-generated persona drafts ({ personas: [{ name, filters }] }). " +
+    "Body + response shapes are owned by the downstream service — passthrough only.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: { content: { "application/json": { schema: PersonaRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Persona drafts", content: { "application/json": { schema: PersonasResponseSchema } } },
+    400: { description: "Validation error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
   path: "/v1/brands/{id}/personas/{personaId}/duplicate",
   tags: ["Brand"],
   summary: "Duplicate a customer persona",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5542,6 +5542,60 @@ registry.registerPath({
   },
 });
 
+// Brand – Daily Budget (proxy to billing-service)
+// Per-brand daily spend ceiling (pacing/allocation), SEPARATE from org credit
+// balance/affordability. GET proxies billing /internal/brands/:brandId/daily-budget
+// (unset -> dailyBudgetCents null); PATCH proxies billing /v1/brands/:brandId/daily-budget.
+// Downstream owns body + response shapes — passthrough only (CLAUDE.md #8).
+const BrandDailyBudgetParam = z.object({
+  brandId: z.string().uuid().describe("Brand ID"),
+});
+const DailyBudgetResponseSchema = z.object({}).passthrough().openapi("DailyBudgetResponse");
+const DailyBudgetRequestSchema = z.object({}).passthrough().openapi("DailyBudgetRequest");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{brandId}/daily-budget",
+  tags: ["Billing"],
+  summary: "Get a brand's daily budget",
+  description:
+    "Proxy to billing-service GET /internal/brands/{brandId}/daily-budget. " +
+    "Returns the brand's current daily spend ceiling (per-day pacing/allocation " +
+    "value, separate from org credit balance/affordability). An unset brand returns " +
+    "{ dailyBudgetCents: null }. Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandDailyBudgetParam },
+  responses: {
+    200: { description: "Brand daily budget (dailyBudgetCents null when unset)", content: { "application/json": { schema: DailyBudgetResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/brands/{brandId}/daily-budget",
+  tags: ["Billing"],
+  summary: "Set a brand's daily budget",
+  description:
+    "Proxy to billing-service PATCH /v1/brands/{brandId}/daily-budget. " +
+    "Sets the brand's daily spend ceiling. Body { dailyBudgetCents } (number or " +
+    "decimal string, >= 0; 0 = pause). Identity headers (x-org-id, x-user-id, " +
+    "x-run-id) are forwarded. Body + response shapes are owned by the downstream " +
+    "service; its 4xx validation errors propagate verbatim.",
+  security: authed,
+  request: {
+    params: BrandDailyBudgetParam,
+    body: { content: { "application/json": { schema: DailyBudgetRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Updated brand daily budget", content: { "application/json": { schema: DailyBudgetResponseSchema } } },
+    400: { description: "Validation error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
 
 // ===================================================================
 // TRANSACTIONAL EMAILS

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8389,3 +8389,55 @@ registry.registerPath({
     403: { description: "orgId path does not match authenticated org", content: errorContent },
   },
 });
+
+// ---------------------------------------------------------------------------
+// Brand pause state — owned by CAMPAIGN-SERVICE (not brand-service).
+// Proxies to campaign-service /brands/:brandId/pause.
+// ---------------------------------------------------------------------------
+const BrandPauseParam = z.object({
+  brandId: z.string().describe("Brand ID"),
+});
+
+const BrandPauseRequestSchema = z
+  .object({ paused: z.boolean().describe("Desired pause state for the brand") })
+  .openapi("BrandPauseRequest");
+
+// Passthrough — response shape owned by campaign-service (CLAUDE.md #8).
+const BrandPauseResponseSchema = z.object({}).passthrough().openapi("BrandPauseResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{brandId}/pause",
+  tags: ["Campaigns"],
+  summary: "Get a brand's pause state",
+  description:
+    "Proxy to campaign-service GET /brands/{brandId}/pause. " +
+    "Returns the brand's pause state. Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandPauseParam },
+  responses: {
+    200: { description: "Brand pause state", content: { "application/json": { schema: BrandPauseResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/brands/{brandId}/pause",
+  tags: ["Campaigns"],
+  summary: "Update a brand's pause state",
+  description:
+    "Proxy to campaign-service PATCH /brands/{brandId}/pause. " +
+    "Body { paused: boolean }. Body + response shapes are owned by the downstream service.",
+  security: authed,
+  request: {
+    params: BrandPauseParam,
+    body: { content: { "application/json": { schema: BrandPauseRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Updated brand pause state", content: { "application/json": { schema: BrandPauseResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});

--- a/tests/unit/billing-proxy.test.ts
+++ b/tests/unit/billing-proxy.test.ts
@@ -55,10 +55,10 @@ describe("Billing proxy routes", () => {
   });
 
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
-    // 6 routes + 1 import = 7
+    // 8 routes + 1 import = 9
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    expect(authMatches!.length).toBe(7);
+    expect(authMatches!.length).toBe(9);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints (no x-key-source)", () => {
@@ -66,7 +66,14 @@ describe("Billing proxy routes", () => {
     expect(content).not.toContain('"x-key-source"');
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(6);
+    expect(headerMatches!.length).toBe(8);
+  });
+
+  it("should have GET + PATCH /brands/:brandId/daily-budget endpoints", () => {
+    expect(content).toContain('"/brands/:brandId/daily-budget"');
+    // GET proxies billing internal read; PATCH proxies billing /v1 write
+    expect(content).toContain("`/internal/brands/${req.params.brandId}/daily-budget`");
+    expect(content).toContain("`/v1/brands/${req.params.brandId}/daily-budget`");
   });
 
   it("should proxy to externalServices.billing", () => {
@@ -120,6 +127,12 @@ describe("Billing OpenAPI schemas", () => {
 
   it("should use Billing tag", () => {
     expect(schemaContent).toContain('tags: ["Billing"]');
+  });
+
+  it("should register brand daily-budget paths (passthrough)", () => {
+    expect(schemaContent).toContain('path: "/v1/brands/{brandId}/daily-budget"');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("DailyBudgetResponse")');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("DailyBudgetRequest")');
   });
 
   it("should define request schemas with new names", () => {

--- a/tests/unit/brand-pause-proxy.test.ts
+++ b/tests/unit/brand-pause-proxy.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * GET/PATCH /v1/brands/:brandId/pause must forward to CAMPAIGN-SERVICE
+ * /brands/:brandId/pause (campaign-service owns the pause flag), NOT brand-service.
+ * Existing /v1/brands/* brand-service routes must remain unaffected by the
+ * brand-pause router being mounted first.
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import brandPauseRouter from "../../src/routes/brand-pause.js";
+import brandRouter from "../../src/routes/brand.js";
+
+// Defaults from src/lib/service-client.ts when env unset.
+const CAMPAIGN_BASE = "http://localhost:3004";
+const BRAND_BASE = "https://brand.distribute.you";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  // Same mount order as src/index.ts: pause router before brand router.
+  app.use("/v1", brandPauseRouter);
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+describe("GET /v1/brands/:brandId/pause → campaign-service", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ brandId: "brand-1", orgId: "org_test456", paused: true, updatedAt: "2026-06-17T00:00:00Z" }),
+      };
+    });
+  });
+
+  it("forwards to campaign-service /brands/:brandId/pause", async () => {
+    const res = await request(buildApp()).get("/v1/brands/brand-1/pause");
+    expect(res.status).toBe(200);
+    const call = calls.find((c) => c.url.includes("/brands/brand-1/pause"));
+    expect(call).toBeDefined();
+    expect(call!.url.startsWith(CAMPAIGN_BASE)).toBe(true);
+    expect(call!.url).not.toContain(BRAND_BASE);
+  });
+
+  it("returns the campaign-service body verbatim", async () => {
+    const res = await request(buildApp()).get("/v1/brands/brand-1/pause");
+    expect(res.body).toEqual({
+      brandId: "brand-1",
+      orgId: "org_test456",
+      paused: true,
+      updatedAt: "2026-06-17T00:00:00Z",
+    });
+  });
+});
+
+describe("PATCH /v1/brands/:brandId/pause → campaign-service", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ brandId: "brand-1", orgId: "org_test456", paused: false, updatedAt: "2026-06-17T01:00:00Z" }),
+      };
+    });
+  });
+
+  it("forwards PATCH with body unchanged to campaign-service", async () => {
+    const res = await request(buildApp()).patch("/v1/brands/brand-1/pause").send({ paused: false });
+    expect(res.status).toBe(200);
+    const call = calls.find((c) => c.url.includes("/brands/brand-1/pause"));
+    expect(call).toBeDefined();
+    expect(call!.url.startsWith(CAMPAIGN_BASE)).toBe(true);
+    expect(call!.options.method).toBe("PATCH");
+    expect(JSON.parse(call!.options.body)).toEqual({ paused: false });
+  });
+
+  it("returns the updated body verbatim", async () => {
+    const res = await request(buildApp()).patch("/v1/brands/brand-1/pause").send({ paused: false });
+    expect(res.body).toEqual({
+      brandId: "brand-1",
+      orgId: "org_test456",
+      paused: false,
+      updatedAt: "2026-06-17T01:00:00Z",
+    });
+  });
+});
+
+describe("no regression: brand-service brand routes unaffected", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: "brand-1", name: "A" }),
+      };
+    });
+  });
+
+  it("GET /v1/brands/:id still forwards to brand-service, not campaign-service", async () => {
+    const res = await request(buildApp()).get("/v1/brands/brand-1");
+    expect(res.status).toBe(200);
+    const call = calls.find((c) => c.url.includes("/brands/brand-1") || c.url.includes("brand-1"));
+    expect(call).toBeDefined();
+    expect(call!.url.startsWith(BRAND_BASE)).toBe(true);
+    expect(call!.url.startsWith(CAMPAIGN_BASE)).toBe(false);
+  });
+});

--- a/tests/unit/brand-personas-profile-proxy.test.ts
+++ b/tests/unit/brand-personas-profile-proxy.test.ts
@@ -121,6 +121,32 @@ describe("POST /v1/brands/:id/personas", () => {
   });
 });
 
+describe("POST /v1/brands/:id/personas/suggest", () => {
+  const body = { count: 3 };
+  const suggestPayload = { personas: [{ name: "Eco shopper", filters: { interest: "sustainability" } }] };
+
+  it("forwards body byte-identical to the suggest path and returns payload + status verbatim", async () => {
+    mockUpstream(200, suggestPayload);
+    const app = buildApp();
+    const res = await request(app).post(`/v1/brands/${BRAND_ID}/personas/suggest`).send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(suggestPayload);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/personas/suggest`);
+    expect(capturedInit?.method).toBe("POST");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual(body);
+  });
+
+  it("propagates an upstream error verbatim", async () => {
+    mockUpstream(404, { error: "brand not found" });
+    const app = buildApp();
+    const res = await request(app).post(`/v1/brands/${BRAND_ID}/personas/suggest`).send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("brand not found");
+  });
+});
+
 describe("POST /v1/brands/:id/personas/:personaId/duplicate", () => {
   it("forwards to the duplicate path and returns 201 verbatim", async () => {
     mockUpstream(201, personaPayload);


### PR DESCRIPTION
## What
Adds two transparent proxy routes exposing a brand's **pause state** to the authed dashboard:

- `GET /v1/brands/:brandId/pause`
- `PATCH /v1/brands/:brandId/pause` (body `{ paused: boolean }`)

Both forward to **campaign-service** `/brands/:brandId/pause` (campaign-service owns the scheduler that gates sending), mirroring the existing `/v1/campaigns/*` proxies: `authenticate + requireOrg + requireUser`, headers via `buildInternalHeaders`, passthrough response (CLAUDE.md #8), upstream errors surfaced verbatim (#7).

## Routing / no collision
Client-facing path is under `/v1/brands/*` but forwards to campaign-service, **not** brand-service. The `brand-pause` router is mounted **before** `brandRoutes` so the specific `/brands/:brandId/pause` routes win over any future brand-service brand proxy. No collision today — brand.ts has no `/brands/:id/pause` route, and `/brands/:id` is single-segment (won't match the two-segment pause path).

## Tests
`tests/unit/brand-pause-proxy.test.ts` (5 cases): GET+PATCH forward to campaign-service base, body forwarded byte-identical, and `GET /v1/brands/:id` still routes to brand-service (no regression). Full suite green (1482 pass).

## ⚠️ Deploy gate
Registry shows campaign-service has **0** `/brands/*` endpoints deployed yet — the downstream `/brands/:brandId/pause` routes are being built in parallel. This proxy 404s until campaign-service ships its pause routes to staging. Additive/zero-blast-radius, so merge order is safe; feature is live once both land on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)