### PR TITLE
Add features pipeline activity proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8342,6 +8342,10 @@
           "brandIds"
         ]
       },
+      "FeaturePipelineActivityResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "FeatureStatsResponse": {
         "type": "object",
         "properties": {}
@@ -32862,6 +32866,163 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/features/{featureSlug}/pipeline-activity": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Feature pipeline activity",
+        "description": "7-day pipeline activity for a brand overview chart. Scoped by brandId, days, and timezone. Proxied from features-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug",
+            "name": "featureSlug",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand UUID (required)",
+              "example": "brand-uuid-123"
+            },
+            "required": true,
+            "description": "Brand UUID (required)",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Number of days to include",
+              "example": "7"
+            },
+            "required": true,
+            "description": "Number of days to include",
+            "name": "days",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "IANA timezone for day bucketing",
+              "example": "America/New_York"
+            },
+            "required": true,
+            "description": "IANA timezone for day bucketing",
+            "name": "timezone",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature pipeline activity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeaturePipelineActivityResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -257,6 +257,29 @@ router.post("/features/:slug/prefill", authenticate, requireOrg, requireUser, as
 });
 
 /**
+ * GET /v1/features/:slug/pipeline-activity
+ * 7-day pipeline activity for a brand. Proxied to features-service GET /features/:slug/pipeline-activity.
+ */
+router.get("/features/:slug/pipeline-activity", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = new URLSearchParams();
+    for (const key of ["brandId", "days", "timezone"]) {
+      if (req.query[key]) params.set(key, req.query[key] as string);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/features/${encodeURIComponent(req.params.slug)}/pipeline-activity${qs}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Feature pipeline-activity error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature pipeline activity" });
+  }
+});
+
+/**
  * GET /v1/features/:slug
  * Get a single feature by slug
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7141,6 +7141,30 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/features/{featureSlug}/pipeline-activity",
+  tags: ["Features"],
+  summary: "Feature pipeline activity",
+  description:
+    "7-day pipeline activity for a brand overview chart. Scoped by brandId, days, and timezone. Proxied from features-service.",
+  security: authed,
+  request: {
+    params: z.object({ featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug") }),
+    query: z.object({
+      brandId: z.string().openapi({ example: "brand-uuid-123" }).describe("Brand UUID (required)"),
+      days: z.string().openapi({ example: "7" }).describe("Number of days to include"),
+      timezone: z.string().openapi({ example: "America/New_York" }).describe("IANA timezone for day bucketing"),
+    }),
+  },
+  responses: {
+    200: { description: "Feature pipeline activity", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeaturePipelineActivityResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/features/{featureSlug}/stats",
   tags: ["Features"],
   summary: "Feature stats",

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -31,7 +31,7 @@ describe("Features proxy routes", () => {
 
   it("should have GET /features/:slug with auth + requireOrg + requireUser", () => {
     const line = content.split("\n").find((l) =>
-      l.includes("router.get") && l.includes('"/features/:slug"') && !l.includes("/stats")
+      l.includes('router.get("/features/:slug"')
     );
     expect(line).toBeDefined();
     expect(line).toContain("authenticate");
@@ -130,6 +130,25 @@ describe("Features proxy routes", () => {
     expect(revenueBlock).toContain("/revenue");
   });
 
+  it("should have GET /features/:slug/pipeline-activity with auth + requireOrg + requireUser", () => {
+    expect(content).toContain('"/features/:slug/pipeline-activity"');
+    const line = content.split("\n").find((l) =>
+      l.includes('"/features/:slug/pipeline-activity"')
+    );
+    expect(line).toContain("authenticate");
+    expect(line).toContain("requireOrg");
+    expect(line).toContain("requireUser");
+  });
+
+  it("should forward brandId, days, and timezone on GET /features/:slug/pipeline-activity", () => {
+    const pipelineActivityIdx = content.indexOf('"/features/:slug/pipeline-activity"');
+    const pipelineActivityBlock = content.slice(pipelineActivityIdx, pipelineActivityIdx + 500);
+    expect(pipelineActivityBlock).toContain('"brandId"');
+    expect(pipelineActivityBlock).toContain('"days"');
+    expect(pipelineActivityBlock).toContain('"timezone"');
+    expect(pipelineActivityBlock).toContain("/pipeline-activity");
+  });
+
   it("should have GET /features/:slug/workflow-projection with auth + requireOrg + requireUser", () => {
     expect(content).toContain('"/features/:slug/workflow-projection"');
     const line = content.split("\n").find((l) =>
@@ -165,10 +184,18 @@ describe("Features proxy routes", () => {
     const entitiesRegistryIdx = content.indexOf('"/features/entities/registry"');
     const registryIdx = content.indexOf('"/features/stats/registry"');
     const globalStatsIdx = content.indexOf('"/features/stats"');
-    const slugIdx = content.indexOf('"/features/:slug"');
+    const slugIdx = content.indexOf('router.get("/features/:slug",');
     expect(entitiesRegistryIdx).toBeLessThan(slugIdx);
     expect(registryIdx).toBeLessThan(slugIdx);
     expect(globalStatsIdx).toBeLessThan(slugIdx);
+  });
+
+  it("should register pipeline-activity before parameterized :slug route", () => {
+    const pipelineActivityIdx = content.indexOf('"/features/:slug/pipeline-activity"');
+    const slugIdx = content.indexOf('router.get("/features/:slug",');
+    expect(pipelineActivityIdx).toBeGreaterThanOrEqual(0);
+    expect(slugIdx).toBeGreaterThanOrEqual(0);
+    expect(pipelineActivityIdx).toBeLessThan(slugIdx);
   });
 
   it("should NOT have dynasty-specific routes (dynasty concept removed)", () => {
@@ -247,6 +274,11 @@ describe("Features OpenAPI schemas", () => {
 
   it("should register GET /v1/features/{featureSlug}/revenue", () => {
     expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/revenue"');
+  });
+
+  it("should register GET /v1/features/{featureSlug}/pipeline-activity", () => {
+    expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/pipeline-activity"');
+    expect(schemaContent).toContain("FeaturePipelineActivityResponse");
   });
 
   it("should register GET /v1/features/{featureSlug}/workflow-projection", () => {

--- a/tests/unit/features-stats.test.ts
+++ b/tests/unit/features-stats.test.ts
@@ -30,7 +30,12 @@ vi.mock("../../src/lib/service-client.js", () => ({
 }));
 
 vi.mock("../../src/middleware/auth.js", () => ({
-  authenticate: (_req: any, _res: any, next: any) => next(),
+  authenticate: (req: any, _res: any, next: any) => {
+    req.orgId = "org-uuid-123";
+    req.userId = "user-uuid-456";
+    req.runId = "run-uuid-789";
+    next();
+  },
   requireOrg: (_req: any, _res: any, next: any) => next(),
   requireUser: (_req: any, _res: any, next: any) => next(),
   AuthenticatedRequest: {},
@@ -295,6 +300,23 @@ const MOCK_WORKFLOW_REVENUE = {
   ],
 };
 
+const MOCK_PIPELINE_ACTIVITY = {
+  featureSlug: "sales-cold-email-outreach",
+  brandId: "brand-uuid-123",
+  timezone: "America/New_York",
+  days: [
+    {
+      date: "2026-06-11",
+      sent: 12,
+      opened: 7,
+      clicked: 3,
+      replied: 1,
+      downstreamAddedField: { preserved: true },
+    },
+  ],
+  producerOwnedField: "kept",
+};
+
 const MOCK_PUBLIC_BRAND_REVENUE = {
   featureSlug: "sales-cold-email-outreach",
   groupBy: "brand",
@@ -348,6 +370,62 @@ const MOCK_PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY = {
     },
   ],
 };
+
+describe("GET /v1/features/:slug/pipeline-activity", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("proxies to features-service /features/:slug/pipeline-activity and returns the body verbatim", async () => {
+    const app = createApp();
+    mockCallExternalService.mockImplementation((service: any, path: string) => {
+      if (service.url === "http://mock-features" && path.startsWith("/features/sales-cold-email-outreach/pipeline-activity")) {
+        return Promise.resolve(MOCK_PIPELINE_ACTIVITY);
+      }
+      return Promise.resolve({});
+    });
+
+    const res = await request(app).get("/v1/features/sales-cold-email-outreach/pipeline-activity?brandId=brand-uuid-123&days=7&timezone=America/New_York");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_PIPELINE_ACTIVITY);
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/features/sales-cold-email-outreach/pipeline-activity"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("brandId")).toBe("brand-uuid-123");
+    expect(params.get("days")).toBe("7");
+    expect(params.get("timezone")).toBe("America/New_York");
+
+    const options = call![2] as { headers: Record<string, string> };
+    expect(options.headers).toMatchObject({
+      "x-org-id": "org-uuid-123",
+      "x-user-id": "user-uuid-456",
+      "x-run-id": "run-uuid-789",
+      "x-brand-id": "brand-uuid-123",
+    });
+  });
+
+  it("does not forward unrelated query params to pipeline-activity", async () => {
+    const app = createApp();
+    mockCallExternalService.mockResolvedValue(MOCK_PIPELINE_ACTIVITY);
+
+    await request(app).get("/v1/features/sales-cold-email-outreach/pipeline-activity?brandId=brand-uuid-123&days=7&timezone=America/New_York&campaignId=campaign-uuid-456&groupBy=workflowSlug");
+
+    const call = mockCallExternalService.mock.calls.find(
+      (c: any[]) => typeof c[1] === "string" && c[1].startsWith("/features/sales-cold-email-outreach/pipeline-activity"),
+    );
+    expect(call).toBeDefined();
+    const url = call![1] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("brandId")).toBe("brand-uuid-123");
+    expect(params.get("days")).toBe("7");
+    expect(params.get("timezone")).toBe("America/New_York");
+    expect(params.has("campaignId")).toBe(false);
+    expect(params.has("groupBy")).toBe(false);
+  });
+});
 
 describe("GET /v1/features/:slug/revenue", () => {
   beforeEach(() => vi.clearAllMocks());


### PR DESCRIPTION
## Summary
- add authenticated GET /v1/features/:featureSlug/pipeline-activity proxy to features-service
- forward brandId, days, and timezone with existing org/user/run header conventions
- document passthrough OpenAPI response and add proxy tests

## Verification
- pnpm test -- tests/unit/features-proxy.test.ts tests/unit/features-stats.test.ts (ran full suite: 127 files, 1503 tests passed)
- pnpm build

Note: features-service registry did not yet list the locked producer route when checked; this PR keeps api-service as a fail-loud transparent proxy with no readiness fallback.