### PR TITLE
Proxy persona avatar regeneration

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -21223,6 +21223,158 @@
         }
       }
     },
+    "/v1/brands/{id}/personas/{personaId}/avatar/regenerate": {
+      "post": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Regenerate a customer persona avatar",
+        "description": "Proxy to brand-service POST /orgs/brands/{id}/personas/{personaId}/avatar/regenerate. Brand-service owns avatar generation, storage, cost declaration, and response shape; api-service forwards the request body and downstream response/status verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Persona ID"
+            },
+            "required": true,
+            "description": "Persona ID",
+            "name": "personaId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PersonaRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Persona avatar regenerated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonasResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand or persona not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/brands/{id}/personas/{personaId}/status": {
       "patch": {
         "tags": [

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -607,6 +607,24 @@ router.post("/brands/:id/personas/:personaId/duplicate", authenticate, requireOr
 });
 
 /**
+ * POST /v1/brands/:id/personas/:personaId/avatar/regenerate
+ * Proxy to brand-service POST /orgs/brands/:id/personas/:personaId/avatar/regenerate.
+ */
+router.post("/brands/:id/personas/:personaId/avatar/regenerate", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/personas/${req.params.personaId}/avatar/regenerate${rawQuery(req)}`,
+      { method: "POST", headers: buildInternalHeaders(req), body: req.body },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Regenerate persona avatar error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to regenerate persona avatar" });
+  }
+});
+
+/**
  * PATCH /v1/brands/:id/personas/:personaId/status
  * Proxy to brand-service PATCH /orgs/brands/:id/personas/:personaId/status.
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3705,6 +3705,29 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{id}/personas/{personaId}/avatar/regenerate",
+  tags: ["Brand"],
+  summary: "Regenerate a customer persona avatar",
+  description:
+    "Proxy to brand-service POST /orgs/brands/{id}/personas/{personaId}/avatar/regenerate. " +
+    "Brand-service owns avatar generation, storage, cost declaration, and response shape; " +
+    "api-service forwards the request body and downstream response/status verbatim.",
+  security: authed,
+  request: {
+    params: PersonaParam,
+    body: { content: { "application/json": { schema: PersonaRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Persona avatar regenerated", content: { "application/json": { schema: PersonasResponseSchema } } },
+    400: { description: "Validation error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand or persona not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "patch",
   path: "/v1/brands/{id}/personas/{personaId}/status",
   tags: ["Brand"],

--- a/tests/unit/brand-personas-profile-proxy.test.ts
+++ b/tests/unit/brand-personas-profile-proxy.test.ts
@@ -51,8 +51,10 @@ beforeEach(() => {
   capturedInit = undefined;
 });
 
-const personasPayload = { personas: [{ id: PERSONA_ID, name: "Eco shopper", status: "active" }] };
-const personaPayload = { persona: { id: PERSONA_ID, name: "Eco shopper", status: "active" } };
+const personasPayload = {
+  personas: [{ id: PERSONA_ID, name: "Eco shopper", status: "active", avatarUrl: "https://cdn.example.com/persona.png" }],
+};
+const personaPayload = { persona: { id: PERSONA_ID, name: "Eco shopper", status: "active", avatarUrl: null } };
 const profilePayload = { brandProfile: { id: "prof_1", version: 3 } };
 
 describe("GET /v1/brands/:id/personas", () => {
@@ -157,6 +159,38 @@ describe("POST /v1/brands/:id/personas/:personaId/duplicate", () => {
     expect(res.body).toEqual(personaPayload);
     expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/personas/${PERSONA_ID}/duplicate`);
     expect(capturedInit?.method).toBe("POST");
+  });
+});
+
+describe("POST /v1/brands/:id/personas/:personaId/avatar/regenerate", () => {
+  const regeneratedPayload = {
+    persona: {
+      id: PERSONA_ID,
+      name: "Eco shopper",
+      status: "active",
+      avatarUrl: "https://cdn.example.com/persona-regenerated.png",
+    },
+  };
+
+  it("forwards empty body to the avatar regenerate path and returns payload + status verbatim", async () => {
+    mockUpstream(200, regeneratedPayload);
+    const app = buildApp();
+    const res = await request(app).post(`/v1/brands/${BRAND_ID}/personas/${PERSONA_ID}/avatar/regenerate`).send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(regeneratedPayload);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/personas/${PERSONA_ID}/avatar/regenerate`);
+    expect(capturedInit?.method).toBe("POST");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual({});
+  });
+
+  it("propagates an upstream avatar regeneration error verbatim", async () => {
+    mockUpstream(404, { error: "persona not found" });
+    const app = buildApp();
+    const res = await request(app).post(`/v1/brands/${BRAND_ID}/personas/${PERSONA_ID}/avatar/regenerate`).send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("persona not found");
   });
 });
 

--- a/tests/unit/dashboard-endpoints-openapi.test.ts
+++ b/tests/unit/dashboard-endpoints-openapi.test.ts
@@ -39,6 +39,10 @@ describe("Dashboard endpoints OpenAPI documentation", () => {
     expect(content).toContain('path: "/v1/campaigns/stats"');
   });
 
+  it("should register POST /v1/brands/{id}/personas/{personaId}/avatar/regenerate", () => {
+    expect(content).toContain('path: "/v1/brands/{id}/personas/{personaId}/avatar/regenerate"');
+  });
+
   it("should document status query param on GET /v1/campaigns", () => {
     // Find the registerPath block for GET /v1/campaigns and verify status is in the query schema
     const listStart = content.indexOf('path: "/v1/campaigns"');


### PR DESCRIPTION
## Summary

- Adds dashboard-facing `POST /v1/brands/{id}/personas/{personaId}/avatar/regenerate` as a transparent api-service proxy.
- Forwards to brand-service downstream route `POST /orgs/brands/{id}/personas/{personaId}/avatar/regenerate`.
- Keeps persona request/response schemas passthrough so existing persona responses expose `avatarUrl: string | null` when brand-service returns it.
- Does not add image generation, provider fallback, OpenAI dependency, or env vars in api-service.

## Verification

- `pnpm generate:openapi`
- `pnpm exec vitest run tests/unit/brand-personas-profile-proxy.test.ts tests/unit/dashboard-endpoints-openapi.test.ts tests/unit/openapi-response-schemas.test.ts`
- `pnpm build`

## Notes

- Staging API registry currently lists the existing brand-service persona routes but does not yet publish the new avatar regenerate route, so runtime success depends on the paired brand-service staging feature/migration landing.
- A broad accidental `pnpm test -- ...` invocation ran the full suite and surfaced two unrelated pre-existing 404 failures in `tests/unit/features-stats.test.ts` and `tests/unit/brand-extract-fields-byBrand.test.ts`; the targeted persona/OpenAPI checks passed.
