### PR TITLE
fix: proxy billing wallet setup

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6870,6 +6870,14 @@
             "format": "uri",
             "description": "URL to redirect on cancellation"
           },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "payment",
+              "setup"
+            ],
+            "description": "Stripe checkout mode. Setup mode stores a payment method and does not require a top-up amount."
+          },
           "topup_amount_cents": {
             "anyOf": [
               {
@@ -6885,8 +6893,57 @@
         },
         "required": [
           "success_url",
-          "cancel_url",
-          "topup_amount_cents"
+          "cancel_url"
+        ]
+      },
+      "WalletSetupResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "WalletSetupRequest": {
+        "type": "object",
+        "properties": {
+          "initial_load_amount_cents": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)?$"
+              }
+            ],
+            "description": "Initial wallet load amount in cents (integer or decimal string)"
+          },
+          "topup_amount_cents": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)?$"
+              }
+            ],
+            "description": "Auto-topup amount in cents (integer or decimal string)"
+          },
+          "topup_threshold_cents": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)?$"
+              }
+            ],
+            "description": "Balance threshold in cents that triggers auto-topup (integer or decimal string)"
+          }
+        },
+        "required": [
+          "initial_load_amount_cents",
+          "topup_amount_cents",
+          "topup_threshold_cents"
         ]
       },
       "BillingPortalSessionResponse": {
@@ -26536,7 +26593,7 @@
           "Billing"
         ],
         "summary": "Create Stripe checkout session",
-        "description": "Create a Stripe checkout session for purchasing credits",
+        "description": "Create a Stripe checkout session for purchasing credits or setting up a payment method.",
         "security": [
           {
             "bearerAuth": []
@@ -26558,6 +26615,128 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BillingCheckoutResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/billing/accounts/wallet_setup": {
+      "post": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Configure wallet setup",
+        "description": "Configure first-campaign wallet funding and process the initial load. Pass-through from billing-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WalletSetupRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Wallet setup configured — pass-through from billing-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletSetupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -94,7 +94,10 @@ router.delete("/billing/accounts/auto_topup", authenticate, requireOrg, async (r
 // POST /v1/billing/checkout-sessions — create Stripe checkout session
 router.post("/billing/checkout-sessions", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
   try {
-    if (!requireBodyFields(res, req.body, ["success_url", "cancel_url", "topup_amount_cents"])) return;
+    const requiredFields = req.body?.mode === "setup"
+      ? ["success_url", "cancel_url"]
+      : ["success_url", "cancel_url", "topup_amount_cents"];
+    if (!requireBodyFields(res, req.body, requiredFields)) return;
     const result = await callExternalService(
       externalServices.billing,
       "/v1/checkout-sessions",
@@ -103,6 +106,20 @@ router.post("/billing/checkout-sessions", authenticate, requireOrg, async (req: 
     res.json(result);
   } catch (error: any) {
     res.status(500).json({ error: error.message || "Failed to create checkout session" });
+  }
+});
+
+// POST /v1/billing/accounts/wallet_setup — configure first-campaign wallet funding
+router.post("/billing/accounts/wallet_setup", authenticate, requireOrg, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.billing,
+      "/v1/accounts/wallet_setup",
+      { method: "POST", body: req.body, headers: buildInternalHeaders(req) }
+    );
+    res.json(result);
+  } catch (error: any) {
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to configure wallet setup" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5325,11 +5325,28 @@ export const CreateCheckoutSessionRequestSchema = z
   .object({
     success_url: z.string().url().describe("URL to redirect after successful payment"),
     cancel_url: z.string().url().describe("URL to redirect on cancellation"),
-    topup_amount_cents: inboundCents.describe(
+    mode: z.enum(["payment", "setup"]).optional().describe(
+      "Stripe checkout mode. Setup mode stores a payment method and does not require a top-up amount.",
+    ),
+    topup_amount_cents: inboundCents.optional().describe(
       "Amount to top up in cents (integer or decimal string)",
     ),
   })
   .openapi("CreateCheckoutSessionRequest");
+
+export const WalletSetupRequestSchema = z
+  .object({
+    initial_load_amount_cents: inboundCents.describe(
+      "Initial wallet load amount in cents (integer or decimal string)",
+    ),
+    topup_amount_cents: inboundCents.describe(
+      "Auto-topup amount in cents (integer or decimal string)",
+    ),
+    topup_threshold_cents: inboundCents.describe(
+      "Balance threshold in cents that triggers auto-topup (integer or decimal string)",
+    ),
+  })
+  .openapi("WalletSetupRequest");
 
 export const CreatePortalSessionRequestSchema = z
   .object({
@@ -5511,7 +5528,7 @@ registry.registerPath({
   path: "/v1/billing/checkout-sessions",
   tags: ["Billing"],
   summary: "Create Stripe checkout session",
-  description: "Create a Stripe checkout session for purchasing credits",
+  description: "Create a Stripe checkout session for purchasing credits or setting up a payment method.",
   security: authed,
   request: {
     body: {
@@ -5529,6 +5546,35 @@ registry.registerPath({
         },
       },
     },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/billing/accounts/wallet_setup",
+  tags: ["Billing"],
+  summary: "Configure wallet setup",
+  description: "Configure first-campaign wallet funding and process the initial load. Pass-through from billing-service.",
+  security: authed,
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: WalletSetupRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Wallet setup configured — pass-through from billing-service",
+      content: {
+        "application/json": {
+          schema: z.object({}).passthrough().openapi("WalletSetupResponse"),
+        },
+      },
+    },
+    400: { description: "Invalid request", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     500: { description: "Internal error", content: errorContent },
   },

--- a/tests/unit/billing-proxy-fractional.test.ts
+++ b/tests/unit/billing-proxy-fractional.test.ts
@@ -176,7 +176,37 @@ describe("billing proxy — passthrough contract", () => {
     expect(opts?.method).toBe("DELETE");
   });
 
-  it("POST /billing/checkout-sessions rejects missing topup amount before downstream", async () => {
+  it("POST /billing/checkout-sessions forwards setup mode without topup amount", async () => {
+    const upstream = { url: "https://stripe.example/setup" };
+    mockCallExternalService.mockResolvedValue(upstream);
+    const reqBody = {
+      success_url: "https://example.com/success",
+      cancel_url: "https://example.com/cancel",
+      mode: "setup",
+    };
+
+    const res = await request(createApp())
+      .post("/billing/checkout-sessions")
+      .send(reqBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstream);
+    const [service, downstreamPath, opts] = mockCallExternalService.mock.calls[0] as [
+      unknown,
+      string,
+      { method?: string; body?: unknown; headers?: Record<string, string> },
+    ];
+    expect(service).toEqual({ url: "http://mock-billing", apiKey: "k" });
+    expect(downstreamPath).toBe("/v1/checkout-sessions");
+    expect(opts?.method).toBe("POST");
+    expect(opts?.body).toEqual(reqBody);
+    expect(opts?.headers).toMatchObject({
+      "x-org-id": "org-test",
+      "x-user-id": "user-test",
+    });
+  });
+
+  it("POST /billing/checkout-sessions still rejects payment checkout without topup amount", async () => {
     const res = await request(createApp())
       .post("/billing/checkout-sessions")
       .send({ success_url: "https://example.com/success", cancel_url: "https://example.com/cancel" });
@@ -187,6 +217,39 @@ describe("billing proxy — passthrough contract", () => {
       missingFields: ["topup_amount_cents"],
     });
     expect(mockCallExternalService).not.toHaveBeenCalled();
+  });
+
+  it("POST /billing/accounts/wallet_setup forwards body byte-identical to /v1/accounts/wallet_setup", async () => {
+    const upstream = {
+      wallet_setup_complete: true,
+      checkout_required: false,
+    };
+    mockCallExternalService.mockResolvedValue(upstream);
+    const reqBody = {
+      initial_load_amount_cents: 50000,
+      topup_amount_cents: 25000,
+      topup_threshold_cents: 10000,
+    };
+
+    const res = await request(createApp())
+      .post("/billing/accounts/wallet_setup")
+      .send(reqBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstream);
+    const [service, downstreamPath, opts] = mockCallExternalService.mock.calls[0] as [
+      unknown,
+      string,
+      { method?: string; body?: unknown; headers?: Record<string, string> },
+    ];
+    expect(service).toEqual({ url: "http://mock-billing", apiKey: "k" });
+    expect(downstreamPath).toBe("/v1/accounts/wallet_setup");
+    expect(opts?.method).toBe("POST");
+    expect(opts?.body).toEqual(reqBody);
+    expect(opts?.headers).toMatchObject({
+      "x-org-id": "org-test",
+      "x-user-id": "user-test",
+    });
   });
 
   it("PATCH /brands/:brandId/daily-budget forwards body and identity headers", async () => {

--- a/tests/unit/billing-proxy.test.ts
+++ b/tests/unit/billing-proxy.test.ts
@@ -50,15 +50,19 @@ describe("Billing proxy routes", () => {
     expect(content).toContain('"/billing/checkout-sessions"');
   });
 
+  it("should have POST /billing/accounts/wallet_setup endpoint", () => {
+    expect(content).toContain('"/billing/accounts/wallet_setup"');
+  });
+
   it("should have POST /billing/portal-sessions endpoint", () => {
     expect(content).toContain('"/billing/portal-sessions"');
   });
 
   it("should use authenticate and requireOrg on all authenticated endpoints", () => {
-    // 8 routes + 1 import = 9
+    // 9 routes + 1 import = 10
     const authMatches = content.match(/authenticate, requireOrg/g);
     expect(authMatches).not.toBeNull();
-    expect(authMatches!.length).toBe(9);
+    expect(authMatches!.length).toBe(10);
   });
 
   it("should use buildInternalHeaders for all authenticated endpoints (no x-key-source)", () => {
@@ -66,7 +70,7 @@ describe("Billing proxy routes", () => {
     expect(content).not.toContain('"x-key-source"');
     const headerMatches = content.match(/buildInternalHeaders\(req\)/g);
     expect(headerMatches).not.toBeNull();
-    expect(headerMatches!.length).toBe(8);
+    expect(headerMatches!.length).toBe(9);
   });
 
   it("should have GET + PATCH /brands/:brandId/daily-budget endpoints", () => {
@@ -99,6 +103,7 @@ describe("Billing proxy routes", () => {
     expect(content).toContain('"/v1/accounts/balance"');
     expect(content).toContain('"/v1/accounts/auto_topup"');
     expect(content).toContain('"/v1/checkout-sessions"');
+    expect(content).toContain('"/v1/accounts/wallet_setup"');
     expect(content).toContain('"/v1/portal-sessions"');
   });
 });
@@ -124,6 +129,7 @@ describe("Billing OpenAPI schemas", () => {
     expect(schemaContent).toContain('path: "/v1/billing/accounts/balance"');
     expect(schemaContent).toContain('path: "/v1/billing/accounts/auto_topup"');
     expect(schemaContent).toContain('path: "/v1/billing/checkout-sessions"');
+    expect(schemaContent).toContain('path: "/v1/billing/accounts/wallet_setup"');
     expect(schemaContent).toContain('path: "/v1/billing/portal-sessions"');
   });
 
@@ -160,6 +166,7 @@ describe("Billing OpenAPI schemas", () => {
   it("should define request schemas with new names", () => {
     expect(schemaContent).toContain("ConfigureAutoTopupRequestSchema");
     expect(schemaContent).toContain("CreateCheckoutSessionRequestSchema");
+    expect(schemaContent).toContain("WalletSetupRequestSchema");
     expect(schemaContent).not.toContain("ConfigureAutoReloadRequestSchema");
     expect(schemaContent).not.toContain("SwitchBillingModeRequestSchema");
     expect(schemaContent).not.toContain("DeductCreditsRequestSchema");
@@ -168,6 +175,7 @@ describe("Billing OpenAPI schemas", () => {
   it("should use topup_amount_cents in request schemas (not reload_amount_cents)", () => {
     expect(schemaContent).toContain("topup_amount_cents");
     expect(schemaContent).toContain("topup_threshold_cents");
+    expect(schemaContent).toContain("initial_load_amount_cents");
     expect(schemaContent).not.toContain("reload_amount_cents");
     expect(schemaContent).not.toContain("reload_threshold_cents");
   });
@@ -185,6 +193,7 @@ describe("Billing OpenAPI schemas", () => {
     expect(schemaContent).toContain('z.object({}).passthrough().openapi("ConfigureAutoTopupResponse")');
     expect(schemaContent).toContain('z.object({}).passthrough().openapi("DisableAutoTopupResponse")');
     expect(schemaContent).toContain('z.object({}).passthrough().openapi("BillingCheckoutResponse")');
+    expect(schemaContent).toContain('z.object({}).passthrough().openapi("WalletSetupResponse")');
     expect(schemaContent).toContain('z.object({}).passthrough().openapi("BillingPortalSessionResponse")');
     expect(schemaContent).toContain('z.object({}).passthrough().openapi("PublicBillingStatsResponse")');
     expect(schemaContent).not.toContain("TransactionListResponse");


### PR DESCRIPTION
## Summary
- Allow `POST /v1/billing/checkout-sessions` setup-mode bodies to omit `topup_amount_cents` while keeping payment checkout amount validation.
- Add transparent `POST /v1/billing/accounts/wallet_setup` proxy to billing-service `/v1/accounts/wallet_setup`.
- Regenerate `openapi.json` and add billing proxy tests for setup checkout and wallet setup forwarding.

## Contract
- Gateway path: `POST /v1/billing/checkout-sessions` -> billing-service `POST /v1/checkout-sessions`
- Gateway path: `POST /v1/billing/accounts/wallet_setup` -> billing-service `POST /v1/accounts/wallet_setup`
- Responses remain pass-through from billing-service.

## Verification
- `pnpm exec vitest run tests/unit/billing-proxy.test.ts tests/unit/billing-proxy-fractional.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm test:unit` (126 files, 1510 tests)
