### PR TITLE
feat(audiences): proxy PATCH /v1/orgs/audiences/:id/status to human-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -39063,6 +39063,139 @@
           }
         }
       }
+    },
+    "/v1/orgs/audiences/{id}/status": {
+      "patch": {
+        "tags": [
+          "Audiences"
+        ],
+        "summary": "Change an audience's status (active / paused / archived)",
+        "description": "Proxy to human-service PATCH /orgs/audiences/{id}/status. Body { status } + response shapes owned by human-service. Forwarded untransformed.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Audience ID"
+            },
+            "required": true,
+            "description": "Audience ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated audience",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AudienceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "human-service unreachable / not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/routes/audiences.ts
+++ b/src/routes/audiences.ts
@@ -124,6 +124,20 @@ router.get("/orgs/audiences/:id/members", ...authChain, async (req: Authenticate
   }
 });
 
+// PATCH /v1/orgs/audiences/:id/status → human-service PATCH /orgs/audiences/{id}/status
+router.patch("/orgs/audiences/:id/status", ...authChain, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.human,
+      `/orgs/audiences/${encodeURIComponent(req.params.id)}/status`,
+      { method: "PATCH", headers: buildInternalHeaders(req), body: req.body },
+    );
+    res.json(result);
+  } catch (error: any) {
+    fail(res, error, "Update audience status error");
+  }
+});
+
 // GET /v1/orgs/audiences/:id → human-service GET /orgs/audiences/{id}
 router.get("/orgs/audiences/:id", ...authChain, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8747,6 +8747,26 @@ registry.registerPath({
 
 registry.registerPath({
   method: "patch",
+  path: "/v1/orgs/audiences/{id}/status",
+  tags: ["Audiences"],
+  summary: "Change an audience's status (active / paused / archived)",
+  description:
+    "Proxy to human-service PATCH /orgs/audiences/{id}/status. Body { status } + response shapes owned by human-service. Forwarded untransformed.",
+  security: authed,
+  request: {
+    params: AudienceIdParam,
+    body: { content: { "application/json": { schema: AudiencePassthroughBody } } },
+  },
+  responses: {
+    200: { description: "Updated audience", content: { "application/json": { schema: AudienceResponse } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+    502: { description: "human-service unreachable / not configured", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
   path: "/v1/orgs/audiences/{id}",
   tags: ["Audiences"],
   summary: "Update an audience",

--- a/tests/unit/audiences-proxy.test.ts
+++ b/tests/unit/audiences-proxy.test.ts
@@ -95,6 +95,13 @@ describe("/v1/orgs/audiences/* → human-service", () => {
     expect(JSON.parse(calls[0].options.body)).toEqual({ name: "renamed" });
   });
 
+  it("PATCH /:id/status forwards body verbatim to the status path", async () => {
+    await request(buildApp()).patch("/v1/orgs/audiences/aud-1/status").send({ status: "paused" });
+    expect(calls[0].url).toBe(`${HUMAN_BASE}/orgs/audiences/aud-1/status`);
+    expect(calls[0].options.method).toBe("PATCH");
+    expect(JSON.parse(calls[0].options.body)).toEqual({ status: "paused" });
+  });
+
   it("DELETE /:id forwards", async () => {
     await request(buildApp()).delete("/v1/orgs/audiences/aud-1");
     expect(calls[0].url).toBe(`${HUMAN_BASE}/orgs/audiences/aud-1`);


### PR DESCRIPTION
## What
Adds the missing audiences lifecycle-status route to the gateway proxy.

`PATCH /v1/orgs/audiences/{id}/status` → human-service `PATCH /orgs/audiences/{id}/status` (active | paused | archived).

## Why
human-service gained a status lifecycle in prod (Wave 2 persona→audience unification). The gateway already transparently proxies all other `/v1/orgs/audiences/*` routes (PR #579) but not the new status route. Dashboard needs to pause/resume/archive an audience through the gateway.

## How
Mirror of PR #579 — pure passthrough:
- `src/routes/audiences.ts` — new `router.patch("/orgs/audiences/:id/status", ...authChain, ...)`, body + identity headers forwarded, response untransformed.
- `src/schemas.ts` — `registerPath` with `AudiencePassthroughBody` request + `AudienceResponse` passthrough (no field re-declaration, CLAUDE.md #8).
- `tests/unit/audiences-proxy.test.ts` — forwards body verbatim to the status path.
- `openapi.json` — regenerated.

No new env var (`HUMAN_SERVICE_URL` already wired). No caps, no fallback, no body transform.

## Contract (byte-equal)
- Gateway: `PATCH /v1/orgs/audiences/{id}/status`
- Downstream: `PATCH /orgs/audiences/{id}/status` (verified live in prod api-registry)
- Body passthrough `{ status }`; response passthrough `{ audience }`.

## Triage
Hotfix → main. Additive transparent-proxy route, zero blast radius on existing handlers (additive-gateway-route prod-direct carve-out). Staging skipped.

## Tests
1529/1529 unit tests green; build + openapi regen OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)