### PR TITLE
hotfix: Forward status query param on GET /v1/orgs/audiences to human-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -38286,7 +38286,7 @@
           "Audiences"
         ],
         "summary": "List audiences for an org",
-        "description": "Proxy to human-service GET /orgs/audiences. Optional brandId filter + limit/offset pagination forwarded untransformed.",
+        "description": "Proxy to human-service GET /orgs/audiences. Optional brandId + status (lifecycle) filters + limit/offset pagination forwarded untransformed.",
         "security": [
           {
             "bearerAuth": []
@@ -38301,6 +38301,15 @@
             },
             "required": false,
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Lifecycle filter (suggested|active|paused|archived) — forwarded to human-service"
+            },
+            "required": false,
+            "name": "status",
             "in": "query"
           },
           {

--- a/src/routes/audiences.ts
+++ b/src/routes/audiences.ts
@@ -87,7 +87,7 @@ router.get("/orgs/audiences", ...authChain, async (req: AuthenticatedRequest, re
   try {
     const result = await callExternalService(
       externalServices.human,
-      `/orgs/audiences${passthroughQuery(req, ["limit", "offset", "brandId"])}`,
+      `/orgs/audiences${passthroughQuery(req, ["limit", "offset", "brandId", "status"])}`,
       { headers: buildInternalHeaders(req) },
     );
     res.json(result);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8671,11 +8671,12 @@ registry.registerPath({
   tags: ["Audiences"],
   summary: "List audiences for an org",
   description:
-    "Proxy to human-service GET /orgs/audiences. Optional brandId filter + limit/offset pagination forwarded untransformed.",
+    "Proxy to human-service GET /orgs/audiences. Optional brandId + status (lifecycle) filters + limit/offset pagination forwarded untransformed.",
   security: authed,
   request: {
     query: z.object({
       brandId: z.string().uuid().optional().openapi({ description: "Brand ID filter" }),
+      status: z.string().optional().openapi({ description: "Lifecycle filter (suggested|active|paused|archived) — forwarded to human-service" }),
       limit: z.coerce.number().int().optional().openapi({ description: "Max results (human-service enforces its own cap)" }),
       offset: z.coerce.number().int().optional().openapi({ description: "Pagination offset" }),
     }),

--- a/tests/unit/audiences-proxy.test.ts
+++ b/tests/unit/audiences-proxy.test.ts
@@ -72,6 +72,12 @@ describe("/v1/orgs/audiences/* → human-service", () => {
     expect(calls[0].url).toBe(`${HUMAN_BASE}/orgs/audiences?limit=50&offset=10&brandId=b1`);
   });
 
+  it("GET list forwards status (lifecycle) filter", async () => {
+    const res = await request(buildApp()).get("/v1/orgs/audiences?brandId=b1&status=active");
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe(`${HUMAN_BASE}/orgs/audiences?brandId=b1&status=active`);
+  });
+
   it("GET /:id forwards to the by-id path", async () => {
     await request(buildApp()).get("/v1/orgs/audiences/aud-1");
     expect(calls[0].url).toBe(`${HUMAN_BASE}/orgs/audiences/aud-1`);


### PR DESCRIPTION
Automated by release.sh