### PR TITLE
feat(admin): proxy DELETE /internal/admin/orgs/by-external/:externalOrgId

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -254,6 +254,27 @@ router.get("/admin/services/:name/tables/:table/rows", authenticatePlatform, asy
   });
 });
 
+// ── DELETE /admin/orgs/by-external/:externalOrgId ───────────────────────────
+// Staff-only org cascade teardown keyed by the Clerk org id. Pure proxy to
+// client-service, which resolves the Clerk org to the internal org, runs the
+// full teardown cascade, and deletes the org's Clerk users. Mirrors the
+// by-internal-id route below: the gateway adds no logic and propagates the
+// upstream status + body verbatim so a partial teardown fails loud (CLAUDE.md #7).
+router.delete("/admin/orgs/by-external/:externalOrgId", authenticatePlatform, async (req: Request, res: Response) => {
+  const { externalOrgId } = req.params;
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.client,
+      `/internal/orgs/by-external/${encodeURIComponent(externalOrgId)}`,
+      { method: "DELETE" },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error(`[api-service] org teardown (by-external) failed for ${externalOrgId}:`, error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to tear down org" });
+  }
+});
+
 // ── DELETE /admin/orgs/:orgId ───────────────────────────────────────────────
 // Staff-only org cascade teardown. Pure proxy to client-service, which owns the
 // org-lifecycle orchestration: it deletes its own org data, the Clerk org

--- a/tests/unit/admin-org-teardown-by-external.test.ts
+++ b/tests/unit/admin-org-teardown-by-external.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Keep authenticatePlatform real — this is a staff-only platform route.
+vi.mock("../../src/middleware/auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/middleware/auth.js")>();
+  return { ...actual };
+});
+
+import adminRoutes from "../../src/routes/admin.js";
+
+const VALID_API_KEY = "test-admin-distribute-key";
+const EXTERNAL_ORG_ID = "org_clerk_external_456";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/internal", adminRoutes);
+  return app;
+}
+
+const downstreamBody = {
+  deleted: true,
+  externalOrgId: EXTERNAL_ORG_ID,
+  orgId: "org_internal_789",
+  clerkUsers: "deleted",
+};
+
+describe("DELETE /internal/admin/orgs/by-external/:externalOrgId", () => {
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_DISTRIBUTE_API_KEY = VALID_API_KEY;
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(downstreamBody),
+      };
+    });
+  });
+
+  it("forwards to client-service DELETE /internal/orgs/by-external/:externalOrgId", async () => {
+    const app = createApp();
+    await request(app)
+      .delete(`/internal/admin/orgs/by-external/${EXTERNAL_ORG_ID}`)
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(capturedUrl).toContain(`/internal/orgs/by-external/${EXTERNAL_ORG_ID}`);
+    expect(capturedInit?.method).toBe("DELETE");
+  });
+
+  it("returns the downstream JSON body + status verbatim on success", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .delete(`/internal/admin/orgs/by-external/${EXTERNAL_ORG_ID}`)
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(downstreamBody);
+  });
+
+  it("sends X-API-Key to client-service", async () => {
+    const app = createApp();
+    await request(app)
+      .delete(`/internal/admin/orgs/by-external/${EXTERNAL_ORG_ID}`)
+      .set("X-API-Key", VALID_API_KEY);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["X-API-Key"]).toBeDefined();
+  });
+
+  it("rejects requests without platform API key (401)", async () => {
+    const app = createApp();
+    const res = await request(app).delete(`/internal/admin/orgs/by-external/${EXTERNAL_ORG_ID}`);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests with a wrong platform API key (401)", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .delete(`/internal/admin/orgs/by-external/${EXTERNAL_ORG_ID}`)
+      .set("X-API-Key", "wrong-key");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("propagates an upstream 404 verbatim", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"org not found"}'),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .delete(`/internal/admin/orgs/by-external/${EXTERNAL_ORG_ID}`)
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("org not found");
+  });
+
+  it("propagates an upstream 500 verbatim (fail loud on partial teardown)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Clerk user deletion failed"),
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .delete(`/internal/admin/orgs/by-external/${EXTERNAL_ORG_ID}`)
+      .set("X-API-Key", VALID_API_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("Clerk user deletion failed");
+  });
+});


### PR DESCRIPTION
## What

Adds a staff-only gateway proxy route:

`DELETE /internal/admin/orgs/by-external/:externalOrgId` → client-service `DELETE /internal/orgs/by-external/:externalOrgId`

client-service resolves the Clerk org id to the internal org, runs the full org-teardown cascade, and deletes the org's Clerk users. The gateway is a pure passthrough — `authenticatePlatform` auth, forwards upstream status + body verbatim, propagates upstream error bodies unmasked (CLAUDE.md #7). Mirrors the existing `DELETE /internal/admin/orgs/:orgId` route in `src/routes/admin.ts`.

## Tests

New `tests/unit/admin-org-teardown-by-external.test.ts` (7 cases): forward to correct downstream path, verbatim body+status on success, X-API-Key sent downstream, 401 without key, 401 with wrong key, upstream 404 + 500 propagated verbatim.

Full suite: 1527 passed. Build (tsc + openapi gen) green.

## Triage

Additive, zero-blast-radius proxy (new route, no existing handler/shape/migration touched) → hotfix → main. End-to-end depends on client-service's route being deployed; ships independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)