### PR TITLE
feat(outlets): forward enrich query param on GET /v1/outlets

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12136,6 +12136,16 @@
           },
           {
             "schema": {
+              "type": "string",
+              "description": "Opt-in enrichment. Pass 'ahref' to have each outlet returned with its Ahrefs Domain Rating + monthly traffic (resolved by outlets-service). Forwarded verbatim; absent = unchanged."
+            },
+            "required": false,
+            "description": "Opt-in enrichment. Pass 'ahref' to have each outlet returned with its Ahrefs Domain Rating + monthly traffic (resolved by outlets-service). Forwarded verbatim; absent = unchanged.",
+            "name": "enrich",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "integer",
               "minimum": 0,
               "exclusiveMinimum": true

--- a/src/routes/outlets.ts
+++ b/src/routes/outlets.ts
@@ -9,7 +9,7 @@ const router = Router();
 router.get("/outlets", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlugs", "featureDynastySlug"]) {
+    for (const key of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlugs", "featureDynastySlug", "enrich"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1015,6 +1015,7 @@ registry.registerPath({
       runId: z.string().optional().openapi({ description: "Filter by run ID (from discover endpoint)" }),
       featureSlugs: z.string().optional().describe("Filter by feature slugs (comma-separated). Use a single slug or multiple."),
       featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug (resolved to all versioned slugs via features-service). Takes priority over featureSlugs."),
+      enrich: z.string().optional().describe("Opt-in enrichment. Pass 'ahref' to have each outlet returned with its Ahrefs Domain Rating + monthly traffic (resolved by outlets-service). Forwarded verbatim; absent = unchanged."),
       limit: z.coerce.number().int().positive().optional(),
       offset: z.coerce.number().int().min(0).optional(),
     }),

--- a/tests/unit/outlets-proxy.test.ts
+++ b/tests/unit/outlets-proxy.test.ts
@@ -26,7 +26,7 @@ describe("Outlets proxy routes", () => {
   });
 
   it("should forward query params on GET /outlets", () => {
-    for (const param of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlugs", "featureDynastySlug"]) {
+    for (const param of ["campaignId", "brandId", "status", "runId", "limit", "offset", "featureSlugs", "featureDynastySlug", "enrich"]) {
       expect(content).toContain(`"${param}"`);
     }
   });
@@ -271,6 +271,16 @@ describe("Outlets OpenAPI schemas", () => {
       getOutletsSection.indexOf("responses:")
     );
     expect(queryBlock).not.toMatch(/\bfeatureSlug\b(?!s)/);
+  });
+
+  it("should include enrich filter on GET /v1/outlets (forwarded verbatim)", () => {
+    const getOutletsSection = schemaContent.slice(
+      schemaContent.indexOf('path: "/v1/outlets"'),
+      schemaContent.indexOf('path: "/v1/outlets"') + 1700
+    );
+    expect(getOutletsSection).toContain("enrich:");
+    // route forwards the enrich query param to outlets-service
+    expect(content).toContain('"enrich"');
   });
 
   it("should document deduplicated response with campaigns[] array on GET /v1/outlets", () => {


### PR DESCRIPTION
## What
Add `enrich` to the `GET /v1/outlets` query-param allowlist so a caller hitting `GET /v1/outlets?...&enrich=ahref` has `enrich` forwarded verbatim to outlets-service `GET /orgs/outlets`.

outlets-service uses this opt-in to return each outlet already carrying its Ahrefs Domain Rating + monthly traffic, so the dashboard can drop its fragile client-side fan-out.

## Why
The gateway drops any query param not on the allowlist, so `enrich` never reached outlets-service. This is a pure-additive transparent passthrough — forwarded only when present, byte-unchanged when absent. No response reshaping, no aggregation (gateway stays a pure proxy per CLAUDE.md).

## Changes
- `src/routes/outlets.ts` — add `"enrich"` to the `GET /outlets` param allowlist
- `src/schemas.ts` — add optional `enrich` to the OpenAPI query schema (loose `z.string()`, no enum cap, per transparent-proxy convention so future `enrich` values pass through)
- `openapi.json` — regenerated
- `tests/unit/outlets-proxy.test.ts` — assert `enrich` is forwarded + present in the OpenAPI schema

## DOD / AC
- ✅ `GET /v1/outlets?brandId=...&enrich=ahref` reaches outlets-service with `enrich=ahref` on the query string
- ✅ All existing forwarded params unchanged
- ✅ openapi/tests updated — 1550 tests pass, `tsc` build clean

## Triage
Additive, zero-blast gateway passthrough param → hotfix→main (prod-direct) per repo ship convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)