### PR TITLE
feat: gateway proxy for per-brand click-destination URL

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4938,6 +4938,30 @@
         "type": "object",
         "properties": {}
       },
+      "ClickDestinationResponse": {
+        "type": "object",
+        "properties": {
+          "clickDestinationUrl": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "clickDestinationUrl"
+        ]
+      },
+      "ClickDestinationRequest": {
+        "type": "object",
+        "properties": {
+          "clickDestinationUrl": {
+            "type": "string",
+            "description": "Page outreach clicks should land on. Must be a valid http(s) URL.",
+            "example": "https://acme.com/welcome"
+          }
+        },
+        "required": [
+          "clickDestinationUrl"
+        ]
+      },
       "IcpSuggestResponse": {
         "type": "object",
         "properties": {}
@@ -20772,6 +20796,158 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/click-destination": {
+      "put": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Set a brand's outreach click-destination URL",
+        "description": "Proxy to brand-service PUT /orgs/brands/{id}/click-destination. Sets the per-brand page outreach clicks should land on (default = brand domain, user-overridable). Body + response shapes are owned by the downstream service; its 4xx validation errors (incl. 400 on a non-http(s)/invalid URL) propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClickDestinationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Click destination saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClickDestinationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid click-destination URL (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand not in caller's org (forwarded verbatim)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -383,6 +383,31 @@ router.put("/brands/:id/sales-economics", authenticate, requireOrg, requireUser,
 });
 
 /**
+ * PUT /v1/brands/:id/click-destination
+ * Proxy to brand-service PUT /orgs/brands/:id/click-destination.
+ * Sets the per-brand page outreach clicks should land on. Body + response
+ * shapes are owned by the downstream service; its 4xx validation errors
+ * (incl. 400 on a non-http(s)/invalid URL) propagate verbatim — passthrough only.
+ */
+router.put("/brands/:id/click-destination", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/click-destination`,
+      {
+        method: "PUT",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Save click destination error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to save click destination" });
+  }
+});
+
+/**
  * POST /v1/brands/:id/transfer
  * Transfer a brand to a different org. Resolves the Clerk org ID to an internal UUID,
  * then proxies to brand-service which orchestrates the full transfer.

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3603,6 +3603,48 @@ registry.registerPath({
 });
 
 // ===================================================================
+// Brand – Click Destination (proxy to brand-service /orgs/brands/:id/click-destination)
+// Downstream owns body + response shapes — passthrough only. No gateway
+// re-validation, so brand-service's 4xx errors propagate verbatim.
+// ===================================================================
+const ClickDestinationRequestSchema = z
+  .object({
+    clickDestinationUrl: z.string().openapi({
+      description: "Page outreach clicks should land on. Must be a valid http(s) URL.",
+      example: "https://acme.com/welcome",
+    }),
+  })
+  .openapi("ClickDestinationRequest");
+const ClickDestinationResponseSchema = z
+  .object({ clickDestinationUrl: z.string() })
+  .openapi("ClickDestinationResponse");
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/brands/{id}/click-destination",
+  tags: ["Brand"],
+  summary: "Set a brand's outreach click-destination URL",
+  description:
+    "Proxy to brand-service PUT /orgs/brands/{id}/click-destination. " +
+    "Sets the per-brand page outreach clicks should land on (default = brand domain, " +
+    "user-overridable). Body + response shapes are owned by the downstream service; its " +
+    "4xx validation errors (incl. 400 on a non-http(s)/invalid URL) propagate verbatim.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: { content: { "application/json": { schema: ClickDestinationRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Click destination saved", content: { "application/json": { schema: ClickDestinationResponseSchema } } },
+    400: { description: "Invalid click-destination URL (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand not in caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+// ===================================================================
 // Brand – ICP Suggest + Brand Profile
 // Transparent proxies to brand-service /orgs/brands/:id/{icp/suggest,brand-profile}.
 // Downstream owns body + response shapes — passthrough only. No gateway

--- a/tests/unit/brand-click-destination.test.ts
+++ b/tests/unit/brand-click-destination.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.brandId = "brand_testabc";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+const BRAND_ID = "11111111-1111-4111-8111-111111111111";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+const savedResponse = { clickDestinationUrl: "https://acme.com/welcome" };
+const putBody = { clickDestinationUrl: "https://acme.com/welcome" };
+
+describe("PUT /v1/brands/:id/click-destination", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(savedResponse),
+      };
+    });
+  });
+
+  it("should return the downstream response verbatim on success", async () => {
+    const res = await request(app).put(`/v1/brands/${BRAND_ID}/click-destination`).send(putBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(savedResponse);
+  });
+
+  it("should forward the body byte-identical (PUT) to brand-service /orgs/brands/:id/click-destination", async () => {
+    await request(app).put(`/v1/brands/${BRAND_ID}/click-destination`).send(putBody);
+
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/click-destination`);
+    expect(capturedInit?.method).toBe("PUT");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual(putBody);
+  });
+
+  it("should forward identity headers (x-org-id, x-user-id, x-run-id)", async () => {
+    await request(app).put(`/v1/brands/${BRAND_ID}/click-destination`).send(putBody);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+  });
+
+  it("should propagate an upstream 400 (invalid URL) verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"error":"Invalid request"}'),
+    }));
+
+    const res = await request(app)
+      .put(`/v1/brands/${BRAND_ID}/click-destination`)
+      .send({ clickDestinationUrl: "ftp://acme.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid request");
+  });
+
+  it("should propagate an upstream 403 (foreign brand) verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve('{"error":"Brand does not belong to the caller\'s org"}'),
+    }));
+
+    const res = await request(app).put(`/v1/brands/${BRAND_ID}/click-destination`).send(putBody);
+
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## What
Gateway proxy so the distribute.you dashboard can persist a brand's **click-destination URL** (the page outreach clicks land on). Pairs with brand-service PR #298 which adds the storage + downstream route.

## Contract (byte-equal: dashboard ↔ api-service ↔ brand-service)
- **`PUT /v1/brands/:id/click-destination`** → brand-service `PUT /orgs/brands/:id/click-destination`. Body `{ clickDestinationUrl: string }` + response owned by brand-service — passthrough verbatim, downstream 4xx (400 invalid URL / 403 foreign / 404 unknown) propagate unchanged. Auth = `authenticate + requireOrg + requireUser + buildInternalHeaders`, identical to the existing `PUT /v1/brands/:id/sales-economics` proxy.
- **Read:** the `clickDestinationUrl` field rides on the existing brand GET proxies (`/v1/brands/:id`, `/v1/brands/by-ids`) with no change — brand-service surfaces it on those reads.

## Changes
- `src/routes/brand.ts` — new PUT proxy mirroring the sales-economics block exactly (passthrough, no re-validation per gateway conventions).
- `src/schemas.ts` — OpenAPI `registerPath` + request/response schemas; `openapi.json` regenerated.
- `tests/unit/brand-click-destination.test.ts` — 5 proxy tests.

## AC
1. ✅ `PUT /v1/brands/:id/click-destination` forwards to brand-service and returns its response verbatim, propagating downstream 4xx.
2. ✅ OpenAPI updated; build + tests green.

## Tests
5 proxy unit tests pass (verbatim response, byte-identical body forward to the correct downstream path, identity-header forwarding, 400 + 403 propagation). Build (`tsc` + openapi gen) green.

## Rollout
Additive. Merge after brand-service #298 lands on staging so the downstream route exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)