### PR TITLE
Retry undici socket-close service calls

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -21,9 +21,10 @@ const TRANSIENT_FETCH_ERROR_CODES = new Set([
   "ENOTFOUND",
   "ETIMEDOUT",
   "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
 ]);
 
-const TRANSIENT_FETCH_ERROR_MESSAGE = /\b(EAI_AGAIN|ECONNREFUSED|ECONNRESET|ENOTFOUND|ETIMEDOUT)\b|timeout (expired|exceeded)/i;
+const TRANSIENT_FETCH_ERROR_MESSAGE = /\b(EAI_AGAIN|ECONNREFUSED|ECONNRESET|ENOTFOUND|ETIMEDOUT|UND_ERR_SOCKET)\b|timeout (expired|exceeded)|other side closed/i;
 const TRANSIENT_FETCH_RETRY_DELAYS_MS = [250, 500, 1_000] as const;
 
 function findTransientFetchCause(error: unknown, seen = new Set<unknown>()): string | null {

--- a/tests/unit/service-client-error-handling.test.ts
+++ b/tests/unit/service-client-error-handling.test.ts
@@ -131,6 +131,32 @@ describe("callExternalService error handling", () => {
     );
   });
 
+  it("retries undici socket-close failures before returning success", async () => {
+    const retrySpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const networkError = new TypeError("fetch failed");
+    (networkError as any).cause = {
+      code: "UND_ERR_SOCKET",
+      message: "other side closed",
+      socket: { bytesWritten: 691, bytesRead: 0 },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ audiences: [] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(callExternalService(service, "/orgs/audiences/suggest", { method: "POST" })).resolves.toEqual({ audiences: [] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(retrySpy).toHaveBeenCalledWith(
+      expect.stringContaining("cause: UND_ERR_SOCKET"),
+    );
+  });
+
   it("does not retry completed upstream HTTP errors", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Summary
- classify undici `UND_ERR_SOCKET` / `other side closed` as a transient fetch failure in the shared service client
- add a regression test matching the human-service audience suggest failure shape

## Verification
- `pnpm vitest run tests/unit/service-client-error-handling.test.ts`
- `pnpm vitest run tests/unit/auth-middleware.test.ts`
- `pnpm vitest run tests/unit/service-client-error-handling.test.ts tests/unit/auth-middleware.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`

Note: `pnpm test` has an order-dependent existing failure in `tests/unit/auth-middleware.test.ts` when run as the full suite (3 status assertions fail). The same auth file passes alone and paired with the changed service-client test.