### PR TITLE
hotfix: Abort upstream SSE fetch on client disconnect to stop OOM memory leak

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -326,6 +326,14 @@ export async function streamExternalService(
   const { method = "POST", body, headers = {}, expressRes } = options;
   const url = `${service.url}${path}`;
 
+  // Abort the upstream fetch the moment the client socket closes. Without this,
+  // a client that disconnects mid-stream (closed tab, navigation, network drop)
+  // leaves the read loop below draining the upstream SSE for its full lifetime
+  // (chat sessions run 30–60 min) — each orphaned reader pins native undici
+  // buffers that never get freed, leaking memory until the container OOMs.
+  const controller = new AbortController();
+  expressRes.on("close", () => controller.abort());
+
   const init: RequestInit & { dispatcher?: Dispatcher } = {
     method,
     headers: {
@@ -334,6 +342,7 @@ export async function streamExternalService(
       ...headers,
     },
     body: body ? JSON.stringify(body) : undefined,
+    signal: controller.signal,
   };
   if (service.dispatcher) init.dispatcher = service.dispatcher;
   const response = await fetch(url, init);
@@ -367,7 +376,11 @@ export async function streamExternalService(
       expressRes.write(value);
     }
   } catch (err) {
-    console.error("[streamExternalService] Stream error:", (err as Error).message);
+    // controller.abort() on client disconnect surfaces here as an AbortError —
+    // that's the expected teardown path, not a failure worth logging as an error.
+    if (!controller.signal.aborted) {
+      console.error("[streamExternalService] Stream error:", (err as Error).message);
+    }
   } finally {
     expressRes.end();
   }

--- a/tests/unit/service-client-error-handling.test.ts
+++ b/tests/unit/service-client-error-handling.test.ts
@@ -192,6 +192,7 @@ describe("streamExternalService error logging", () => {
     const expressRes = {
       status: vi.fn().mockReturnThis(),
       json: vi.fn(),
+      on: vi.fn(),
     } as any;
 
     await streamExternalService(service, "/chat", {

--- a/tests/unit/stream-abort.test.ts
+++ b/tests/unit/stream-abort.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+// streamExternalService must abort the upstream fetch when the client socket
+// closes, otherwise an orphaned reader keeps draining the upstream SSE for its
+// full lifetime and leaks native undici buffers until the container OOMs.
+const clientPath = path.join(__dirname, "../../src/lib/service-client.ts");
+const src = fs.readFileSync(clientPath, "utf-8");
+
+// Narrow to the streamExternalService function body so assertions can't be
+// satisfied by unrelated code elsewhere in the file.
+const streamFn = src.slice(src.indexOf("export async function streamExternalService"));
+
+describe("streamExternalService — client-disconnect abort (OOM fix)", () => {
+  it("creates an AbortController", () => {
+    expect(streamFn).toContain("new AbortController()");
+  });
+
+  it("passes the abort signal to fetch init", () => {
+    expect(streamFn).toContain("signal: controller.signal");
+  });
+
+  it("aborts the upstream fetch when the client socket closes", () => {
+    expect(streamFn).toContain('expressRes.on("close"');
+    expect(streamFn).toContain("controller.abort()");
+  });
+
+  it("does not log an abort-driven teardown as a real error", () => {
+    expect(streamFn).toContain("controller.signal.aborted");
+  });
+});


### PR DESCRIPTION
Automated by release.sh