### PR TITLE
hotfix: Let an org read its own credit-grants ledger (relax per-org grants route to org auth)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -26297,11 +26297,11 @@
         "tags": [
           "Billing"
         ],
-        "summary": "Get an org's credit-grants ledger (staff only)",
-        "description": "List credit grants for the org in context. Staff-only (platform API key + STAFF_EMAILS x-email). Transparent proxy to billing-service GET /v1/credits/grants; response owned by the downstream service.",
+        "summary": "Get the org's own credit-grants ledger",
+        "description": "List the credit grants (welcome credit, first-deposit match, staff bonuses, referral credits) for the org in context — powers the customer dashboard 'Gifts received' section. Normal org auth (same tier as GET /v1/billing/accounts); billing-service scopes the response to the caller's x-org-id, so an org reads only its own grants. Transparent proxy to billing-service GET /v1/credits/grants; response owned by the downstream service.",
         "security": [
           {
-            "apiKeyAuth": []
+            "bearerAuth": []
           }
         ],
         "responses": {
@@ -26317,16 +26317,6 @@
           },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Not staff",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -12,14 +12,20 @@ import { buildInternalHeaders } from "../lib/internal-headers.js";
 const router = Router();
 
 // ---------------------------------------------------------------------------
-// Staff-only credit-grant + grants-ledger proxies to billing-service.
+// Credit-grant + grants-ledger proxies to billing-service.
 //
-// All three routes are gated by `requireStaff` (src/middleware/auth.ts): the caller
-// must come in via the platform API key (authType "admin") AND carry an `x-email` in
-// the STAFF_EMAILS allowlist. The platform key alone is shared with the customer
-// dashboard's server-side proxy, so it does NOT distinguish staff from customer —
-// x-email (forwarded from the verified dashboard/admin session) is the staff signal. A customer
-// can never reach these routes, so cannot self-credit.
+// Two auth tiers:
+//   - STAFF-ONLY (requireStaff): mutating grant (POST /billing/credits/grant) and the
+//     cross-org platform ledger (GET /billing/credits/grants/all). The caller must come in
+//     via the platform API key (authType "admin") AND carry an `x-email` in the STAFF_EMAILS
+//     allowlist. The platform key alone is shared with the customer dashboard's server-side
+//     proxy, so it does NOT distinguish staff from customer — x-email (forwarded from the
+//     verified dashboard/admin session) is the staff signal. A customer can never reach these
+//     routes, so cannot self-credit and cannot read other orgs' grants.
+//   - ORG-SCOPED (authenticate + requireOrg): the per-org grants ledger
+//     (GET /billing/credits/grants). Any authenticated org reads its OWN grants — the customer
+//     dashboard "Gifts received" section. billing-service scopes the response to the caller's
+//     x-org-id, so there is ZERO cross-org exposure (same trust model as GET /billing/accounts).
 //
 // Transparent proxy (CLAUDE.md): body forwarded as-is (rule #4), responses passthrough
 // (rule #8), upstream errors propagated verbatim (rule #7).
@@ -61,18 +67,20 @@ router.post(
   },
 );
 
-// GET /v1/billing/credits/grants — per-org grants ledger (staff only).
+// GET /v1/billing/credits/grants — the org's OWN grants ledger (normal org auth).
+// Powers the customer dashboard "Gifts received" section. billing-service scopes the
+// response to the caller's x-org-id, so an org reads only its own grants (no cross-org
+// exposure). Same auth tier as GET /v1/billing/accounts.
 router.get(
   "/billing/credits/grants",
   authenticate,
   requireOrg,
-  requireStaff,
   async (req: AuthenticatedRequest, res) => {
     try {
       const result = await callExternalService(
         externalServices.billing,
         "/v1/credits/grants",
-        { headers: staffHeaders(req, buildInternalHeaders(req)) },
+        { headers: buildInternalHeaders(req) },
       );
       res.json(result);
     } catch (error: any) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5496,16 +5496,17 @@ registry.registerPath({
   method: "get",
   path: "/v1/billing/credits/grants",
   tags: ["Billing"],
-  summary: "Get an org's credit-grants ledger (staff only)",
+  summary: "Get the org's own credit-grants ledger",
   description:
-    "List credit grants for the org in context. Staff-only (platform API key + STAFF_EMAILS " +
-    "x-email). Transparent proxy to billing-service GET /v1/credits/grants; response owned by " +
-    "the downstream service.",
-  security: platformAuth,
+    "List the credit grants (welcome credit, first-deposit match, staff bonuses, referral " +
+    "credits) for the org in context — powers the customer dashboard 'Gifts received' section. " +
+    "Normal org auth (same tier as GET /v1/billing/accounts); billing-service scopes the response " +
+    "to the caller's x-org-id, so an org reads only its own grants. Transparent proxy to " +
+    "billing-service GET /v1/credits/grants; response owned by the downstream service.",
+  security: authed,
   responses: {
     200: { description: "Org grants ledger — pass-through from billing-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("CreditGrantsResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
-    403: { description: "Not staff", content: errorContent },
     500: { description: "Upstream error", content: errorContent },
   },
 });

--- a/tests/unit/credits-proxy.test.ts
+++ b/tests/unit/credits-proxy.test.ts
@@ -29,11 +29,24 @@ describe("Credit-grant proxy routes (source)", () => {
     expect(content).toContain('"/billing/credits/grants/all"');
   });
 
-  it("should gate org-scoped routes with authenticate + requireOrg + requireStaff", () => {
-    // 2 routes use the org-resolving chain
+  it("should gate the staff grant mutation with authenticate + requireOrg + requireStaff", () => {
+    // Only POST /billing/credits/grant uses the staff org-resolving chain now.
     const matches = content.match(/authenticate,\s*requireOrg,\s*requireStaff/g);
     expect(matches).not.toBeNull();
-    expect(matches!.length).toBe(2);
+    expect(matches!.length).toBe(1);
+  });
+
+  it("should gate the per-org grants ledger with normal org auth (NO requireStaff)", () => {
+    // GET /billing/credits/grants is now readable by any org for its OWN grants
+    // (customer dashboard "Gifts received"). It must use authenticate + requireOrg WITHOUT
+    // requireStaff — same tier as GET /billing/accounts.
+    // Slice just the middleware list of the per-org route: from its mount string up to the
+    // start of its async handler (so the grants/all comment that follows is excluded).
+    const mountIdx = content.indexOf('"/billing/credits/grants"');
+    const middlewares = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(middlewares).toContain("authenticate,");
+    expect(middlewares).toContain("requireOrg,");
+    expect(middlewares).not.toContain("requireStaff");
   });
 
   it("should gate the cross-org ledger with authenticatePlatform + requireStaff (no org)", () => {
@@ -43,10 +56,12 @@ describe("Credit-grant proxy routes (source)", () => {
     expect(matches!.length).toBe(1);
   });
 
-  it("every route uses requireStaff", () => {
-    const matches = content.match(/requireStaff/g);
-    // 1 import + 3 route usages
-    expect(matches!.length).toBeGreaterThanOrEqual(4);
+  it("staff gate (requireStaff) remains on exactly the mutating grant + cross-org ledger", () => {
+    // Match `requireStaff,` (import + middleware usages) — prose comments mentioning the
+    // word lack the trailing comma, so this counts code references only.
+    const matches = content.match(/requireStaff,/g);
+    // 1 import + 2 route usages (POST grant, GET grants/all). The per-org GET grants dropped it.
+    expect(matches!.length).toBe(3);
   });
 
   it("should forward correct LOCKED downstream billing paths", () => {


### PR DESCRIPTION
Automated by release.sh