### PR TITLE
hotfix: Forward statuses query param on audience-stats proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -33742,6 +33742,17 @@
             "in": "query"
           },
           {
+            "schema": {
+              "type": "string",
+              "description": "Optional comma-separated subset of active,paused,archived to scope which audiences are included (features-service owns the default)",
+              "example": "active,paused,archived"
+            },
+            "required": false,
+            "description": "Optional comma-separated subset of active,paused,archived to scope which audiences are included (features-service owns the default)",
+            "name": "statuses",
+            "in": "query"
+          },
+          {
             "name": "x-org-id",
             "in": "header",
             "required": false,

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -350,7 +350,7 @@ router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, asy
 router.get("/features/:slug/audience-stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "goal", "brandProfileId", "limit"]) {
+    for (const key of ["brandId", "goal", "brandProfileId", "limit", "statuses"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7306,6 +7306,7 @@ registry.registerPath({
       goal: z.string().openapi({ example: "signup" }).describe("Optimization goal (required)"),
       brandProfileId: z.string().optional().openapi({ example: "profile-uuid-123" }).describe("Optional brand-profile version to scope evidence"),
       limit: z.string().optional().openapi({ example: "3" }).describe("Optional row limit after sorting"),
+      statuses: z.string().optional().openapi({ example: "active,paused,archived" }).describe("Optional comma-separated subset of active,paused,archived to scope which audiences are included (features-service owns the default)"),
     }),
   },
   responses: {

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -140,13 +140,14 @@ describe("Features proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
-  it("should forward brandId, goal, brandProfileId, and limit on GET /features/:slug/audience-stats", () => {
+  it("should forward brandId, goal, brandProfileId, limit, and statuses on GET /features/:slug/audience-stats", () => {
     const audienceStatsIdx = content.indexOf('"/features/:slug/audience-stats"');
     const audienceStatsBlock = content.slice(audienceStatsIdx, audienceStatsIdx + 500);
     expect(audienceStatsBlock).toContain('"brandId"');
     expect(audienceStatsBlock).toContain('"goal"');
     expect(audienceStatsBlock).toContain('"brandProfileId"');
     expect(audienceStatsBlock).toContain('"limit"');
+    expect(audienceStatsBlock).toContain('"statuses"');
     expect(audienceStatsBlock).toContain("/audience-stats");
   });
 


### PR DESCRIPTION
Automated by release.sh