### PR TITLE
feat(emails): proxy GET /v1/emails/by-lead/:leadId to content-generation-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7142,6 +7142,19 @@
           "emails"
         ]
       },
+      "EmailByLeadResponse": {
+        "type": "object",
+        "properties": {
+          "generation": {
+            "type": "object",
+            "nullable": true,
+            "properties": {}
+          }
+        },
+        "required": [
+          "generation"
+        ]
+      },
       "WorkflowExamplesResponse": {
         "type": "object",
         "properties": {
@@ -27239,6 +27252,118 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/emails/by-lead/{leadId}": {
+      "get": {
+        "tags": [
+          "Emails"
+        ],
+        "summary": "Get the generated email for a lead",
+        "description": "The generated email (subject + body + follow-up sequence) for a single lead. Transparent proxy to content-generation-service GET /generations/by-lead/{leadId}; body forwarded verbatim. Returns { generation: null } when no email has been generated for the lead yet (a normal empty state, not an error).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Lead ID"
+            },
+            "required": true,
+            "name": "leadId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The lead's generated email, or null if none exists yet (passthrough — owned by content-generation-service)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailByLeadResponse"
                 }
               }
             }

--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -86,6 +86,40 @@ router.get("/emails", authenticate, requireOrg, requireUser, async (req: Authent
 });
 
 /**
+ * GET /v1/emails/by-lead/:leadId — the generated email for ONE lead.
+ * Transparent proxy to content-generation-service GET /generations/by-lead/:leadId
+ * (org-scoped via identity headers). Body forwarded verbatim (CLAUDE.md #8 — downstream
+ * owns the generation shape; no field re-declaration / stripping).
+ *
+ * Upstream 404 ("Generation not found") is a NORMAL empty state ("no email yet for this
+ * lead"), so it maps to 200 { generation: null } — NOT a client-facing error. Any other
+ * upstream error propagates verbatim (fail loud).
+ */
+router.get(
+  "/emails/by-lead/:leadId",
+  authenticate,
+  requireOrg,
+  requireUser,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const result = await callExternalService(
+        externalServices.emailgen,
+        `/generations/by-lead/${encodeURIComponent(req.params.leadId)}`,
+        { headers: buildInternalHeaders(req) },
+      ) as { generation: Record<string, unknown> };
+      res.json({ generation: result.generation });
+    } catch (error: any) {
+      // No generation yet for this lead → normal empty state, not an error.
+      if (error.statusCode === 404) {
+        return res.json({ generation: null });
+      }
+      console.error("[api-service] Get email by lead error:", error.message);
+      res.status(error.statusCode || 500).json({ error: error.message || "Failed to get email for lead" });
+    }
+  },
+);
+
+/**
  * POST /v1/emails/send
  * Send a transactional email via the transactional-email service
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5794,6 +5794,39 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/emails/by-lead/{leadId}",
+  tags: ["Emails"],
+  summary: "Get the generated email for a lead",
+  description:
+    "The generated email (subject + body + follow-up sequence) for a single lead. " +
+    "Transparent proxy to content-generation-service GET /generations/by-lead/{leadId}; body forwarded verbatim. " +
+    "Returns { generation: null } when no email has been generated for the lead yet (a normal empty state, not an error).",
+  security: authed,
+  request: {
+    params: z.object({
+      leadId: z.string().openapi({ description: "Lead ID" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "The lead's generated email, or null if none exists yet (passthrough — owned by content-generation-service)",
+      content: {
+        "application/json": {
+          // Passthrough per CLAUDE.md #8 — downstream owns the generation shape; do NOT re-declare fields.
+          schema: z
+            .object({ generation: z.object({}).passthrough().nullable() })
+            .passthrough()
+            .openapi("EmailByLeadResponse"),
+        },
+      },
+    },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/workflow-examples",
   tags: ["Emails"],
   summary: "List example emails for a workflow",

--- a/tests/unit/emails.test.ts
+++ b/tests/unit/emails.test.ts
@@ -195,6 +195,74 @@ describe("GET /v1/emails/stats", () => {
   });
 });
 
+describe("GET /v1/emails/by-lead/:leadId", () => {
+  let app: express.Express;
+
+  function mockFetch(impl: (url: string, init?: RequestInit) => any) {
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const headers = init?.headers ? Object.fromEntries(Object.entries(init.headers)) : undefined;
+      fetchCalls.push({ url, method: init?.method, headers });
+      return impl(url, init);
+    });
+    app = createApp();
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+  });
+
+  it("proxies to content-gen /generations/by-lead/:leadId and forwards the generation byte-identical", async () => {
+    const generation = {
+      id: "gen_1",
+      campaignId: "camp_1",
+      subject: "Hi Kevin",
+      bodyHtml: "<p>Hi</p>",
+      bodyText: "Hi",
+      sequence: [{ step: 1, subject: "Follow up" }],
+      leadId: "lead_abc",
+      createdAt: "2026-06-28T00:00:00.000Z",
+    };
+    mockFetch(() => ({ ok: true, json: () => Promise.resolve({ generation }) }));
+
+    const res = await request(app).get("/v1/emails/by-lead/lead_abc");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ generation });
+
+    const call = fetchCalls.find((c) => c.url.includes("/generations/by-lead/"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("/generations/by-lead/lead_abc");
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-user-id"]).toBe("user_test123");
+  });
+
+  it("maps upstream 404 (no generation yet) to 200 { generation: null }", async () => {
+    mockFetch(() => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"Generation not found"}'),
+    }));
+
+    const res = await request(app).get("/v1/emails/by-lead/lead_none");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ generation: null });
+  });
+
+  it("propagates non-404 upstream errors (fail loud)", async () => {
+    mockFetch(() => ({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('{"error":"boom"}'),
+    }));
+
+    const res = await request(app).get("/v1/emails/by-lead/lead_err");
+
+    expect(res.status).toBe(500);
+  });
+});
+
 describe("PUT /v1/emails/templates", () => {
   let app: express.Express;
 


### PR DESCRIPTION
## What
New org-scoped gateway route for the distribute.you Leads page (lead detail right panel): fetch the generated email (subject + body + follow-up sequence) for ONE lead.

`GET /v1/emails/by-lead/:leadId`

## How
- `authenticate + requireOrg + requireUser` (same tier as `GET /v1/emails`); identity headers forwarded via `buildInternalHeaders` so content-gen scopes by org.
- Transparent proxy → content-generation-service `GET /generations/by-lead/:leadId`.
- Passthrough response per CLAUDE.md #8 — no field re-declaration / stripping (dashboard reads `subject`, `bodyHtml`, `bodyText`, `sequence`, `createdAt`, `leadId`).
- **Upstream 404** ("Generation not found") → `200 { generation: null }` — "no email yet" is a normal empty state, not an error.
- Other upstream errors propagate verbatim (fail loud).
- OpenAPI regenerated (`EmailByLeadResponse`).

## Contract (LOCKED, dashboard ↔ api-service, byte-equal)
- Path: `GET /v1/emails/by-lead/:leadId`
- Success: `200 { "generation": <content-gen generation object> | null }`

## Tests
- New `emails.test.ts` cases: proxies to correct downstream path + forwards generation byte-identical + identity headers; 404→`{generation:null}`; non-404 propagates as error.
- Full suite green: 1564 pass, 0 fail. `tsc` + build green.

Triage: staging (additive, zero-blast-radius proxy route), promotable to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)