### PR TITLE
feat(instantly): staff-gated proxy GET /v1/instantly/audit/reconcile

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6921,6 +6921,10 @@
         "type": "object",
         "properties": {}
       },
+      "InstantlyReconcileResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "BillingCheckoutResponse": {
         "type": "object",
         "properties": {}
@@ -26552,6 +26556,119 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/InstantlySendingForecastResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not staff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/instantly/audit/reconcile": {
+      "get": {
+        "tags": [
+          "Instantly"
+        ],
+        "summary": "Get the platform local-vs-Instantly reconciliation audit (staff only)",
+        "description": "Fleet-wide Instantly reconciliation audit: for each countable fact, our LOCAL number vs INSTANTLY's number plus the delta, so staff can spot cold-email data drift (cross-org ops data, NOT customer data) — powers the staff 'Audit → Instantly' ops page. Staff-only (platform API key + STAFF_EMAILS x-email); no org context required. Transparent proxy to instantly-service GET /internal/audit/reconcile; response owned by the downstream service.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reconciliation audit — pass-through from instantly-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstantlyReconcileResponse"
                 }
               }
             }

--- a/src/routes/instantly.ts
+++ b/src/routes/instantly.ts
@@ -54,4 +54,27 @@ router.get(
   },
 );
 
+// GET /v1/instantly/audit/reconcile — platform local-vs-Instantly reconciliation audit (staff only).
+// Transparent proxy to instantly-service GET /internal/audit/reconcile; no org
+// context, response owned by the downstream service.
+router.get(
+  "/instantly/audit/reconcile",
+  authenticatePlatform,
+  requireStaff,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const result = await callExternalService(
+        externalServices.instantly,
+        "/internal/audit/reconcile",
+        { headers: staffHeaders(req) },
+      );
+      res.json(result);
+    } catch (error: any) {
+      res
+        .status(error.statusCode || 500)
+        .json({ error: error.message || "Failed to get instantly reconcile audit" });
+    }
+  },
+);
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5549,6 +5549,26 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/v1/instantly/audit/reconcile",
+  tags: ["Instantly"],
+  summary: "Get the platform local-vs-Instantly reconciliation audit (staff only)",
+  description:
+    "Fleet-wide Instantly reconciliation audit: for each countable fact, our LOCAL number vs " +
+    "INSTANTLY's number plus the delta, so staff can spot cold-email data drift (cross-org ops " +
+    "data, NOT customer data) — powers the staff 'Audit → Instantly' ops page. Staff-only " +
+    "(platform API key + STAFF_EMAILS x-email); no org context required. Transparent proxy to " +
+    "instantly-service GET /internal/audit/reconcile; response owned by the downstream service.",
+  security: platformAuth,
+  responses: {
+    200: { description: "Reconciliation audit — pass-through from instantly-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("InstantlyReconcileResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Not staff", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "post",
   path: "/v1/billing/checkout-sessions",
   tags: ["Billing"],

--- a/tests/unit/instantly-proxy.test.ts
+++ b/tests/unit/instantly-proxy.test.ts
@@ -54,3 +54,29 @@ describe("Instantly audit proxy route (source)", () => {
     expect(schemaContent).toContain("security: platformAuth");
   });
 });
+
+describe("Instantly reconcile audit proxy route (source)", () => {
+  it("should have GET /instantly/audit/reconcile route", () => {
+    expect(content).toContain('"/instantly/audit/reconcile"');
+    expect(content).toContain("router.get");
+  });
+
+  it("forwards to instantly-service downstream path verbatim", () => {
+    expect(content).toContain("externalServices.instantly");
+    expect(content).toContain('"/internal/audit/reconcile"');
+  });
+
+  it("is staff-gated with authenticatePlatform + requireStaff (no org)", () => {
+    const mountIdx = content.indexOf('"/instantly/audit/reconcile"');
+    const chain = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(chain).toContain("authenticatePlatform,");
+    expect(chain).toContain("requireStaff,");
+    expect(chain).not.toContain("requireOrg");
+  });
+
+  it("registers the OpenAPI path with passthrough response + platform auth", () => {
+    expect(schemaContent).toContain('path: "/v1/instantly/audit/reconcile"');
+    expect(schemaContent).toContain('InstantlyReconcileResponse');
+    expect(schemaContent).toContain("security: platformAuth");
+  });
+});


### PR DESCRIPTION
Transparent proxy exposing instantly-service's new staff reconcile audit through the gateway, mirroring the existing sending-forecast audit proxy.

## What
- `GET /v1/instantly/audit/reconcile` → instantly-service `GET /internal/audit/reconcile`
- Staff-only tier: `authenticatePlatform + requireStaff` (no org context, cross-org ops read)
- Forwards verified `x-email` downstream for staff attribution
- Passthrough response (`InstantlyReconcileResponse`), shape owned by downstream (5 metrics: activeCampaigns, emailsSent, contactedDispatched, contactsStored, pendingSends)
- OpenAPI regenerated

## Why
Powers the admin "Audit → Instantly" reconciliation page (local count vs Instantly count + delta) on admin.distribute.you, exactly like the sending-forecast audit.

## Verification
- Build green, 1575 tests pass (incl. new `instantly-proxy.test.ts` reconcile cases)
- Downstream endpoint verified live on instantly-service `origin/main` (tag v0.50.5, `src/routes/audit.ts`)

Triage: hotfix → main (additive transparent proxy, zero blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)