### PR TITLE
feat(leads): guard + document per-lead `audience` passthrough on GET /v1/leads (#637)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4632,7 +4632,7 @@
                 "nullable": true
               }
             },
-            "description": "Array of LeadDetail objects from lead-service. Each item includes top-level fields (id, leadId, email, namespace, apolloPersonId, emailStatus, status, statusReason, statusDetails, parentRunId, runId, brandIds, campaignId, orgId, userId, workflowSlug, featureSlug, servedAt, contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global) plus a canonical `lead: FullLead | null` payload."
+            "description": "Array of LeadDetail objects from lead-service. Each item includes top-level fields (id, leadId, email, namespace, apolloPersonId, emailStatus, status, statusReason, statusDetails, parentRunId, runId, brandIds, campaignId, orgId, userId, workflowSlug, featureSlug, servedAt, contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global, audience: { id, name, avatarUrl } | null) plus a canonical `lead: FullLead | null` payload."
           }
         },
         "required": [

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3052,7 +3052,7 @@ registry.registerPath({
                 "(id, leadId, email, namespace, apolloPersonId, emailStatus, status, statusReason, statusDetails, " +
                 "parentRunId, runId, brandIds, campaignId, orgId, userId, workflowSlug, featureSlug, servedAt, " +
                 "contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, " +
-                "lastDeliveredAt, global) plus a canonical `lead: FullLead | null` payload."
+                "lastDeliveredAt, global, audience: { id, name, avatarUrl } | null) plus a canonical `lead: FullLead | null` payload."
               ),
             })
             .openapi("BrandLeadsResponse"),

--- a/tests/unit/leads-audience-passthrough.regression.test.ts
+++ b/tests/unit/leads-audience-passthrough.regression.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * Regression test (api-service#637): GET /v1/leads is a transparent proxy to
+ * lead-service GET /orgs/leads. Each lead's new `audience` object
+ * ({ id, name, avatarUrl } | null, resolved server-side by lead-service#346)
+ * MUST be forwarded byte-identical on both the basic and full views — no
+ * stripping, no re-declaring downstream fields (per CLAUDE.md rules #6/#8).
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import leadsRouter from "../../src/routes/leads.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", leadsRouter);
+  return app;
+}
+
+// Upstream body exactly as lead-service returns it, including the new per-lead
+// `audience` object and one lead with `audience: null` (no audience resolved).
+const upstreamBody = {
+  leads: [
+    {
+      id: "row-1",
+      leadId: "lead-1",
+      email: "a@example.com",
+      status: "active",
+      audience: { id: "aud-1", name: "Founders", avatarUrl: "https://cdn/x.png" },
+      lead: { firstName: "A" },
+    },
+    {
+      id: "row-2",
+      leadId: "lead-2",
+      email: "b@example.com",
+      status: "active",
+      audience: null,
+      lead: { firstName: "B" },
+    },
+  ],
+};
+
+describe("GET /v1/leads — per-lead audience passthrough (#637)", () => {
+  let capturedUrls: string[];
+
+  beforeEach(() => {
+    capturedUrls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrls.push(url);
+      return { ok: true, json: () => Promise.resolve(upstreamBody) };
+    });
+  });
+
+  it("forwards the upstream body verbatim (audience included) on view=basic", async () => {
+    const res = await request(buildApp()).get(
+      "/v1/leads?brandId=11111111-1111-1111-1111-111111111111&view=basic"
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstreamBody);
+  });
+
+  it("forwards the upstream body verbatim (audience included) on the full view", async () => {
+    const res = await request(buildApp()).get(
+      "/v1/leads?brandId=11111111-1111-1111-1111-111111111111"
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(upstreamBody);
+  });
+
+  it("does not strip or transform the audience object on any lead", async () => {
+    const res = await request(buildApp()).get(
+      "/v1/leads?brandId=11111111-1111-1111-1111-111111111111&view=basic"
+    );
+    expect(res.body.leads[0].audience).toEqual({
+      id: "aud-1",
+      name: "Founders",
+      avatarUrl: "https://cdn/x.png",
+    });
+    expect(res.body.leads[1].audience).toBeNull();
+  });
+
+  it("forwards view=basic to lead-service /orgs/leads", async () => {
+    await request(buildApp()).get(
+      "/v1/leads?brandId=11111111-1111-1111-1111-111111111111&view=basic"
+    );
+    const call = capturedUrls.find((u) => u.includes("/orgs/leads"));
+    expect(call).toBeDefined();
+    expect(call).toContain("view=basic");
+  });
+});


### PR DESCRIPTION
## What

`GET /v1/leads` is already a **transparent record passthrough** to lead-service `GET /orgs/leads` (`res.json(result)`; the OpenAPI response schema `z.array(z.record(z.unknown()))` is doc-only, never applied at runtime). So the new per-lead `audience` object (`{ id, name, avatarUrl } | null`, resolved server-side by **sales-lead-service#346**) forwards **unchanged on both `view=basic` and the full view with zero handler change**.

This PR makes that guarantee explicit and permanent — it does **not** change forwarding behavior:

- **Regression test** (`tests/unit/leads-audience-passthrough.regression.test.ts`) — byte-identical forward assertion: `audience` (incl. the `null` case) survives on both views; `view=basic` reaches lead-service. Follows the rule #6 passthrough-test convention (assert forwarded path + byte-identical body, no downstream shape re-declaration).
- **OpenAPI doc** — note `audience: { id, name, avatarUrl } | null` in the `GET /v1/leads` description enumeration; regenerate `openapi.json`.

## AC
- ✅ AC1 — per-lead `audience` forwarded unchanged on `/v1/leads`, both views (guarded by test).
- ✅ AC2 — no behavior change to any other lead field (pure passthrough; test asserts full-body equality).

## ⚠️ Merge held — BLOCKED BY sales-lead-service#346
Verified against lead-service `main` openapi: **`audience`/`avatarUrl` not yet shipped** (issue #346 still OPEN). Per the brief's gate, **do not merge until the field is live on lead-service staging**. Merging this early is harmless (pure passthrough) but the OpenAPI doc would advertise `audience` before upstream serves it — hold until #346 lands.

Closes the api-service side of #637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)