### PR TITLE
feat(features): staff-gated proxy GET /v1/features/audit/accounts

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -189,6 +189,10 @@
         "type": "object",
         "properties": {}
       },
+      "StaffAccountsResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -10388,6 +10392,119 @@
             }
           }
         }
+      }
+    },
+    "/v1/features/audit/accounts": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Staff fleet customer accounts + financials (staff only)",
+        "description": "STAFF-ONLY cross-org listing of customer accounts plus fleet financial stats (total daily budget, MRR, ARR). The stats carry cross-org fleet financials, so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/send-forecast); no org context required, no query params. Transparent proxy to features-service GET /internal/stats/accounts. Response (rows + stats + asOf) is producer-owned.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cross-org accounts + fleet financial stats — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffAccountsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not staff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/workflows/ranked": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -290,6 +290,29 @@ router.get("/features/audit/send-forecast", authenticatePlatform, requireStaff, 
 });
 
 /**
+ * GET /v1/features/audit/accounts
+ * STAFF-ONLY cross-org listing of customer accounts plus fleet financial stats (total daily budget,
+ * MRR, ARR). Cross-org fleet financials, so gated by authenticatePlatform + requireStaff (same tier
+ * as GET /v1/features/audit/send-forecast): the caller must come in via the platform API key
+ * (authType "admin") AND carry an x-email in the STAFF_EMAILS allowlist. No org context (cross-org
+ * read), no query params. Transparent proxy to features-service GET /internal/stats/accounts;
+ * response (rows + stats + asOf) owned by the downstream service.
+ */
+router.get("/features/audit/accounts", authenticatePlatform, requireStaff, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      `/internal/stats/accounts`,
+      { headers: staffHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Staff accounts audit error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get accounts" });
+  }
+});
+
+/**
  * GET /v1/features/:slug/pipeline-activity
  * 7-day pipeline activity for a brand. Proxied to features-service GET /features/:slug/pipeline-activity.
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -335,6 +335,24 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/audit/accounts",
+  tags: ["Features"],
+  summary: "Staff fleet customer accounts + financials (staff only)",
+  description:
+    "STAFF-ONLY cross-org listing of customer accounts plus fleet financial stats (total daily budget, MRR, ARR). The stats carry " +
+    "cross-org fleet financials, so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/send-forecast); " +
+    "no org context required, no query params. Transparent proxy to features-service GET /internal/stats/accounts. Response (rows + stats + asOf) is producer-owned.",
+  security: platformAuth,
+  responses: {
+    200: { description: "Cross-org accounts + fleet financial stats — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("StaffAccountsResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Not staff", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
 // Authenticated endpoints — proxied to features-service
 registry.registerPath({
   method: "get",

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -469,6 +469,39 @@ describe("Staff fleet send-forecast proxy route (source)", () => {
   });
 });
 
+describe("Staff fleet accounts audit proxy route (source)", () => {
+  it("registers GET /features/audit/accounts on the router", () => {
+    expect(content).toContain('"/features/audit/accounts"');
+    expect(content).toContain("router.get");
+  });
+
+  it("is staff-gated with authenticatePlatform + requireStaff (no org)", () => {
+    const mountIdx = content.indexOf('"/features/audit/accounts"');
+    const chain = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(chain).toContain("authenticatePlatform,");
+    expect(chain).toContain("requireStaff,");
+    expect(chain).not.toContain("requireOrg");
+  });
+
+  it("proxies to features-service GET /internal/stats/accounts", () => {
+    const mountIdx = content.indexOf('"/features/audit/accounts"');
+    const block = content.slice(mountIdx, mountIdx + 500);
+    expect(block).toContain("externalServices.features");
+    expect(block).toContain("`/internal/stats/accounts`");
+  });
+
+  it("forwards the verified staff x-email downstream for attribution", () => {
+    const mountIdx = content.indexOf('"/features/audit/accounts"');
+    const block = content.slice(mountIdx, mountIdx + 500);
+    expect(block).toContain("staffHeaders(req)");
+  });
+
+  it("registers the OpenAPI path with passthrough response + platform auth", () => {
+    expect(schemaContent).toContain('path: "/v1/features/audit/accounts"');
+    expect(schemaContent).toContain("StaffAccountsResponse");
+  });
+});
+
 describe("Features routes are mounted in index.ts", () => {
   it("should import and mount features routes", () => {
     expect(indexContent).toContain("featuresRoutes");


### PR DESCRIPTION
## What

Add transparent proxy route `GET /v1/features/audit/accounts` to the gateway.

- Auth: `authenticatePlatform` + `requireStaff` (identical tier to `GET /v1/features/audit/send-forecast`).
- Forwards to features-service `GET /internal/stats/accounts` with `staffHeaders(req)`. No query params.
- Response owned by features-service — passthrough (`StaffAccountsResponse` = `z.object({}).passthrough()`), no re-shape.

Powers the admin Audit → Accounts page (cross-org customer accounts + fleet financials: total daily budget, MRR, ARR).

## Notes

- Additive, zero blast radius. The features-service `/internal/stats/accounts` endpoint may not be live on staging yet — this proxy is safe to ship ahead.
- Mirrors the send-forecast block byte-for-byte in shape (route, OpenAPI registration, tests).

## Tests

`pnpm test` → 1592 passed. Build regenerates `openapi.json` (path present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)