### PR TITLE
feat(instantly): proxy staff capacity-history audit to instantly-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6943,6 +6943,10 @@
         "type": "object",
         "properties": {}
       },
+      "InstantlyCapacityHistoryResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "InstantlyReconcileResponse": {
         "type": "object",
         "properties": {}
@@ -27021,6 +27025,130 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/instantly/audit/capacity-history": {
+      "get": {
+        "tags": [
+          "Instantly"
+        ],
+        "summary": "Get the platform sending-capacity-over-time audit (staff only)",
+        "description": "Fleet-wide Instantly sending-capacity history: a time series of in-production sending accounts and daily sending capacity, so staff can chart how the cold-email fleet's capacity evolves (cross-org sending infrastructure ops data, NOT customer data) — powers the staff 'Audit → Instantly' ops page. Staff-only (platform API key + STAFF_EMAILS x-email); no org context required. Transparent proxy to instantly-service GET /internal/audit/capacity-history; response owned by the downstream service.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Number of days of history to return (forwarded to instantly-service)"
+            },
+            "required": false,
+            "description": "Number of days of history to return (forwarded to instantly-service)",
+            "name": "days",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sending-capacity history — pass-through from instantly-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstantlyCapacityHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not staff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/instantly/audit/reconcile": {

--- a/src/routes/instantly.ts
+++ b/src/routes/instantly.ts
@@ -77,6 +77,32 @@ router.get(
   },
 );
 
+// GET /v1/instantly/audit/capacity-history — platform sending-capacity-over-time audit (staff only).
+// Transparent proxy to instantly-service GET /internal/audit/capacity-history; no org
+// context, response owned by the downstream service. Optional `days` query param forwarded through.
+router.get(
+  "/instantly/audit/capacity-history",
+  authenticatePlatform,
+  requireStaff,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const params = new URLSearchParams();
+      if (req.query.days) params.set("days", req.query.days as string);
+      const queryString = params.toString() ? `?${params.toString()}` : "";
+      const result = await callExternalService(
+        externalServices.instantly,
+        `/internal/audit/capacity-history${queryString}`,
+        { headers: staffHeaders(req) },
+      );
+      res.json(result);
+    } catch (error: any) {
+      res
+        .status(error.statusCode || 500)
+        .json({ error: error.message || "Failed to get instantly capacity-history audit" });
+    }
+  },
+);
+
 // GET /v1/instantly/audit/reconcile — platform local-vs-Instantly reconciliation audit (staff only).
 // Transparent proxy to instantly-service GET /internal/audit/reconcile; no org
 // context, response owned by the downstream service.

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5621,6 +5621,32 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/instantly/audit/capacity-history",
+  tags: ["Instantly"],
+  summary: "Get the platform sending-capacity-over-time audit (staff only)",
+  description:
+    "Fleet-wide Instantly sending-capacity history: a time series of in-production sending accounts " +
+    "and daily sending capacity, so staff can chart how the cold-email fleet's capacity evolves " +
+    "(cross-org sending infrastructure ops data, NOT customer data) — powers the staff 'Audit → " +
+    "Instantly' ops page. Staff-only (platform API key + STAFF_EMAILS x-email); no org context " +
+    "required. Transparent proxy to instantly-service GET /internal/audit/capacity-history; response " +
+    "owned by the downstream service.",
+  security: platformAuth,
+  request: {
+    query: z.object({
+      days: z.coerce.number().int().optional().describe("Number of days of history to return (forwarded to instantly-service)"),
+    }),
+  },
+  responses: {
+    200: { description: "Sending-capacity history — pass-through from instantly-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("InstantlyCapacityHistoryResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Not staff", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/instantly/audit/reconcile",
   tags: ["Instantly"],
   summary: "Get the platform local-vs-Instantly reconciliation audit (staff only)",

--- a/tests/unit/instantly-proxy.test.ts
+++ b/tests/unit/instantly-proxy.test.ts
@@ -81,6 +81,41 @@ describe("Instantly account-health audit proxy route (source)", () => {
   });
 });
 
+describe("Instantly capacity-history audit proxy route (source)", () => {
+  it("should have GET /instantly/audit/capacity-history route", () => {
+    expect(content).toContain('"/instantly/audit/capacity-history"');
+    expect(content).toContain("router.get");
+  });
+
+  it("forwards to instantly-service downstream path verbatim", () => {
+    expect(content).toContain("externalServices.instantly");
+    expect(content).toContain("/internal/audit/capacity-history");
+  });
+
+  it("forwards the optional days query param through", () => {
+    const mountIdx = content.indexOf('"/instantly/audit/capacity-history"');
+    const handler = content.slice(mountIdx, mountIdx + 700);
+    expect(handler).toContain("req.query.days");
+    expect(handler).toContain('params.set("days"');
+  });
+
+  it("is staff-gated with authenticatePlatform + requireStaff (no org)", () => {
+    const mountIdx = content.indexOf('"/instantly/audit/capacity-history"');
+    const chain = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(chain).toContain("authenticatePlatform,");
+    expect(chain).toContain("requireStaff,");
+    expect(chain).not.toContain("requireOrg");
+  });
+
+  it("registers the OpenAPI path with passthrough response + platform auth", () => {
+    expect(schemaContent).toContain('path: "/v1/instantly/audit/capacity-history"');
+    expect(schemaContent).toContain('InstantlyCapacityHistoryResponse');
+    const mountIdx = schemaContent.indexOf('path: "/v1/instantly/audit/capacity-history"');
+    const block = schemaContent.slice(mountIdx, mountIdx + 1400);
+    expect(block).toContain("security: platformAuth");
+  });
+});
+
 describe("Instantly reconcile audit proxy route (source)", () => {
   it("should have GET /instantly/audit/reconcile route", () => {
     expect(content).toContain('"/instantly/audit/reconcile"');


### PR DESCRIPTION
## What

Adds a staff-only transparent passthrough at the gateway:

`GET /v1/instantly/audit/capacity-history` → instantly-service `GET /internal/audit/capacity-history`

Mirrors the existing instantly audit proxies (`account-health`, `sending-forecast`, `reconcile`):
- Auth tier: `authenticatePlatform` + `requireStaff` (cross-org platform read, no org context)
- Staff `x-email` forwarded downstream for actor attribution
- Optional `days` query param forwarded through
- Response owned by downstream — passthrough, no shape re-declaration (CLAUDE.md rules #4/#8), upstream errors propagated verbatim (rule #7)

Powers the sending-capacity chart on the admin.distribute.you "Audit → Instantly" ops page.

## Files
- `src/routes/instantly.ts` — new GET route
- `src/schemas.ts` — OpenAPI path registration (passthrough response, `days` query param, platform auth)
- `openapi.json` — regenerated
- `tests/unit/instantly-proxy.test.ts` — mirror test block (26/26 pass)

## ⚠️ Deployment ordering
Additive + dormant. The downstream endpoint (`GET /internal/audit/capacity-history`) is still on instantly-service staging / not yet in prod, and the dashboard consumer has not shipped. **Nothing calls this route yet** — it 502s IF called before the downstream lands, but no caller exists. Safe to land ahead of both. Order for prod: instantly-service endpoint → this gateway route → dashboard chart.

## Tests
- `pnpm build` (tsc + openapi gen) ✅
- `pnpm vitest run` → 1612 pass / 0 fail ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)