### PR TITLE
feat(features): reshape workflow-projection proxy + drop candidates route

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8534,10 +8534,6 @@
         "type": "object",
         "properties": {}
       },
-      "FeatureCandidatesResponse": {
-        "type": "object",
-        "properties": {}
-      },
       "PublicUserStatsResponse": {
         "type": "object",
         "properties": {}
@@ -34994,7 +34990,7 @@
           "Features"
         ],
         "summary": "Feature workflow projection",
-        "description": "Ranks a brand's workflows by cost-per-close and projects a budget through the sales funnel for a specific feature. Scoped by brandId (+ objective, budgetUsd). Proxied from features-service.",
+        "description": "Serves a 3-grain cost-per-outcome projection ladder (crossOrg → brand → audience) + a resolved pick per (audienceId?, workflow dynasty), scoped by brandId (+ goal/objective, audienceId, budgetUsd). Folds in the audience×workflow grain formerly served by the removed /candidates endpoint. Passthrough proxy from features-service — forwards all query params.",
         "security": [
           {
             "bearerAuth": []
@@ -35015,33 +35011,55 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand UUID (required) — scopes the projection to one brand",
+              "description": "Brand UUID (required) — conversion economics are brand-scoped",
               "example": "brand-uuid-123"
             },
             "required": true,
-            "description": "Brand UUID (required) — scopes the projection to one brand",
+            "description": "Brand UUID (required) — conversion economics are brand-scoped",
             "name": "brandId",
             "in": "query"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Sales-funnel objective to project toward",
+              "description": "Optional audience UUID context (echoed via audience rows; audience rows enumerate ALL of the brand's active audiences that ran the workflow)",
+              "example": "audience-uuid-123"
+            },
+            "required": false,
+            "description": "Optional audience UUID context (echoed via audience rows; audience rows enumerate ALL of the brand's active audiences that ran the workflow)",
+            "name": "audienceId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optimization goal (accepts camel/snake/kebab; alias of objective). Defaults to meeting-booked",
+              "example": "meetingBooked"
+            },
+            "required": false,
+            "description": "Optimization goal (accepts camel/snake/kebab; alias of objective). Defaults to meeting-booked",
+            "name": "goal",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Alias of goal (snake/kebab spelling) — kept for back-compat",
               "example": "meeting-booked"
             },
             "required": false,
-            "description": "Sales-funnel objective to project toward",
+            "description": "Alias of goal (snake/kebab spelling) — kept for back-compat",
             "name": "objective",
             "in": "query"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Budget in USD to project through the funnel",
+              "description": "Optional budget context (accepted for back-compat)",
               "example": "1000"
             },
             "required": false,
-            "description": "Budget in USD to project through the funnel",
+            "description": "Optional budget context (accepted for back-compat)",
             "name": "budgetUsd",
             "in": "query"
           },
@@ -35108,163 +35126,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkflowProjectionResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Feature not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/features/{featureSlug}/candidates": {
-      "get": {
-        "tags": [
-          "Features"
-        ],
-        "summary": "Feature candidate evidence set",
-        "description": "Serves the (audienceId, workflow) candidate evidence set for a brand + feature + goal, with per-candidate cost-per-outcome at the audience / brand-goal / goal-global grain ladder. Scoped by brandId + goal (+ optional brandProfileId). Proxied from features-service.",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Feature slug",
-              "example": "sales-cold-email-outreach"
-            },
-            "required": true,
-            "description": "Feature slug",
-            "name": "featureSlug",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Brand UUID (required) — conversion economics are brand-scoped",
-              "example": "brand-uuid-123"
-            },
-            "required": true,
-            "description": "Brand UUID (required) — conversion economics are brand-scoped",
-            "name": "brandId",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Optimization target (required): signup | meetingBooked | purchase",
-              "example": "meetingBooked"
-            },
-            "required": true,
-            "description": "Optimization target (required): signup | meetingBooked | purchase",
-            "name": "goal",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Brand-profile-version context (optional, echoed)",
-              "example": "profile-uuid-123"
-            },
-            "required": false,
-            "description": "Brand-profile-version context (optional, echoed)",
-            "name": "brandProfileId",
-            "in": "query"
-          },
-          {
-            "name": "x-org-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-user-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
-          },
-          {
-            "name": "x-campaign-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-brand-id",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "example": "uuid1,uuid2,uuid3"
-            },
-            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-workflow-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
-          },
-          {
-            "name": "x-feature-slug",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Feature candidate evidence set",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FeatureCandidatesResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -424,14 +424,18 @@ router.get("/features/:slug/audience-stats", authenticate, requireOrg, requireUs
 
 /**
  * GET /v1/features/:slug/workflow-projection
- * Ranks a brand's workflows by cost-per-close and projects a budget through the sales funnel,
- * scoped by brandId. Proxied to features-service GET /features/:slug/workflow-projection.
+ * Serves the 3-grain (crossOrg → brand → audience) cost-per-outcome projection ladder + a
+ * resolved pick per (audienceId?, workflow dynasty), scoped by brandId (+ goal/objective,
+ * audienceId, budgetUsd). Folds in the audience×workflow grain formerly served by the removed candidates route.
+ * Transparent proxy: forwards ALL query params so new downstream params need no api-service edit.
+ * Proxied to features-service GET /features/:slug/workflow-projection.
  */
 router.get("/features/:slug/workflow-projection", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "objective", "budgetUsd"]) {
-      if (req.query[key]) params.set(key, req.query[key] as string);
+    for (const [key, value] of Object.entries(req.query)) {
+      if (typeof value === "string") params.set(key, value);
+      else if (Array.isArray(value)) for (const v of value) if (typeof v === "string") params.append(key, v);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";
     const result = await callExternalService(
@@ -443,31 +447,6 @@ router.get("/features/:slug/workflow-projection", authenticate, requireOrg, requ
   } catch (error: any) {
     console.error("Feature workflow-projection error:", error.message);
     res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature workflow projection" });
-  }
-});
-
-/**
- * GET /v1/features/:slug/candidates
- * Serves the (audienceId, workflow) candidate evidence set for a brand + feature + goal,
- * with per-candidate cost-per-outcome at the audience / brand-goal / goal-global grain ladder.
- * Scoped by brandId + goal. Proxied to features-service GET /features/:slug/candidates.
- */
-router.get("/features/:slug/candidates", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
-  try {
-    const params = new URLSearchParams();
-    for (const key of ["brandId", "goal", "brandProfileId"]) {
-      if (req.query[key]) params.set(key, req.query[key] as string);
-    }
-    const qs = params.toString() ? `?${params.toString()}` : "";
-    const result = await callExternalService(
-      externalServices.features,
-      `/features/${encodeURIComponent(req.params.slug)}/candidates${qs}`,
-      { headers: buildInternalHeaders(req) },
-    );
-    res.json(result);
-  } catch (error: any) {
-    console.error("Feature candidates error:", error.message);
-    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get feature candidates" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7540,42 +7540,20 @@ registry.registerPath({
   tags: ["Features"],
   summary: "Feature workflow projection",
   description:
-    "Ranks a brand's workflows by cost-per-close and projects a budget through the sales funnel for a specific feature. Scoped by brandId (+ objective, budgetUsd). Proxied from features-service.",
-  security: authed,
-  request: {
-    params: z.object({ featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug") }),
-    query: z.object({
-      brandId: z.string().openapi({ example: "brand-uuid-123" }).describe("Brand UUID (required) — scopes the projection to one brand"),
-      objective: z.string().optional().openapi({ example: "meeting-booked" }).describe("Sales-funnel objective to project toward"),
-      budgetUsd: z.string().optional().openapi({ example: "1000" }).describe("Budget in USD to project through the funnel"),
-    }),
-  },
-  responses: {
-    200: { description: "Feature workflow projection", content: { "application/json": { schema: z.object({}).passthrough().openapi("WorkflowProjectionResponse") } } },
-    401: { description: "Unauthorized", content: errorContent },
-    404: { description: "Feature not found", content: errorContent },
-    500: { description: "Internal error", content: errorContent },
-  },
-});
-
-registry.registerPath({
-  method: "get",
-  path: "/v1/features/{featureSlug}/candidates",
-  tags: ["Features"],
-  summary: "Feature candidate evidence set",
-  description:
-    "Serves the (audienceId, workflow) candidate evidence set for a brand + feature + goal, with per-candidate cost-per-outcome at the audience / brand-goal / goal-global grain ladder. Scoped by brandId + goal (+ optional brandProfileId). Proxied from features-service.",
+    "Serves a 3-grain cost-per-outcome projection ladder (crossOrg → brand → audience) + a resolved pick per (audienceId?, workflow dynasty), scoped by brandId (+ goal/objective, audienceId, budgetUsd). Folds in the audience×workflow grain formerly served by the removed /candidates endpoint. Passthrough proxy from features-service — forwards all query params.",
   security: authed,
   request: {
     params: z.object({ featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug") }),
     query: z.object({
       brandId: z.string().openapi({ example: "brand-uuid-123" }).describe("Brand UUID (required) — conversion economics are brand-scoped"),
-      goal: z.string().openapi({ example: "meetingBooked" }).describe("Optimization target (required): signup | meetingBooked | purchase"),
-      brandProfileId: z.string().optional().openapi({ example: "profile-uuid-123" }).describe("Brand-profile-version context (optional, echoed)"),
+      audienceId: z.string().optional().openapi({ example: "audience-uuid-123" }).describe("Optional audience UUID context (echoed via audience rows; audience rows enumerate ALL of the brand's active audiences that ran the workflow)"),
+      goal: z.string().optional().openapi({ example: "meetingBooked" }).describe("Optimization goal (accepts camel/snake/kebab; alias of objective). Defaults to meeting-booked"),
+      objective: z.string().optional().openapi({ example: "meeting-booked" }).describe("Alias of goal (snake/kebab spelling) — kept for back-compat"),
+      budgetUsd: z.string().optional().openapi({ example: "1000" }).describe("Optional budget context (accepted for back-compat)"),
     }),
   },
   responses: {
-    200: { description: "Feature candidate evidence set", content: { "application/json": { schema: z.object({}).passthrough().openapi("FeatureCandidatesResponse") } } },
+    200: { description: "Feature workflow projection", content: { "application/json": { schema: z.object({}).passthrough().openapi("WorkflowProjectionResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     500: { description: "Internal error", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -180,13 +180,17 @@ describe("Features proxy routes", () => {
     expect(line).toContain("requireUser");
   });
 
-  it("should forward brandId, objective and budgetUsd on GET /features/:slug/workflow-projection", () => {
+  it("should forward ALL query params (passthrough) on GET /features/:slug/workflow-projection", () => {
     const projectionIdx = content.indexOf('"/features/:slug/workflow-projection"');
-    const projectionBlock = content.slice(projectionIdx, projectionIdx + 400);
-    expect(projectionBlock).toContain('"brandId"');
-    expect(projectionBlock).toContain('"objective"');
-    expect(projectionBlock).toContain('"budgetUsd"');
+    const projectionBlock = content.slice(projectionIdx, projectionIdx + 600);
+    // Transparent proxy: iterate req.query rather than a fixed whitelist, so brandId,
+    // objective, goal, audienceId, budgetUsd (and any future downstream param) all forward.
+    expect(projectionBlock).toContain("Object.entries(req.query)");
     expect(projectionBlock).toContain("/workflow-projection");
+  });
+
+  it("should NOT proxy the removed GET /features/:slug/candidates route (deleted upstream)", () => {
+    expect(content).not.toContain("/candidates");
   });
 
   it("should enforce requireOrg + requireUser on ALL org-scoped authenticated feature routes", () => {
@@ -313,6 +317,20 @@ describe("Features OpenAPI schemas", () => {
 
   it("should register GET /v1/features/{featureSlug}/workflow-projection", () => {
     expect(schemaContent).toContain('path: "/v1/features/{featureSlug}/workflow-projection"');
+  });
+
+  it("should document audienceId + goal query params on workflow-projection", () => {
+    const idx = schemaContent.indexOf('path: "/v1/features/{featureSlug}/workflow-projection"');
+    const block = schemaContent.slice(idx, idx + 2400);
+    expect(block).toContain("audienceId:");
+    expect(block).toContain("goal:");
+    expect(block).toContain("objective:");
+    expect(block).toContain("budgetUsd:");
+  });
+
+  it("should NOT register the removed GET /v1/features/{featureSlug}/candidates path", () => {
+    expect(schemaContent).not.toContain('path: "/v1/features/{featureSlug}/candidates"');
+    expect(schemaContent).not.toContain("FeatureCandidatesResponse");
   });
 
   it("should document groupBy query param on stats endpoints", () => {


### PR DESCRIPTION
## What

features-service (staging PR #449) reshaped `GET /features/:slug/workflow-projection` (new `rows[]` grain-ladder + `resolved` shape; now also accepts `audienceId` + `goal` query params) and **DELETED** `GET /features/:slug/candidates`. This updates the api-service transparent proxy in lockstep.

## Changes

- **workflow-projection** — forward **ALL** query params (passthrough) instead of the `[brandId, objective, budgetUsd]` whitelist. So `brandId + objective + goal + audienceId + budgetUsd` (and any future downstream param) forward with zero api-service edit. Response stays `res.json(result)` passthrough (CLAUDE.md #8 — proxy forwards bytes, does not re-declare the new `rows[]`/`resolved` body).
- **candidates** — dropped the `GET /v1/features/:slug/candidates` proxy route (removed upstream; rule #5).
- **schemas / OpenAPI** — document `audienceId` + `goal` on workflow-projection; remove the candidates `registerPath` + `FeatureCandidatesResponse`; regenerated `openapi.json`.

## Verification

- `tsc && build` green, `openapi.json` regenerated (candidates path + `FeatureCandidatesResponse` gone, `audienceId`/`goal` present).
- 1625 unit tests pass, incl. new assertions: forward-all mechanism, no `/candidates` route, no candidates schema registration.
- Downstream contract confirmed via staging api-registry: `/features/{featureSlug}/candidates` absent; workflow-projection accepts `brandId` (required), `audienceId`/`goal`/`objective`/`budgetUsd` (optional).

## ⚠️ Follow-up (separate repo — surfacing, not blocking this PR)

**distribute.you** still calls the candidates proxy: `apps/dashboard/src/lib/api.ts:~2014` → `/features/:slug/candidates`. That call is **already broken** (downstream deleted `/candidates` regardless of this PR). The dashboard must migrate to `workflow-projection`'s `rows[]` (the audience×workflow grain is folded into the audience grain rows). Needs a distribute.you workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)