### PR TITLE
feat(features): proxy two new public cost-per-outcome stats endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -185,6 +185,14 @@
         "type": "object",
         "properties": {}
       },
+      "PublicCostPerOutcomeTrendResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "PublicWorkflowCostPerOutcomeResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "StaffSendForecastResponse": {
         "type": "object",
         "properties": {}
@@ -10289,6 +10297,178 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicCostProjectionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/features/cost-per-outcome-trend": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Public cost-per-outcome trend",
+        "description": "Public cross-org dated moving-average cost-per-outcome series for a feature and one objective. Proxied to features-service GET /public/stats/cost-per-outcome-trend. Forwards featureSlug, objective, and optional days/windowOutcomes. Response is producer-owned. No authentication required.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug (required).",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug (required).",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required).",
+              "example": "positiveReply"
+            },
+            "required": true,
+            "description": "Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required).",
+            "name": "objective",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Number of trailing display days to emit (default 30, max 180).",
+              "example": "30"
+            },
+            "required": false,
+            "description": "Number of trailing display days to emit (default 30, max 180).",
+            "name": "days",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Target outcomes per moving-average window (default 100).",
+              "example": "100"
+            },
+            "required": false,
+            "description": "Target outcomes per moving-average window (default 100).",
+            "name": "windowOutcomes",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public cost-per-outcome trend — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicCostPerOutcomeTrendResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/features/workflow-cost-per-outcome": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Public per-workflow cost-per-outcome",
+        "description": "Public cross-org per-workflow-dynasty cost-per-outcome ratio for a feature and one objective. Proxied to features-service GET /public/stats/workflow-cost-per-outcome. Forwards featureSlug and objective. Response is producer-owned. No authentication required.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug (required).",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug (required).",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required).",
+              "example": "positiveReply"
+            },
+            "required": true,
+            "description": "Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required).",
+            "name": "objective",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public per-workflow cost-per-outcome — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicWorkflowCostPerOutcomeResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -20,6 +20,8 @@ const PUBLIC_BEST_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_REVENUE_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_COST_PROJECTION_PARAMS = ["featureSlug"];
+const PUBLIC_COST_PER_OUTCOME_TREND_PARAMS = ["featureSlug", "objective", "days", "windowOutcomes"];
+const PUBLIC_WORKFLOW_COST_PER_OUTCOME_PARAMS = ["featureSlug", "objective"];
 const AUDIT_SEND_FORECAST_PARAMS = ["days"];
 
 // Forward the verified staff email downstream for actor attribution (no org context).
@@ -126,6 +128,46 @@ router.get("/public/features/cost-projection", async (req: Request, res: Respons
   } catch (error: any) {
     console.error("[api-service] Public feature cost projection error:", error.message);
     res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public feature cost projection" });
+  }
+});
+
+/**
+ * GET /v1/public/features/cost-per-outcome-trend
+ * Public dated moving-average cost-per-outcome series for one objective.
+ * Proxied to features-service GET /public/stats/cost-per-outcome-trend.
+ */
+router.get("/public/features/cost-per-outcome-trend", async (req: Request, res: Response) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, PUBLIC_COST_PER_OUTCOME_TREND_PARAMS);
+    const result = await callExternalService(
+      externalServices.features,
+      `/public/stats/cost-per-outcome-trend?${params}`,
+      {},
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public cost-per-outcome trend error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public cost-per-outcome trend" });
+  }
+});
+
+/**
+ * GET /v1/public/features/workflow-cost-per-outcome
+ * Public per-workflow cross-org cost-per-outcome ratio for one objective.
+ * Proxied to features-service GET /public/stats/workflow-cost-per-outcome.
+ */
+router.get("/public/features/workflow-cost-per-outcome", async (req: Request, res: Response) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, PUBLIC_WORKFLOW_COST_PER_OUTCOME_PARAMS);
+    const result = await callExternalService(
+      externalServices.features,
+      `/public/stats/workflow-cost-per-outcome?${params}`,
+      {},
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public workflow cost-per-outcome error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public workflow cost-per-outcome" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -189,6 +189,18 @@ const publicCostProjectionQueryParams = z.object({
   featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
 });
 
+const publicCostPerOutcomeTrendQueryParams = z.object({
+  featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
+  objective: z.string().openapi({ example: "positiveReply" }).describe("Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required)."),
+  days: z.string().optional().openapi({ example: "30" }).describe("Number of trailing display days to emit (default 30, max 180)."),
+  windowOutcomes: z.string().optional().openapi({ example: "100" }).describe("Target outcomes per moving-average window (default 100)."),
+});
+
+const publicWorkflowCostPerOutcomeQueryParams = z.object({
+  featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
+  objective: z.string().openapi({ example: "positiveReply" }).describe("Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required)."),
+});
+
 const auditSendForecastQueryParams = z.object({
   days: z.coerce.number().int().optional().openapi({ example: 14 }).describe("Future horizon in days (1..90). A 7-day past tail is always included. Optional; downstream defaults to 14."),
 });
@@ -311,6 +323,40 @@ registry.registerPath({
   request: { query: publicCostProjectionQueryParams },
   responses: {
     200: { description: "Public feature cost projection — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicCostProjectionResponse") } } },
+    400: { description: "Bad request from features-service", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/public/features/cost-per-outcome-trend",
+  tags: ["Features"],
+  summary: "Public cost-per-outcome trend",
+  description:
+    "Public cross-org dated moving-average cost-per-outcome series for a feature and one objective. " +
+    "Proxied to features-service GET /public/stats/cost-per-outcome-trend. Forwards featureSlug, objective, and optional days/windowOutcomes. Response is producer-owned. No authentication required.",
+  request: { query: publicCostPerOutcomeTrendQueryParams },
+  responses: {
+    200: { description: "Public cost-per-outcome trend — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicCostPerOutcomeTrendResponse") } } },
+    400: { description: "Bad request from features-service", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/public/features/workflow-cost-per-outcome",
+  tags: ["Features"],
+  summary: "Public per-workflow cost-per-outcome",
+  description:
+    "Public cross-org per-workflow-dynasty cost-per-outcome ratio for a feature and one objective. " +
+    "Proxied to features-service GET /public/stats/workflow-cost-per-outcome. Forwards featureSlug and objective. Response is producer-owned. No authentication required.",
+  request: { query: publicWorkflowCostPerOutcomeQueryParams },
+  responses: {
+    200: { description: "Public per-workflow cost-per-outcome — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicWorkflowCostPerOutcomeResponse") } } },
     400: { description: "Bad request from features-service", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -411,6 +411,34 @@ describe("Public features proxy routes", () => {
     expect(content).toContain("`/public/stats/cost-projection");
   });
 
+  it("should have GET /public/features/cost-per-outcome-trend without auth middleware", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/public/features/cost-per-outcome-trend"')
+    );
+    expect(line).toBeDefined();
+    expect(line).not.toContain("authenticate");
+    expect(line).not.toContain("requireOrg");
+  });
+
+  it("should proxy public cost-per-outcome trend to /public/stats/cost-per-outcome-trend on features-service", () => {
+    expect(content).toContain('"/public/features/cost-per-outcome-trend"');
+    expect(content).toContain("`/public/stats/cost-per-outcome-trend");
+  });
+
+  it("should have GET /public/features/workflow-cost-per-outcome without auth middleware", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/public/features/workflow-cost-per-outcome"')
+    );
+    expect(line).toBeDefined();
+    expect(line).not.toContain("authenticate");
+    expect(line).not.toContain("requireOrg");
+  });
+
+  it("should proxy public workflow cost-per-outcome to /public/stats/workflow-cost-per-outcome on features-service", () => {
+    expect(content).toContain('"/public/features/workflow-cost-per-outcome"');
+    expect(content).toContain("`/public/stats/workflow-cost-per-outcome");
+  });
+
   it("should NOT expose a public send-forecast route (cross-org fleet financials moved to staff)", () => {
     expect(content).not.toContain('"/public/features/send-forecast"');
     expect(content).not.toContain("/public/stats/send-forecast");
@@ -445,6 +473,16 @@ describe("Public features OpenAPI schemas", () => {
   it("should register GET /v1/public/features/cost-projection", () => {
     expect(schemaContent).toContain('path: "/v1/public/features/cost-projection"');
     expect(schemaContent).toContain("PublicCostProjectionResponse");
+  });
+
+  it("should register GET /v1/public/features/cost-per-outcome-trend", () => {
+    expect(schemaContent).toContain('path: "/v1/public/features/cost-per-outcome-trend"');
+    expect(schemaContent).toContain("PublicCostPerOutcomeTrendResponse");
+  });
+
+  it("should register GET /v1/public/features/workflow-cost-per-outcome", () => {
+    expect(schemaContent).toContain('path: "/v1/public/features/workflow-cost-per-outcome"');
+    expect(schemaContent).toContain("PublicWorkflowCostPerOutcomeResponse");
   });
 
   it("should NOT register GET /v1/public/features/send-forecast (moved to staff)", () => {


### PR DESCRIPTION
## What

Forward the two new features-service **public cross-org** stats endpoints through the gateway, under the same `/v1/public/features` namespace + remapping convention the existing public feature-stats proxies (ranked / best / revenue / cost-projection / workflow-engagement-latency) already use.

| Gateway (new) | Downstream (features-service) | Params |
|---|---|---|
| `GET /v1/public/features/cost-per-outcome-trend` | `GET /public/stats/cost-per-outcome-trend` | `featureSlug`, `objective` (req); `days`, `windowOutcomes` (opt) |
| `GET /v1/public/features/workflow-cost-per-outcome` | `GET /public/stats/workflow-cost-per-outcome` | `featureSlug`, `objective` (req) |

Unblocks the staff admin analytics page (distribute.you #2486) which reads these cross-org public stats through the gateway.

## Why

The gateway forwards the `/public/stats/*` family via explicit per-route proxies, not a wildcard — so the two brand-new members (features-service#485) were 404 at the gateway until mirrored here.

## How

- `src/routes/features.ts` — two GET handlers, no auth, query params forwarded, JSON relayed byte-identical (same shape as sibling `cost-projection` / `ranked` public proxies).
- `src/schemas.ts` — passthrough response schemas (`z.object({}).passthrough()`, per CLAUDE.md #8) + query-param schemas.
- `openapi.json` regenerated.
- `tests/unit/features-proxy.test.ts` — route + OpenAPI registration assertions mirroring existing public proxies.

## Contract discovery

Paths + params read from api-registry **staging** (features-service deployed shape), not source.

## No-gos honored

- Transparent passthrough only — no response reshape, no business logic.
- No new auth — public, api-key-free, exactly like sibling public proxies.
- Additive — existing public feature-stats proxies untouched.

## Tests

`pnpm test` → 1641 passed (136 files). `pnpm build` clean (tsc + openapi gen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
