### PR TITLE
feat(features): proxy public lifetime cost-per-outcome stats endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -193,6 +193,10 @@
         "type": "object",
         "properties": {}
       },
+      "PublicCostPerOutcomeLifetimeResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "StaffSendForecastResponse": {
         "type": "object",
         "properties": {}
@@ -10469,6 +10473,70 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicWorkflowCostPerOutcomeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/features/cost-per-outcome-lifetime": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Public lifetime cost-per-outcome",
+        "description": "Public lifetime (all-history) cross-org average cost-per-outcome across all optimization objectives for a feature. Proxied to features-service GET /public/stats/cost-per-outcome-lifetime. Forwards featureSlug. Response is producer-owned. No authentication required.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug (required).",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug (required).",
+            "name": "featureSlug",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public lifetime cost-per-outcome — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicCostPerOutcomeLifetimeResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -22,6 +22,7 @@ const PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_COST_PROJECTION_PARAMS = ["featureSlug"];
 const PUBLIC_COST_PER_OUTCOME_TREND_PARAMS = ["featureSlug", "objective", "days", "windowOutcomes"];
 const PUBLIC_WORKFLOW_COST_PER_OUTCOME_PARAMS = ["featureSlug", "objective"];
+const PUBLIC_COST_PER_OUTCOME_LIFETIME_PARAMS = ["featureSlug"];
 const AUDIT_SEND_FORECAST_PARAMS = ["days"];
 
 // Forward the verified staff email downstream for actor attribution (no org context).
@@ -168,6 +169,26 @@ router.get("/public/features/workflow-cost-per-outcome", async (req: Request, re
   } catch (error: any) {
     console.error("[api-service] Public workflow cost-per-outcome error:", error.message);
     res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public workflow cost-per-outcome" });
+  }
+});
+
+/**
+ * GET /v1/public/features/cost-per-outcome-lifetime
+ * Public lifetime (all-history) cross-org average cost-per-outcome across all objectives for a feature.
+ * Proxied to features-service GET /public/stats/cost-per-outcome-lifetime.
+ */
+router.get("/public/features/cost-per-outcome-lifetime", async (req: Request, res: Response) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, PUBLIC_COST_PER_OUTCOME_LIFETIME_PARAMS);
+    const result = await callExternalService(
+      externalServices.features,
+      `/public/stats/cost-per-outcome-lifetime?${params}`,
+      {},
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public cost-per-outcome lifetime error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public cost-per-outcome lifetime" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -201,6 +201,10 @@ const publicWorkflowCostPerOutcomeQueryParams = z.object({
   objective: z.string().openapi({ example: "positiveReply" }).describe("Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required)."),
 });
 
+const publicCostPerOutcomeLifetimeQueryParams = z.object({
+  featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
+});
+
 const auditSendForecastQueryParams = z.object({
   days: z.coerce.number().int().optional().openapi({ example: 14 }).describe("Future horizon in days (1..90). A 7-day past tail is always included. Optional; downstream defaults to 14."),
 });
@@ -357,6 +361,23 @@ registry.registerPath({
   request: { query: publicWorkflowCostPerOutcomeQueryParams },
   responses: {
     200: { description: "Public per-workflow cost-per-outcome — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicWorkflowCostPerOutcomeResponse") } } },
+    400: { description: "Bad request from features-service", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/public/features/cost-per-outcome-lifetime",
+  tags: ["Features"],
+  summary: "Public lifetime cost-per-outcome",
+  description:
+    "Public lifetime (all-history) cross-org average cost-per-outcome across all optimization objectives for a feature. " +
+    "Proxied to features-service GET /public/stats/cost-per-outcome-lifetime. Forwards featureSlug. Response is producer-owned. No authentication required.",
+  request: { query: publicCostPerOutcomeLifetimeQueryParams },
+  responses: {
+    200: { description: "Public lifetime cost-per-outcome — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicCostPerOutcomeLifetimeResponse") } } },
     400: { description: "Bad request from features-service", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -439,6 +439,20 @@ describe("Public features proxy routes", () => {
     expect(content).toContain("`/public/stats/workflow-cost-per-outcome");
   });
 
+  it("should have GET /public/features/cost-per-outcome-lifetime without auth middleware", () => {
+    const line = content.split("\n").find((l) =>
+      l.includes("router.get") && l.includes('"/public/features/cost-per-outcome-lifetime"')
+    );
+    expect(line).toBeDefined();
+    expect(line).not.toContain("authenticate");
+    expect(line).not.toContain("requireOrg");
+  });
+
+  it("should proxy public cost-per-outcome lifetime to /public/stats/cost-per-outcome-lifetime on features-service", () => {
+    expect(content).toContain('"/public/features/cost-per-outcome-lifetime"');
+    expect(content).toContain("`/public/stats/cost-per-outcome-lifetime");
+  });
+
   it("should NOT expose a public send-forecast route (cross-org fleet financials moved to staff)", () => {
     expect(content).not.toContain('"/public/features/send-forecast"');
     expect(content).not.toContain("/public/stats/send-forecast");
@@ -483,6 +497,11 @@ describe("Public features OpenAPI schemas", () => {
   it("should register GET /v1/public/features/workflow-cost-per-outcome", () => {
     expect(schemaContent).toContain('path: "/v1/public/features/workflow-cost-per-outcome"');
     expect(schemaContent).toContain("PublicWorkflowCostPerOutcomeResponse");
+  });
+
+  it("should register GET /v1/public/features/cost-per-outcome-lifetime", () => {
+    expect(schemaContent).toContain('path: "/v1/public/features/cost-per-outcome-lifetime"');
+    expect(schemaContent).toContain("PublicCostPerOutcomeLifetimeResponse");
   });
 
   it("should NOT register GET /v1/public/features/send-forecast (moved to staff)", () => {


### PR DESCRIPTION
## What

Expose the new features-service public endpoint `GET /public/stats/cost-per-outcome-lifetime` through the gateway as `GET /v1/public/features/cost-per-outcome-lifetime`, mirroring the 7 existing public-features proxies.

Consumer: staff admin app (distribute.you #2486) "Features → Sales Cold Emails Outreach" economics page needs the lifetime cross-org avg cost-per-outcome per objective.

## Mapping

| Gateway | Upstream (features-service) |
|---|---|
| `GET /v1/public/features/cost-per-outcome-lifetime?featureSlug=<slug>` | `GET /public/stats/cost-per-outcome-lifetime?featureSlug=<slug>` |

## Convention

Transparent passthrough per api-service CLAUDE.md #8:
- No auth (public tier), forwards `featureSlug` only
- Response is producer-owned: `z.object({}).passthrough().openapi("PublicCostPerOutcomeLifetimeResponse")`
- Upstream 400/404 surfaced verbatim (no body sanitizing, rule #7)
- OpenAPI regenerated

## Upstream

features-service#485 (merged as #496, deployed to staging). Registry sync lagging at author time; path confirmed via merged PR.

## Tests

+4 unit tests (route no-auth, upstream path, schema registration). Full suite: 1641 passing, build + openapi green.

Closes the gateway side of features-service#485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)