### PR TITLE
fix(features-proxy): forward ?pricing=net to features-service

### DIFF
--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -467,9 +467,7 @@ router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async
 router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    // `pricing` (gross|net) selects the org's discounted (net) vs list (gross) cost
-    // figures — the dashboard sends net so a discounted brand's spend cards match the
-    // net-paced budget. Dropping it here silently served gross under a net request.
+    // `pricing` (gross|net) forwarded so a discounted org's dashboard shows net, not gross.
     for (const key of ["brandId", "campaignId", "workflowSlug", "groupBy", "lens", "pricing"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
@@ -493,8 +491,7 @@ router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, asy
 router.get("/features/:slug/audience-stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    // `pricing` (gross|net) → net returns the org's frozen discounted per-audience cost
-    // metrics so the ranking matches the net brand-overview cost cards. Must be forwarded.
+    // `pricing` (gross|net) forwarded so a discounted org's audience cost metrics show net.
     for (const key of ["brandId", "goal", "brandProfileId", "limit", "statuses", "pricing"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -467,7 +467,10 @@ router.get("/features/:slug/stats", authenticate, requireOrg, requireUser, async
 router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "campaignId", "workflowSlug", "groupBy", "lens"]) {
+    // `pricing` (gross|net) selects the org's discounted (net) vs list (gross) cost
+    // figures — the dashboard sends net so a discounted brand's spend cards match the
+    // net-paced budget. Dropping it here silently served gross under a net request.
+    for (const key of ["brandId", "campaignId", "workflowSlug", "groupBy", "lens", "pricing"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";
@@ -490,7 +493,9 @@ router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, asy
 router.get("/features/:slug/audience-stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "goal", "brandProfileId", "limit", "statuses"]) {
+    // `pricing` (gross|net) → net returns the org's frozen discounted per-audience cost
+    // metrics so the ranking matches the net brand-overview cost cards. Must be forwarded.
+    for (const key of ["brandId", "goal", "brandProfileId", "limit", "statuses", "pricing"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";


### PR DESCRIPTION
## Root cause
distribute.you dashboard #2647 made the brand cost cards request `?pricing=net` on `/features/:slug/revenue` + `/audience-stats` so a usage-discounted brand shows NET (post-discount) spend, coherent with the net-paced campaign budget. But **the gateway dropped the param**: both proxy routes rebuild the upstream query from a fixed allowlist that omitted `pricing`, so features-service defaulted to GROSS.

Observed on a 50%-discounted brand (org `17d240d8…`): "Budget spent today" rendered gross **$14.18 / $7** (>100%) while the runs frozen NET for today is **$7.10**.

## Fix
Add `"pricing"` to both forward allowlists:
- `/features/:slug/revenue` → `[…, "pricing"]`
- `/features/:slug/audience-stats` → `[…, "pricing"]`

## Blast radius
Additive, zero risk: absent param → `gross` (byte-unchanged for every existing caller); only a caller that already sends `pricing=net` (the dashboard, now deployed) is affected. features-service reads runs-service's FROZEN net twin (no read-time discount math) and fails loud (502) if the twin is missing — no silent gross fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)