### PR TITLE
feat(features): staff-gated per-user active-history audit proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -213,6 +213,10 @@
         "type": "object",
         "properties": {}
       },
+      "StaffActiveUsersByUserResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -11082,6 +11086,119 @@
             }
           }
         }
+      }
+    },
+    "/v1/features/audit/active-users-by-user": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Staff fleet per-user active history (staff only)",
+        "description": "STAFF-ONLY cross-org, fleet-wide PER-USER active history: for each user (a distinct org with an active, funded, non-paused cold-email brand), that user's active months/weeks/days, first/last active month+week, retention window in weeks, and current-week/current-month active flags. This is the per-user companion to GET /v1/features/audit/active-users (the aggregate history). Cross-org fleet data (per-org rows), so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/accounts); no org context required, no query params. Transparent proxy to features-service GET /internal/stats/active-users-by-user. Response is producer-owned.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cross-org per-user active history — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffActiveUsersByUserResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not staff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
       }
     },
     "/v1/workflows/ranked": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -425,6 +425,32 @@ router.get("/features/audit/active-users", authenticatePlatform, requireStaff, a
 });
 
 /**
+ * GET /v1/features/audit/active-users-by-user
+ * STAFF-ONLY cross-org, fleet-wide PER-USER active history: for each user (a distinct org with an
+ * active, funded, non-paused cold-email brand), that user's active months/weeks/days, first/last
+ * active month+week, retention window in weeks, and current-week/current-month active flags. This is
+ * the per-user companion to GET /v1/features/audit/active-users (the aggregate history). Cross-org
+ * fleet data (per-org rows), so gated by authenticatePlatform + requireStaff (same tier as
+ * GET /v1/features/audit/accounts): the caller must come in via the platform API key (authType
+ * "admin") AND carry an x-email in the STAFF_EMAILS allowlist. No org context (cross-org read), no
+ * query params. Transparent proxy to features-service GET /internal/stats/active-users-by-user;
+ * response owned by the downstream service.
+ */
+router.get("/features/audit/active-users-by-user", authenticatePlatform, requireStaff, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      `/internal/stats/active-users-by-user`,
+      { headers: staffHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Staff active-users-by-user audit error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get active users by user" });
+  }
+});
+
+/**
  * GET /v1/features/:slug/pipeline-activity
  * 7-day pipeline activity for a brand. Proxied to features-service GET /features/:slug/pipeline-activity.
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -471,6 +471,26 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/audit/active-users-by-user",
+  tags: ["Features"],
+  summary: "Staff fleet per-user active history (staff only)",
+  description:
+    "STAFF-ONLY cross-org, fleet-wide PER-USER active history: for each user (a distinct org with an active, funded, non-paused cold-email " +
+    "brand), that user's active months/weeks/days, first/last active month+week, retention window in weeks, and current-week/current-month " +
+    "active flags. This is the per-user companion to GET /v1/features/audit/active-users (the aggregate history). Cross-org fleet data (per-org " +
+    "rows), so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/accounts); no org context required, " +
+    "no query params. Transparent proxy to features-service GET /internal/stats/active-users-by-user. Response is producer-owned.",
+  security: platformAuth,
+  responses: {
+    200: { description: "Cross-org per-user active history — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("StaffActiveUsersByUserResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Not staff", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
 // Authenticated endpoints — proxied to features-service
 registry.registerPath({
   method: "get",

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -637,6 +637,40 @@ describe("Staff fleet active-users audit proxy route (source)", () => {
   });
 });
 
+describe("Staff fleet active-users-by-user audit proxy route (source)", () => {
+  it("registers GET /features/audit/active-users-by-user on the router", () => {
+    expect(content).toContain('"/features/audit/active-users-by-user"');
+    expect(content).toContain("router.get");
+  });
+
+  it("is staff-gated with authenticatePlatform + requireStaff (no org)", () => {
+    const mountIdx = content.indexOf('"/features/audit/active-users-by-user"');
+    const chain = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(chain).toContain("authenticatePlatform,");
+    expect(chain).toContain("requireStaff,");
+    expect(chain).not.toContain("requireOrg");
+  });
+
+  it("proxies to features-service GET /internal/stats/active-users-by-user", () => {
+    const mountIdx = content.indexOf('"/features/audit/active-users-by-user"');
+    const block = content.slice(mountIdx, mountIdx + 600);
+    expect(block).toContain("externalServices.features");
+    expect(block).toContain("`/internal/stats/active-users-by-user`");
+  });
+
+  it("forwards the verified staff x-email downstream for attribution", () => {
+    const mountIdx = content.indexOf('"/features/audit/active-users-by-user"');
+    const block = content.slice(mountIdx, mountIdx + 600);
+    expect(block).toContain("staffHeaders(req)");
+  });
+
+  it("registers the OpenAPI path with passthrough response + platform auth", () => {
+    expect(schemaContent).toContain('path: "/v1/features/audit/active-users-by-user"');
+    expect(schemaContent).toContain("StaffActiveUsersByUserResponse");
+    expect(schemaContent).toContain("security: platformAuth");
+  });
+});
+
 describe("Features routes are mounted in index.ts", () => {
   it("should import and mount features routes", () => {
     expect(indexContent).toContain("featuresRoutes");


### PR DESCRIPTION
## What

New staff-gated api-service audit proxy: **`GET /v1/features/audit/active-users-by-user`** → features-service **`GET /internal/stats/active-users-by-user`**.

Per-USER companion to the existing aggregate `GET /v1/features/audit/active-users`. For each user (a distinct org with an active, funded, non-paused cold-email brand): active months/weeks/days, first/last active month+week, retention window in weeks, current-week/current-month active flags (tab counts). Cross-org staff-only fleet data (per-org rows).

Consumed by the admin build-in-public metrics dashboard (`admin.distribute.you/metrics`, staff-only), same tier as the sibling audit proxies it already reads.

## How

Mirrors the closest sibling `GET /v1/features/audit/accounts`:
- `authenticatePlatform + requireStaff` (platform API key + `STAFF_EMAILS` x-email) — cross-org fleet data, never public.
- No org context, no query params.
- Transparent passthrough; forwards verified staff `x-email` downstream for attribution.
- Response owned by features-service — `z.object({}).passthrough()`, no field re-declaration (CLAUDE.md #8).

Downstream endpoint verified deployed via api-registry (summary: "staff-gated at api-service").

## Verification

- ✅ `pnpm build` (tsc + openapi regen) — `openapi.json` includes the new path.
- ✅ Full unit suite: 1676 pass / 0 fail. New proxy tests assert route mount, staff gate (no requireOrg), downstream path, x-email forward, OpenAPI passthrough registration.
- 200 for staff caller; 401/403 for non-staff / non-platform (via `authenticatePlatform + requireStaff`).

## Triage

Additive, zero-blast-radius gateway passthrough (new route, no existing handler/shape touched) → **hotfix → main (prod-direct)**, matching how the sibling audit proxies ship. Admin (Vercel, deploys from main) conforms after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)