### PR TITLE
feat(features): staff-gated fleet revenue history audit proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -217,6 +217,10 @@
         "type": "object",
         "properties": {}
       },
+      "StaffRevenueResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -11199,6 +11203,155 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/features/audit/revenue": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Staff fleet realized-revenue history (staff only)",
+        "description": "STAFF-ONLY cross-org, fleet-wide HISTORY of REALIZED REVENUE (the sum of actualized cold-email spend per day — the money twin of active-users): total revenue since inception, plus monthly, weekly, and daily revenue buckets each with a period-over-period growth rate, and current MRR. Aggregate cross-org fleet financials, so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users); no org context required. Forwards optional window params `days`/`weeks`/`months`. Transparent proxy to features-service GET /internal/stats/revenue. Response is producer-owned.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Trailing days in the daily revenue series. Optional; downstream default applies.",
+              "example": 90
+            },
+            "required": false,
+            "description": "Trailing days in the daily revenue series. Optional; downstream default applies.",
+            "name": "days",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Trailing ISO weeks in the weekly revenue series. Optional; downstream default applies.",
+              "example": 26
+            },
+            "required": false,
+            "description": "Trailing ISO weeks in the weekly revenue series. Optional; downstream default applies.",
+            "name": "weeks",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Trailing months in the monthly revenue series. Optional; downstream default applies.",
+              "example": 12
+            },
+            "required": false,
+            "description": "Trailing months in the monthly revenue series. Optional; downstream default applies.",
+            "name": "months",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fleet realized-revenue history (total + MRR + monthly/weekly/daily + asOf) — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffRevenueResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not staff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/workflows/ranked": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -26,6 +26,7 @@ const PUBLIC_COST_PER_OUTCOME_LIFETIME_PARAMS = ["featureSlug"];
 const PUBLIC_COST_PER_OUTCOME_DISTRIBUTION_PARAMS = ["featureSlug", "objective", "buckets"];
 const AUDIT_SEND_FORECAST_PARAMS = ["days"];
 const AUDIT_ACTIVE_USERS_PARAMS = ["days", "weeks", "months"];
+const AUDIT_REVENUE_PARAMS = ["days", "weeks", "months"];
 
 // Forward the verified staff email downstream for actor attribution (no org context).
 function staffHeaders(req: AuthenticatedRequest): Record<string, string> {
@@ -447,6 +448,33 @@ router.get("/features/audit/active-users-by-user", authenticatePlatform, require
   } catch (error: any) {
     console.error("[api-service] Staff active-users-by-user audit error:", error.message);
     res.status(error.statusCode || 502).json({ error: error.message || "Failed to get active users by user" });
+  }
+});
+
+/**
+ * GET /v1/features/audit/revenue
+ * STAFF-ONLY cross-org, fleet-wide HISTORY of REALIZED REVENUE (the sum of actualized cold-email spend
+ * per day — the money twin of active-users): total revenue since inception, plus monthly/weekly/daily
+ * revenue buckets each with period-over-period growth, and current MRR. Aggregate cross-org fleet
+ * financials, so gated by authenticatePlatform + requireStaff (same tier as GET /v1/features/audit/
+ * active-users): the caller must come in via the platform API key (authType "admin") AND carry an
+ * x-email in the STAFF_EMAILS allowlist. No org context (cross-org read). Forwards optional window
+ * params `days`/`weeks`/`months`. Transparent proxy to features-service GET /internal/stats/revenue;
+ * response owned by the downstream service.
+ */
+router.get("/features/audit/revenue", authenticatePlatform, requireStaff, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, AUDIT_REVENUE_PARAMS);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/internal/stats/revenue${qs}`,
+      { headers: staffHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Staff revenue audit error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get revenue" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -221,6 +221,12 @@ const auditActiveUsersQueryParams = z.object({
   months: z.coerce.number().int().optional().openapi({ example: 12 }).describe("Trailing months in the monthly series. Optional; downstream defaults to 12 (max 36)."),
 });
 
+const auditRevenueQueryParams = z.object({
+  days: z.coerce.number().int().optional().openapi({ example: 90 }).describe("Trailing days in the daily revenue series. Optional; downstream default applies."),
+  weeks: z.coerce.number().int().optional().openapi({ example: 26 }).describe("Trailing ISO weeks in the weekly revenue series. Optional; downstream default applies."),
+  months: z.coerce.number().int().optional().openapi({ example: 12 }).describe("Trailing months in the monthly revenue series. Optional; downstream default applies."),
+});
+
 const WorkflowMetadataSchema = z
   .object({
     id: z.string().describe("Workflow ID"),
@@ -485,6 +491,27 @@ registry.registerPath({
   security: platformAuth,
   responses: {
     200: { description: "Cross-org per-user active history — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("StaffActiveUsersByUserResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Not staff", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/audit/revenue",
+  tags: ["Features"],
+  summary: "Staff fleet realized-revenue history (staff only)",
+  description:
+    "STAFF-ONLY cross-org, fleet-wide HISTORY of REALIZED REVENUE (the sum of actualized cold-email spend per day — the money twin of " +
+    "active-users): total revenue since inception, plus monthly, weekly, and daily revenue buckets each with a period-over-period growth rate, " +
+    "and current MRR. Aggregate cross-org fleet financials, so this is gated by platform API key + STAFF_EMAILS x-email (same tier as " +
+    "GET /v1/features/audit/active-users); no org context required. Forwards optional window params `days`/`weeks`/`months`. Transparent proxy " +
+    "to features-service GET /internal/stats/revenue. Response is producer-owned.",
+  security: platformAuth,
+  request: { query: auditRevenueQueryParams },
+  responses: {
+    200: { description: "Fleet realized-revenue history (total + MRR + monthly/weekly/daily + asOf) — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("StaffRevenueResponse") } } },
     401: { description: "Unauthorized", content: errorContent },
     403: { description: "Not staff", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -671,6 +671,44 @@ describe("Staff fleet active-users-by-user audit proxy route (source)", () => {
   });
 });
 
+describe("Staff fleet revenue audit proxy route (source)", () => {
+  it("registers GET /features/audit/revenue on the router", () => {
+    expect(content).toContain('"/features/audit/revenue"');
+    expect(content).toContain("router.get");
+  });
+
+  it("is staff-gated with authenticatePlatform + requireStaff (no org)", () => {
+    const mountIdx = content.indexOf('"/features/audit/revenue"');
+    const chain = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(chain).toContain("authenticatePlatform,");
+    expect(chain).toContain("requireStaff,");
+    expect(chain).not.toContain("requireOrg");
+  });
+
+  it("proxies to features-service GET /internal/stats/revenue", () => {
+    const mountIdx = content.indexOf('"/features/audit/revenue"');
+    const block = content.slice(mountIdx, mountIdx + 700);
+    expect(block).toContain("externalServices.features");
+    expect(block).toContain("`/internal/stats/revenue");
+  });
+
+  it("forwards the days/weeks/months window query params", () => {
+    expect(content).toContain('AUDIT_REVENUE_PARAMS = ["days", "weeks", "months"]');
+  });
+
+  it("forwards the verified staff x-email downstream for attribution", () => {
+    const mountIdx = content.indexOf('"/features/audit/revenue"');
+    const block = content.slice(mountIdx, mountIdx + 700);
+    expect(block).toContain("staffHeaders(req)");
+  });
+
+  it("registers the OpenAPI path with passthrough response + platform auth", () => {
+    expect(schemaContent).toContain('path: "/v1/features/audit/revenue"');
+    expect(schemaContent).toContain("StaffRevenueResponse");
+    expect(schemaContent).toContain("security: platformAuth");
+  });
+});
+
 describe("Features routes are mounted in index.ts", () => {
   it("should import and mount features routes", () => {
     expect(indexContent).toContain("featuresRoutes");


### PR DESCRIPTION
## What

New transparent, staff-gated gateway proxy: `GET /v1/features/audit/revenue` → features-service `GET /internal/stats/revenue`.

Feeds the admin console (admin.distribute.you) Revenue tab: fleet-wide realized-revenue history (total since inception, monthly/weekly/daily buckets with growth, current MRR) — the money twin of the active-users audit history.

## How

Mirrors the existing `/v1/features/audit/{accounts,active-users,active-users-by-user}` audit proxies exactly:
- `authenticatePlatform + requireStaff` (platform API key + `x-email` in `STAFF_EMAILS`); non-staff → 403, same as the sibling audit routes.
- No org context (cross-org read). Forwards optional `days`/`weeks`/`months` window params.
- Transparent passthrough — `StaffRevenueResponse` is `z.object({}).passthrough()`, downstream owns the shape. No aggregation, no reshaping.
- Staff `x-email` forwarded downstream for attribution via `staffHeaders(req)`.

Downstream path discovered via api-registry / the in-flight features-service `revenue-stats-endpoint` branch (`revenue-history-client.ts` names the target `GET /internal/stats/revenue`).

## Test

- New source-assertion suite in `tests/unit/features-proxy.test.ts` mirroring the active-users block (route registration, staff-gate chain, downstream path, window params, staff-header forward, OpenAPI passthrough registration).
- Full suite green: 137 files / 1682 tests. `tsc` + openapi regen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
