### PR TITLE
feat(features): staff-gated fleet realized-revenue audit proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -217,6 +217,10 @@
         "type": "object",
         "properties": {}
       },
+      "StaffRevenueResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "MeResponse": {
         "type": "object",
         "properties": {
@@ -11199,6 +11203,155 @@
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
         ]
+      }
+    },
+    "/v1/features/audit/revenue": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Staff fleet realized-revenue history (staff only)",
+        "description": "STAFF-ONLY cross-org, fleet-wide HISTORY of realized revenue (summed actualized cold-email spend across all orgs) bucketed monthly, weekly, and daily, each with a period-over-period growth rate, plus the total since inception, a per-day-since-inception MRR-over-time line, and the current live MRR. The realized-revenue companion to GET /v1/features/audit/active-users (same universe + signal). Aggregate cross-org fleet financials, so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users); no org context required. Forwards optional window params `days`/`weeks`/`months`. Transparent proxy to features-service GET /internal/stats/revenue. Response is producer-owned.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Trailing days in the daily series. Optional; downstream defaults to 90 (max 365).",
+              "example": 90
+            },
+            "required": false,
+            "description": "Trailing days in the daily series. Optional; downstream defaults to 90 (max 365).",
+            "name": "days",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Trailing ISO weeks in the weekly series. Optional; downstream defaults to 26 (max 104).",
+              "example": 26
+            },
+            "required": false,
+            "description": "Trailing ISO weeks in the weekly series. Optional; downstream defaults to 26 (max 104).",
+            "name": "weeks",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "nullable": true,
+              "description": "Trailing months in the monthly series. Optional; downstream defaults to 12 (max 36).",
+              "example": 12
+            },
+            "required": false,
+            "description": "Trailing months in the monthly series. Optional; downstream defaults to 12 (max 36).",
+            "name": "months",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fleet realized-revenue history (total + monthly/weekly/daily + mrrOverTime + currentMrr + asOf) — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffRevenueResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not staff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/workflows/ranked": {

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -451,6 +451,34 @@ router.get("/features/audit/active-users-by-user", authenticatePlatform, require
 });
 
 /**
+ * GET /v1/features/audit/revenue
+ * STAFF-ONLY cross-org, fleet-wide HISTORY of realized revenue (summed actualized cold-email spend
+ * across all orgs) bucketed monthly/weekly/daily with period-over-period growth, plus the total since
+ * inception, a per-day-since-inception MRR-over-time line, and the current live MRR. The realized-revenue
+ * companion to GET /v1/features/audit/active-users (same universe, same "active = real billed cold-email
+ * spend" signal). Aggregate cross-org fleet financials, so gated by authenticatePlatform + requireStaff
+ * (same tier as GET /v1/features/audit/active-users): the caller must come in via the platform API key
+ * (authType "admin") AND carry an x-email in the STAFF_EMAILS allowlist. No org context (cross-org read).
+ * Forwards optional window params `days`/`weeks`/`months`. Transparent proxy to features-service
+ * GET /internal/stats/revenue; response owned by the downstream service.
+ */
+router.get("/features/audit/revenue", authenticatePlatform, requireStaff, async (req: AuthenticatedRequest, res) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, AUDIT_ACTIVE_USERS_PARAMS);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const result = await callExternalService(
+      externalServices.features,
+      `/internal/stats/revenue${qs}`,
+      { headers: staffHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Staff revenue audit error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get revenue" });
+  }
+});
+
+/**
  * GET /v1/features/:slug/pipeline-activity
  * 7-day pipeline activity for a brand. Proxied to features-service GET /features/:slug/pipeline-activity.
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -491,6 +491,28 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/features/audit/revenue",
+  tags: ["Features"],
+  summary: "Staff fleet realized-revenue history (staff only)",
+  description:
+    "STAFF-ONLY cross-org, fleet-wide HISTORY of realized revenue (summed actualized cold-email spend across all orgs) bucketed monthly, " +
+    "weekly, and daily, each with a period-over-period growth rate, plus the total since inception, a per-day-since-inception MRR-over-time " +
+    "line, and the current live MRR. The realized-revenue companion to GET /v1/features/audit/active-users (same universe + signal). Aggregate " +
+    "cross-org fleet financials, so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users); " +
+    "no org context required. Forwards optional window params `days`/`weeks`/`months`. Transparent proxy to features-service " +
+    "GET /internal/stats/revenue. Response is producer-owned.",
+  security: platformAuth,
+  request: { query: auditActiveUsersQueryParams },
+  responses: {
+    200: { description: "Fleet realized-revenue history (total + monthly/weekly/daily + mrrOverTime + currentMrr + asOf) — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("StaffRevenueResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Not staff", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
 // Authenticated endpoints — proxied to features-service
 registry.registerPath({
   method: "get",

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -671,6 +671,46 @@ describe("Staff fleet active-users-by-user audit proxy route (source)", () => {
   });
 });
 
+describe("Staff fleet revenue audit proxy route (source)", () => {
+  it("registers GET /features/audit/revenue on the router", () => {
+    expect(content).toContain('"/features/audit/revenue"');
+    expect(content).toContain("router.get");
+  });
+
+  it("is staff-gated with authenticatePlatform + requireStaff (no org)", () => {
+    const mountIdx = content.indexOf('"/features/audit/revenue"');
+    const chain = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(chain).toContain("authenticatePlatform,");
+    expect(chain).toContain("requireStaff,");
+    expect(chain).not.toContain("requireOrg");
+  });
+
+  it("proxies to features-service GET /internal/stats/revenue", () => {
+    const mountIdx = content.indexOf('"/features/audit/revenue"');
+    const block = content.slice(mountIdx, mountIdx + 700);
+    expect(block).toContain("externalServices.features");
+    expect(block).toContain("`/internal/stats/revenue");
+  });
+
+  it("forwards the days/weeks/months window query params", () => {
+    const mountIdx = content.indexOf('"/features/audit/revenue"');
+    const block = content.slice(mountIdx, mountIdx + 700);
+    expect(block).toContain("AUDIT_ACTIVE_USERS_PARAMS");
+  });
+
+  it("forwards the verified staff x-email downstream for attribution", () => {
+    const mountIdx = content.indexOf('"/features/audit/revenue"');
+    const block = content.slice(mountIdx, mountIdx + 700);
+    expect(block).toContain("staffHeaders(req)");
+  });
+
+  it("registers the OpenAPI path with passthrough response + platform auth", () => {
+    expect(schemaContent).toContain('path: "/v1/features/audit/revenue"');
+    expect(schemaContent).toContain("StaffRevenueResponse");
+    expect(schemaContent).toContain("security: platformAuth");
+  });
+});
+
 describe("Features routes are mounted in index.ts", () => {
   it("should import and mount features routes", () => {
     expect(indexContent).toContain("featuresRoutes");


### PR DESCRIPTION
## What

New transparent, staff-gated gateway route **`GET /v1/features/audit/revenue`** → features-service **`GET /internal/stats/revenue`**.

Powers the admin.distribute.you **Revenue tab**: fleet-wide realized-revenue history (total since inception, monthly/weekly/daily buckets with period-over-period growth, per-day MRR-over-time line, current live MRR).

## How

Mirrors the existing `/v1/features/audit/active-users` audit proxy exactly:
- `authenticatePlatform + requireStaff` — platform API key (`authType: "admin"`) **AND** an `x-email` in `STAFF_EMAILS`. Non-staff → 403, same as the sibling audit routes.
- No org context (cross-org read).
- Forwards optional `days`/`weeks`/`months` window params (reuses `AUDIT_ACTIVE_USERS_PARAMS`).
- Forwards the verified staff `x-email` downstream for attribution (`staffHeaders(req)`).
- Passthrough response — `z.object({}).passthrough()`; features-service owns the shape (no re-declaration, per CLAUDE.md #8).

## Scope

- Additive, zero blast radius. No existing handler/route/schema touched.
- Downstream path confirmed against the in-flight features-service endpoint (`GET /internal/stats/revenue`, params `days`/`weeks`/`months`) — ships in parallel; dormant here until that lands on staging.
- `openapi.json` regenerated → route discoverable via api-registry after deploy.

## Tests

6 new source tests (route registered, staff-gated, proxies to `/internal/stats/revenue`, window params, staff x-email forward, OpenAPI passthrough + platform auth). Full suite **1682 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
