### PR TITLE
feat(features): staff-gated fleet customer-success audit proxy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -217,6 +217,10 @@
         "type": "object",
         "properties": {}
       },
+      "StaffCustomerSuccessResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "StaffRevenueResponse": {
         "type": "object",
         "properties": {}
@@ -11111,6 +11115,119 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/StaffActiveUsersByUserResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Not staff",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/features/audit/customer-success": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Staff fleet customer-success health board (staff only)",
+        "description": "STAFF-ONLY cross-org, fleet-wide CUSTOMER-SUCCESS health board: one composed row per ever-active customer (name, CAC, grain, and the rest of the health signals the downstream computes). Cross-org fleet data (per-customer rows), so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users-by-user); no org context required, no query params. Transparent proxy to features-service GET /internal/stats/customer-success. Response is producer-owned.",
+        "security": [
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cross-org customer-success health board — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaffCustomerSuccessResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -479,6 +479,30 @@ router.get("/features/audit/revenue", authenticatePlatform, requireStaff, async 
 });
 
 /**
+ * GET /v1/features/audit/customer-success
+ * STAFF-ONLY cross-org, fleet-wide CUSTOMER-SUCCESS health board: one composed row per ever-active
+ * customer (name, CAC, grain, and the rest of the health signals the downstream computes). Cross-org
+ * fleet data (per-customer rows), so gated by authenticatePlatform + requireStaff (same tier as
+ * GET /v1/features/audit/active-users-by-user): the caller must come in via the platform API key
+ * (authType "admin") AND carry an x-email in the STAFF_EMAILS allowlist. No org context (cross-org
+ * read), no query params. Transparent proxy to features-service GET /internal/stats/customer-success;
+ * response owned by the downstream service.
+ */
+router.get("/features/audit/customer-success", authenticatePlatform, requireStaff, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.features,
+      `/internal/stats/customer-success`,
+      { headers: staffHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Staff customer-success audit error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get customer success" });
+  }
+});
+
+/**
  * GET /v1/features/:slug/pipeline-activity
  * 7-day pipeline activity for a brand. Proxied to features-service GET /features/:slug/pipeline-activity.
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -499,6 +499,25 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/features/audit/customer-success",
+  tags: ["Features"],
+  summary: "Staff fleet customer-success health board (staff only)",
+  description:
+    "STAFF-ONLY cross-org, fleet-wide CUSTOMER-SUCCESS health board: one composed row per ever-active customer (name, CAC, grain, and the rest " +
+    "of the health signals the downstream computes). Cross-org fleet data (per-customer rows), so this is gated by platform API key + " +
+    "STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users-by-user); no org context required, no query params. Transparent " +
+    "proxy to features-service GET /internal/stats/customer-success. Response is producer-owned.",
+  security: platformAuth,
+  responses: {
+    200: { description: "Cross-org customer-success health board — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("StaffCustomerSuccessResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Not staff", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/features/audit/revenue",
   tags: ["Features"],
   summary: "Staff fleet realized-revenue history (staff only)",

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -671,6 +671,40 @@ describe("Staff fleet active-users-by-user audit proxy route (source)", () => {
   });
 });
 
+describe("Staff fleet customer-success audit proxy route (source)", () => {
+  it("registers GET /features/audit/customer-success on the router", () => {
+    expect(content).toContain('"/features/audit/customer-success"');
+    expect(content).toContain("router.get");
+  });
+
+  it("is staff-gated with authenticatePlatform + requireStaff (no org)", () => {
+    const mountIdx = content.indexOf('"/features/audit/customer-success"');
+    const chain = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(chain).toContain("authenticatePlatform,");
+    expect(chain).toContain("requireStaff,");
+    expect(chain).not.toContain("requireOrg");
+  });
+
+  it("proxies to features-service GET /internal/stats/customer-success", () => {
+    const mountIdx = content.indexOf('"/features/audit/customer-success"');
+    const block = content.slice(mountIdx, mountIdx + 600);
+    expect(block).toContain("externalServices.features");
+    expect(block).toContain("`/internal/stats/customer-success`");
+  });
+
+  it("forwards the verified staff x-email downstream for attribution", () => {
+    const mountIdx = content.indexOf('"/features/audit/customer-success"');
+    const block = content.slice(mountIdx, mountIdx + 600);
+    expect(block).toContain("staffHeaders(req)");
+  });
+
+  it("registers the OpenAPI path with passthrough response + platform auth", () => {
+    expect(schemaContent).toContain('path: "/v1/features/audit/customer-success"');
+    expect(schemaContent).toContain("StaffCustomerSuccessResponse");
+    expect(schemaContent).toContain("security: platformAuth");
+  });
+});
+
 describe("Staff fleet revenue audit proxy route (source)", () => {
   it("registers GET /features/audit/revenue on the router", () => {
     expect(content).toContain('"/features/audit/revenue"');


### PR DESCRIPTION
## What

Transparent gateway proxy so **admin.distribute.you** can reach features-service's new customer-success fleet-health board through the api gateway, under the same staff-gated audit-stats convention as the existing `/v1/features/audit/*` family.

`GET /v1/features/audit/customer-success` → features-service `GET /internal/stats/customer-success`

## How (mirrors sibling audit routes)

- `authenticatePlatform + requireStaff` — platform API key (`authType admin`) + `x-email` in `STAFF_EMAILS` allowlist, no org context, no query params
- Forwards verified staff `x-email` downstream for actor attribution
- Passthrough response (`StaffCustomerSuccessResponse`) — producer owns the shape (CLAUDE.md #8), zero field re-declaration
- OpenAPI path registered + `openapi.json` regenerated
- 5 source-level proxy tests mirroring `active-users-by-user`

## Notes

- Producer path `GET /internal/stats/customer-success` is in flight in a parallel features-service workspace (`ashgabat`, branch `KevinLourd/customer-success-health-board`) — path + api-key gating confirmed against that workspace's converging design and the existing 5 `/internal/stats/*` siblings. Additive, zero blast radius: route 502s harmlessly until the producer deploys.
- No aggregation, no body/response transform (gateway convention).

## Tests

1684 unit tests pass (136 files), incl. the 5 new proxy tests. `tsc` + openapi build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)