### PR TITLE
hotfix: Point customer-success audit proxy at deployed features-service /internal/stats/customer-health

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11215,7 +11215,7 @@
           "Features"
         ],
         "summary": "Staff fleet customer-success health board (staff only)",
-        "description": "STAFF-ONLY cross-org, fleet-wide CUSTOMER-SUCCESS health board: one composed row per ever-active customer (name, CAC, grain, and the rest of the health signals the downstream computes). Cross-org fleet data (per-customer rows), so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users-by-user); no org context required, no query params. Transparent proxy to features-service GET /internal/stats/customer-success. Response is producer-owned.",
+        "description": "STAFF-ONLY cross-org, fleet-wide CUSTOMER-SUCCESS health board: one composed row per ever-active customer (name, CAC, grain, and the rest of the health signals the downstream computes). Cross-org fleet data (per-customer rows), so this is gated by platform API key + STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users-by-user); no org context required, no query params. Transparent proxy to features-service GET /internal/stats/customer-health. Response is producer-owned.",
         "security": [
           {
             "apiKeyAuth": []

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -485,14 +485,14 @@ router.get("/features/audit/revenue", authenticatePlatform, requireStaff, async 
  * fleet data (per-customer rows), so gated by authenticatePlatform + requireStaff (same tier as
  * GET /v1/features/audit/active-users-by-user): the caller must come in via the platform API key
  * (authType "admin") AND carry an x-email in the STAFF_EMAILS allowlist. No org context (cross-org
- * read), no query params. Transparent proxy to features-service GET /internal/stats/customer-success;
+ * read), no query params. Transparent proxy to features-service GET /internal/stats/customer-health;
  * response owned by the downstream service.
  */
 router.get("/features/audit/customer-success", authenticatePlatform, requireStaff, async (req: AuthenticatedRequest, res) => {
   try {
     const result = await callExternalService(
       externalServices.features,
-      `/internal/stats/customer-success`,
+      `/internal/stats/customer-health`,
       { headers: staffHeaders(req) },
     );
     res.json(result);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -506,7 +506,7 @@ registry.registerPath({
     "STAFF-ONLY cross-org, fleet-wide CUSTOMER-SUCCESS health board: one composed row per ever-active customer (name, CAC, grain, and the rest " +
     "of the health signals the downstream computes). Cross-org fleet data (per-customer rows), so this is gated by platform API key + " +
     "STAFF_EMAILS x-email (same tier as GET /v1/features/audit/active-users-by-user); no org context required, no query params. Transparent " +
-    "proxy to features-service GET /internal/stats/customer-success. Response is producer-owned.",
+    "proxy to features-service GET /internal/stats/customer-health. Response is producer-owned.",
   security: platformAuth,
   responses: {
     200: { description: "Cross-org customer-success health board — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("StaffCustomerSuccessResponse") } } },

--- a/tests/unit/features-proxy.test.ts
+++ b/tests/unit/features-proxy.test.ts
@@ -685,11 +685,11 @@ describe("Staff fleet customer-success audit proxy route (source)", () => {
     expect(chain).not.toContain("requireOrg");
   });
 
-  it("proxies to features-service GET /internal/stats/customer-success", () => {
+  it("proxies to features-service GET /internal/stats/customer-health", () => {
     const mountIdx = content.indexOf('"/features/audit/customer-success"');
     const block = content.slice(mountIdx, mountIdx + 600);
     expect(block).toContain("externalServices.features");
-    expect(block).toContain("`/internal/stats/customer-success`");
+    expect(block).toContain("`/internal/stats/customer-health`");
   });
 
   it("forwards the verified staff x-email downstream for attribution", () => {


### PR DESCRIPTION
Automated by release.sh