### PR TITLE
hotfix: Forward brandId scope through by-lead email proxy

### DIFF
--- a/src/routes/emails.ts
+++ b/src/routes/emails.ts
@@ -91,6 +91,10 @@ router.get("/emails", authenticate, requireOrg, requireUser, async (req: Authent
  * (org-scoped via identity headers). Body forwarded verbatim (CLAUDE.md #8 — downstream
  * owns the generation shape; no field re-declaration / stripping).
  *
+ * When the caller passes ?brandId=<uuid> (the brand the user is viewing), it is forwarded
+ * as brand scope so content-generation-service returns the brand-correct generation for a
+ * lead contacted by multiple brands in one org. Without it, behavior is unchanged.
+ *
  * Upstream 404 ("Generation not found") is a NORMAL empty state ("no email yet for this
  * lead"), so it maps to 200 { generation: null } — NOT a client-facing error. Any other
  * upstream error propagates verbatim (fail loud).
@@ -102,9 +106,14 @@ router.get(
   requireUser,
   async (req: AuthenticatedRequest, res) => {
     try {
+      const { brandId } = req.query as { brandId?: string };
+      const params = new URLSearchParams();
+      if (brandId) params.set("brandId", brandId);
+      const qs = params.toString();
+
       const result = await callExternalService(
         externalServices.emailgen,
-        `/generations/by-lead/${encodeURIComponent(req.params.leadId)}`,
+        `/generations/by-lead/${encodeURIComponent(req.params.leadId)}${qs ? `?${qs}` : ""}`,
         { headers: buildInternalHeaders(req) },
       ) as { generation: Record<string, unknown> };
       res.json({ generation: result.generation });

--- a/tests/unit/emails.test.ts
+++ b/tests/unit/emails.test.ts
@@ -233,6 +233,24 @@ describe("GET /v1/emails/by-lead/:leadId", () => {
     const call = fetchCalls.find((c) => c.url.includes("/generations/by-lead/"));
     expect(call).toBeDefined();
     expect(call!.url).toContain("/generations/by-lead/lead_abc");
+    // Unscoped call (no brandId) must carry NO query string — byte-unchanged from before.
+    expect(call!.url).not.toContain("?");
+    expect(call!.headers!["x-org-id"]).toBe("org_test456");
+    expect(call!.headers!["x-user-id"]).toBe("user_test123");
+  });
+
+  it("forwards ?brandId brand scope through to content-gen by-lead read", async () => {
+    mockFetch(() => ({ ok: true, json: () => Promise.resolve({ generation: { id: "gen_2" } }) }));
+
+    const res = await request(app).get(
+      "/v1/emails/by-lead/lead_abc?brandId=11111111-2222-3333-4444-555555555555",
+    );
+
+    expect(res.status).toBe(200);
+    const call = fetchCalls.find((c) => c.url.includes("/generations/by-lead/"));
+    expect(call).toBeDefined();
+    expect(call!.url).toContain("/generations/by-lead/lead_abc");
+    expect(call!.url).toContain("brandId=11111111-2222-3333-4444-555555555555");
     expect(call!.headers!["x-org-id"]).toBe("org_test456");
     expect(call!.headers!["x-user-id"]).toBe("user_test123");
   });


### PR DESCRIPTION
Automated by release.sh