### PR TITLE
feat(features-proxy): forward ?campaignId= to features-service audience-stats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -36540,6 +36540,17 @@
           {
             "schema": {
               "type": "string",
+              "description": "Optional single-campaign scope for the stats (audiences stay brand-wide; only the per-audience cost + outcome numerators narrow to this campaign). Omit for brand-wide numbers",
+              "example": "campaign-uuid-123"
+            },
+            "required": false,
+            "description": "Optional single-campaign scope for the stats (audiences stay brand-wide; only the per-audience cost + outcome numerators narrow to this campaign). Omit for brand-wide numbers",
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "description": "Optional row limit after sorting",
               "example": "3"
             },

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -596,7 +596,7 @@ router.get("/features/:slug/revenue", authenticate, requireOrg, requireUser, asy
 router.get("/features/:slug/audience-stats", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const params = new URLSearchParams();
-    for (const key of ["brandId", "goal", "brandProfileId", "limit", "statuses", "pricing"]) {
+    for (const key of ["brandId", "goal", "brandProfileId", "limit", "statuses", "pricing", "campaignId"]) {
       if (req.query[key]) params.set(key, req.query[key] as string);
     }
     const qs = params.toString() ? `?${params.toString()}` : "";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -7884,6 +7884,7 @@ registry.registerPath({
       brandId: z.string().openapi({ example: "brand-uuid-123" }).describe("Brand UUID (required)"),
       goal: z.string().openapi({ example: "signup" }).describe("Optimization goal (required)"),
       brandProfileId: z.string().optional().openapi({ example: "profile-uuid-123" }).describe("Optional brand-profile version to scope evidence"),
+      campaignId: z.string().optional().openapi({ example: "campaign-uuid-123" }).describe("Optional single-campaign scope for the stats (audiences stay brand-wide; only the per-audience cost + outcome numerators narrow to this campaign). Omit for brand-wide numbers"),
       limit: z.string().optional().openapi({ example: "3" }).describe("Optional row limit after sorting"),
       statuses: z.string().optional().openapi({ example: "active,paused,archived" }).describe("Optional comma-separated subset of active,paused,archived to scope which audiences are included (features-service owns the default)"),
     }),


### PR DESCRIPTION
## What

Adds `campaignId` to the forward whitelist of the `GET /v1/features/:slug/audience-stats` gateway proxy so the dashboard's per-campaign v2 audience view can scope per-audience performance to a single campaign end-to-end.

- Whitelist: `[brandId, goal, brandProfileId, limit, statuses, pricing, **campaignId**]` (same passthrough treatment as `pricing`).
- OpenAPI schema documents the optional `campaignId` query param.

Additive, **zero blast radius**: existing callers never send `campaignId` → byte-identical behavior.

## Consumer

features-service PR #598 adds the `?campaignId=` scope on the downstream endpoint (audiences stay brand-wide; only the per-audience cost + outcome numerators narrow). This PR is the gateway forward so the dashboard can reach it.

Build + openapi regen clean.

Triage: **staging** (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)