### PR TITLE
feat(campaigns,features): proxy per-campaign daily budget + campaign-scoped audience stats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -562,6 +562,24 @@
           "campaign"
         ]
       },
+      "SetBrandCampaignsDailyBudgetResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "SetBrandCampaignsDailyBudgetRequest": {
+        "type": "object",
+        "properties": {
+          "dailyBudgetCents": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0,
+            "description": "Daily budget in cents for every sales campaign of the brand; null clears each campaign's own budget"
+          }
+        },
+        "required": [
+          "dailyBudgetCents"
+        ]
+      },
       "StopCampaignResponse": {
         "type": "object",
         "properties": {
@@ -12374,6 +12392,139 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UpdateCampaignResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{brandId}/campaigns/daily-budget": {
+      "patch": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Set daily budget for all of a brand's campaigns",
+        "description": "Proxy to campaign-service PATCH /brands/{brandId}/daily-budget. Sets dailyBudgetCents on EVERY sales campaign of the brand at once — the brand-page propagation lever: when a customer edits their daily budget on the brand page it flows down to the brand's campaign(s). Distinct from PATCH /v1/brands/{brandId}/daily-budget (billing-service brand spend cap). Body { dailyBudgetCents } (integer cents >= 0, or null to clear each campaign's own budget so they fall back to the brand daily budget). Identity headers (x-org-id, x-user-id, x-run-id) are forwarded. Body + response shapes are owned by campaign-service; its 4xx validation errors propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetBrandCampaignsDailyBudgetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-campaign daily budgets updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetBrandCampaignsDailyBudgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -390,6 +390,38 @@ router.patch("/campaigns/:id", authenticate, requireOrg, requireUser, async (req
 });
 
 /**
+ * PATCH /v1/brands/:brandId/campaigns/daily-budget
+ * Set the daily budget for ALL of a brand's sales campaigns at once.
+ *
+ * Brand-page propagation lever: when a customer edits their daily budget on the brand page,
+ * that number must flow down to the brand's campaign(s) so per-campaign pacing enforces it.
+ * Distinct from PATCH /v1/brands/:brandId/daily-budget (billing-service brand spend cap) — this
+ * targets campaign-service's per-campaign budget. dailyBudgetCents:null clears each campaign's
+ * own budget so they fall back to the brand daily budget.
+ * Proxies to campaign-service PATCH /brands/:brandId/daily-budget. Body + response are
+ * downstream-owned and forwarded byte-identical.
+ */
+router.patch("/brands/:brandId/campaigns/daily-budget", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { brandId } = req.params;
+
+    const result = await callExternalService(
+      externalServices.campaign,
+      `/brands/${brandId}/daily-budget`,
+      {
+        method: "PATCH",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      }
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("Set brand campaigns daily budget error:", error);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to set brand campaigns daily budget" });
+  }
+});
+
+/**
  * POST /v1/campaigns/:id/stop
  * Stop a running campaign
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -858,6 +858,48 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "patch",
+  path: "/v1/brands/{brandId}/campaigns/daily-budget",
+  tags: ["Campaigns"],
+  summary: "Set daily budget for all of a brand's campaigns",
+  description:
+    "Proxy to campaign-service PATCH /brands/{brandId}/daily-budget. Sets dailyBudgetCents on " +
+    "EVERY sales campaign of the brand at once — the brand-page propagation lever: when a customer " +
+    "edits their daily budget on the brand page it flows down to the brand's campaign(s). Distinct " +
+    "from PATCH /v1/brands/{brandId}/daily-budget (billing-service brand spend cap). Body " +
+    "{ dailyBudgetCents } (integer cents >= 0, or null to clear each campaign's own budget so they " +
+    "fall back to the brand daily budget). Identity headers (x-org-id, x-user-id, x-run-id) are " +
+    "forwarded. Body + response shapes are owned by campaign-service; its 4xx validation errors " +
+    "propagate verbatim.",
+  security: authed,
+  request: {
+    params: z.object({ brandId: z.string().uuid().describe("Brand ID") }),
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              dailyBudgetCents: z
+                .number()
+                .int()
+                .nonnegative()
+                .nullable()
+                .describe("Daily budget in cents for every sales campaign of the brand; null clears each campaign's own budget"),
+            })
+            .openapi("SetBrandCampaignsDailyBudgetRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: { description: "Per-campaign daily budgets updated", content: { "application/json": { schema: z.object({}).passthrough().openapi("SetBrandCampaignsDailyBudgetResponse") } } },
+    400: { description: "Validation error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
+registry.registerPath({
   method: "post",
   path: "/v1/campaigns/{id}/stop",
   tags: ["Campaigns"],

--- a/tests/unit/per-campaign-budget-proxy.test.ts
+++ b/tests/unit/per-campaign-budget-proxy.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+// externalServices (src/lib/service-client.ts) snapshots *_SERVICE_URL at module load,
+// so the bases must be set BEFORE the routers import. vi.hoisted runs before imports.
+const { CAMPAIGN_BASE, FEATURES_BASE } = vi.hoisted(() => {
+  const CAMPAIGN_BASE = "http://campaign.test.local";
+  const FEATURES_BASE = "http://features.test.local";
+  process.env.CAMPAIGN_SERVICE_URL = CAMPAIGN_BASE;
+  process.env.CAMPAIGN_SERVICE_API_KEY = "campaign-test-key";
+  process.env.FEATURES_SERVICE_URL = FEATURES_BASE;
+  process.env.FEATURES_SERVICE_API_KEY = "features-test-key";
+  return { CAMPAIGN_BASE, FEATURES_BASE };
+});
+
+/**
+ * Dashboard v2 per-campaign budget + per-campaign audience stats.
+ *
+ * Two transparent proxies (CLAUDE.md rules #1/#4/#6/#8 — assert the downstream path +
+ * byte-identical body/query forwarding, NOT the downstream response shape):
+ *
+ *  #2  PATCH /v1/brands/:brandId/campaigns/daily-budget  → campaign-service
+ *        PATCH /brands/:brandId/daily-budget   (set every sales campaign's daily budget at once).
+ *        Distinct gateway path from PATCH /v1/brands/:brandId/daily-budget (billing brand cap).
+ *  #3  GET /v1/features/:slug/audience-stats?campaignId=  → features-service, campaignId forwarded.
+ *
+ * (#1 — single-campaign budget — is already served by PATCH /v1/campaigns/:id forwarding
+ *  maxBudgetDailyUsd; unchanged, covered elsewhere.)
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "user_key";
+    next();
+  },
+  authenticatePlatform: (_req: any, _res: any, next: any) => next(),
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  requireStaff: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import campaignsRouter from "../../src/routes/campaigns.js";
+import featuresRouter from "../../src/routes/features.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignsRouter);
+  app.use("/v1", featuresRouter);
+  return app;
+}
+
+describe("per-campaign budget + audience-stats proxies", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return { ok: true, status: 200, json: () => Promise.resolve({ ok: true }) };
+    });
+  });
+
+  // ── #2 set all of a brand's campaigns' daily budget ──────────────────────────
+  it("PATCH /v1/brands/:brandId/campaigns/daily-budget → campaign-service /brands/:brandId/daily-budget, body verbatim", async () => {
+    const body = { dailyBudgetCents: 5000 };
+    const res = await request(buildApp())
+      .patch("/v1/brands/brand-uuid-1/campaigns/daily-budget")
+      .send(body);
+    expect(res.status).toBe(200);
+    const call = calls[0];
+    expect(call.url).toBe(`${CAMPAIGN_BASE}/brands/brand-uuid-1/daily-budget`);
+    expect(call.options.method).toBe("PATCH");
+    expect(JSON.parse(call.options.body)).toEqual(body);
+    expect(call.options.headers["X-API-Key"]).toBe("campaign-test-key");
+    expect(call.options.headers["x-org-id"]).toBe("org_test456");
+    expect(call.options.headers["x-user-id"]).toBe("user_test123");
+  });
+
+  it("PATCH /v1/brands/:brandId/campaigns/daily-budget forwards null (clear) verbatim", async () => {
+    const body = { dailyBudgetCents: null };
+    const res = await request(buildApp())
+      .patch("/v1/brands/brand-uuid-2/campaigns/daily-budget")
+      .send(body);
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe(`${CAMPAIGN_BASE}/brands/brand-uuid-2/daily-budget`);
+    expect(JSON.parse(calls[0].options.body)).toEqual(body);
+  });
+
+  it("returns campaign-service body verbatim (no shape assertion / transform)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ brandId: "brand-uuid-1", orgId: "org_test456", dailyBudgetCents: 5000, updatedCount: 2 }),
+    });
+    const res = await request(buildApp())
+      .patch("/v1/brands/brand-uuid-1/campaigns/daily-budget")
+      .send({ dailyBudgetCents: 5000 });
+    expect(res.body).toEqual({ brandId: "brand-uuid-1", orgId: "org_test456", dailyBudgetCents: 5000, updatedCount: 2 });
+  });
+
+  it("does NOT collide with billing PATCH /v1/brands/:brandId/daily-budget (different path)", async () => {
+    // The campaigns router must only answer the /campaigns/daily-budget sub-path, never the
+    // 3-segment billing path — Express should not match this route for the shorter path.
+    const res = await request(buildApp())
+      .patch("/v1/brands/brand-uuid-1/daily-budget")
+      .send({ dailyBudgetCents: 5000 });
+    // No campaigns-router handler for that path → 404 here (billing router, not mounted in this
+    // test app, owns it in prod). The key assertion: campaign-service was NOT called.
+    expect(res.status).toBe(404);
+    expect(calls.length).toBe(0);
+  });
+
+  // ── #3 audience stats scoped to a single campaign ────────────────────────────
+  it("GET /v1/features/:slug/audience-stats forwards campaignId scope", async () => {
+    const res = await request(buildApp()).get(
+      "/v1/features/sales-cold-email-outreach/audience-stats?brandId=b1&goal=websiteVisit&campaignId=camp-1",
+    );
+    expect(res.status).toBe(200);
+    const url = new URL(calls[0].url);
+    expect(url.pathname).toBe("/features/sales-cold-email-outreach/audience-stats");
+    expect(url.searchParams.get("brandId")).toBe("b1");
+    expect(url.searchParams.get("goal")).toBe("websiteVisit");
+    expect(url.searchParams.get("campaignId")).toBe("camp-1");
+  });
+
+  it("GET /v1/features/:slug/audience-stats without campaignId is unchanged (no campaignId param)", async () => {
+    const res = await request(buildApp()).get(
+      "/v1/features/sales-cold-email-outreach/audience-stats?brandId=b1&goal=signup",
+    );
+    expect(res.status).toBe(200);
+    const url = new URL(calls[0].url);
+    expect(url.searchParams.has("campaignId")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Dashboard v2 (staff/beta) needs, through this gateway:
1. **Set one campaign's daily budget** — already works: `PATCH /v1/campaigns/:id` forwards `maxBudgetDailyUsd`. No change.
2. **Set the daily budget for ALL of a brand's campaigns at once** (brand-page propagation) — new proxy.
3. **Read audience stats scoped to a single campaign** — new query param.

## Changes

- **`PATCH /v1/brands/:brandId/campaigns/daily-budget`** → campaign-service `PATCH /brands/:brandId/daily-budget`. Sets `dailyBudgetCents` on every sales campaign of the brand. `null` clears each campaign's own budget (falls back to brand daily budget). Body + response forwarded byte-identical (passthrough).
  - Client-facing path is **deliberately distinct** from the existing billing proxy `PATCH /v1/brands/:brandId/daily-budget` (#556, brand spend cap — different service, different concept). The **downstream** path string matches campaign-service's actual route (rule #1). No route collision (billing = 3 segments, this = 4).
- **`GET /v1/features/:slug/audience-stats?campaignId=`** — forward optional `campaignId` to features-service to scope per-audience stats to one campaign. Omitted → brand-wide, byte-identical to today.

## Downstream contracts (verified against pushed producer branches)

- campaign-service `KevinLourd/per-campaign-daily-budget`: `PATCH /brands/:brandId/daily-budget`, body `{dailyBudgetCents: int≥0|null}`, resp `{brandId,orgId,dailyBudgetCents,updatedCount}`.
- features-service `KevinLourd/audience-stats-campaign-scope`: `?campaignId=` on `/features/:slug/audience-stats`.

Transparent proxy — no aggregation (rule #2), bodies/queries forwarded verbatim (rules #4/#6/#8).

## Tests

`tests/unit/per-campaign-budget-proxy.test.ts` — path + byte-identical body/query forwarding, `null` clear, response passthrough, no billing-path collision, campaignId scope + absence. Full suite green (1692/0). openapi regenerated.

## Triage

staging (additive feature). Merge gated on both producer branches deploying to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)