### PR TITLE
feat(public-features): proxy best-model-cost-per-outcome-trend

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -193,6 +193,10 @@
         "type": "object",
         "properties": {}
       },
+      "PublicBestModelCostPerOutcomeTrendResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "PublicWorkflowCostPerOutcomeResponse": {
         "type": "object",
         "properties": {}
@@ -10574,6 +10578,103 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicCostPerOutcomeTrendResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Feature not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/features/best-model-cost-per-outcome-trend": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Public best-model cost-per-outcome trend",
+        "description": "Public cross-org dated cost-per-outcome timeseries of the single BEST workflow model for a feature and one objective — the drop-in replacement for the pooled cost-per-outcome-trend, coherent with the best-model headline (min cost-per-outcome across workflows). Every point is a single workflow's cost, never pooled across workflows. Proxied to features-service GET /public/stats/best-model-cost-per-outcome-trend. Forwards featureSlug, objective, and optional days/windowOutcomes. Response is producer-owned. No authentication required.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug (required).",
+              "example": "sales-cold-email-outreach"
+            },
+            "required": true,
+            "description": "Feature slug (required).",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required).",
+              "example": "positiveReply"
+            },
+            "required": true,
+            "description": "Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required).",
+            "name": "objective",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Number of trailing display days to emit (default 30, max 180).",
+              "example": "30"
+            },
+            "required": false,
+            "description": "Number of trailing display days to emit (default 30, max 180).",
+            "name": "days",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Target outcomes per moving-average window (default 100).",
+              "example": "100"
+            },
+            "required": false,
+            "description": "Target outcomes per moving-average window (default 100).",
+            "name": "windowOutcomes",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public best-model cost-per-outcome trend — pass-through from features-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBestModelCostPerOutcomeTrendResponse"
                 }
               }
             }

--- a/src/routes/features.ts
+++ b/src/routes/features.ts
@@ -21,6 +21,7 @@ const PUBLIC_REVENUE_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_WORKFLOW_ENGAGEMENT_LATENCY_PARAMS = ["featureSlug", "groupBy"];
 const PUBLIC_COST_PROJECTION_PARAMS = ["featureSlug"];
 const PUBLIC_COST_PER_OUTCOME_TREND_PARAMS = ["featureSlug", "objective", "days", "windowOutcomes"];
+const PUBLIC_BEST_MODEL_COST_PER_OUTCOME_TREND_PARAMS = ["featureSlug", "objective", "days", "windowOutcomes"];
 const PUBLIC_WORKFLOW_COST_PER_OUTCOME_PARAMS = ["featureSlug", "objective"];
 const PUBLIC_COST_PER_OUTCOME_LIFETIME_PARAMS = ["featureSlug"];
 const PUBLIC_COST_PER_OUTCOME_DISTRIBUTION_PARAMS = ["featureSlug", "objective", "buckets"];
@@ -152,6 +153,26 @@ router.get("/public/features/cost-per-outcome-trend", async (req: Request, res: 
   } catch (error: any) {
     console.error("[api-service] Public cost-per-outcome trend error:", error.message);
     res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public cost-per-outcome trend" });
+  }
+});
+
+/**
+ * GET /v1/public/features/best-model-cost-per-outcome-trend
+ * Public dated cost-per-outcome trend of the single BEST cross-org workflow model for one objective.
+ * Proxied to features-service GET /public/stats/best-model-cost-per-outcome-trend.
+ */
+router.get("/public/features/best-model-cost-per-outcome-trend", async (req: Request, res: Response) => {
+  try {
+    const params = buildParams(req.query as Record<string, unknown>, PUBLIC_BEST_MODEL_COST_PER_OUTCOME_TREND_PARAMS);
+    const result = await callExternalService(
+      externalServices.features,
+      `/public/stats/best-model-cost-per-outcome-trend?${params}`,
+      {},
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Public best-model cost-per-outcome trend error:", error.message);
+    res.status(error.statusCode || 502).json({ error: error.message || "Failed to get public best-model cost-per-outcome trend" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -196,6 +196,13 @@ const publicCostPerOutcomeTrendQueryParams = z.object({
   windowOutcomes: z.string().optional().openapi({ example: "100" }).describe("Target outcomes per moving-average window (default 100)."),
 });
 
+const publicBestModelCostPerOutcomeTrendQueryParams = z.object({
+  featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
+  objective: z.string().openapi({ example: "positiveReply" }).describe("Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required)."),
+  days: z.string().optional().openapi({ example: "30" }).describe("Number of trailing display days to emit (default 30, max 180)."),
+  windowOutcomes: z.string().optional().openapi({ example: "100" }).describe("Target outcomes per moving-average window (default 100)."),
+});
+
 const publicWorkflowCostPerOutcomeQueryParams = z.object({
   featureSlug: z.string().openapi({ example: "sales-cold-email-outreach" }).describe("Feature slug (required)."),
   objective: z.string().openapi({ example: "positiveReply" }).describe("Optimization objective — one of websiteVisit / positiveReply / signup / formSubmission / meetingBooked / purchase (required)."),
@@ -362,6 +369,23 @@ registry.registerPath({
   request: { query: publicCostPerOutcomeTrendQueryParams },
   responses: {
     200: { description: "Public cost-per-outcome trend — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicCostPerOutcomeTrendResponse") } } },
+    400: { description: "Bad request from features-service", content: errorContent },
+    404: { description: "Feature not found", content: errorContent },
+    502: { description: "Upstream service error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/public/features/best-model-cost-per-outcome-trend",
+  tags: ["Features"],
+  summary: "Public best-model cost-per-outcome trend",
+  description:
+    "Public cross-org dated cost-per-outcome timeseries of the single BEST workflow model for a feature and one objective — the drop-in replacement for the pooled cost-per-outcome-trend, coherent with the best-model headline (min cost-per-outcome across workflows). Every point is a single workflow's cost, never pooled across workflows. " +
+    "Proxied to features-service GET /public/stats/best-model-cost-per-outcome-trend. Forwards featureSlug, objective, and optional days/windowOutcomes. Response is producer-owned. No authentication required.",
+  request: { query: publicBestModelCostPerOutcomeTrendQueryParams },
+  responses: {
+    200: { description: "Public best-model cost-per-outcome trend — pass-through from features-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("PublicBestModelCostPerOutcomeTrendResponse") } } },
     400: { description: "Bad request from features-service", content: errorContent },
     404: { description: "Feature not found", content: errorContent },
     502: { description: "Upstream service error", content: errorContent },


### PR DESCRIPTION
## What
Transparent gateway proxy **`GET /v1/public/features/best-model-cost-per-outcome-trend`** → features-service `GET /public/stats/best-model-cost-per-outcome-trend`. Forwards `featureSlug`, `objective`, `days`, `windowOutcomes`. Response is producer-owned (passthrough). No auth.

## Why
Lets distribute.you (public landing) call the new best-model cost-per-outcome trend with no auth. That endpoint replaces the pooled `/cost-per-outcome-trend` on the landing "live cost of acquisition" chart so the line agrees with the best-model headline (min cost-per-outcome across workflows, never a pooled ~$250 blend). Mirrors the sibling `/public/features/cost-per-outcome-trend` proxy exactly.

## Producer
features-service PR: dated best-model cost-per-outcome trend (`/public/stats/best-model-cost-per-outcome-trend`).

## Triage
Additive transparent proxy, zero blast radius → main (prod-direct), matching the sibling public-features proxies. `tsc` clean, `openapi.json` regen'd, 1712 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)