### PR TITLE
feat(brands): proxy brand user-fields GET/PUT + extract-fields provenance passthrough

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5122,6 +5122,14 @@
         "type": "object",
         "properties": {}
       },
+      "BrandUserFieldsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "BrandUserFieldsRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "TransferBrandResponse": {
         "type": "object",
         "properties": {
@@ -23242,6 +23250,269 @@
           },
           "409": {
             "description": "Conflict (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/user-fields": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get a brand's confirmed user-facing fields",
+        "description": "Proxy to brand-service GET /orgs/brands/{id}/user-fields. Returns { fields: { <key>: { value, provenance } } } for the 7 user-facing keys (confirmed value wins with provenance `confirmed`, else the most-recent non-expired auto-extract prefill with provenance `suggested`). Response shape is owned by the downstream service — passthrough only. Any query string is forwarded verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User-facing fields with provenance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandUserFieldsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Confirm (upsert) a brand's user-facing fields",
+        "description": "Proxy to brand-service PUT /orgs/brands/{id}/user-fields. Body { fields: { <key>: value } } upserts confirmed (durable) values; returns the updated view in the same shape as GET. Body + response shapes are owned by the downstream service; its 4xx (incl. 400 on an unknown key) propagate verbatim — passthrough only.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BrandUserFieldsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated user-facing fields with provenance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandUserFieldsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error / unknown key (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -656,4 +656,46 @@ router.post("/brands/:id/brand-profile", authenticate, requireOrg, requireUser, 
   }
 });
 
+/**
+ * GET /v1/brands/:id/user-fields
+ * Proxy to brand-service GET /orgs/brands/:id/user-fields.
+ * Returns the brand's 7 user-facing fields as { fields: { <key>: { value, provenance } } }
+ * (confirmed value wins, else the most-recent non-expired auto-extract prefill). Response
+ * shape is owned by the downstream service — passthrough only. Query string forwarded verbatim.
+ */
+router.get("/brands/:id/user-fields", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/user-fields${rawQuery(req)}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Get brand user-fields error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get brand user-fields" });
+  }
+});
+
+/**
+ * PUT /v1/brands/:id/user-fields
+ * Proxy to brand-service PUT /orgs/brands/:id/user-fields. Upserts confirmed user fields
+ * (body { fields: { <key>: value } }); returns the updated view in the same shape as GET.
+ * Body + response shapes are owned by the downstream service; its 4xx (incl. 400 on an
+ * unknown key) propagate verbatim — passthrough only.
+ */
+router.put("/brands/:id/user-fields", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/user-fields${rawQuery(req)}`,
+      { method: "PUT", headers: buildInternalHeaders(req), body: req.body },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Save brand user-fields error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to save brand user-fields" });
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4004,6 +4004,8 @@ const IcpSuggestRequestSchema = z.object({}).passthrough().openapi("IcpSuggestRe
 const IcpSuggestResponseSchema = z.object({}).passthrough().openapi("IcpSuggestResponse");
 const BrandProfileResponseSchema = z.object({}).passthrough().openapi("BrandProfileResponse");
 const BrandProfileRequestSchema = z.object({}).passthrough().openapi("BrandProfileRequest");
+const BrandUserFieldsResponseSchema = z.object({}).passthrough().openapi("BrandUserFieldsResponse");
+const BrandUserFieldsRequestSchema = z.object({}).passthrough().openapi("BrandUserFieldsRequest");
 
 registry.registerPath({
   method: "post",
@@ -4070,6 +4072,51 @@ registry.registerPath({
     401: { description: "Unauthorized", content: errorContent },
     404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
     409: { description: "Conflict (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{id}/user-fields",
+  tags: ["Brand"],
+  summary: "Get a brand's confirmed user-facing fields",
+  description:
+    "Proxy to brand-service GET /orgs/brands/{id}/user-fields. " +
+    "Returns { fields: { <key>: { value, provenance } } } for the 7 user-facing keys " +
+    "(confirmed value wins with provenance `confirmed`, else the most-recent non-expired " +
+    "auto-extract prefill with provenance `suggested`). Response shape is owned by the " +
+    "downstream service — passthrough only. Any query string is forwarded verbatim.",
+  security: authed,
+  request: { params: BrandIdParam },
+  responses: {
+    200: { description: "User-facing fields with provenance", content: { "application/json": { schema: BrandUserFieldsResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/brands/{id}/user-fields",
+  tags: ["Brand"],
+  summary: "Confirm (upsert) a brand's user-facing fields",
+  description:
+    "Proxy to brand-service PUT /orgs/brands/{id}/user-fields. Body { fields: { <key>: value } } " +
+    "upserts confirmed (durable) values; returns the updated view in the same shape as GET. " +
+    "Body + response shapes are owned by the downstream service; its 4xx (incl. 400 on an " +
+    "unknown key) propagate verbatim — passthrough only.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: { content: { "application/json": { schema: BrandUserFieldsRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Updated user-facing fields with provenance", content: { "application/json": { schema: BrandUserFieldsResponseSchema } } },
+    400: { description: "Validation error / unknown key (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
     500: { description: "Upstream error", content: errorContent },
   },
 });

--- a/tests/unit/brand-user-fields-proxy.test.ts
+++ b/tests/unit/brand-user-fields-proxy.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.brandId = "brand_testabc";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+const BRAND_ID = "11111111-1111-4111-8111-111111111111";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+let capturedUrl: string | undefined;
+let capturedInit: RequestInit | undefined;
+
+function mockUpstream(status: number, payload: unknown, ok = status < 400) {
+  global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    capturedUrl = url;
+    capturedInit = init;
+    return ok
+      ? { ok: true, status, json: () => Promise.resolve(payload) }
+      : { ok: false, status, text: () => Promise.resolve(JSON.stringify(payload)) };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedUrl = undefined;
+  capturedInit = undefined;
+});
+
+// Full downstream shape incl. the { value, provenance } wrapper — must pass through verbatim.
+const fieldsPayload = {
+  fields: {
+    services: { value: "SEO consulting", provenance: "confirmed" },
+    dreamOutcome: { value: "Rank #1 on Google", provenance: "suggested" },
+    perceivedLikelihood: { value: null, provenance: "suggested" },
+    socialProof: { value: ["500+ clients"], provenance: "confirmed" },
+    riskReversal: { value: "30-day guarantee", provenance: "confirmed" },
+    urgency: { value: null, provenance: "suggested" },
+    scarcity: { value: null, provenance: "suggested" },
+  },
+};
+
+describe("GET /v1/brands/:id/user-fields", () => {
+  it("forwards to brand-service /orgs/brands/:id/user-fields and returns { fields } + status verbatim", async () => {
+    mockUpstream(200, fieldsPayload);
+    const app = buildApp();
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/user-fields`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fieldsPayload);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/user-fields`);
+    expect(capturedInit?.method ?? "GET").toBe("GET");
+  });
+
+  it("preserves the { value, provenance } wrapper on every key (no stripping)", async () => {
+    mockUpstream(200, fieldsPayload);
+    const app = buildApp();
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/user-fields`);
+
+    expect(res.body.fields.services).toEqual({ value: "SEO consulting", provenance: "confirmed" });
+    expect(res.body.fields.perceivedLikelihood).toEqual({ value: null, provenance: "suggested" });
+  });
+
+  it("forwards identity headers (x-org-id, x-user-id, x-run-id)", async () => {
+    mockUpstream(200, fieldsPayload);
+    const app = buildApp();
+    await request(app).get(`/v1/brands/${BRAND_ID}/user-fields`);
+
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+  });
+
+  it.each([
+    [404, { error: "Brand not found" }, "Brand not found"],
+    [401, { error: "Unauthorized" }, "Unauthorized"],
+  ])("propagates upstream %i status + body verbatim", async (status, payload, expected) => {
+    mockUpstream(status, payload);
+    const app = buildApp();
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/user-fields`);
+
+    expect(res.status).toBe(status);
+    expect(res.body.error).toContain(expected);
+  });
+});
+
+describe("PUT /v1/brands/:id/user-fields", () => {
+  const body = { fields: { services: "SEO consulting", riskReversal: "30-day guarantee" } };
+
+  it("forwards body byte-identical to downstream and returns { fields } verbatim", async () => {
+    mockUpstream(200, fieldsPayload);
+    const app = buildApp();
+    const res = await request(app).put(`/v1/brands/${BRAND_ID}/user-fields`).send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(fieldsPayload);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/user-fields`);
+    expect(capturedInit?.method).toBe("PUT");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual(body);
+  });
+
+  it("propagates an upstream 400 on an unknown key + body verbatim", async () => {
+    mockUpstream(400, { error: "Unknown field key: bogus" });
+    const app = buildApp();
+    const res = await request(app).put(`/v1/brands/${BRAND_ID}/user-fields`).send({ fields: { bogus: "x" } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Unknown field key");
+  });
+});


### PR DESCRIPTION
## What

Adds gateway proxies for brand-service's new 2-layer brand-fields model.

- `GET /v1/brands/:id/user-fields` → brand-service `GET /orgs/brands/:id/user-fields`
- `PUT /v1/brands/:id/user-fields` → brand-service `PUT /orgs/brands/:id/user-fields`

Both org-scoped (`authenticate + requireOrg + requireUser`), forward identity headers via `buildInternalHeaders`, use `callExternalServiceWithStatus` so downstream 4xx (incl. 400 on unknown key) propagate verbatim, and pass the raw query string through. Response passthrough: `{ fields: { <key>: { value, provenance } } }`, shape owned by brand-service.

### extract-fields `provenance` — no code change needed
`POST /v1/brands/extract-fields` response schema is already `z.object({}).passthrough()` (schemas.ts) and the route returns `res.json(result)` verbatim. The new additive `provenance` sibling field flows through untouched. Verified against the staging API registry (`responseFields: [brands, fields, provenance]`).

### Unchanged
Existing brand-profile proxies (`GET/POST /v1/brands/:id/brand-profile`) untouched — brand-service keeps them as a compat shim during migration.

## Tests
`tests/unit/brand-user-fields-proxy.test.ts` mirrors the existing brand-profile proxy tests: correct downstream path, identity-header forwarding, verbatim response incl the `{ value, provenance }` wrapper (no stripping), body byte-identical on PUT, error propagation (404/401/400). Full suite green: 141 files / 1722 tests. `tsc` + openapi regen clean.

## Deployment ordering
These routes are **dormant until brand-service's `/orgs/brands/:id/user-fields` endpoints are live in prod**. Additive, zero blast radius to existing traffic — safe to ship ahead of the downstream deploy. When called before brand-service is deployed, they simply proxy through and surface brand-service's response verbatim (404 if the route isn't there yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
