### PR TITLE
feat(crm): proxy GET /orgs/contacts/serve-stats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -43005,6 +43005,129 @@
           }
         }
       }
+    },
+    "/v1/orgs/contacts/serve-stats": {
+      "get": {
+        "tags": [
+          "CRM Contacts"
+        ],
+        "summary": "Served vs remaining sendable counts for a brand",
+        "description": "Proxy to crm-service GET /orgs/contacts/serve-stats. `brandId` query forwarded untransformed. Response shape (served / remainingSendable / totalSendable) owned by crm-service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Brand ID (required)"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Serve stats as returned by crm-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrmContactsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "crm-service unreachable / not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/routes/crm.ts
+++ b/src/routes/crm.ts
@@ -81,4 +81,19 @@ router.get("/orgs/contacts/uploads", ...authChain, async (req: AuthenticatedRequ
   }
 });
 
+// GET /v1/orgs/contacts/serve-stats → crm-service GET /orgs/contacts/serve-stats
+// (served / remainingSendable / totalSendable counts for a brand)
+router.get("/orgs/contacts/serve-stats", ...authChain, async (req: AuthenticatedRequest, res) => {
+  try {
+    const brandId = req.query?.brandId;
+    const qs = typeof brandId === "string" && brandId.length > 0 ? `?brandId=${encodeURIComponent(brandId)}` : "";
+    const result = await callExternalService(externalServices.crm, `/orgs/contacts/serve-stats${qs}`, {
+      headers: buildInternalHeaders(req),
+    });
+    res.json(result);
+  } catch (error: any) {
+    fail(res, error, "Contact serve-stats error");
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -9653,3 +9653,24 @@ registry.registerPath({
     502: { description: "crm-service unreachable / not configured", content: errorContent },
   },
 });
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/orgs/contacts/serve-stats",
+  tags: ["CRM Contacts"],
+  summary: "Served vs remaining sendable counts for a brand",
+  description:
+    "Proxy to crm-service GET /orgs/contacts/serve-stats. `brandId` query forwarded untransformed. Response shape (served / remainingSendable / totalSendable) owned by crm-service.",
+  security: authed,
+  request: {
+    query: z.object({
+      brandId: z.string().uuid().openapi({ description: "Brand ID (required)" }),
+    }),
+  },
+  responses: {
+    200: { description: "Serve stats as returned by crm-service", content: { "application/json": { schema: CrmPassthroughResponse } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+    502: { description: "crm-service unreachable / not configured", content: errorContent },
+  },
+});

--- a/tests/unit/crm-proxy.test.ts
+++ b/tests/unit/crm-proxy.test.ts
@@ -91,6 +91,17 @@ describe("/v1/orgs/contacts/* → crm-service", () => {
     expect(calls[0].url).toBe(`${CRM_BASE}/orgs/contacts/uploads?brandId=brand-uuid-1`);
   });
 
+  it("GET /orgs/contacts/serve-stats forwards brandId + identity + api-key headers", async () => {
+    const res = await request(buildApp()).get("/v1/orgs/contacts/serve-stats?brandId=brand-uuid-1");
+    expect(res.status).toBe(200);
+    const call = calls[0];
+    expect(call.url).toBe(`${CRM_BASE}/orgs/contacts/serve-stats?brandId=brand-uuid-1`);
+    expect(call.options.method ?? "GET").toBe("GET");
+    expect(call.options.headers["X-API-Key"]).toBe("crm-test-key");
+    expect(call.options.headers["x-org-id"]).toBe("org_test456");
+    expect(call.options.headers["x-user-id"]).toBe("user_test123");
+  });
+
   it("propagates upstream error status + verbatim body (no mask)", async () => {
     (global.fetch as any).mockImplementationOnce(async (url: string, options: any) => {
       calls.push({ url, options });


### PR DESCRIPTION
## What

Expose crm-service's existing `GET /orgs/contacts/serve-stats?brandId=<uuid>` through the gateway's transparent CRM proxy, mirroring the sibling `GET /orgs/contacts` and `GET /orgs/contacts/uploads` routes already forwarded in `src/routes/crm.ts` (#740).

Returns crm-service's `served` / `remainingSendable` / `totalSendable` counts for a brand. Path preserved, `brandId` query forwarded untransformed, identity org+user headers + `x-api-key` forwarded, response passthrough (crm-service owns the shape, CLAUDE.md #8). Auth chain `authenticate + requireOrg + requireUser`, identical to siblings.

## Why

Admin dashboard **Services > CRM** page (#2962) wants a header stat: how many of a brand's uploaded contacts have been served vs remain sendable. serve-stats was the only brand-scoped crm-service read not yet forwarded by this gateway; the other three siblings landed in #740.

## Changes (3-per-endpoint convention)

- `src/routes/crm.ts` — new `GET /orgs/contacts/serve-stats` handler
- `src/schemas.ts` — `registerPath` (passthrough response)
- `openapi.json` — regenerated
- `tests/unit/crm-proxy.test.ts` — coverage mirroring the uploads route

## Verification

- `pnpm test:unit` → 1717 passed (140 files)
- `pnpm build` (tsc + openapi regen) → clean

## Dependency

crm-service `GET /orgs/contacts/serve-stats` is already **live** (verified via api-registry prod). No downstream coordination needed.

## Triage

Additive, zero blast radius — new dormant proxy route, no existing handler/response/middleware touched, nothing calls it until the admin consumer ships. Prod-direct → main per this repo's additive-gateway convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)