### PR TITLE
hotfix: Buffer multipart CSV upload body so content-length matches (fix prod fetch failed 500)

### DIFF
--- a/src/lib/service-client.ts
+++ b/src/lib/service-client.ts
@@ -407,22 +407,33 @@ export async function streamExternalService(
 }
 
 /**
- * Stream a multipart/form-data request body straight through to a downstream
- * service without buffering or parsing it. Used for file uploads (e.g. crm-service
- * CSV ingest, up to ~80K rows) where re-encoding the body would corrupt the
- * multipart boundary and buffering the whole file wastes memory.
+ * Forward a multipart/form-data request body to a downstream service (e.g.
+ * crm-service CSV ingest). The whole body is BUFFERED into memory first, then
+ * sent as a single Buffer so undici derives a `content-length` that exactly
+ * matches the bytes on the wire.
  *
- * The Express `req` (a Node Readable) is passed as the fetch body with
- * `duplex: "half"`; the original `content-type` (INCLUDING the multipart
- * boundary) and `content-length` are forwarded verbatim, plus the identity
- * headers and `X-API-Key`. The upstream JSON response is parsed and returned
- * with its status. On a non-2xx the upstream body is thrown verbatim (CLAUDE.md
- * rule #7) with `statusCode` set, so the route can surface it to the client.
+ * Why buffer instead of stream: passing the raw Express `req` (a Node Readable)
+ * as the fetch body with `duplex: "half"` WHILE forwarding the inbound
+ * `content-length` header makes undici abort with "Request body length does not
+ * match content-length header" the moment the streamed byte count diverges from
+ * the declared length — surfacing to the client as an opaque
+ * `TypeError: fetch failed` (500). Buffering removes the mismatch entirely:
+ * undici sets `content-length` from the Buffer, and the multipart boundary in
+ * the forwarded `content-type` stays intact because the raw bytes are copied
+ * verbatim (no re-encoding, no field stripping — CLAUDE.md rules #1/#4). CSV
+ * uploads are bounded/small, so the memory cost is negligible.
  *
- * No transient-network retry here: the request stream is single-use and can't be
- * replayed once consumed.
+ * The original `content-type` (INCLUDING the multipart boundary) is forwarded
+ * verbatim, plus the identity headers and `X-API-Key`. The inbound
+ * `content-length` is deliberately NOT forwarded — undici recomputes it. The
+ * upstream JSON response is parsed and returned with its status. On a non-2xx
+ * the upstream body is thrown verbatim (CLAUDE.md rule #7) with `statusCode`
+ * set, so the route can surface it to the client.
+ *
+ * No transient-network retry here: the request body is consumed once while
+ * buffering and the semantics of a partial upload retry are undefined.
  */
-export async function streamMultipartUpload<T>(
+export async function forwardMultipartUpload<T>(
   service: { url: string; apiKey: string; dispatcher?: Dispatcher },
   path: string,
   options: { req: import("express").Request; headers?: Record<string, string> },
@@ -430,20 +441,27 @@ export async function streamMultipartUpload<T>(
   const { req, headers = {} } = options;
   const url = `${service.url}${path}`;
 
+  // Buffer the entire multipart body. `express.json()` skips non-JSON content
+  // types, so the multipart stream reaches here untouched and fully readable.
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const bodyBuffer = Buffer.concat(chunks);
+
   const forwardHeaders: Record<string, string> = {
     "X-API-Key": service.apiKey,
     ...headers,
   };
   const contentType = req.headers["content-type"];
   if (contentType) forwardHeaders["content-type"] = contentType;
-  const contentLength = req.headers["content-length"];
-  if (contentLength) forwardHeaders["content-length"] = contentLength;
+  // Do NOT forward the inbound `content-length` — undici sets it from
+  // `bodyBuffer`, guaranteeing the declared length matches the bytes sent.
 
-  const init: RequestInit & { dispatcher?: Dispatcher; duplex: "half" } = {
+  const init: RequestInit & { dispatcher?: Dispatcher } = {
     method: "POST",
     headers: forwardHeaders,
-    body: req as unknown as ReadableStream,
-    duplex: "half",
+    body: bodyBuffer,
   };
   if (service.dispatcher) init.dispatcher = service.dispatcher;
 
@@ -451,7 +469,7 @@ export async function streamMultipartUpload<T>(
 
   if (!response.ok) {
     const errorText = await response.text();
-    console.error(`[streamMultipartUpload] POST ${url} upstream error ${response.status}:`, errorText);
+    console.error(`[forwardMultipartUpload] POST ${url} upstream error ${response.status}:`, errorText);
     const message = errorText || `Service call failed: ${response.status}`;
     const err = new Error(message) as Error & { statusCode: number };
     err.statusCode = response.status;

--- a/src/routes/crm.ts
+++ b/src/routes/crm.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { authenticate, requireOrg, requireUser, AuthenticatedRequest } from "../middleware/auth.js";
 import {
   callExternalService,
-  streamMultipartUpload,
+  forwardMultipartUpload,
   externalServices,
 } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
@@ -21,11 +21,12 @@ import { buildInternalHeaders } from "../lib/internal-headers.js";
  * `statusCode: 502`, so a deploy that lands before the Railway vars are set
  * degrades to a 502 on these routes only — never a boot-loop.
  *
- * The upload route is a MULTIPART file upload (a CSV, up to ~80K rows). It is
- * streamed straight through via `streamMultipartUpload` — the request body is
- * NOT buffered or parsed, so the multipart boundary stays intact and there is
- * no size ceiling (the global `express.json()` only parses application/json, so
- * a multipart body reaches the handler as an untouched readable stream).
+ * The upload route is a MULTIPART file upload (a CSV, up to ~80K rows). The body
+ * is buffered whole and forwarded via `forwardMultipartUpload` — the multipart
+ * boundary stays intact (raw bytes copied verbatim) and undici sets a
+ * `content-length` matching the buffered bytes. The global `express.json()`
+ * only parses application/json, so the multipart body reaches the handler as an
+ * untouched readable stream.
  *
  * crm-service `/internal/contacts/promote` is deliberately NOT proxied — it is
  * an internal-tier route, not a dashboard path (CLAUDE.md rule #3).
@@ -40,10 +41,10 @@ function fail(res: import("express").Response, error: any, msg: string): void {
 }
 
 // POST /v1/orgs/contacts/upload → crm-service POST /orgs/contacts/upload
-// Multipart CSV upload streamed through untouched.
+// Multipart CSV upload buffered + forwarded untouched.
 router.post("/orgs/contacts/upload", ...authChain, async (req: AuthenticatedRequest, res) => {
   try {
-    const { status, data } = await streamMultipartUpload(externalServices.crm, "/orgs/contacts/upload", {
+    const { status, data } = await forwardMultipartUpload(externalServices.crm, "/orgs/contacts/upload", {
       req,
       headers: buildInternalHeaders(req),
     });

--- a/tests/unit/crm-proxy.test.ts
+++ b/tests/unit/crm-proxy.test.ts
@@ -54,7 +54,7 @@ describe("/v1/orgs/contacts/* → crm-service", () => {
     delete process.env.CRM_SERVICE_API_KEY;
   });
 
-  it("POST /orgs/contacts/upload streams multipart through with identity + api-key headers", async () => {
+  it("POST /orgs/contacts/upload buffers multipart + forwards with identity + api-key headers", async () => {
     const res = await request(buildApp())
       .post("/v1/orgs/contacts/upload")
       .field("brandId", "brand-uuid-1")
@@ -64,11 +64,17 @@ describe("/v1/orgs/contacts/* → crm-service", () => {
     const call = calls[0];
     expect(call.url).toBe(`${CRM_BASE}/orgs/contacts/upload`);
     expect(call.options.method).toBe("POST");
-    // Multipart streamed through untouched: content-type carries the boundary,
-    // body is the raw request stream (NOT a JSON string), duplex is half.
+    // Multipart forwarded untouched: content-type carries the boundary, body is
+    // the buffered raw bytes (a Buffer, NOT a JSON string). The inbound
+    // content-length is NOT re-forwarded — undici derives it from the Buffer so
+    // the declared length always matches the bytes sent (the fix for the
+    // "Request body length does not match content-length" → fetch failed 500).
     expect(call.options.headers["content-type"]).toMatch(/^multipart\/form-data; boundary=/);
-    expect(call.options.duplex).toBe("half");
-    expect(typeof call.options.body).not.toBe("string");
+    expect(call.options.headers["content-length"]).toBeUndefined();
+    expect(call.options.duplex).toBeUndefined();
+    expect(Buffer.isBuffer(call.options.body)).toBe(true);
+    // Body carries the CSV field content verbatim through the multipart wrapper.
+    expect(call.options.body.toString()).toContain("a@b.com,Al");
     expect(call.options.headers["X-API-Key"]).toBe("crm-test-key");
     expect(call.options.headers["x-org-id"]).toBe("org_test456");
     expect(call.options.headers["x-user-id"]).toBe("user_test123");


### PR DESCRIPTION
Automated by release.sh