### PR TITLE
feat(brands): no-website brands + large business-context body

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5045,12 +5045,14 @@
           "url": {
             "type": "string",
             "minLength": 1,
-            "description": "Brand website URL"
+            "description": "Brand website URL (omit for a no-website brand)"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Brand name — identity source when no URL is provided"
           }
-        },
-        "required": [
-          "url"
-        ]
+        }
       },
       "BrandRunsResponse": {
         "type": "object",

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,10 @@ app.use(cors({
   credentials: true,
 }));
 
-app.use(express.json());
+// Raised from the 100kb express default: no-website brands post a large
+// free-form business-context body (~1MB / ~300k chars, "5 PDFs of 20 pages")
+// that brand-service stores + uses as the field-extraction source.
+app.use(express.json({ limit: "10mb" }));
 
 // OpenAPI spec endpoint
 const openapiPath = join(__dirname, "..", "openapi.json");

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -17,7 +17,13 @@ router.post("/brands", authenticate, requireOrg, requireUser, async (req: Authen
     if (!parsed.success) {
       return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
     }
+    // A brand needs an identity: a website URL, or a name for the no-website case.
+    if (!parsed.data.url && !parsed.data.name) {
+      return res.status(400).json({ error: "Invalid request", details: "Either url or name is required" });
+    }
 
+    // Pure passthrough: forward the body verbatim (url and/or name, plus any
+    // free-form business-context field) with the resolved org/user identity.
     const result = await callExternalService<{ brandId: string }>(
       externalServices.brand,
       "/orgs/brands",
@@ -25,7 +31,7 @@ router.post("/brands", authenticate, requireOrg, requireUser, async (req: Authen
         method: "POST",
         headers: buildInternalHeaders(req),
         body: {
-          url: parsed.data.url,
+          ...parsed.data,
           orgId: req.orgId!,
           userId: req.userId!,
         },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3440,10 +3440,16 @@ registry.registerPath({
 // ===================================================================
 
 
+// Passthrough — brand-service owns this shape. A brand may have NO website:
+// callers send `name` (identity source) instead of `url`, and may include a
+// large free-form business-context field. Both are forwarded as-is; the
+// route handler enforces "at least one of url/name" (fail loud).
 export const BrandUpsertRequestSchema = z
   .object({
-    url: z.string().min(1).describe("Brand website URL"),
+    url: z.string().min(1).optional().describe("Brand website URL (omit for a no-website brand)"),
+    name: z.string().min(1).optional().describe("Brand name — identity source when no URL is provided"),
   })
+  .passthrough()
   .openapi("BrandUpsertRequest");
 
 export const IcpSuggestionRequestSchema = z

--- a/tests/unit/brand-upsert.test.ts
+++ b/tests/unit/brand-upsert.test.ts
@@ -27,7 +27,8 @@ import brandRouter from "../../src/routes/brand.js";
 
 function buildApp() {
   const app = express();
-  app.use(express.json());
+  // Mirror src/index.ts: raised limit so a large business-context body is accepted.
+  app.use(express.json({ limit: "10mb" }));
   app.use("/v1", brandRouter);
   return app;
 }
@@ -68,7 +69,35 @@ describe("POST /v1/brands – upsert brand", () => {
     });
   });
 
-  it("should return 400 when url is missing", async () => {
+  it("should create a no-website brand from name only and forward name, orgId, userId", async () => {
+    const res = await request(app)
+      .post("/v1/brands")
+      .send({ name: "Acme Co" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ brandId: "brand-abc" });
+    expect(capturedBody).toEqual({
+      name: "Acme Co",
+      orgId: "org_test456",
+      userId: "user_test123",
+    });
+  });
+
+  it("should forward a large free-form business-context field verbatim (passthrough)", async () => {
+    const businessContext = "x".repeat(300_000);
+    await request(app)
+      .post("/v1/brands")
+      .send({ name: "Acme Co", businessContext });
+
+    expect(capturedBody).toEqual({
+      name: "Acme Co",
+      businessContext,
+      orgId: "org_test456",
+      userId: "user_test123",
+    });
+  });
+
+  it("should return 400 when neither url nor name is provided", async () => {
     const res = await request(app)
       .post("/v1/brands")
       .send({});


### PR DESCRIPTION
## What

Enable the **no-website brand** flow through the gateway. Dashboard onboarding lets a user paste large free-form business text (~1MB / ~300k chars) for a brand that has no website URL; brand-service (shipping in parallel) stores it and uses it as the field-extraction source.

## Changes
- **Body limit** `express.json` 100kb → **10mb** (`src/index.ts`) so a ~1MB pasted business-context body reaches brand-service without `request entity too large`.
- **POST /v1/brands** now accepts `name` (no-website identity source) alongside `url`, and forwards the body **verbatim** (passthrough) instead of cherry-picking only `url`. Fails loud (400) when neither `url` nor `name` is present.
- **BrandUpsertRequestSchema**: `url` optional, `name` added, `.passthrough()` for any free-form field (e.g. `businessContext`). Regenerated `openapi.json` (drops `required: [url]`).

## Out of scope (blocked on producer)
The dedicated per-brand **business-context write route** is owned by brand-service and does **not yet exist** on any branch / PR / issue / deployed route across the fleet. Per repo rule #5 (no path invention) it will be forwarded as a pure passthrough once brand-service publishes the path. The body-limit raise already makes the gateway ready for it.

## Verification
- `tsc` clean, `pnpm build` green, **1722/1722** unit tests pass.
- New tests: null-URL (name-only) create forwards `{name, orgId, userId}`; 300k-char `businessContext` forwarded verbatim; `{}` → 400.

## Triage
staging (additive passthrough + body-limit raise, zero blast radius on existing brand routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)