### PR TITLE
feat(brands,campaigns): gateway passthrough for no-website brand context + campaign create by brandIds

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -492,7 +492,16 @@
               "minLength": 1
             },
             "minItems": 1,
-            "description": "Brand website URLs. First URL is the primary brand; additional URLs are secondary brands."
+            "description": "Brand website URLs. First URL is the primary brand; additional URLs are secondary brands. Provide this (website path) OR brandIds (no-website path) — exactly one."
+          },
+          "brandIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "description": "Brand UUIDs of already-created brands (no-website path). First id is the primary brand. When provided, api-service skips the brandUrls→brand upsert and forwards these ids straight to campaign-service. Provide this OR brandUrls — exactly one."
           },
           "featureSlug": {
             "type": "string",
@@ -601,7 +610,6 @@
         },
         "required": [
           "name",
-          "brandUrls",
           "featureInputs"
         ],
         "example": {
@@ -5102,6 +5110,48 @@
         },
         "required": [
           "clickDestinationUrl"
+        ]
+      },
+      "BusinessContextResponse": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "BusinessContextRequest": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Free-form business context field-extraction reads from for a no-website brand. Large bodies (~up to 1MB) accepted.",
+            "example": "Acme Corp is a B2B SaaS selling AI-powered analytics to mid-market retailers..."
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "AttachBrandWebsiteResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "AttachBrandWebsiteRequest": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The website URL to attach to the no-website brand. Must be a valid http(s) URL.",
+            "example": "https://acme.com"
+          }
+        },
+        "required": [
+          "url"
         ]
       },
       "ConversionTokenResponse": {
@@ -21309,6 +21359,156 @@
             }
           }
         }
+      },
+      "patch": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Attach a website to an existing no-website brand",
+        "description": "Proxy to brand-service PATCH /orgs/brands/{id}. Attaches a website to an existing no-website brand (sets brands.url + domain); the next post-cache-expiry field extraction re-sources from the site automatically. Body { url } + response shape ({ brandId, domain, name, url }) are owned by the downstream service; its 4xx validation errors and 409 domain-conflict propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachBrandWebsiteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Website attached",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachBrandWebsiteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid URL (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Domain already in use by another brand (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/brands/extract-fields": {
@@ -22553,6 +22753,269 @@
           },
           "403": {
             "description": "Brand not in caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/business-context": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get a no-website brand's pasted business context",
+        "description": "Proxy to brand-service GET /orgs/brands/{id}/business-context. Returns { content: string | null } — the free-form business context used as the field-extraction source for a no-website brand, or null when unset. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business context (or null when unset)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BusinessContextResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Save a no-website brand's business context",
+        "description": "Proxy to brand-service PUT /orgs/brands/{id}/business-context. Saves the free-form business context field-extraction reads from when the brand has no website (idempotent on brand_id). Large bodies (~up to 1MB) are accepted. Body { content } + response shapes are owned by the downstream service; its 4xx validation errors propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BusinessContextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Business context saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BusinessContextResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -414,6 +414,78 @@ router.put("/brands/:id/click-destination", authenticate, requireOrg, requireUse
 });
 
 /**
+ * GET /v1/brands/:id/business-context
+ * Proxy to brand-service GET /orgs/brands/:id/business-context.
+ * Returns the pasted business context for a no-website brand (the alternative
+ * field-extraction source), or { content: null } when unset. Response shape is
+ * owned by the downstream service — passthrough only.
+ */
+router.get("/brands/:id/business-context", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/business-context`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Get business context error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to get business context" });
+  }
+});
+
+/**
+ * PUT /v1/brands/:id/business-context
+ * Proxy to brand-service PUT /orgs/brands/:id/business-context.
+ * Saves the free-form business context field-extraction reads from when the brand
+ * has no website. Large bodies (~up to 1MB) are accepted (the global JSON cap is
+ * 10mb). Body + response shapes are owned by the downstream service; its 4xx
+ * validation errors propagate verbatim — passthrough only.
+ */
+router.put("/brands/:id/business-context", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/business-context`,
+      {
+        method: "PUT",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Save business context error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to save business context" });
+  }
+});
+
+/**
+ * PATCH /v1/brands/:id
+ * Proxy to brand-service PATCH /orgs/brands/:id.
+ * Attaches a website to an existing no-website brand (sets brands.url + domain).
+ * Body { url } + response shapes are owned by the downstream service; its 4xx
+ * validation errors and 409 domain-conflict propagate verbatim — passthrough only.
+ */
+router.patch("/brands/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}`,
+      {
+        method: "PATCH",
+        headers: buildInternalHeaders(req),
+        body: req.body,
+      },
+    );
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Set brand website error:", error.message);
+    res.status(error.statusCode || 500).json({ error: error.message || "Failed to set brand website" });
+  }
+});
+
+/**
  * GET /v1/brands/:id/conversion-token
  * Proxy to lead-service GET /orgs/brands/:id/conversion-token.
  * Returns the brand's per-brand conversion-tracking publishable token + ingest URL

--- a/src/routes/campaigns.ts
+++ b/src/routes/campaigns.ts
@@ -67,7 +67,7 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       });
     }
 
-    const { featureSlug, featureDynastySlug, featureInputs, brandUrls } = parsed.data;
+    const { featureSlug, featureDynastySlug, featureInputs, brandUrls, brandIds: providedBrandIds } = parsed.data;
     // Prefer dynasty slug for features-service lookups (accepts both)
     const featureLookupSlug = featureDynastySlug ?? featureSlug!;
 
@@ -95,30 +95,39 @@ router.post("/campaigns", authenticate, requireOrg, requireUser, async (req: Aut
       inputCount: Object.keys(featureInputs).length,
     });
 
-    // 3. Upsert brands to get brandIds (resolve all URLs in parallel)
-    console.log("[api-service] POST /v1/campaigns — upserting brands", { brandUrls, orgId: req.orgId });
-    const brandResults = await Promise.all(
-      brandUrls.map((url) =>
-        callExternalService<{ brandId: string }>(
-          externalServices.brand,
-          "/orgs/brands",
-          {
-            method: "POST",
-            headers: buildInternalHeaders(req),
-            body: {
-              orgId: req.orgId,
-              url,
-              userId: req.userId,
-            },
-          }
+    // 3. Resolve brandIds.
+    // No-website path: the brand is already created (by name), so brandIds arrive
+    // in the body — forward them verbatim, skip the brandUrls→brand upsert entirely.
+    // Website path: upsert each URL to brand-service to resolve its brandId.
+    let brandIds: string[];
+    if (providedBrandIds) {
+      brandIds = providedBrandIds;
+      console.log("[api-service] POST /v1/campaigns — using provided brandIds (no-website path)", { brandIds });
+    } else {
+      console.log("[api-service] POST /v1/campaigns — upserting brands", { brandUrls, orgId: req.orgId });
+      const brandResults = await Promise.all(
+        brandUrls!.map((url) =>
+          callExternalService<{ brandId: string }>(
+            externalServices.brand,
+            "/orgs/brands",
+            {
+              method: "POST",
+              headers: buildInternalHeaders(req),
+              body: {
+                orgId: req.orgId,
+                url,
+                userId: req.userId,
+              },
+            }
+          )
         )
-      )
-    );
-    const brandIds = brandResults.map((r) => r.brandId);
-    console.log("[api-service] POST /v1/campaigns — brands upserted", { brandIds });
+      );
+      brandIds = brandResults.map((r) => r.brandId);
+      console.log("[api-service] POST /v1/campaigns — brands upserted", { brandIds });
+    }
 
     // 4. Forward to campaign-service (featureInputs forwarded as-is, never inspected)
-    const { workflowSlug, workflowDynastySlug, brandUrls: _brandUrls, ...restData } = parsed.data;
+    const { workflowSlug, workflowDynastySlug, brandUrls: _brandUrls, brandIds: _brandIds, ...restData } = parsed.data;
     // Use dynasty slug or exact slug for campaign type derivation
     const workflowSlugForType = workflowDynastySlug ?? workflowSlug!;
     const campaignType = deriveCampaignType(workflowSlugForType);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -626,7 +626,8 @@ export const CreateCampaignRequestSchema = z
     name: z.string().describe("Campaign name"),
     workflowSlug: z.string().min(1).optional().describe("Exact versioned workflow slug (e.g. 'sales-email-cold-outreach-sienna-v3'). Use for pinning to a specific version. Provide this OR workflowDynastySlug."),
     workflowDynastySlug: z.string().min(1).optional().describe("Stable dynasty slug for the workflow lineage (e.g. 'sales-email-cold-outreach-sienna'). Campaign-service resolves to the latest version automatically. Preferred over workflowSlug for dashboard use."),
-    brandUrls: z.array(z.string().min(1)).min(1).describe("Brand website URLs. First URL is the primary brand; additional URLs are secondary brands."),
+    brandUrls: z.array(z.string().min(1)).min(1).optional().describe("Brand website URLs. First URL is the primary brand; additional URLs are secondary brands. Provide this (website path) OR brandIds (no-website path) — exactly one."),
+    brandIds: z.array(z.string().min(1)).min(1).optional().describe("Brand UUIDs of already-created brands (no-website path). First id is the primary brand. When provided, api-service skips the brandUrls→brand upsert and forwards these ids straight to campaign-service. Provide this OR brandUrls — exactly one."),
     featureSlug: z.string().min(1).optional().describe("Exact versioned feature slug. Use for pinning to a specific version. Provide this OR featureDynastySlug."),
     featureDynastySlug: z.string().min(1).optional().describe("Stable dynasty slug for the feature lineage (e.g. 'pr-cold-email-outreach'). Campaign-service resolves to the latest version automatically. Preferred over featureSlug for dashboard use."),
     featureInputs: z.record(z.unknown()).describe("Opaque feature inputs. Validated by key-presence against features-service, never inspected by api-service."),
@@ -650,6 +651,10 @@ export const CreateCampaignRequestSchema = z
   .refine(
     (d) => d.featureSlug || d.featureDynastySlug,
     { message: "Either featureSlug or featureDynastySlug is required", path: ["featureSlug"] },
+  )
+  .refine(
+    (d) => Boolean(d.brandUrls) !== Boolean(d.brandIds),
+    { message: "Provide exactly one of brandUrls (website path) or brandIds (no-website path)", path: ["brandUrls"] },
   )
   .openapi("CreateCampaignRequest", {
     example: {
@@ -3949,6 +3954,113 @@ registry.registerPath({
     401: { description: "Unauthorized", content: errorContent },
     403: { description: "Brand not in caller's org (forwarded verbatim)", content: errorContent },
     404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+// ===================================================================
+// Brand – Business Context (proxy to brand-service /orgs/brands/:id/business-context)
+// The free-form business context field-extraction reads from when a brand has no
+// website. Downstream owns body + response shapes — passthrough only.
+// GET returns { content: string | null }; PUT body { content: string }.
+// ===================================================================
+const BusinessContextResponseSchema = z
+  .object({ content: z.string().nullable() })
+  .openapi("BusinessContextResponse");
+const BusinessContextRequestSchema = z
+  .object({
+    content: z.string().openapi({
+      description: "Free-form business context field-extraction reads from for a no-website brand. Large bodies (~up to 1MB) accepted.",
+      example: "Acme Corp is a B2B SaaS selling AI-powered analytics to mid-market retailers...",
+    }),
+  })
+  .openapi("BusinessContextRequest");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{id}/business-context",
+  tags: ["Brand"],
+  summary: "Get a no-website brand's pasted business context",
+  description:
+    "Proxy to brand-service GET /orgs/brands/{id}/business-context. " +
+    "Returns { content: string | null } — the free-form business context used as the " +
+    "field-extraction source for a no-website brand, or null when unset. " +
+    "Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandIdParam },
+  responses: {
+    200: { description: "Business context (or null when unset)", content: { "application/json": { schema: BusinessContextResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/brands/{id}/business-context",
+  tags: ["Brand"],
+  summary: "Save a no-website brand's business context",
+  description:
+    "Proxy to brand-service PUT /orgs/brands/{id}/business-context. " +
+    "Saves the free-form business context field-extraction reads from when the brand " +
+    "has no website (idempotent on brand_id). Large bodies (~up to 1MB) are accepted. " +
+    "Body { content } + response shapes are owned by the downstream service; its 4xx " +
+    "validation errors propagate verbatim.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: { content: { "application/json": { schema: BusinessContextRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Business context saved", content: { "application/json": { schema: BusinessContextResponseSchema } } },
+    400: { description: "Validation error (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+// ===================================================================
+// Brand – Attach Website (proxy to brand-service PATCH /orgs/brands/:id)
+// Attaches a website to an existing no-website brand (sets url + domain).
+// Downstream owns body { url } + response shapes — passthrough only.
+// ===================================================================
+const AttachBrandWebsiteRequestSchema = z
+  .object({
+    url: z.string().openapi({
+      description: "The website URL to attach to the no-website brand. Must be a valid http(s) URL.",
+      example: "https://acme.com",
+    }),
+  })
+  .openapi("AttachBrandWebsiteRequest");
+const AttachBrandWebsiteResponseSchema = z
+  .object({})
+  .passthrough()
+  .openapi("AttachBrandWebsiteResponse");
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/brands/{id}",
+  tags: ["Brand"],
+  summary: "Attach a website to an existing no-website brand",
+  description:
+    "Proxy to brand-service PATCH /orgs/brands/{id}. " +
+    "Attaches a website to an existing no-website brand (sets brands.url + domain); the " +
+    "next post-cache-expiry field extraction re-sources from the site automatically. " +
+    "Body { url } + response shape ({ brandId, domain, name, url }) are owned by the " +
+    "downstream service; its 4xx validation errors and 409 domain-conflict propagate verbatim.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: { content: { "application/json": { schema: AttachBrandWebsiteRequestSchema } } },
+  },
+  responses: {
+    200: { description: "Website attached", content: { "application/json": { schema: AttachBrandWebsiteResponseSchema } } },
+    400: { description: "Invalid URL (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    409: { description: "Domain already in use by another brand (forwarded verbatim)", content: errorContent },
     500: { description: "Upstream error", content: errorContent },
   },
 });

--- a/tests/unit/brand-business-context.test.ts
+++ b/tests/unit/brand-business-context.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * Tests for the no-website-brand gateway passthrough routes:
+ *   GET   /v1/brands/:id/business-context  -> brand-service GET  /orgs/brands/:id/business-context
+ *   PUT   /v1/brands/:id/business-context  -> brand-service PUT  /orgs/brands/:id/business-context
+ *   PATCH /v1/brands/:id                   -> brand-service PATCH /orgs/brands/:id
+ * All pure passthrough: body forwarded verbatim, identity headers forwarded,
+ * downstream owns the response shape and 4xx/409 errors propagate verbatim.
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.runId = "run_test789";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import brandRouter from "../../src/routes/brand.js";
+
+const BRAND_ID = "11111111-1111-4111-8111-111111111111";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: "10mb" }));
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+describe("GET /v1/brands/:id/business-context", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+  const downstream = { content: "Acme is a B2B SaaS." };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return { ok: true, status: 200, json: () => Promise.resolve(downstream) };
+    });
+  });
+
+  it("returns the downstream response verbatim", async () => {
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/business-context`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(downstream);
+  });
+
+  it("forwards a GET to brand-service /orgs/brands/:id/business-context with identity headers", async () => {
+    await request(app).get(`/v1/brands/${BRAND_ID}/business-context`);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/business-context`);
+    expect((capturedInit?.method ?? "GET")).toMatch(/GET/i);
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+  });
+
+  it("propagates an upstream 404 verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"Brand not found"}'),
+    }));
+    const res = await request(app).get(`/v1/brands/${BRAND_ID}/business-context`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PUT /v1/brands/:id/business-context", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      return { ok: true, status: 200, json: () => Promise.resolve({ content: body.content }) };
+    });
+  });
+
+  it("returns the downstream response verbatim on success", async () => {
+    const putBody = { content: "Acme is a B2B SaaS for retailers." };
+    const res = await request(app).put(`/v1/brands/${BRAND_ID}/business-context`).send(putBody);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(putBody);
+  });
+
+  it("forwards the body byte-identical (PUT) to brand-service /orgs/brands/:id/business-context", async () => {
+    const putBody = { content: "hello world" };
+    await request(app).put(`/v1/brands/${BRAND_ID}/business-context`).send(putBody);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}/business-context`);
+    expect(capturedInit?.method).toBe("PUT");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual(putBody);
+  });
+
+  it("forwards identity headers (x-org-id, x-user-id, x-run-id)", async () => {
+    await request(app).put(`/v1/brands/${BRAND_ID}/business-context`).send({ content: "x" });
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+    expect(headers["x-run-id"]).toBe("run_test789");
+  });
+
+  it("forwards a large (~1MB) body intact", async () => {
+    const bigContent = "a".repeat(1_000_000);
+    const res = await request(app)
+      .put(`/v1/brands/${BRAND_ID}/business-context`)
+      .send({ content: bigContent });
+    expect(res.status).toBe(200);
+    expect(JSON.parse(capturedInit?.body as string).content).toHaveLength(1_000_000);
+  });
+
+  it("propagates an upstream 400 (validation) verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"error":"Invalid request"}'),
+    }));
+    const res = await request(app).put(`/v1/brands/${BRAND_ID}/business-context`).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid request");
+  });
+});
+
+describe("PATCH /v1/brands/:id (attach website)", () => {
+  let app: express.Express;
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+  const downstream = { brandId: BRAND_ID, domain: "acme.com", name: "Acme", url: "https://acme.com" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    capturedUrl = undefined;
+    capturedInit = undefined;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return { ok: true, status: 200, json: () => Promise.resolve(downstream) };
+    });
+  });
+
+  it("returns the downstream response verbatim on success", async () => {
+    const res = await request(app).patch(`/v1/brands/${BRAND_ID}`).send({ url: "https://acme.com" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(downstream);
+  });
+
+  it("forwards the body { url } byte-identical (PATCH) to brand-service /orgs/brands/:id", async () => {
+    const patchBody = { url: "https://acme.com" };
+    await request(app).patch(`/v1/brands/${BRAND_ID}`).send(patchBody);
+    expect(capturedUrl).toContain(`/orgs/brands/${BRAND_ID}`);
+    expect(capturedUrl).not.toContain("business-context");
+    expect(capturedInit?.method).toBe("PATCH");
+    expect(JSON.parse(capturedInit?.body as string)).toEqual(patchBody);
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org_test456");
+    expect(headers["x-user-id"]).toBe("user_test123");
+  });
+
+  it("propagates an upstream 409 (domain conflict) verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 409,
+      text: () => Promise.resolve('{"error":"Domain already in use","code":"BRAND_DOMAIN_CONFLICT"}'),
+    }));
+    const res = await request(app).patch(`/v1/brands/${BRAND_ID}`).send({ url: "https://taken.com" });
+    expect(res.status).toBe(409);
+  });
+
+  it("propagates an upstream 400 (invalid url) verbatim", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('{"error":"Invalid request"}'),
+    }));
+    const res = await request(app).patch(`/v1/brands/${BRAND_ID}`).send({ url: "not-a-url" });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/campaign-no-website-brandids.test.ts
+++ b/tests/unit/campaign-no-website-brandids.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * POST /v1/campaigns — no-website path.
+ * A caller may pass brandIds (UUIDs of already-created brands) INSTEAD of brandUrls.
+ * When brandIds is provided, api-service SKIPS the brandUrls->brand upsert and
+ * forwards those ids straight to campaign-service (still setting x-brand-id).
+ * Exactly one of brandUrls / brandIds is required.
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_test456";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (req: any, res: any, next: any) => {
+    if (!req.orgId) return res.status(400).json({ error: "Organization context required" });
+    next();
+  },
+  requireUser: (req: any, res: any, next: any) => {
+    if (!req.userId) return res.status(401).json({ error: "User identity required" });
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("@distribute/runs-client", () => ({
+  getRunsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import campaignRouter from "../../src/routes/campaigns.js";
+
+const BRAND_ID = "22222222-2222-4222-8222-222222222222";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", campaignRouter);
+  return app;
+}
+
+describe("POST /v1/campaigns — no-website brandIds path", () => {
+  let fetchCalls: Array<{ url: string; method?: string; body?: Record<string, unknown>; headers?: Record<string, string> }>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchCalls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      const headers = init?.headers
+        ? Object.fromEntries(Object.entries(init.headers as Record<string, string>))
+        : undefined;
+      fetchCalls.push({ url, method: init?.method, body, headers });
+
+      if (url.includes("/features/") && url.includes("/inputs")) {
+        return { ok: true, json: () => Promise.resolve({ inputs: [{ key: "targetAudience", required: true }] }) };
+      }
+      if (url.includes("/brands") && init?.method === "POST") {
+        return { ok: true, json: () => Promise.resolve({ brandId: "SHOULD-NOT-BE-CALLED" }) };
+      }
+      if (url.includes("/campaigns") && init?.method === "POST") {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ campaign: { id: "campaign-1", brandIds: body?.brandIds } }),
+        };
+      }
+      return { ok: true, json: () => Promise.resolve({}) };
+    });
+  });
+
+  it("forwards provided brandIds to campaign-service WITHOUT calling the brand upsert", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "No-website brand",
+        workflowDynastySlug: "sales-email-cold-outreach-sienna",
+        brandIds: [BRAND_ID],
+        featureDynastySlug: "pr-cold-email-outreach",
+        featureInputs: { targetAudience: "SaaS founders" },
+      });
+
+    expect(res.status).toBe(200);
+
+    // The brandUrls->brand upsert must NOT be called on the no-website path.
+    const brandUpsertCalls = fetchCalls.filter((c) => c.url.includes("/orgs/brands") && c.method === "POST");
+    expect(brandUpsertCalls).toHaveLength(0);
+
+    // campaign-service receives the provided brandIds verbatim.
+    const campaignCall = fetchCalls.find((c) => c.url.includes("/campaigns") && c.body?.orgId === "org_test456");
+    expect(campaignCall!.body!.brandIds).toEqual([BRAND_ID]);
+
+    // x-brand-id header is set from the provided ids.
+    expect(campaignCall!.headers!["x-brand-id"]).toBe(BRAND_ID);
+
+    // brandUrls / brandIds do not leak into the campaign-service body beyond the resolved brandIds field.
+    expect(campaignCall!.body!.brandUrls).toBeUndefined();
+  });
+
+  it("rejects when NEITHER brandUrls nor brandIds is provided", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "No brand identity",
+        workflowDynastySlug: "sales-email-cold-outreach-sienna",
+        featureDynastySlug: "pr-cold-email-outreach",
+        featureInputs: { targetAudience: "SaaS founders" },
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects when BOTH brandUrls and brandIds are provided (exactly one)", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/v1/campaigns")
+      .send({
+        name: "Ambiguous",
+        workflowDynastySlug: "sales-email-cold-outreach-sienna",
+        brandUrls: ["https://acme.com"],
+        brandIds: [BRAND_ID],
+        featureDynastySlug: "pr-cold-email-outreach",
+        featureInputs: { targetAudience: "SaaS founders" },
+      });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## What

No-website brand feature follow-up. Adds the api-service gateway passthrough for the brand-service routes shipped in brand-service #366, plus lets `POST /v1/campaigns` launch a no-website brand.

### New gateway routes (explicit per-route proxies, verbatim body, identity forwarded, fail loud)
| Gateway | Downstream (brand-service) | Body / Response |
|---|---|---|
| `PUT /v1/brands/:id/business-context` | `PUT /orgs/brands/:id/business-context` | body `{ content }` (~1MB), returns `{ content }` |
| `GET /v1/brands/:id/business-context` | `GET /orgs/brands/:id/business-context` | returns `{ content: string \| null }` |
| `PATCH /v1/brands/:id` | `PATCH /orgs/brands/:id` | body `{ url }`, returns `{ brandId, domain, name, url }` (409 on domain conflict, verbatim) |

### `POST /v1/campaigns` — accept a no-website brand
`CreateCampaignRequest` now takes **either** `brandUrls` (website path, unchanged) **or** `brandIds` (array of brand UUIDs, min 1) — exactly one required (400 if neither/both). When `brandIds` is provided the handler **skips** the `brandUrls`→brand upsert and forwards those ids straight to campaign-service (still sets the `x-brand-id` header from them). campaign-service's create already accepts `brandIds` directly.

**Caller shape (no-website launch):**
```json
POST /v1/campaigns
{
  "name": "...",
  "workflowDynastySlug": "sales-email-cold-outreach-sienna",
  "brandIds": ["<brand-uuid>"],
  "featureDynastySlug": "pr-cold-email-outreach",
  "featureInputs": { "targetAudience": "..." }
}
```
(website launch is unchanged: pass `brandUrls: ["https://..."]` instead of `brandIds`.)

## Tests
- `tests/unit/brand-business-context.test.ts` — GET/PUT business-context + PATCH attach-website: verbatim body, identity headers, ~1MB body, 400/404/409 propagation.
- `tests/unit/campaign-no-website-brandids.test.ts` — `{brandIds}` forwards to campaign-service and does NOT call the brand upsert; rejects neither/both.
- Full suite green (1737).
- `openapi.json` regenerated.

## ⚠️ Deployment ordering
Downstream brand-service routes (#366) are already on staging. campaign-service already accepts `brandIds`. No new env vars (reuses `externalServices.brand` / `externalServices.campaign`). Dormant-safe additive routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
