### PR TITLE
hotfix: Point the invite-claim proxy at client-service's real handler

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -41168,7 +41168,7 @@
           "Invites"
         ],
         "summary": "Claim an invite code for the authenticated org",
-        "description": "Pass-through to client-service POST /internal/orgs/{orgId}/invites/claim. Downstream orchestrates: record claim row -> grant $25 to inviter + $25 to invitee via billing-service -> send invite-claimed-welcome + invite-success-notification via transactional-email-service. Idempotent on (code, inviteeOrgId). The {orgId} path segment MUST match the authenticated x-org-id; mismatch returns 403. Body + response shapes are owned by the downstream service.",
+        "description": "Pass-through to client-service POST /internal/invites/claim. Send only { code }: the gateway supplies the downstream-required inviteeOrgId from the authenticated identity, and discards any inviteeOrgId in the request body so a caller can never claim on behalf of another org. Downstream orchestrates: record claim row -> grant credits to inviter + invitee via billing-service -> send the invite confirmation emails via transactional-email-service. Idempotent on (code, inviteeOrgId). The {orgId} path segment MUST match the authenticated x-org-id; mismatch returns 403. Body + response shapes are owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
@@ -41287,6 +41287,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown invite code (forwarded verbatim from downstream)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Invite cap reached. Downstream body is forwarded field-for-field, including used / total.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgInvitesClaimResponse"
                 }
               }
             }

--- a/src/routes/invites.ts
+++ b/src/routes/invites.ts
@@ -7,6 +7,7 @@ import {
 } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
+import { respondUpstreamError } from "../lib/upstream-error.js";
 
 const router = Router();
 
@@ -54,9 +55,20 @@ router.get(
 );
 
 // POST /v1/orgs/:orgId/invites/claim — authed claim. Downstream client-service
-// orchestrates: record claim row → grant $25 to inviter + $25 to invitee via
-// billing-service → send invite-claimed-welcome + invite-success-notification
-// via transactional-email-service. api-service stays a transparent proxy.
+// orchestrates: record claim row → grant credits to inviter + invitee via
+// billing-service → send the invite confirmation emails via
+// transactional-email-service. api-service stays a transparent proxy.
+//
+// The downstream route is POST /internal/invites/claim — NOT org-scoped in the
+// path. It identifies the claiming org from the request BODY (`inviteeOrgId`),
+// so the gateway supplies that field from the identity `authenticate` resolved
+// (`req.orgId`, an internal UUID). This is the one place the gateway writes a
+// body field rather than forwarding it: letting the browser name the claiming
+// org would let any signed-in caller claim on behalf of another org. The
+// spread-then-override order is deliberate — a client-supplied `inviteeOrgId`
+// is discarded, and any future downstream body field still passes through.
+// The {orgId} path segment is kept (published contract + the self-claim check
+// below); it is validated against the authenticated org and never forwarded.
 router.post(
   "/orgs/:orgId/invites/claim",
   authenticate,
@@ -71,18 +83,20 @@ router.post(
       }
       const result = await callExternalService(
         externalServices.client,
-        `/internal/orgs/${encodeURIComponent(req.params.orgId)}/invites/claim`,
+        "/internal/invites/claim",
         {
           method: "POST",
-          body: req.body,
+          body: { ...req.body, inviteeOrgId: req.orgId },
           headers: buildInternalHeaders(req),
         },
       );
       res.json(result);
-    } catch (error: any) {
-      res
-        .status(error.statusCode || 500)
-        .json({ error: error.message || "Failed to claim invite" });
+    } catch (error) {
+      // Forward the upstream body field-for-field (CLAUDE.md #7 corollary): the
+      // cap rejection is `{ error, used, total }` and the dashboard branches on
+      // `used`/`total`. Flattening it into `{ error: <stringified body> }` would
+      // destroy those fields.
+      respondUpstreamError(res, error, "Failed to claim invite");
     }
   },
 );

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -9352,9 +9352,12 @@ registry.registerPath({
   tags: ["Invites"],
   summary: "Claim an invite code for the authenticated org",
   description:
-    "Pass-through to client-service POST /internal/orgs/{orgId}/invites/claim. " +
-    "Downstream orchestrates: record claim row -> grant $25 to inviter + $25 to invitee via " +
-    "billing-service -> send invite-claimed-welcome + invite-success-notification via " +
+    "Pass-through to client-service POST /internal/invites/claim. " +
+    "Send only { code }: the gateway supplies the downstream-required inviteeOrgId " +
+    "from the authenticated identity, and discards any inviteeOrgId in the request body " +
+    "so a caller can never claim on behalf of another org. " +
+    "Downstream orchestrates: record claim row -> grant credits to inviter + invitee via " +
+    "billing-service -> send the invite confirmation emails via " +
     "transactional-email-service. Idempotent on (code, inviteeOrgId). " +
     "The {orgId} path segment MUST match the authenticated x-org-id; mismatch returns 403. " +
     "Body + response shapes are owned by the downstream service.",
@@ -9373,6 +9376,12 @@ registry.registerPath({
     400: { description: "Invalid code (forwarded verbatim from downstream)", content: errorContent },
     401: { description: "Unauthorized", content: errorContent },
     403: { description: "orgId path does not match authenticated org", content: errorContent },
+    404: { description: "Unknown invite code (forwarded verbatim from downstream)", content: errorContent },
+    409: {
+      description:
+        "Invite cap reached. Downstream body is forwarded field-for-field, including used / total.",
+      content: { "application/json": { schema: OrgInvitesClaimResponseSchema } },
+    },
   },
 });
 

--- a/tests/unit/invites-claim-downstream-path.test.ts
+++ b/tests/unit/invites-claim-downstream-path.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * POST /v1/orgs/:orgId/invites/claim must reach client-service's real claim
+ * handler, POST /internal/invites/claim.
+ *
+ * The gateway shipped pointing at /internal/orgs/{orgId}/invites/claim — a path
+ * client-service has never served — so every claim would have 404'd. Nothing had
+ * called the route (the dashboard's referral card was decorative), so no test
+ * caught it: the old assertions only checked the middleware chain and a
+ * "/internal/orgs/" substring, both of which the broken path satisfied.
+ *
+ * client-service identifies the claiming org from the BODY (`inviteeOrgId`), not
+ * from the path, so the gateway supplies it from the authenticated identity.
+ */
+
+const AUTH_ORG = "11111111-1111-4111-8111-111111111111";
+const OTHER_ORG = "22222222-2222-4222-8222-222222222222";
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "44444444-4444-4444-8444-444444444444";
+    req.orgId = AUTH_ORG;
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import invitesRouter from "../../src/routes/invites.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", invitesRouter);
+  return app;
+}
+
+type Captured = { url: string; init: any };
+
+describe("POST /v1/orgs/:orgId/invites/claim", () => {
+  let calls: Captured[];
+
+  function mockUpstream(status: number, body: unknown) {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init: any) => {
+      calls.push({ url, init });
+      const text = JSON.stringify(body);
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(text),
+      };
+    }) as any;
+  }
+
+  beforeEach(() => {
+    mockUpstream(200, { ok: true, inviterOrgId: OTHER_ORG });
+  });
+
+  it("forwards to client-service POST /internal/invites/claim", async () => {
+    const res = await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "acme-corp" });
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain("/internal/invites/claim");
+    expect(calls[0].init.method).toBe("POST");
+  });
+
+  it("does NOT forward to the org-scoped path client-service never served", async () => {
+    await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "acme-corp" });
+
+    expect(calls[0].url).not.toContain("/internal/orgs/");
+  });
+
+  it("supplies inviteeOrgId from the authenticated identity", async () => {
+    await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "acme-corp" });
+
+    expect(JSON.parse(calls[0].init.body)).toEqual({
+      code: "acme-corp",
+      inviteeOrgId: AUTH_ORG,
+    });
+  });
+
+  it("discards a client-supplied inviteeOrgId — the caller cannot claim for another org", async () => {
+    await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "acme-corp", inviteeOrgId: OTHER_ORG });
+
+    expect(JSON.parse(calls[0].init.body).inviteeOrgId).toBe(AUTH_ORG);
+  });
+
+  it("refuses a claim on behalf of a different org with 403, before any downstream call", async () => {
+    const res = await request(buildApp())
+      .post(`/v1/orgs/${OTHER_ORG}/invites/claim`)
+      .send({ code: "acme-corp" });
+
+    expect(res.status).toBe(403);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("forwards the upstream success body verbatim", async () => {
+    const res = await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "acme-corp" });
+
+    expect(res.body).toEqual({ ok: true, inviterOrgId: OTHER_ORG });
+  });
+
+  it("forwards the cap rejection with its status AND its machine-readable fields", async () => {
+    mockUpstream(409, { error: "Invite cap reached", used: 3, total: 3 });
+
+    const res = await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "acme-corp" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: "Invite cap reached", used: 3, total: 3 });
+  });
+
+  it("forwards an unknown-code rejection with its status and body", async () => {
+    mockUpstream(404, { error: "Unknown invite code" });
+
+    const res = await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "nope" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Unknown invite code" });
+  });
+
+  it("forwards identity headers to client-service", async () => {
+    await request(buildApp())
+      .post(`/v1/orgs/${AUTH_ORG}/invites/claim`)
+      .send({ code: "acme-corp" });
+
+    expect(calls[0].init.headers["x-org-id"]).toBe(AUTH_ORG);
+  });
+});

--- a/tests/unit/invites-waitlist-proxy.test.ts
+++ b/tests/unit/invites-waitlist-proxy.test.ts
@@ -52,8 +52,21 @@ describe("Invites proxy routes", () => {
     expect(block).toContain("authenticate");
     expect(block).toContain("requireOrg");
     expect(block).toContain("requireUser");
-    expect(block).toContain("/internal/orgs/");
-    expect(block).toContain("/invites/claim");
+  });
+
+  it("POST /orgs/:orgId/invites/claim targets the real downstream path, not an org-scoped one", () => {
+    const block = blockFor(invitesContent, "post", "/orgs/:orgId/invites/claim");
+    expect(block).toContain('"/internal/invites/claim"');
+    // client-service serves the claim under /internal/invites/claim; the
+    // org-scoped shape it does NOT serve must never come back.
+    expect(block).not.toContain("/internal/orgs/");
+  });
+
+  it("supplies inviteeOrgId from the authenticated org, overriding the request body", () => {
+    const block = blockFor(invitesContent, "post", "/orgs/:orgId/invites/claim");
+    expect(block).toContain("inviteeOrgId: req.orgId");
+    // Spread first, identity last — a client-supplied inviteeOrgId is discarded.
+    expect(block).toMatch(/\.\.\.req\.body,\s*inviteeOrgId: req\.orgId/);
   });
 
   it("authed routes guard params.orgId !== req.orgId with 403", () => {


### PR DESCRIPTION
## What was broken

`POST /v1/orgs/:orgId/invites/claim` forwarded to client-service `/internal/orgs/{orgId}/invites/claim` — a path client-service has never served. Every claim through the gateway would have returned 404.

client-service serves the claim as **`POST /internal/invites/claim`** (verified against the deployed registry and `origin/main`), and it identifies the claiming org from the request **body** (`inviteeOrgId`), not from the path.

The mismatch has been latent since the route shipped: the dashboard's old referral card was decorative copy with no backend, so nothing ever called it. It was also invisible to the tests — they asserted the middleware chain and a `"/internal/orgs/"` substring, both of which the broken path satisfied.

The sibling status route (`GET /v1/orgs/:orgId/invites/status`) is correct and is untouched.

## Contract for the consumer

The dashboard has not shipped a caller yet, so this is the shape to build against:

```
POST /v1/orgs/{orgId}/invites/claim
Body: { "code": "<invite-code>" }
```

- **Path is unchanged.** `{orgId}` must equal the authenticated org; a mismatch is still a 403 before any downstream call.
- **Send only `code`.** The gateway supplies `inviteeOrgId` from the identity `authenticate` resolved (`req.orgId`, an internal UUID). An `inviteeOrgId` in the request body is **discarded** — the spread-then-override order guarantees it, so a signed-in caller can never claim on behalf of another org. This is the one place this route writes a body field rather than forwarding it; letting the browser name the claiming org is the whole attack.
- **Response is unchanged** and still owned by client-service (`{ ok, inviterOrgId }` on success).
- **Errors now arrive intact.** The route moved to `respondUpstreamError` (CLAUDE.md #7 corollary). The cap rejection is `{ error, used, total }` and the dashboard branches on `used`/`total`; the old `{ error: err.message }` envelope flattened the whole downstream JSON body into the `error` string and destroyed those fields.

## Coordination

A client-service workspace (`KevinLourd/uncapped-invites-billing-notify`) is concurrently changing the same claim handler — adding a downstream notification and lifting the invite cap. Confirmed against that branch: it does **not** move or rename the path, and the body stays `{ code, inviteeOrgId }`. This PR conforms to what is deployed today and stays correct after that lands.

## Verification

- 1762 tests green, `pnpm build` green, `openapi.json` regenerated.
- New `tests/unit/invites-claim-downstream-path.test.ts` drives the route through supertest: forwards to `/internal/invites/claim`, never to `/internal/orgs/`, supplies `inviteeOrgId` from the authenticated identity, discards a client-supplied one, 403s a cross-org claim before any downstream call, and forwards the 409 cap body with `used`/`total` intact.
- OpenAPI description now names the real downstream path and the body rule, and declares the 404 / 409 the route actually returns.

Read-only from a money standpoint — this route moves no money directly; the credit grants are client-service's orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
