### PR TITLE
feat(brands): proxy the brand share-link credential

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5158,6 +5158,10 @@
         "type": "object",
         "properties": {}
       },
+      "BrandShareLinkProxyResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "IcpSuggestResponse": {
         "type": "object",
         "properties": {}
@@ -23222,6 +23226,655 @@
           },
           "404": {
             "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/share-link": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get a brand's public share credential",
+        "description": "Proxy to brand-service GET /orgs/brands/{id}/share-link. Returns the credential currently letting someone outside the org open a read-only view of this brand, or { token: null } when the brand has never been shared. A READ: it does NOT mint one, so opening a share menu cannot accidentally start sharing a brand. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current share credential (token null when unshared)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Start sharing a brand, returning its credential",
+        "description": "Proxy to brand-service POST /orgs/brands/{id}/share-link. Mints the credential that lets someone outside the org open a read-only view of this brand. Idempotent: a brand already shared gets its EXISTING token back rather than a fresh one, so pressing share twice cannot silently invalidate a link the customer already sent. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Share credential",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Stop sharing a brand",
+        "description": "Proxy to brand-service DELETE /orgs/brands/{id}/share-link. Revokes the credential so the public link stops resolving. Idempotent — a brand that was not shared is already in the requested end state. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Whether a link existed and was removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/share-link/rotate": {
+      "post": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Rotate a brand's public share credential",
+        "description": "Proxy to brand-service POST /orgs/brands/{id}/share-link/rotate. Replaces the credential, so the previous link stops working immediately — this is how a customer takes back a link already in someone else's hands. Downstream 404s a brand that was never shared rather than minting one, and that propagates verbatim. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "New share credential",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found, or brand is not shared (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brand-share-links/{token}": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Resolve a brand share credential",
+        "description": "Proxy to brand-service GET /internal/brand-share-links/{token}. Resolves a share credential to the org and brand it opens. Authenticated but NOT org-scoped, uniquely among the brand routes: the caller is a trusted server-side renderer holding a platform key that has no org context YET — resolving the token is precisely how it learns which org to act as, so requiring one here would make the route unusable for its only purpose. Downstream 404s unknown, revoked and rotated-away tokens alike, and that propagates verbatim. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "token",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The org and brand the credential opens",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Share link not found (forwarded verbatim)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -740,4 +740,125 @@ router.put("/brands/:id/user-fields", authenticate, requireOrg, requireUser, asy
   }
 });
 
+/**
+ * Brand share link — the credential someone OUTSIDE the org presents to open a
+ * read-only view of one brand.
+ *
+ * Four org-scoped routes below (read / mint / rotate / revoke) are ordinary
+ * passthroughs to brand-service; the resolve route further down is the odd one
+ * and is documented there.
+ */
+
+/**
+ * GET /v1/brands/:id/share-link
+ * Proxy to brand-service GET /orgs/brands/:id/share-link. Returns the current
+ * credential or `{ token: null }` when the brand has never been shared; it does
+ * NOT mint one. Response shape is owned by the downstream service — passthrough
+ * only.
+ */
+router.get("/brands/:id/share-link", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/share-link`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Get brand share link error:", error.message);
+    respondUpstreamError(res, error, "Failed to get brand share link");
+  }
+});
+
+/**
+ * POST /v1/brands/:id/share-link
+ * Proxy to brand-service POST /orgs/brands/:id/share-link. Starts sharing and
+ * returns the credential; idempotent, so an already-shared brand gets its
+ * existing token back. Response shape is owned by the downstream service —
+ * passthrough only.
+ */
+router.post("/brands/:id/share-link", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/share-link`,
+      { method: "POST", headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Create brand share link error:", error.message);
+    respondUpstreamError(res, error, "Failed to create brand share link");
+  }
+});
+
+/**
+ * POST /v1/brands/:id/share-link/rotate
+ * Proxy to brand-service POST /orgs/brands/:id/share-link/rotate. Replaces the
+ * credential so the previous link stops working; its 404 on a brand that was
+ * never shared propagates verbatim — passthrough only.
+ */
+router.post("/brands/:id/share-link/rotate", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/share-link/rotate`,
+      { method: "POST", headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Rotate brand share link error:", error.message);
+    respondUpstreamError(res, error, "Failed to rotate brand share link");
+  }
+});
+
+/**
+ * DELETE /v1/brands/:id/share-link
+ * Proxy to brand-service DELETE /orgs/brands/:id/share-link. Stops sharing;
+ * idempotent. Response shape is owned by the downstream service — passthrough
+ * only.
+ */
+router.delete("/brands/:id/share-link", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/share-link`,
+      { method: "DELETE", headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Revoke brand share link error:", error.message);
+    respondUpstreamError(res, error, "Failed to revoke brand share link");
+  }
+});
+
+/**
+ * GET /v1/brand-share-links/:token
+ * Proxy to brand-service GET /internal/brand-share-links/:token. Resolves a
+ * share credential to the org + brand it opens.
+ *
+ * `authenticate` WITHOUT `requireOrg`, deliberately and uniquely on this file:
+ * the caller is a trusted server-side renderer holding a platform key that has
+ * no org context YET — resolving the token is precisely how it learns which org
+ * to act as. Requiring an org here would make the route unusable for its only
+ * purpose. It stays authenticated so the token oracle is never reachable
+ * unauthenticated from the internet.
+ *
+ * Mounted on its own path rather than under `/brands/` so it cannot be confused
+ * with a brand-id route. brand-service's 404 (unknown, revoked or rotated-away
+ * token alike) propagates verbatim.
+ */
+router.get("/brand-share-links/:token", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/internal/brand-share-links/${encodeURIComponent(req.params.token)}`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Resolve brand share link error:", error.message);
+    respondUpstreamError(res, error, "Failed to resolve brand share link");
+  }
+});
+
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4113,6 +4113,122 @@ registry.registerPath({
 });
 
 // ===================================================================
+// Brand – Share Link (proxy to brand-service
+// /orgs/brands/:id/share-link[/rotate] + /internal/brand-share-links/:token).
+// The credential someone OUTSIDE the org presents to open a read-only view of
+// one brand. Downstream owns the response shape — passthrough only.
+// ===================================================================
+const BrandShareLinkResponseSchema = z.object({}).passthrough().openapi("BrandShareLinkProxyResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{id}/share-link",
+  tags: ["Brand"],
+  summary: "Get a brand's public share credential",
+  description:
+    "Proxy to brand-service GET /orgs/brands/{id}/share-link. Returns the credential " +
+    "currently letting someone outside the org open a read-only view of this brand, or " +
+    "{ token: null } when the brand has never been shared. A READ: it does NOT mint one, so " +
+    "opening a share menu cannot accidentally start sharing a brand. Response shape is owned " +
+    "by the downstream service.",
+  security: authed,
+  request: { params: BrandIdParam },
+  responses: {
+    200: { description: "Current share credential (token null when unshared)", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{id}/share-link",
+  tags: ["Brand"],
+  summary: "Start sharing a brand, returning its credential",
+  description:
+    "Proxy to brand-service POST /orgs/brands/{id}/share-link. Mints the credential that lets " +
+    "someone outside the org open a read-only view of this brand. Idempotent: a brand already " +
+    "shared gets its EXISTING token back rather than a fresh one, so pressing share twice " +
+    "cannot silently invalidate a link the customer already sent. Response shape is owned by " +
+    "the downstream service.",
+  security: authed,
+  request: { params: BrandIdParam },
+  responses: {
+    200: { description: "Share credential", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{id}/share-link/rotate",
+  tags: ["Brand"],
+  summary: "Rotate a brand's public share credential",
+  description:
+    "Proxy to brand-service POST /orgs/brands/{id}/share-link/rotate. Replaces the credential, " +
+    "so the previous link stops working immediately — this is how a customer takes back a link " +
+    "already in someone else's hands. Downstream 404s a brand that was never shared rather than " +
+    "minting one, and that propagates verbatim. Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandIdParam },
+  responses: {
+    200: { description: "New share credential", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found, or brand is not shared (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/v1/brands/{id}/share-link",
+  tags: ["Brand"],
+  summary: "Stop sharing a brand",
+  description:
+    "Proxy to brand-service DELETE /orgs/brands/{id}/share-link. Revokes the credential so the " +
+    "public link stops resolving. Idempotent — a brand that was not shared is already in the " +
+    "requested end state. Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandIdParam },
+  responses: {
+    200: { description: "Whether a link existed and was removed", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brand-share-links/{token}",
+  tags: ["Brand"],
+  summary: "Resolve a brand share credential",
+  description:
+    "Proxy to brand-service GET /internal/brand-share-links/{token}. Resolves a share credential " +
+    "to the org and brand it opens. Authenticated but NOT org-scoped, uniquely among the brand " +
+    "routes: the caller is a trusted server-side renderer holding a platform key that has no org " +
+    "context YET — resolving the token is precisely how it learns which org to act as, so " +
+    "requiring one here would make the route unusable for its only purpose. Downstream 404s " +
+    "unknown, revoked and rotated-away tokens alike, and that propagates verbatim. Response shape " +
+    "is owned by the downstream service.",
+  security: authed,
+  request: { params: z.object({ token: z.string() }) },
+  responses: {
+    200: { description: "The org and brand the credential opens", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "Share link not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+// ===================================================================
 // Brand – ICP Suggest
 // Transparent proxies to brand-service /orgs/brands/:id/{icp/suggest,user-fields}.
 // Downstream owns body + response shapes — passthrough only. No gateway


### PR DESCRIPTION
Gateway half of the brand share link — the read-only public link a customer hands to someone outside their org. Producer is brand-service [#398](https://github.com/shamanic-technologies/brand-service/pull/398); the dashboard's share menu and public page follow.

Five transparent proxies:

| Route | Downstream |
|---|---|
| `GET /v1/brands/{id}/share-link` | `GET /orgs/brands/:id/share-link` |
| `POST /v1/brands/{id}/share-link` | `POST /orgs/brands/:id/share-link` |
| `POST /v1/brands/{id}/share-link/rotate` | `POST /orgs/brands/:id/share-link/rotate` |
| `DELETE /v1/brands/{id}/share-link` | `DELETE /orgs/brands/:id/share-link` |
| `GET /v1/brand-share-links/{token}` | `GET /internal/brand-share-links/:token` |

The first four are ordinary org-scoped passthroughs, mounted alongside the conversion-token pair they sit next to.

## The resolve route is the one to review

`authenticate` **without** `requireOrg`, deliberately and uniquely on this file. Its caller is a trusted server-side renderer holding a platform key that has no org context yet — resolving the token is precisely how it learns which org to act as — so requiring an org here would make the route unusable for its only purpose. It stays authenticated, so the token oracle is never reachable unauthenticated from the internet.

`buildInternalHeaders` already omits `x-org-id` when absent, so nothing downstream receives a malformed identity.

It is mounted on its own path rather than under `/brands/` so it cannot be confused with a brand-id route.

## Passthrough

Response shapes stay owned by brand-service per gateway convention — the OpenAPI entries register `z.object({}).passthrough()`, mirroring `ConversionTokenResponse`. brand-service's 403 on a foreign brand, and its 404 on an unknown, revoked or rotated-away token, propagate verbatim through `callExternalServiceWithStatus` + `respondUpstreamError`.

1762 tests pass. Additive: no existing route or response shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
