### PR TITLE
feat(billing): proxy the free-credit promises an org is still waiting on

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7150,6 +7150,10 @@
         "type": "object",
         "properties": {}
       },
+      "FreeCreditPromisesResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "PlatformCreditGrantsResponse": {
         "type": "object",
         "properties": {}
@@ -28831,6 +28835,109 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CreditGrantsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
+    "/v1/billing/free-credit-promises": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Free credits this org is still waiting on",
+        "description": "Every outstanding free-credit promise for the org in context: the welcome remainder, plus a promise for each converting referral. Each carries what it is worth, the level of cumulative payments that unlocks it, how far along the org is, and — when the promise exists because someone this org referred converted — which org that was, which the dashboard resolves to a brand through brand-service. An outstanding promise is a promise, not money: it is not part of credited, balance or spendable. Normal org auth (same tier as GET /v1/billing/credits/grants); billing-service scopes the response to the caller's x-org-id, so an org reads only its own promises and the client never names an org. Transparent proxy to billing-service GET /v1/free-credit-promises; response owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outstanding promises — pass-through from billing-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FreeCreditPromisesResponse"
                 }
               }
             }

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -8,6 +8,7 @@ import {
 } from "../middleware/auth.js";
 import { callExternalService, externalServices } from "../lib/service-client.js";
 import { buildInternalHeaders } from "../lib/internal-headers.js";
+import { respondUpstreamError } from "../lib/upstream-error.js";
 
 const router = Router();
 
@@ -85,6 +86,38 @@ router.get(
       res.json(result);
     } catch (error: any) {
       res.status(error.statusCode || 500).json({ error: error.message || "Failed to get grants ledger" });
+    }
+  },
+);
+
+// GET /v1/billing/free-credit-promises — the free credits this org is still waiting on.
+//
+// The customer's own view of every outstanding promise: the welcome remainder and,
+// since the referral launched, a $500 promise for each converting referral. Each one
+// carries what it is worth, the cumulative-payments bar that unlocks it, and how far
+// along the org is.
+//
+// Same auth tier as the org's own grants ledger above: billing-service scopes the
+// response to the caller's x-org-id, so an org reads only its own promises and the
+// client never names an org.
+//
+// Transparent passthrough. The response is billing's, including `referred_org_id`
+// (the org whose conversion opened the promise), which the dashboard resolves to a
+// brand through brand-service. The gateway does not reshape or compute anything.
+router.get(
+  "/billing/free-credit-promises",
+  authenticate,
+  requireOrg,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const result = await callExternalService(
+        externalServices.billing,
+        "/v1/free-credit-promises",
+        { headers: buildInternalHeaders(req) },
+      );
+      res.json(result);
+    } catch (error: unknown) {
+      respondUpstreamError(res, error, "Failed to get free-credit promises");
     }
   },
 );

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6066,6 +6066,30 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/v1/billing/free-credit-promises",
+  tags: ["Billing"],
+  summary: "Free credits this org is still waiting on",
+  description:
+    "Every outstanding free-credit promise for the org in context: the welcome remainder, " +
+    "plus a promise for each converting referral. Each carries what it is worth, the level of " +
+    "cumulative payments that unlocks it, how far along the org is, and — when the promise " +
+    "exists because someone this org referred converted — which org that was, which the " +
+    "dashboard resolves to a brand through brand-service. An outstanding promise is a promise, " +
+    "not money: it is not part of credited, balance or spendable. Normal org auth (same tier as " +
+    "GET /v1/billing/credits/grants); billing-service scopes the response to the caller's " +
+    "x-org-id, so an org reads only its own promises and the client never names an org. " +
+    "Transparent proxy to billing-service GET /v1/free-credit-promises; response owned by the " +
+    "downstream service.",
+  security: authed,
+  responses: {
+    200: { description: "Outstanding promises — pass-through from billing-service", content: { "application/json": { schema: z.object({}).passthrough().openapi("FreeCreditPromisesResponse") } } },
+    401: { description: "Unauthorized", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/v1/billing/credits/grants/all",
   tags: ["Billing"],
   summary: "Get the platform-wide credit-grants ledger (staff only)",

--- a/tests/unit/credits-proxy.test.ts
+++ b/tests/unit/credits-proxy.test.ts
@@ -191,3 +191,47 @@ describe("requireStaff runtime gate", () => {
     expect(res.statusCode).toBe(403);
   });
 });
+
+describe("GET /v1/billing/free-credit-promises (source)", () => {
+  const mountIdx = content.indexOf('"/billing/free-credit-promises"');
+
+  it("is mounted", () => {
+    expect(mountIdx).toBeGreaterThan(-1);
+  });
+
+  it("reads the org from the authenticated identity, never from the client", () => {
+    // The route takes no org parameter at all: billing-service scopes the response
+    // to the caller's x-org-id. A client-supplied org is the whole attack.
+    const middlewares = content.slice(mountIdx, content.indexOf("async (req", mountIdx));
+    expect(middlewares).toContain("authenticate,");
+    expect(middlewares).toContain("requireOrg,");
+    expect(middlewares).not.toContain("requireStaff");
+    expect(content).not.toContain("/billing/free-credit-promises/:");
+  });
+
+  it("forwards to billing's real path", () => {
+    expect(content).toContain('"/v1/free-credit-promises"');
+  });
+
+  it("forwards the downstream error with its status and body intact", () => {
+    // Rebuilding the envelope as { error: err.message } stringifies the whole
+    // downstream JSON into the message and destroys its fields (CLAUDE.md #7).
+    const body = content.slice(mountIdx, mountIdx + 900);
+    expect(body).toContain("respondUpstreamError");
+    expect(body).not.toContain("error.message ||");
+  });
+
+  it("is a transparent passthrough that reshapes nothing", () => {
+    // billing owns the response, including referred_org_id. The gateway must not
+    // re-declare, trim or compute any of it.
+    const body = content.slice(mountIdx, mountIdx + 900);
+    expect(body).toContain("res.json(result)");
+    expect(body).not.toContain("referred_org_id");
+    expect(body).not.toContain("map(");
+  });
+
+  it("is published on the OpenAPI surface", () => {
+    expect(schemaContent).toContain('path: "/v1/billing/free-credit-promises"');
+    expect(schemaContent).toContain("FreeCreditPromisesResponse");
+  });
+});


### PR DESCRIPTION
## What

`GET /v1/billing/free-credit-promises` — the free credits an org is still waiting on.

billing-service **v0.59.0** (#328, in prod) shipped the referral offer: an org can now carry several outstanding free-credit promises at once, each worth a different amount and each unlocking at its own level of cumulative payments. It serves them at `GET /v1/free-credit-promises`. The gateway did not forward that, so the customer dashboard could not show a customer what is coming or what unlocks it.

## Shape

Transparent passthrough. Same auth tier as the org's own grants ledger sitting beside it (`authenticate` + `requireOrg`, no staff gate): billing scopes the response to the caller's `x-org-id`, so an org reads only its own promises.

**The route takes no org parameter at all**, which is what makes it impossible for a client to name one. Guarded by a test asserting no `:param` variant exists.

The response is billing's and is forwarded verbatim, including `referred_org_id` (the org whose conversion opened the promise). The gateway does not reshape, trim or compute any of it — also guarded.

Errors go through `respondUpstreamError`, so a downstream status and body arrive intact rather than being flattened into a message string (CLAUDE.md #7).

## Verification

- **29/29** `credits-proxy.test.ts` green, including 6 new cases: mounted, org from identity only, forwards to billing's real path, upstream errors intact, reshapes nothing, published on the OpenAPI surface.
- `tsc --noEmit` clean, `openapi.json` regenerated (not hand-edited).
- Downstream contract read from the **prod** api-registry (`billing` `GET /v1/free-credit-promises`, live), not from a brief.

## Deployment ordering

None blocking. billing's read is already in **prod** (v0.59.0), so this route works the moment it deploys. Its consumer (the dashboard's Billing "On the way" card) is built in parallel and gates its own merge on this being live, since the dashboard deploys straight to prod from `main` with no staging buffer.

## Note

Built in a worktree off `origin/main` rather than a spawned workspace: the Conductor GUI spawn silently failed to create a workspace twice in a row, and a third keystroke attempt risked landing in a live sibling session. Per the skill's headless fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
