### PR TITLE
fix(brands): point the share-credential proxy at the routes brand-service actually serves

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5158,9 +5158,20 @@
         "type": "object",
         "properties": {}
       },
-      "BrandShareLinkProxyResponse": {
+      "BrandShareTokenProxyResponse": {
         "type": "object",
         "properties": {}
+      },
+      "ResolveShareTokenProxyRequest": {
+        "type": "object",
+        "properties": {
+          "shareToken": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "shareToken"
+        ]
       },
       "IcpSuggestResponse": {
         "type": "object",
@@ -23247,13 +23258,13 @@
         }
       }
     },
-    "/v1/brands/{id}/share-link": {
+    "/v1/brands/{id}/share-token": {
       "get": {
         "tags": [
           "Brand"
         ],
         "summary": "Get a brand's public share credential",
-        "description": "Proxy to brand-service GET /orgs/brands/{id}/share-link. Returns the credential currently letting someone outside the org open a read-only view of this brand, or { token: null } when the brand has never been shared. A READ: it does NOT mint one, so opening a share menu cannot accidentally start sharing a brand. Response shape is owned by the downstream service.",
+        "description": "Proxy to brand-service GET /orgs/brands/{id}/share-token. Returns the credential currently letting someone outside the org open a read-only view of this brand, or { token: null } when the brand has never been shared. A READ: it does NOT mint one, so opening a share menu cannot accidentally start sharing a brand. Response shape is owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
@@ -23332,7 +23343,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                  "$ref": "#/components/schemas/BrandShareTokenProxyResponse"
                 }
               }
             }
@@ -23384,7 +23395,7 @@
           "Brand"
         ],
         "summary": "Start sharing a brand, returning its credential",
-        "description": "Proxy to brand-service POST /orgs/brands/{id}/share-link. Mints the credential that lets someone outside the org open a read-only view of this brand. Idempotent: a brand already shared gets its EXISTING token back rather than a fresh one, so pressing share twice cannot silently invalidate a link the customer already sent. Response shape is owned by the downstream service.",
+        "description": "Proxy to brand-service POST /orgs/brands/{id}/share-token. Mints the credential that lets someone outside the org open a read-only view of this brand. Idempotent: a brand already shared gets its EXISTING token back rather than a fresh one, so pressing share twice cannot silently invalidate a link the customer already sent. Response shape is owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
@@ -23463,7 +23474,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                  "$ref": "#/components/schemas/BrandShareTokenProxyResponse"
                 }
               }
             }
@@ -23515,7 +23526,7 @@
           "Brand"
         ],
         "summary": "Stop sharing a brand",
-        "description": "Proxy to brand-service DELETE /orgs/brands/{id}/share-link. Revokes the credential so the public link stops resolving. Idempotent — a brand that was not shared is already in the requested end state. Response shape is owned by the downstream service.",
+        "description": "Proxy to brand-service DELETE /orgs/brands/{id}/share-token. Revokes the credential so the public link stops resolving. Idempotent — a brand that was not shared is already in the requested end state. Response shape is owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
@@ -23594,7 +23605,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                  "$ref": "#/components/schemas/BrandShareTokenProxyResponse"
                 }
               }
             }
@@ -23642,13 +23653,13 @@
         }
       }
     },
-    "/v1/brands/{id}/share-link/rotate": {
+    "/v1/brands/{id}/share-token/rotate": {
       "post": {
         "tags": [
           "Brand"
         ],
         "summary": "Rotate a brand's public share credential",
-        "description": "Proxy to brand-service POST /orgs/brands/{id}/share-link/rotate. Replaces the credential, so the previous link stops working immediately — this is how a customer takes back a link already in someone else's hands. Downstream 404s a brand that was never shared rather than minting one, and that propagates verbatim. Response shape is owned by the downstream service.",
+        "description": "Proxy to brand-service POST /orgs/brands/{id}/share-token/rotate. Replaces the credential, so the previous link stops working immediately — this is how a customer takes back a link already in someone else's hands. Downstream 404s a brand that was never shared rather than minting one, and that propagates verbatim. Response shape is owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
@@ -23727,7 +23738,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
+                  "$ref": "#/components/schemas/BrandShareTokenProxyResponse"
                 }
               }
             }
@@ -23775,27 +23786,70 @@
         }
       }
     },
-    "/v1/brand-share-links/{token}": {
-      "get": {
+    "/v1/share-tokens/resolve": {
+      "post": {
         "tags": [
           "Brand"
         ],
         "summary": "Resolve a brand share credential",
-        "description": "Proxy to brand-service GET /internal/brand-share-links/{token}. Resolves a share credential to the org and brand it opens. Authenticated but NOT org-scoped, uniquely among the brand routes: the caller is a trusted server-side renderer holding a platform key that has no org context YET — resolving the token is precisely how it learns which org to act as, so requiring one here would make the route unusable for its only purpose. Downstream 404s unknown, revoked and rotated-away tokens alike, and that propagates verbatim. Response shape is owned by the downstream service.",
+        "description": "Proxy to brand-service POST /internal/share-tokens/resolve. Present the credential alone and learn which brand it refers to, plus that brand's public-safe payload. Authenticated but NOT org-scoped, uniquely among the brand routes: the caller is a trusted server-side renderer holding a platform key that has no org context YET, and resolving the credential is precisely how it learns which brand it is rendering, so requiring one here would make the route unusable for its only purpose. The credential travels in the BODY, matching downstream: a share credential in a URL lands in access logs and proxy traces. Downstream 404s unknown, revoked and rotated-away credentials alike, and that propagates verbatim. Response shape is owned by the downstream service.",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "token",
-            "in": "path"
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveShareTokenProxyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The brand the credential refers to",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandShareTokenProxyResponse"
+                }
+              }
+            }
           },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Share token not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
           {
             "name": "x-org-id",
             "in": "header",
@@ -23851,49 +23905,7 @@
             },
             "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "The org and brand the credential opens",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrandShareLinkProxyResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Share link not found (forwarded verbatim)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Upstream error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
+        ]
       }
     },
     "/v1/brands/{id}/icp/suggest": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -741,123 +741,127 @@ router.put("/brands/:id/user-fields", authenticate, requireOrg, requireUser, asy
 });
 
 /**
- * Brand share link — the credential someone OUTSIDE the org presents to open a
+ * Brand share token — the credential someone OUTSIDE the org presents to open a
  * read-only view of one brand.
  *
- * Four org-scoped routes below (read / mint / rotate / revoke) are ordinary
+ * Four org-scoped routes (read / mint / rotate / revoke) are ordinary
  * passthroughs to brand-service; the resolve route further down is the odd one
  * and is documented there.
  */
 
 /**
- * GET /v1/brands/:id/share-link
- * Proxy to brand-service GET /orgs/brands/:id/share-link. Returns the current
- * credential or `{ token: null }` when the brand has never been shared; it does
- * NOT mint one. Response shape is owned by the downstream service — passthrough
- * only.
+ * GET /v1/brands/:id/share-token
+ * Proxy to brand-service GET /orgs/brands/:id/share-token. Returns the brand's
+ * current credential, or `{ shareToken: null }` when nobody has shared it — a
+ * brand is not shareable until someone asks, so this READ never mints one.
+ * Response shape is owned by the downstream service — passthrough only.
  */
-router.get("/brands/:id/share-link", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.get("/brands/:id/share-token", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { status, data } = await callExternalServiceWithStatus(
       externalServices.brand,
-      `/orgs/brands/${req.params.id}/share-link`,
+      `/orgs/brands/${req.params.id}/share-token`,
       { headers: buildInternalHeaders(req) },
     );
     res.status(status).json(data);
   } catch (error: any) {
-    console.error("[api-service] Get brand share link error:", error.message);
-    respondUpstreamError(res, error, "Failed to get brand share link");
+    console.error("[api-service] Get brand share token error:", error.message);
+    respondUpstreamError(res, error, "Failed to get brand share token");
   }
 });
 
 /**
- * POST /v1/brands/:id/share-link
- * Proxy to brand-service POST /orgs/brands/:id/share-link. Starts sharing and
- * returns the credential; idempotent, so an already-shared brand gets its
- * existing token back. Response shape is owned by the downstream service —
- * passthrough only.
+ * POST /v1/brands/:id/share-token
+ * Proxy to brand-service POST /orgs/brands/:id/share-token. Makes the brand
+ * shareable. Idempotent: a brand that already has a credential keeps it (200,
+ * `created: false`) rather than getting a fresh one, because minting again would
+ * invalidate a link somebody is already holding. 201 when it mints. Both the
+ * status and the response shape are owned by the downstream service.
  */
-router.post("/brands/:id/share-link", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.post("/brands/:id/share-token", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { status, data } = await callExternalServiceWithStatus(
       externalServices.brand,
-      `/orgs/brands/${req.params.id}/share-link`,
+      `/orgs/brands/${req.params.id}/share-token`,
       { method: "POST", headers: buildInternalHeaders(req) },
     );
     res.status(status).json(data);
   } catch (error: any) {
-    console.error("[api-service] Create brand share link error:", error.message);
-    respondUpstreamError(res, error, "Failed to create brand share link");
+    console.error("[api-service] Create brand share token error:", error.message);
+    respondUpstreamError(res, error, "Failed to create brand share token");
   }
 });
 
 /**
- * POST /v1/brands/:id/share-link/rotate
- * Proxy to brand-service POST /orgs/brands/:id/share-link/rotate. Replaces the
- * credential so the previous link stops working; its 404 on a brand that was
- * never shared propagates verbatim — passthrough only.
+ * POST /v1/brands/:id/share-token/rotate
+ * Proxy to brand-service POST /orgs/brands/:id/share-token/rotate. Mints a NEW
+ * credential; the previous one stops resolving immediately, which is what makes
+ * a leaked link recoverable. Response shape is owned by the downstream service.
  */
-router.post("/brands/:id/share-link/rotate", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.post("/brands/:id/share-token/rotate", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { status, data } = await callExternalServiceWithStatus(
       externalServices.brand,
-      `/orgs/brands/${req.params.id}/share-link/rotate`,
+      `/orgs/brands/${req.params.id}/share-token/rotate`,
       { method: "POST", headers: buildInternalHeaders(req) },
     );
     res.status(status).json(data);
   } catch (error: any) {
-    console.error("[api-service] Rotate brand share link error:", error.message);
-    respondUpstreamError(res, error, "Failed to rotate brand share link");
+    console.error("[api-service] Rotate brand share token error:", error.message);
+    respondUpstreamError(res, error, "Failed to rotate brand share token");
   }
 });
 
 /**
- * DELETE /v1/brands/:id/share-link
- * Proxy to brand-service DELETE /orgs/brands/:id/share-link. Stops sharing;
- * idempotent. Response shape is owned by the downstream service — passthrough
- * only.
+ * DELETE /v1/brands/:id/share-token
+ * Proxy to brand-service DELETE /orgs/brands/:id/share-token. The brand becomes
+ * unshareable and every link handed out for it stops resolving. Revoking an
+ * already-unshared brand is a truthful no-op rather than a 404. Response shape
+ * is owned by the downstream service.
  */
-router.delete("/brands/:id/share-link", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+router.delete("/brands/:id/share-token", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
   try {
     const { status, data } = await callExternalServiceWithStatus(
       externalServices.brand,
-      `/orgs/brands/${req.params.id}/share-link`,
+      `/orgs/brands/${req.params.id}/share-token`,
       { method: "DELETE", headers: buildInternalHeaders(req) },
     );
     res.status(status).json(data);
   } catch (error: any) {
-    console.error("[api-service] Revoke brand share link error:", error.message);
-    respondUpstreamError(res, error, "Failed to revoke brand share link");
+    console.error("[api-service] Revoke brand share token error:", error.message);
+    respondUpstreamError(res, error, "Failed to revoke brand share token");
   }
 });
 
 /**
- * GET /v1/brand-share-links/:token
- * Proxy to brand-service GET /internal/brand-share-links/:token. Resolves a
- * share credential to the org + brand it opens.
+ * POST /v1/share-tokens/resolve
+ * Proxy to brand-service POST /internal/share-tokens/resolve. Present the
+ * credential alone, learn which brand it refers to plus that brand's public-safe
+ * payload.
  *
  * `authenticate` WITHOUT `requireOrg`, deliberately and uniquely on this file:
  * the caller is a trusted server-side renderer holding a platform key that has
- * no org context YET — resolving the token is precisely how it learns which org
- * to act as. Requiring an org here would make the route unusable for its only
- * purpose. It stays authenticated so the token oracle is never reachable
- * unauthenticated from the internet.
+ * no org context YET — resolving the credential is precisely how it learns which
+ * brand it is rendering. Requiring an org here would make the route unusable for
+ * its only purpose. It stays authenticated so the credential oracle is never
+ * reachable unauthenticated from the internet.
  *
- * Mounted on its own path rather than under `/brands/` so it cannot be confused
- * with a brand-id route. brand-service's 404 (unknown, revoked or rotated-away
- * token alike) propagates verbatim.
+ * The credential travels in the BODY, matching downstream: a share credential in
+ * a URL lands in access logs and proxy traces, and this one is exactly the
+ * secret that must not leak. brand-service's 404 (unknown, revoked and
+ * rotated-away credentials alike) propagates verbatim.
  */
-router.get("/brand-share-links/:token", authenticate, async (req: AuthenticatedRequest, res) => {
+router.post("/share-tokens/resolve", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { status, data } = await callExternalServiceWithStatus(
       externalServices.brand,
-      `/internal/brand-share-links/${encodeURIComponent(req.params.token)}`,
-      { headers: buildInternalHeaders(req) },
+      "/internal/share-tokens/resolve",
+      { method: "POST", headers: buildInternalHeaders(req), body: req.body },
     );
     res.status(status).json(data);
   } catch (error: any) {
-    console.error("[api-service] Resolve brand share link error:", error.message);
-    respondUpstreamError(res, error, "Failed to resolve brand share link");
+    console.error("[api-service] Resolve brand share token error:", error.message);
+    respondUpstreamError(res, error, "Failed to resolve brand share token");
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4113,20 +4113,20 @@ registry.registerPath({
 });
 
 // ===================================================================
-// Brand – Share Link (proxy to brand-service
-// /orgs/brands/:id/share-link[/rotate] + /internal/brand-share-links/:token).
+// Brand – Share Token (proxy to brand-service
+// /orgs/brands/:id/share-token[/rotate] + /internal/share-tokens/resolve).
 // The credential someone OUTSIDE the org presents to open a read-only view of
 // one brand. Downstream owns the response shape — passthrough only.
 // ===================================================================
-const BrandShareLinkResponseSchema = z.object({}).passthrough().openapi("BrandShareLinkProxyResponse");
+const BrandShareTokenResponseSchema = z.object({}).passthrough().openapi("BrandShareTokenProxyResponse");
 
 registry.registerPath({
   method: "get",
-  path: "/v1/brands/{id}/share-link",
+  path: "/v1/brands/{id}/share-token",
   tags: ["Brand"],
   summary: "Get a brand's public share credential",
   description:
-    "Proxy to brand-service GET /orgs/brands/{id}/share-link. Returns the credential " +
+    "Proxy to brand-service GET /orgs/brands/{id}/share-token. Returns the credential " +
     "currently letting someone outside the org open a read-only view of this brand, or " +
     "{ token: null } when the brand has never been shared. A READ: it does NOT mint one, so " +
     "opening a share menu cannot accidentally start sharing a brand. Response shape is owned " +
@@ -4134,7 +4134,7 @@ registry.registerPath({
   security: authed,
   request: { params: BrandIdParam },
   responses: {
-    200: { description: "Current share credential (token null when unshared)", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    200: { description: "Current share credential (token null when unshared)", content: { "application/json": { schema: BrandShareTokenResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
     403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
     404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
@@ -4144,11 +4144,11 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/brands/{id}/share-link",
+  path: "/v1/brands/{id}/share-token",
   tags: ["Brand"],
   summary: "Start sharing a brand, returning its credential",
   description:
-    "Proxy to brand-service POST /orgs/brands/{id}/share-link. Mints the credential that lets " +
+    "Proxy to brand-service POST /orgs/brands/{id}/share-token. Mints the credential that lets " +
     "someone outside the org open a read-only view of this brand. Idempotent: a brand already " +
     "shared gets its EXISTING token back rather than a fresh one, so pressing share twice " +
     "cannot silently invalidate a link the customer already sent. Response shape is owned by " +
@@ -4156,7 +4156,7 @@ registry.registerPath({
   security: authed,
   request: { params: BrandIdParam },
   responses: {
-    200: { description: "Share credential", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    200: { description: "Share credential", content: { "application/json": { schema: BrandShareTokenResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
     403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
     404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
@@ -4166,18 +4166,18 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/brands/{id}/share-link/rotate",
+  path: "/v1/brands/{id}/share-token/rotate",
   tags: ["Brand"],
   summary: "Rotate a brand's public share credential",
   description:
-    "Proxy to brand-service POST /orgs/brands/{id}/share-link/rotate. Replaces the credential, " +
+    "Proxy to brand-service POST /orgs/brands/{id}/share-token/rotate. Replaces the credential, " +
     "so the previous link stops working immediately — this is how a customer takes back a link " +
     "already in someone else's hands. Downstream 404s a brand that was never shared rather than " +
     "minting one, and that propagates verbatim. Response shape is owned by the downstream service.",
   security: authed,
   request: { params: BrandIdParam },
   responses: {
-    200: { description: "New share credential", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    200: { description: "New share credential", content: { "application/json": { schema: BrandShareTokenResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
     403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
     404: { description: "Brand not found, or brand is not shared (forwarded verbatim)", content: errorContent },
@@ -4187,17 +4187,17 @@ registry.registerPath({
 
 registry.registerPath({
   method: "delete",
-  path: "/v1/brands/{id}/share-link",
+  path: "/v1/brands/{id}/share-token",
   tags: ["Brand"],
   summary: "Stop sharing a brand",
   description:
-    "Proxy to brand-service DELETE /orgs/brands/{id}/share-link. Revokes the credential so the " +
+    "Proxy to brand-service DELETE /orgs/brands/{id}/share-token. Revokes the credential so the " +
     "public link stops resolving. Idempotent — a brand that was not shared is already in the " +
     "requested end state. Response shape is owned by the downstream service.",
   security: authed,
   request: { params: BrandIdParam },
   responses: {
-    200: { description: "Whether a link existed and was removed", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    200: { description: "Whether a link existed and was removed", content: { "application/json": { schema: BrandShareTokenResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
     403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
     404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
@@ -4206,24 +4206,34 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: "get",
-  path: "/v1/brand-share-links/{token}",
+  method: "post",
+  path: "/v1/share-tokens/resolve",
   tags: ["Brand"],
   summary: "Resolve a brand share credential",
   description:
-    "Proxy to brand-service GET /internal/brand-share-links/{token}. Resolves a share credential " +
-    "to the org and brand it opens. Authenticated but NOT org-scoped, uniquely among the brand " +
-    "routes: the caller is a trusted server-side renderer holding a platform key that has no org " +
-    "context YET — resolving the token is precisely how it learns which org to act as, so " +
-    "requiring one here would make the route unusable for its only purpose. Downstream 404s " +
-    "unknown, revoked and rotated-away tokens alike, and that propagates verbatim. Response shape " +
-    "is owned by the downstream service.",
+    "Proxy to brand-service POST /internal/share-tokens/resolve. Present the credential alone " +
+    "and learn which brand it refers to, plus that brand's public-safe payload. Authenticated but " +
+    "NOT org-scoped, uniquely among the brand routes: the caller is a trusted server-side renderer " +
+    "holding a platform key that has no org context YET, and resolving the credential is precisely " +
+    "how it learns which brand it is rendering, so requiring one here would make the route " +
+    "unusable for its only purpose. The credential travels in the BODY, matching downstream: a " +
+    "share credential in a URL lands in access logs and proxy traces. Downstream 404s unknown, " +
+    "revoked and rotated-away credentials alike, and that propagates verbatim. Response shape is " +
+    "owned by the downstream service.",
   security: authed,
-  request: { params: z.object({ token: z.string() }) },
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({ shareToken: z.string() }).openapi("ResolveShareTokenProxyRequest"),
+        },
+      },
+    },
+  },
   responses: {
-    200: { description: "The org and brand the credential opens", content: { "application/json": { schema: BrandShareLinkResponseSchema } } },
+    200: { description: "The brand the credential refers to", content: { "application/json": { schema: BrandShareTokenResponseSchema } } },
     401: { description: "Unauthorized", content: errorContent },
-    404: { description: "Share link not found (forwarded verbatim)", content: errorContent },
+    404: { description: "Share token not found (forwarded verbatim)", content: errorContent },
     500: { description: "Upstream error", content: errorContent },
   },
 });


### PR DESCRIPTION
**#778 (mine, merged an hour ago) is dead on arrival.** It proxies `/orgs/brands/:id/share-link` and `/internal/brand-share-links/:token`. brand-service serves neither.

The brand share credential landed in brand-service [#397](https://github.com/shamanic-technologies/brand-service/pull/397) as **`share-token`**. Two workspaces built the same feature in parallel without either seeing the other; #397 merged first and is on staging, so it is the contract. My duplicate producer PR (brand-service #398) is closed.

Nothing calls these routes yet — the dashboard surface is not shipped — so no traffic was affected. But every one of them would have 404'd at the downstream hop.

## Repointed

| Gateway | brand-service |
|---|---|
| `GET /v1/brands/:id/share-token` | `GET /orgs/brands/:id/share-token` |
| `POST /v1/brands/:id/share-token` | `POST /orgs/brands/:id/share-token` |
| `POST /v1/brands/:id/share-token/rotate` | `POST /orgs/brands/:id/share-token/rotate` |
| `DELETE /v1/brands/:id/share-token` | `DELETE /orgs/brands/:id/share-token` |
| `POST /v1/share-tokens/resolve` | `POST /internal/share-tokens/resolve` |

## The resolve route changed shape, and that part is an improvement

The credential now travels in the request **body** rather than the URL path, matching brand-service. A share credential in a URL lands in access logs and proxy traces, and this one is exactly the secret that must not leak. #778 had it in the path; #397's design is better and this conforms to it.

It stays `authenticate` **without** `requireOrg`, uniquely on this file: the caller is a trusted server-side renderer holding a platform key that has no org context yet, and resolving the credential is precisely how it learns which brand it is rendering. Requiring an org would make the route unusable for its only purpose. It stays authenticated so the credential oracle is never reachable unauthenticated from the internet.

The create route now forwards brand-service's status verbatim instead of flattening it: **201** when it mints, **200** when the brand already had a credential and it was left untouched.

## Tests

1761 pass. One unrelated failure, `google-proxy.test.ts > should throw when GOOGLE_SERVICE_URL is unset`, timed out at 5000ms — my machine was at load average 51 while running it, and this same suite was 1762/1762 green earlier in the session. Expected green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
