### PR TITLE
feat(brands): proxy the sales-funnels routes a brand declares through (#784)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5088,6 +5088,18 @@
         "type": "object",
         "properties": {}
       },
+      "SalesFunnelsResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "SalesFunnelsSetRequest": {
+        "type": "object",
+        "properties": {}
+      },
+      "SalesFunnelRequest": {
+        "type": "object",
+        "properties": {}
+      },
       "ClickDestinationResponse": {
         "type": "object",
         "properties": {
@@ -22570,6 +22582,612 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/sales-funnels": {
+      "get": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Get the sales funnels a brand has declared it sells through",
+        "description": "Proxy to brand-service GET /orgs/brands/{id}/sales-funnels. Returns { declared, funnels }: the funnels the brand declared, in catalogue order, each with its own conversion rates, lifetime revenue, landing page and booking link. Read `declared` BEFORE `funnels` — `declared: true` with an empty list means the brand STATED it sells through none, while `declared: false` means it has never told us anything. Nothing is defaulted: a value the brand never declared reads null, which never means zero. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The declared funnels (possibly empty)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalesFunnelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brand ID format (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "State the whole set of funnels a brand sells through",
+        "description": "Proxy to brand-service PUT /orgs/brands/{id}/sales-funnels. States the WHOLE set at once (body { funnelKeys }): exactly these funnels, no others. Funnels already in the set keep the economics they were priced with; funnels dropped from it lose their declaration and their economics together. `{ \"funnelKeys\": [] }` is legal and is the only way a brand can state it sells through NOTHING. The set is validated whole before anything is written, so a rejected set leaves nothing half-applied. Body + response shapes are owned by the downstream service; its 4xx propagate verbatim.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SalesFunnelsSetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The stated set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalesFunnelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brand ID, unknown funnel key, or a website-led funnel on a brand with no website (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{id}/sales-funnels/{funnelKey}": {
+      "put": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Declare a sales funnel and write its economics",
+        "description": "Proxy to brand-service PUT /orgs/brands/{id}/sales-funnels/{funnelKey}. Declares that the brand sells through this funnel and writes what the body carries of its economics. Idempotent — the declaration IS the row, and a body with no fields declares the funnel without pricing it yet. PARTIAL: an omitted field is left exactly as stored, an explicit null CLEARS the value back to never-declared. brand-service rejects a rate outside this funnel's own chain, a destination the funnel has no use for, an off-domain page destination, and a website-led funnel on a brand with no website; the gateway adds no validation of its own. Body + response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Funnel key: reply_meeting | visit_meeting | visit_signup | visit_form"
+            },
+            "required": true,
+            "description": "Funnel key: reply_meeting | visit_meeting | visit_signup | visit_form",
+            "name": "funnelKey",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SalesFunnelRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The declared funnel",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalesFunnelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brand ID or funnel key, a rate outside this funnel's chain, a destination the funnel has no use for, or a website-led funnel on a brand with no website (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Brand"
+        ],
+        "summary": "Undeclare a sales funnel",
+        "description": "Proxy to brand-service DELETE /orgs/brands/{id}/sales-funnels/{funnelKey}. The brand no longer sells through this funnel, and removing the declaration removes its economics with it. Idempotent — undeclaring a funnel that was never declared is a 200 with the unchanged set. Does NOT un-state the set: a brand that removes its LAST funnel keeps `declared: true`, because it has stated it sells through none. Returns the set that is left. Response shape is owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID"
+            },
+            "required": true,
+            "description": "Brand ID",
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Funnel key: reply_meeting | visit_meeting | visit_signup | visit_form"
+            },
+            "required": true,
+            "description": "Funnel key: reply_meeting | visit_meeting | visit_signup | visit_form",
+            "name": "funnelKey",
+            "in": "path"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The funnels still declared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalesFunnelsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brand ID format or unknown funnel key (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Brand does not belong to the caller's org (forwarded verbatim)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/brand.ts
+++ b/src/routes/brand.ts
@@ -390,6 +390,117 @@ router.put("/brands/:id/sales-economics", authenticate, requireOrg, requireUser,
 });
 
 /**
+ * Brand sales funnels — the funnels a brand DECLARES it sells through, each
+ * carrying its own economics.
+ *
+ * Four org-scoped passthroughs sitting beside the sales-economics proxies above,
+ * with the same auth and the same downstream path shape
+ * (/orgs/brands/:id/sales-funnels[/:funnelKey] → /v1/brands/:id/...).
+ *
+ * `declared` is the one semantic worth naming here, because flattening it is
+ * easy and lies about user data: `declared: false` with an empty list means the
+ * brand has never stated a set, `declared: true` with an empty list means it
+ * stated it sells through none. Both come back untouched — brand-service owns
+ * the shape (CLAUDE.md #8) and this layer re-declares nothing.
+ *
+ * No validation here either (CLAUDE.md rule: no gateway re-validation).
+ * brand-service already rejects a rate outside a funnel's own chain, a
+ * destination the funnel has no use for, and a website-led funnel on a brand
+ * with no website; its 400s reach the caller with status and body intact via
+ * callExternalServiceWithStatus + respondUpstreamError.
+ *
+ * The service-auth GET /internal/brands/:id/sales-funnels is deliberately NOT
+ * proxied: features-service reads it service-to-service, and an internal route
+ * is never mounted client-facing (CLAUDE.md rule #3).
+ */
+
+/**
+ * GET /v1/brands/:id/sales-funnels
+ * Proxy to brand-service GET /orgs/brands/:id/sales-funnels. Returns
+ * { declared, funnels } — the funnels the brand declared, in catalogue order,
+ * each with its own rates, lifetime revenue, landing page and booking link.
+ * Response shape is owned by the downstream service — passthrough only.
+ */
+router.get("/brands/:id/sales-funnels", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/sales-funnels`,
+      { headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Get brand sales funnels error:", error.message);
+    respondUpstreamError(res, error, "Failed to get brand sales funnels");
+  }
+});
+
+/**
+ * PUT /v1/brands/:id/sales-funnels
+ * Proxy to brand-service PUT /orgs/brands/:id/sales-funnels. States the WHOLE
+ * set at once (body { funnelKeys }); `{ "funnelKeys": [] }` is the only way a
+ * brand can state it sells through nothing. Body + response shapes are owned by
+ * the downstream service; its 4xx propagate verbatim — passthrough only.
+ */
+router.put("/brands/:id/sales-funnels", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/sales-funnels`,
+      { method: "PUT", headers: buildInternalHeaders(req), body: req.body },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Save brand sales funnels error:", error.message);
+    respondUpstreamError(res, error, "Failed to save brand sales funnels");
+  }
+});
+
+/**
+ * PUT /v1/brands/:id/sales-funnels/:funnelKey
+ * Proxy to brand-service PUT /orgs/brands/:id/sales-funnels/:funnelKey.
+ * Declares one funnel and writes what the body carries of its economics
+ * (partial: an omitted field is left as stored, an explicit null clears it).
+ * Body + response shapes are owned by the downstream service; its 4xx
+ * propagate verbatim — passthrough only.
+ */
+router.put("/brands/:id/sales-funnels/:funnelKey", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/sales-funnels/${encodeURIComponent(req.params.funnelKey)}`,
+      { method: "PUT", headers: buildInternalHeaders(req), body: req.body },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Declare brand sales funnel error:", error.message);
+    respondUpstreamError(res, error, "Failed to declare brand sales funnel");
+  }
+});
+
+/**
+ * DELETE /v1/brands/:id/sales-funnels/:funnelKey
+ * Proxy to brand-service DELETE /orgs/brands/:id/sales-funnels/:funnelKey. The
+ * brand no longer sells through this funnel, and its economics go with the
+ * declaration. Returns the set that is left; a brand that removes its last
+ * funnel keeps `declared: true`. Response shape is owned by the downstream
+ * service — passthrough only.
+ */
+router.delete("/brands/:id/sales-funnels/:funnelKey", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { status, data } = await callExternalServiceWithStatus(
+      externalServices.brand,
+      `/orgs/brands/${req.params.id}/sales-funnels/${encodeURIComponent(req.params.funnelKey)}`,
+      { method: "DELETE", headers: buildInternalHeaders(req) },
+    );
+    res.status(status).json(data);
+  } catch (error: any) {
+    console.error("[api-service] Undeclare brand sales funnel error:", error.message);
+    respondUpstreamError(res, error, "Failed to undeclare brand sales funnel");
+  }
+});
+
+/**
  * PUT /v1/brands/:id/click-destination
  * Proxy to brand-service PUT /orgs/brands/:id/click-destination.
  * Sets the per-brand page outreach clicks should land on. Body + response

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3917,6 +3917,137 @@ registry.registerPath({
 });
 
 // ===================================================================
+// Brand – Sales Funnels (proxy to brand-service /orgs/brands/:id/sales-funnels[/:funnelKey])
+// The funnels a brand DECLARES it sells through, each carrying its own economics.
+// Downstream owns body + response shapes — passthrough only, no gateway
+// re-validation, so brand-service's 4xx propagate verbatim.
+//
+// The read answers { declared, funnels }, and `declared` is load-bearing:
+// `declared: false` with an empty list means no set has ever been stated,
+// `declared: true` with an empty list means the brand stated it sells through
+// none. Opposite answers, and the flag is the only thing separating them.
+//
+// The service-auth GET /internal/brands/{id}/sales-funnels is NOT proxied:
+// features-service reads it service-to-service.
+// ===================================================================
+const SalesFunnelsResponseSchema = z.object({}).passthrough().openapi("SalesFunnelsResponse");
+const SalesFunnelsSetRequestSchema = z.object({}).passthrough().openapi("SalesFunnelsSetRequest");
+const SalesFunnelRequestSchema = z.object({}).passthrough().openapi("SalesFunnelRequest");
+
+const BrandFunnelKeyParams = z.object({
+  id: z.string().describe("Brand ID"),
+  funnelKey: z
+    .string()
+    .describe("Funnel key: reply_meeting | visit_meeting | visit_signup | visit_form"),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/brands/{id}/sales-funnels",
+  tags: ["Brand"],
+  summary: "Get the sales funnels a brand has declared it sells through",
+  description:
+    "Proxy to brand-service GET /orgs/brands/{id}/sales-funnels. Returns " +
+    "{ declared, funnels }: the funnels the brand declared, in catalogue order, each with " +
+    "its own conversion rates, lifetime revenue, landing page and booking link. Read " +
+    "`declared` BEFORE `funnels` — `declared: true` with an empty list means the brand " +
+    "STATED it sells through none, while `declared: false` means it has never told us " +
+    "anything. Nothing is defaulted: a value the brand never declared reads null, which " +
+    "never means zero. Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandIdParam },
+  responses: {
+    200: { description: "The declared funnels (possibly empty)", content: { "application/json": { schema: SalesFunnelsResponseSchema } } },
+    400: { description: "Invalid brand ID format (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/brands/{id}/sales-funnels",
+  tags: ["Brand"],
+  summary: "State the whole set of funnels a brand sells through",
+  description:
+    "Proxy to brand-service PUT /orgs/brands/{id}/sales-funnels. States the WHOLE set at " +
+    "once (body { funnelKeys }): exactly these funnels, no others. Funnels already in the " +
+    "set keep the economics they were priced with; funnels dropped from it lose their " +
+    "declaration and their economics together. `{ \"funnelKeys\": [] }` is legal and is the " +
+    "only way a brand can state it sells through NOTHING. The set is validated whole before " +
+    "anything is written, so a rejected set leaves nothing half-applied. Body + response " +
+    "shapes are owned by the downstream service; its 4xx propagate verbatim.",
+  security: authed,
+  request: {
+    params: BrandIdParam,
+    body: { content: { "application/json": { schema: SalesFunnelsSetRequestSchema } } },
+  },
+  responses: {
+    200: { description: "The stated set", content: { "application/json": { schema: SalesFunnelsResponseSchema } } },
+    400: { description: "Invalid brand ID, unknown funnel key, or a website-led funnel on a brand with no website (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/brands/{id}/sales-funnels/{funnelKey}",
+  tags: ["Brand"],
+  summary: "Declare a sales funnel and write its economics",
+  description:
+    "Proxy to brand-service PUT /orgs/brands/{id}/sales-funnels/{funnelKey}. Declares that " +
+    "the brand sells through this funnel and writes what the body carries of its economics. " +
+    "Idempotent — the declaration IS the row, and a body with no fields declares the funnel " +
+    "without pricing it yet. PARTIAL: an omitted field is left exactly as stored, an explicit " +
+    "null CLEARS the value back to never-declared. brand-service rejects a rate outside this " +
+    "funnel's own chain, a destination the funnel has no use for, an off-domain page " +
+    "destination, and a website-led funnel on a brand with no website; the gateway adds no " +
+    "validation of its own. Body + response shapes are owned by the downstream service.",
+  security: authed,
+  request: {
+    params: BrandFunnelKeyParams,
+    body: { content: { "application/json": { schema: SalesFunnelRequestSchema } } },
+  },
+  responses: {
+    200: { description: "The declared funnel", content: { "application/json": { schema: SalesFunnelsResponseSchema } } },
+    400: { description: "Invalid brand ID or funnel key, a rate outside this funnel's chain, a destination the funnel has no use for, or a website-led funnel on a brand with no website (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/v1/brands/{id}/sales-funnels/{funnelKey}",
+  tags: ["Brand"],
+  summary: "Undeclare a sales funnel",
+  description:
+    "Proxy to brand-service DELETE /orgs/brands/{id}/sales-funnels/{funnelKey}. The brand no " +
+    "longer sells through this funnel, and removing the declaration removes its economics " +
+    "with it. Idempotent — undeclaring a funnel that was never declared is a 200 with the " +
+    "unchanged set. Does NOT un-state the set: a brand that removes its LAST funnel keeps " +
+    "`declared: true`, because it has stated it sells through none. Returns the set that is " +
+    "left. Response shape is owned by the downstream service.",
+  security: authed,
+  request: { params: BrandFunnelKeyParams },
+  responses: {
+    200: { description: "The funnels still declared", content: { "application/json": { schema: SalesFunnelsResponseSchema } } },
+    400: { description: "Invalid brand ID format or unknown funnel key (forwarded verbatim)", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    403: { description: "Brand does not belong to the caller's org (forwarded verbatim)", content: errorContent },
+    404: { description: "Brand not found (forwarded verbatim)", content: errorContent },
+    500: { description: "Upstream error", content: errorContent },
+  },
+});
+
+// ===================================================================
 // Brand – Click Destination (proxy to brand-service /orgs/brands/:id/click-destination)
 // Downstream owns body + response shapes — passthrough only. No gateway
 // re-validation, so brand-service's 4xx errors propagate verbatim.

--- a/tests/unit/brand-sales-funnels-auth.test.ts
+++ b/tests/unit/brand-sales-funnels-auth.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+// Own file, deliberately WITHOUT the auth mock the behaviour test uses: this exercises
+// the real `authenticate` + `requireOrg` + `requireUser` chain, so "an unauthenticated
+// call is refused" is a real assertion about the shipped gate and not a property of a stub.
+vi.hoisted(() => {
+  process.env.BRAND_SERVICE_URL = "http://brand.test.local";
+  process.env.BRAND_SERVICE_API_KEY = "brand-test-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "admin-test-key";
+});
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+const BRAND_ID = "7f1c2a3b-4d5e-4f60-8a91-b2c3d4e5f607";
+
+const ROUTES: Array<[string, string]> = [
+  ["get", `/v1/brands/${BRAND_ID}/sales-funnels`],
+  ["put", `/v1/brands/${BRAND_ID}/sales-funnels`],
+  ["put", `/v1/brands/${BRAND_ID}/sales-funnels/reply_meeting`],
+  ["delete", `/v1/brands/${BRAND_ID}/sales-funnels/reply_meeting`],
+];
+
+describe("brand sales-funnels routes — auth gate", () => {
+  beforeEach(() => {
+    // Any outbound call from here means the request got past auth, which is the
+    // failure this file exists to catch.
+    global.fetch = vi.fn().mockImplementation(async () => {
+      throw new Error("unexpected outbound call from an unauthenticated request");
+    }) as unknown as typeof fetch;
+  });
+
+  for (const [method, path] of ROUTES) {
+    it(`refuses ${method.toUpperCase()} ${path} with no credentials`, async () => {
+      const res = await (request(buildApp()) as any)[method](path).send({});
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Missing authentication");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it(`refuses ${method.toUpperCase()} ${path} carrying a wrong platform key`, async () => {
+      const res = await (request(buildApp()) as any)
+        [method](path)
+        .set("X-API-Key", "not-the-admin-key")
+        .send({});
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it(`refuses ${method.toUpperCase()} ${path} for an admin-keyed call naming an org it did not authenticate as`, async () => {
+      // The platform key is shared with the dashboard's server-side proxy, so it is
+      // not an identity: without resolvable identity headers the request never
+      // reaches brand-service, and a caller cannot name whose brand to read.
+      const res = await (request(buildApp()) as any)
+        [method](path)
+        .set("X-API-Key", "admin-test-key")
+        .set("x-org-id", "someone-elses-org")
+        .send({});
+      expect(res.status).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  }
+});

--- a/tests/unit/brand-sales-funnels-behavior.test.ts
+++ b/tests/unit/brand-sales-funnels-behavior.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+// externalServices (src/lib/service-client.ts) snapshots *_SERVICE_URL at module load,
+// so the base must be set BEFORE the router imports. vi.hoisted runs before imports.
+const { BRAND_BASE } = vi.hoisted(() => {
+  const BRAND_BASE = "http://brand.test.local";
+  process.env.BRAND_SERVICE_URL = BRAND_BASE;
+  process.env.BRAND_SERVICE_API_KEY = "brand-test-key";
+  return { BRAND_BASE };
+});
+
+/**
+ * The four sales-funnels proxies, driven over the wire.
+ *
+ * A source-substring test cannot see what actually goes downstream (CLAUDE.md #7
+ * corollary 3), and three of this feature's acceptance criteria are about exactly
+ * that: the full downstream path literal, the org identity being the AUTHENTICATED
+ * one, and brand-service's body reaching the caller untouched — `declared`
+ * included, because collapsing it turns "the brand has said nothing" into "the
+ * brand sells through nothing", which is a lie about user data.
+ *
+ * Per CLAUDE.md #6/#8 the payloads below are fixtures, not a contract this repo
+ * owns: what is asserted is the forwarded path, the forwarded identity, and
+ * byte-identical bodies — never brand-service's field names as a shape.
+ */
+
+vi.mock("../../src/middleware/auth.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/middleware/auth.js")>(
+    "../../src/middleware/auth.js",
+  );
+  return {
+    ...actual,
+    authenticate: (req: any, _res: any, next: any) => {
+      req.userId = "user_test123";
+      req.orgId = "org_test456";
+      req.runId = "run_test789";
+      req.authType = "user_key";
+      next();
+    },
+  };
+});
+
+import brandRouter from "../../src/routes/brand.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", brandRouter);
+  return app;
+}
+
+const BRAND_ID = "7f1c2a3b-4d5e-4f60-8a91-b2c3d4e5f607";
+
+// A brand that has stated a set of one, priced end to end.
+const DECLARED_SET = {
+  declared: true,
+  funnels: [
+    {
+      funnelKey: "reply_meeting",
+      name: "Positive reply → Meeting booked → Meeting attended → Paid client",
+      steps: ["Positive reply", "Meeting booked", "Meeting attended", "Paid client"],
+      goal: "booked_meetings",
+      currentGoal: "meetingBooked",
+      rates: {
+        replyToMeetingPct: 30,
+        meetingBookedToAttendedPct: 70,
+        meetingToClosePct: 20,
+      },
+      lifetimeRevenueUsd: 4800,
+      destinationUrl: null,
+      bookingUrl: "https://cal.com/acme/intro",
+      updatedAt: "2026-07-31T09:00:00.000Z",
+    },
+  ],
+};
+
+describe("GET /v1/brands/:id/sales-funnels — over the wire", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return { ok: true, status: 200, json: () => Promise.resolve(DECLARED_SET) };
+    }) as unknown as typeof fetch;
+  });
+
+  it("forwards to brand-service's real path, carrying the resolved org identity", async () => {
+    const res = await request(buildApp()).get(`/v1/brands/${BRAND_ID}/sales-funnels`);
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(`${BRAND_BASE}/orgs/brands/${BRAND_ID}/sales-funnels`);
+    expect(calls[0].options.method).toBe("GET");
+    expect(calls[0].options.body).toBeUndefined();
+    expect(calls[0].options.headers["x-org-id"]).toBe("org_test456");
+    expect(calls[0].options.headers["x-user-id"]).toBe("user_test123");
+    expect(calls[0].options.headers["x-run-id"]).toBe("run_test789");
+    expect(calls[0].options.headers["X-API-Key"]).toBe("brand-test-key");
+  });
+
+  it("returns brand-service's body unchanged", async () => {
+    const res = await request(buildApp()).get(`/v1/brands/${BRAND_ID}/sales-funnels`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(DECLARED_SET);
+  });
+
+  it("keeps `declared: true` with an empty list distinct from `declared: false`", async () => {
+    // The two answers a caller must never see collapsed: "sells through none"
+    // and "has never said". Only the flag separates them, so it has to survive
+    // the hop for both.
+    for (const declared of [true, false]) {
+      calls = [];
+      global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+        calls.push({ url, options });
+        return { ok: true, status: 200, json: () => Promise.resolve({ declared, funnels: [] }) };
+      }) as unknown as typeof fetch;
+
+      const res = await request(buildApp()).get(`/v1/brands/${BRAND_ID}/sales-funnels`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ declared, funnels: [] });
+      expect(res.body.declared).toBe(declared);
+    }
+  });
+
+  it("ignores a caller-supplied org — only the authenticated org reaches brand-service", async () => {
+    const res = await request(buildApp())
+      .get(`/v1/brands/${BRAND_ID}/sales-funnels?orgId=someone-elses-org`)
+      .set("x-org-id", "someone-elses-org");
+
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe(`${BRAND_BASE}/orgs/brands/${BRAND_ID}/sales-funnels`);
+    expect(calls[0].options.headers["x-org-id"]).toBe("org_test456");
+  });
+
+  it("propagates brand-service's 403 for a brand outside the caller's org", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: false,
+        status: 403,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ error: "Brand does not belong to your organization", code: "FORBIDDEN" }),
+          ),
+        json: () => Promise.resolve({}),
+      };
+    }) as unknown as typeof fetch;
+
+    const res = await request(buildApp()).get(`/v1/brands/${BRAND_ID}/sales-funnels`);
+
+    // Refused exactly as the sibling sales-economics routes refuse it, with the
+    // machine-readable fields intact rather than flattened (CLAUDE.md #7).
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: "Brand does not belong to your organization",
+      code: "FORBIDDEN",
+    });
+  });
+});
+
+describe("PUT /v1/brands/:id/sales-funnels — stating the whole set", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return { ok: true, status: 200, json: () => Promise.resolve(DECLARED_SET) };
+    }) as unknown as typeof fetch;
+  });
+
+  it("forwards the set verbatim and returns the stated set unchanged", async () => {
+    const res = await request(buildApp())
+      .put(`/v1/brands/${BRAND_ID}/sales-funnels`)
+      .send({ funnelKeys: ["reply_meeting"] });
+
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe(`${BRAND_BASE}/orgs/brands/${BRAND_ID}/sales-funnels`);
+    expect(calls[0].options.method).toBe("PUT");
+    expect(JSON.parse(calls[0].options.body)).toEqual({ funnelKeys: ["reply_meeting"] });
+    expect(calls[0].options.headers["x-org-id"]).toBe("org_test456");
+    expect(res.body).toEqual(DECLARED_SET);
+  });
+
+  it("forwards an empty set — the only way to state 'we sell through none'", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return { ok: true, status: 200, json: () => Promise.resolve({ declared: true, funnels: [] }) };
+    }) as unknown as typeof fetch;
+
+    const res = await request(buildApp())
+      .put(`/v1/brands/${BRAND_ID}/sales-funnels`)
+      .send({ funnelKeys: [] });
+
+    expect(res.status).toBe(200);
+    // Not dropped as "empty body": an empty array is the statement.
+    expect(JSON.parse(calls[0].options.body)).toEqual({ funnelKeys: [] });
+    expect(res.body).toEqual({ declared: true, funnels: [] });
+  });
+
+  it("propagates brand-service's 400 with status and body intact", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: false,
+        status: 400,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              error: "visit_signup needs a website; this brand has none",
+              code: "FUNNEL_REQUIRES_WEBSITE",
+            }),
+          ),
+        json: () => Promise.resolve({}),
+      };
+    }) as unknown as typeof fetch;
+
+    const res = await request(buildApp())
+      .put(`/v1/brands/${BRAND_ID}/sales-funnels`)
+      .send({ funnelKeys: ["visit_signup"] });
+
+    // The gateway adds no validation of its own, so this 400 can only be
+    // brand-service's — and it must arrive branchable, not stringified.
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "visit_signup needs a website; this brand has none",
+      code: "FUNNEL_REQUIRES_WEBSITE",
+    });
+  });
+});
+
+describe("PUT /v1/brands/:id/sales-funnels/:funnelKey — declaring one funnel", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ funnel: DECLARED_SET.funnels[0] }),
+      };
+    }) as unknown as typeof fetch;
+  });
+
+  it("forwards the funnel key in the path and the economics verbatim", async () => {
+    const body = {
+      rates: { replyToMeetingPct: 30, meetingToClosePct: 20 },
+      lifetimeRevenueUsd: 4800,
+      bookingUrl: "https://cal.com/acme/intro",
+    };
+
+    const res = await request(buildApp())
+      .put(`/v1/brands/${BRAND_ID}/sales-funnels/reply_meeting`)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe(`${BRAND_BASE}/orgs/brands/${BRAND_ID}/sales-funnels/reply_meeting`);
+    expect(calls[0].options.method).toBe("PUT");
+    expect(JSON.parse(calls[0].options.body)).toEqual(body);
+    expect(res.body).toEqual({ funnel: DECLARED_SET.funnels[0] });
+  });
+
+  it("forwards an explicit null rather than stripping it", async () => {
+    // An omitted field leaves the stored value alone; an explicit null CLEARS it
+    // back to never-declared. Stripping nulls here would make the second
+    // impossible to express through the gateway.
+    await request(buildApp())
+      .put(`/v1/brands/${BRAND_ID}/sales-funnels/reply_meeting`)
+      .send({ lifetimeRevenueUsd: null, bookingUrl: null });
+
+    expect(JSON.parse(calls[0].options.body)).toEqual({
+      lifetimeRevenueUsd: null,
+      bookingUrl: null,
+    });
+  });
+
+  it("forwards an empty body — declaring a funnel without pricing it yet", async () => {
+    await request(buildApp()).put(`/v1/brands/${BRAND_ID}/sales-funnels/visit_form`).send({});
+
+    expect(calls[0].url).toBe(`${BRAND_BASE}/orgs/brands/${BRAND_ID}/sales-funnels/visit_form`);
+    expect(JSON.parse(calls[0].options.body)).toEqual({});
+  });
+
+  it("propagates brand-service's 400 on a rate outside this funnel's chain", async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: false,
+        status: 400,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              error: "visitToSignupPct is not a leg of reply_meeting",
+              code: "RATE_NOT_IN_CHAIN",
+            }),
+          ),
+        json: () => Promise.resolve({}),
+      };
+    }) as unknown as typeof fetch;
+
+    const res = await request(buildApp())
+      .put(`/v1/brands/${BRAND_ID}/sales-funnels/reply_meeting`)
+      .send({ rates: { visitToSignupPct: 5 } });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "visitToSignupPct is not a leg of reply_meeting",
+      code: "RATE_NOT_IN_CHAIN",
+    });
+  });
+
+  it("sends an unknown funnel key downstream instead of rejecting it here", async () => {
+    // No gateway re-validation: the catalogue is brand-service's, and a second
+    // opinion on it would be a second source of truth for one 400.
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return {
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve(JSON.stringify({ error: "Unknown funnel key" })),
+        json: () => Promise.resolve({}),
+      };
+    }) as unknown as typeof fetch;
+
+    const res = await request(buildApp())
+      .put(`/v1/brands/${BRAND_ID}/sales-funnels/not_a_funnel`)
+      .send({});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(`${BRAND_BASE}/orgs/brands/${BRAND_ID}/sales-funnels/not_a_funnel`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Unknown funnel key" });
+  });
+});
+
+describe("DELETE /v1/brands/:id/sales-funnels/:funnelKey — undeclaring one funnel", () => {
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      calls.push({ url, options });
+      return { ok: true, status: 200, json: () => Promise.resolve({ declared: true, funnels: [] }) };
+    }) as unknown as typeof fetch;
+  });
+
+  it("forwards to the funnel's own path and returns the set that is left", async () => {
+    const res = await request(buildApp()).delete(
+      `/v1/brands/${BRAND_ID}/sales-funnels/reply_meeting`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe(`${BRAND_BASE}/orgs/brands/${BRAND_ID}/sales-funnels/reply_meeting`);
+    expect(calls[0].options.method).toBe("DELETE");
+    expect(calls[0].options.body).toBeUndefined();
+    expect(calls[0].options.headers["x-org-id"]).toBe("org_test456");
+    // Removing the last funnel leaves `declared: true` — the brand has stated it
+    // sells through none, which is not the same as never having said.
+    expect(res.body).toEqual({ declared: true, funnels: [] });
+  });
+});


### PR DESCRIPTION
Closes #784.

## What was broken

A brand could not state which sales funnels it sells through. The store existed (brand-service#393, brand-service#396, on its `staging`) and the screen existed (distribute.you#3146, on prod since it shipped), but there was no route between them: the gateway proxied `sales-economics` and `sales-economics-effective` for the same brand, and nothing for the funnels.

The consequence was measurable rather than theoretical. **Zero brands had declared a funnel in either environment**, because no surface in the product could write one. features-service's goal arbitration (features-service#704, live on prod since v0.112.0) reads the declared set as its candidate list, so it failed loud for every brand and the whole feature stayed dormant — not because a service was broken, but because the fact it ranks over could never be stated.

## What this adds

Four org-scoped passthroughs sitting beside the sales-economics proxies, with the same auth chain (`authenticate + requireOrg + requireUser`) and the same downstream path shape:

| Gateway | brand-service |
|---|---|
| `GET /v1/brands/:id/sales-funnels` | `GET /orgs/brands/{brandId}/sales-funnels` |
| `PUT /v1/brands/:id/sales-funnels` | `PUT /orgs/brands/{brandId}/sales-funnels` |
| `PUT /v1/brands/:id/sales-funnels/:funnelKey` | `PUT /orgs/brands/{brandId}/sales-funnels/{funnelKey}` |
| `DELETE /v1/brands/:id/sales-funnels/:funnelKey` | `DELETE /orgs/brands/{brandId}/sales-funnels/{funnelKey}` |

All four paths were read from the deployed staging registry rather than from the brief. The service-auth `GET /internal/brands/{brandId}/sales-funnels` is deliberately **not** proxied: features-service reads it service to service, and an internal route is never mounted client-facing (CLAUDE.md rule #3).

## Passthrough, and nothing else

- Response schemas are `z.object({}).passthrough()`; no downstream field is re-declared (CLAUDE.md #8).
- No validation is duplicated here. brand-service already rejects a rate outside a funnel's own chain, a destination the funnel has no use for, an off-domain page destination, and a website-led funnel on a brand with no website. Its 4xx reach the caller with status and body intact through `callExternalServiceWithStatus` + `respondUpstreamError`.
- Bodies are forwarded as-is: an explicit `null` is not stripped (it is how a caller CLEARS a value back to never-declared), an empty body is not dropped (it declares a funnel without pricing it yet), and `{ "funnelKeys": [] }` is not treated as absent (it is the only way a brand can state it sells through nothing).

## `declared`

The read answers `{ declared, funnels }`, and the flag is load-bearing. `declared: false` with an empty list means no set has ever been stated; `declared: true` with an empty list means the brand stated it sells through none. They are opposite answers, and collapsing them reads back to the dashboard as "the brand never declared it", which is a lie about user data. A test pins both cases through the hop.

## Tests

Behavioural, driven through the real router with `supertest` and a stubbed `fetch` — a source-substring test cannot see what goes over the wire (CLAUDE.md #7 corollary 3):

- `tests/unit/brand-sales-funnels-behavior.test.ts` — the full downstream path literal for each route (never a prefix), the forwarded identity being the **authenticated** org even when the caller supplies its own `x-org-id` / `?orgId`, byte-identical bodies in both directions, `declared` surviving for both `true` and `false` with an empty list, and upstream `400` / `403` arriving branchable rather than flattened into a string.
- `tests/unit/brand-sales-funnels-auth.test.ts` — a separate file with **no** auth mock, so the 401/400 gate is a real assertion about the shipped middleware rather than a property of a stub. Covers all four routes.

26 new tests. Full unit suite green (1805). `openapi.json` regenerated; the diff is pure addition (one line removed, a trailing brace shift).

## Verification

Read-only; no money moves on this path. The producer contract was verified against the deployed brand-service `staging` registry (`list_service_endpoints` + `get_endpoint_details` on all four routes, `includeErrors: true`) rather than trusted from the issue text.

## Triage

Staging feature. `staging` currently tracks `main`.

## Tracking

#784 (this request) · brand-service#393, brand-service#396 (the producer) · distribute.you#3149 (the screen, preview-only until this lands) · features-service#704 (the consumer, dormant until a brand can declare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
