### PR TITLE
feat(mailing-lists): proxy the update preview so staff can see an email before sending it

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -45903,6 +45903,148 @@
         }
       }
     },
+    "/v1/mailing-lists/updates/preview": {
+      "post": {
+        "tags": [
+          "Mailing Lists"
+        ],
+        "summary": "Render an update as a recipient will see it, without sending it (staff only)",
+        "description": "Proxy to transactional-email-service POST /mailing-lists/updates/preview. The body carries a markdown body; downstream returns the HTML a recipient would receive, rendered by the same code a real send uses, plus any image URLs no mail client renders. Nothing is sent, nothing is recorded, no suppression list is read. It takes no list slug because a body renders identically whoever receives it. Body and response shapes are owned by the downstream service.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MailingListUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The body as it would arrive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MailingListPassthroughResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid slug, or a bad request forwarded verbatim from transactional-email-service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Staff access required — the caller is not on the staff allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such list (forwarded verbatim)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ]
+      }
+    },
     "/v1/mailing-lists/{slug}/updates": {
       "post": {
         "tags": [

--- a/src/routes/mailing-lists.ts
+++ b/src/routes/mailing-lists.ts
@@ -170,6 +170,33 @@ router.delete(
   },
 );
 
+// POST /v1/mailing-lists/updates/preview — render a draft as a recipient will
+// see it, without sending it (staff only). Proxies transactional-email-service
+// POST /mailing-lists/updates/preview.
+//
+// Deliberately carries NO slug: downstream takes none, because a body renders
+// identically whoever receives it. That is also why this cannot collide with
+// `/mailing-lists/:slug/updates` above — both are three segments, and the third
+// is a different literal, so neither pattern can swallow the other.
+router.post(
+  "/mailing-lists/updates/preview",
+  authenticate,
+  requireOrg,
+  requireStaff,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const result = await callExternalService(
+        externalServices.transactionalEmail,
+        `/mailing-lists/updates/preview${rawQueryString(req.originalUrl)}`,
+        { method: "POST", body: req.body, headers: staffHeaders(req) },
+      );
+      res.json(result);
+    } catch (error) {
+      respondUpstreamError(res, error, "Failed to render the mailing list update preview");
+    }
+  },
+);
+
 // POST /v1/mailing-lists/:slug/updates — send a written update to a list (staff only).
 // Proxies transactional-email-service POST /mailing-lists/{slug}/updates. Body
 // forwarded as-is; downstream renders the markdown, sends one message per recipient,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -10266,6 +10266,28 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
+  path: "/v1/mailing-lists/updates/preview",
+  tags: ["Mailing Lists"],
+  summary: "Render an update as a recipient will see it, without sending it (staff only)",
+  description:
+    "Proxy to transactional-email-service POST /mailing-lists/updates/preview. The body carries " +
+    "a markdown body; downstream returns the HTML a recipient would receive, rendered by the " +
+    "same code a real send uses, plus any image URLs no mail client renders. Nothing is sent, " +
+    "nothing is recorded, no suppression list is read. It takes no list slug because a body " +
+    "renders identically whoever receives it. Body and response shapes are owned by the " +
+    "downstream service.",
+  security: authed,
+  request: {
+    body: { content: { "application/json": { schema: MailingListUpdateRequest } } },
+  },
+  responses: {
+    200: { description: "The body as it would arrive", content: { "application/json": { schema: MailingListPassthroughResponse } } },
+    ...mailingListErrorResponses,
+  },
+});
+
+registry.registerPath({
+  method: "post",
   path: "/v1/mailing-lists/{slug}/updates",
   tags: ["Mailing Lists"],
   summary: "Send a written update to a mailing list (staff only)",

--- a/tests/unit/mailing-lists-auth.test.ts
+++ b/tests/unit/mailing-lists-auth.test.ts
@@ -24,6 +24,7 @@ const ROUTES: Array<[string, string]> = [
   ["get", "/v1/mailing-lists/investors/subscribers"],
   ["post", "/v1/mailing-lists/investors/subscribers"],
   ["delete", "/v1/mailing-lists/investors/subscribers?email=a@b.com"],
+  ["post", "/v1/mailing-lists/updates/preview"],
   ["post", "/v1/mailing-lists/investors/updates"],
   ["get", "/v1/mailing-lists/investors/updates"],
 ];

--- a/tests/unit/mailing-lists-behavior.test.ts
+++ b/tests/unit/mailing-lists-behavior.test.ts
@@ -246,6 +246,41 @@ describe("/v1/mailing-lists — over the wire", () => {
     expect(res.body).toEqual({ error: "No such list", code: "LIST_NOT_FOUND" });
   });
 
+  it("renders a preview through a slug-less path, body untouched, and sends nothing", async () => {
+    stubFetch({
+      htmlBody: "<table><tr><td><h2>July</h2></td></tr></table>",
+      textBody: "## July",
+      unrenderableImages: [],
+    });
+
+    const body = { body: "## July\n\nRevenue up." };
+    const res = await request(buildApp()).post("/v1/mailing-lists/updates/preview").send(body);
+
+    expect(res.status).toBe(200);
+    // No slug reaches downstream — and this three-segment path must not be
+    // swallowed by `/mailing-lists/:slug/updates`, which is also three segments.
+    expect(calls[0].url).toBe(`${TE_BASE}/mailing-lists/updates/preview`);
+    expect(calls[0].options.method).toBe("POST");
+    expect(JSON.parse(calls[0].options.body)).toEqual(body);
+    expect(calls[0].options.headers["x-org-id"]).toBe("org_test456");
+    expect(calls[0].options.headers["x-email"]).toBe("kevin.lourd@gmail.com");
+    expect(res.body).toEqual({
+      htmlBody: "<table><tr><td><h2>July</h2></td></tr></table>",
+      textBody: "## July",
+      unrenderableImages: [],
+    });
+  });
+
+  it("does not route a real send into the preview path", async () => {
+    stubFetch({ updateId: "u1", slug: "updates", subject: "s", status: "sent", recipientCount: 1, skippedOptedOut: [], failures: [] });
+
+    // A list literally named "updates" is legal, and its send must still reach
+    // the send path rather than the preview one.
+    await request(buildApp()).post("/v1/mailing-lists/updates/updates").send({ subject: "s", body: "b" });
+
+    expect(calls[0].url).toBe(`${TE_BASE}/mailing-lists/updates/updates`);
+  });
+
   it("propagates a downstream 502 when provider suppression state is unavailable", async () => {
     calls = [];
     global.fetch = vi.fn().mockImplementation(async () => ({


### PR DESCRIPTION
## What

`POST /v1/mailing-lists/updates/preview` — staff-only transparent proxy to transactional-email-service `POST /mailing-lists/updates/preview` (its #122).

## Why

Staff writing an investor update could not see it until it had already reached everyone. transactional-email-service now renders a draft the way a recipient will receive it, sending nothing and recording nothing. The admin console only ever talks to this gateway, so without this route the surface is unreachable.

## Passthrough

Same posture as the sibling mailing-list routes: `authenticate + requireOrg + requireStaff`, identity from the authenticated caller (a caller-supplied org is ignored), body forwarded as-is, response never reshaped, upstream failures through `respondUpstreamError` so `error` / `code` / `details` survive.

**No slug in the path**, because the downstream takes none — a body renders identically whoever receives it. That also means it shares a segment count with `/mailing-lists/:slug/updates`; the third segment is a different literal, so neither pattern can swallow the other, and a test drives a list literally named `updates` through the send path to keep that true.

## Verification

- `tests/unit/mailing-lists-behavior.test.ts` — asserts the exact downstream URL, the forwarded identity headers, the byte-identical body, and that a send to a list named `updates` still routes to the send path.
- `tests/unit/mailing-lists-auth.test.ts` — the new route is in the non-staff 403 matrix.
- Full suite green: 1884 passed, 0 failed. `tsc` clean, `openapi.json` regenerated.

## Order

Merge after transactional-email-service #122 is live. The admin console change waits on **this** being live in prod (admin deploys from `main` on Vercel, no staging buffer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
