### PR TITLE
feat(leads): read one lead's full record through the gateway

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1957,6 +1957,10 @@
         "type": "object",
         "properties": {}
       },
+      "LeadDetailResponse": {
+        "type": "object",
+        "properties": {}
+      },
       "QualifyResponse": {
         "type": "object",
         "properties": {
@@ -11799,6 +11803,158 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/leads/{id}": {
+      "get": {
+        "tags": [
+          "Leads"
+        ],
+        "summary": "Read one lead's full record",
+        "description": "Pass-through to lead-service GET /orgs/leads/{id}. Returns the full record of a SINGLE lead — the same object GET /v1/leads emits for that row — wrapped as `{ leadDetail }` rather than a one-element list. `id` is the `id` a row of GET /v1/leads already carries, so a caller needs nothing it did not already receive from the list: take the slim list for the table, then ask for depth one row at a time instead of holding the full projection for a whole brand. The whole query string is forwarded to lead-service verbatim: the parameters listed here are the ones documented today, not a whitelist. `brandId` / `campaignId` mean exactly what they mean on the list — which scope the delivery overlay answers for. The read is org-scoped downstream: a lead outside the caller's org is a 404, indistinguishable from one that does not exist. Refer to lead-service openapi.json for the exact response shape — api-service forwards it untransformed.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "The `id` of a lead as returned by GET /v1/leads. A non-uuid value is a 400 from lead-service."
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Delivery-overlay scope, same as on the list. A lead that does not belong to this brand is a 404."
+            },
+            "required": false,
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Campaign scope for the delivery overlay, same as on the list."
+            },
+            "required": false,
+            "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "name": "x-org-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External organization ID (e.g. Clerk org ID `org_2xyz...`). Required when using an app key (`distrib.app_*`) on endpoints that need org context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "External user ID (e.g. Clerk user ID `user_2abc...`). Required when using an app key (`distrib.app_*`) on endpoints that need user context. Ignored when using a user key (`distrib.usr_*`)."
+          },
+          {
+            "name": "x-campaign-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-brand-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "description": "Brand ID(s), comma-separated UUIDs. Supports multi-brand campaigns. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-workflow-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug. Automatically injected by workflow-service on workflow HTTP calls. Optional — forwarded to downstream services for tracking."
+          },
+          {
+            "name": "x-feature-slug",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug. Optional — forwarded to downstream services and runs for tracking."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The lead's full record as returned by lead-service (`{ leadDetail }`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadDetailResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid lead id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such lead in this caller's org (or brand, when brandId is given)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -98,6 +98,50 @@ router.get("/leads/stats", authenticate, requireOrg, requireUser, async (req: Au
 });
 
 /**
+ * GET /v1/leads/:id — pass-through to lead-service GET /orgs/leads/{id}.
+ *
+ * Registered AFTER the literal `/leads/stats` above: a path parameter matches any
+ * single segment, so declaring it first would swallow `/v1/leads/stats` and send
+ * lead-service `stats` as a lead id.
+ *
+ * Reads ONE lead's full record. `id` is the `id` a row of GET /v1/leads already
+ * carries, so a caller needs nothing it did not already receive from the list —
+ * which is the point: a table + detail-panel surface takes the slim list for the
+ * table and asks for depth one row at a time, instead of holding the full
+ * projection for a whole brand (~57k rows / >100 MB on the largest one) so that one
+ * panel can work.
+ *
+ * The caller's query string is forwarded verbatim for the same reason the list
+ * route forwards it: `brandId` / `campaignId` decide which scope lead-service's
+ * delivery overlay answers for, and a filter this gateway has never heard of must
+ * still reach lead-service unchanged (CLAUDE.md rule #11). Nothing is read out of
+ * it here — this route has no guard of its own to raise.
+ *
+ * The org boundary is the authenticated one: `x-org-id` comes from
+ * `buildInternalHeaders(req)`, never from the caller, and lead-service scopes the
+ * lookup on it — a lead in another org is a 404 there, indistinguishable from one
+ * that does not exist.
+ *
+ * One record, not a list: the body is small, so it is forwarded through
+ * `callExternalService` rather than piped (rule #10 is for bodies measured in MB).
+ * The response shape is lead-service's; this gateway does not declare it (rule #8).
+ */
+router.get("/leads/:id", authenticate, requireOrg, requireUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const result = await callExternalService(
+      externalServices.lead,
+      `/orgs/leads/${encodeURIComponent(req.params.id)}${rawQueryString(req.originalUrl)}`,
+      { headers: buildInternalHeaders(req) }
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    console.error("[api-service] Get lead detail error:", error);
+    respondUpstreamError(res, error, "Failed to get lead");
+  }
+});
+
+/**
  * POST /v1/leads/search
  * Search for leads via lead-service
  */

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1758,6 +1758,53 @@ registry.registerPath({
   },
 });
 
+registry.registerPath({
+  method: "get",
+  path: "/v1/leads/{id}",
+  tags: ["Leads"],
+  summary: "Read one lead's full record",
+  description:
+    "Pass-through to lead-service GET /orgs/leads/{id}. Returns the full record of a SINGLE lead — the same object " +
+    "GET /v1/leads emits for that row — wrapped as `{ leadDetail }` rather than a one-element list. " +
+    "`id` is the `id` a row of GET /v1/leads already carries, so a caller needs nothing it did not already receive " +
+    "from the list: take the slim list for the table, then ask for depth one row at a time instead of holding the " +
+    "full projection for a whole brand. The whole query string is forwarded to lead-service verbatim: the parameters " +
+    "listed here are the ones documented today, not a whitelist. `brandId` / `campaignId` mean exactly what they mean " +
+    "on the list — which scope the delivery overlay answers for. The read is org-scoped downstream: a lead outside the " +
+    "caller's org is a 404, indistinguishable from one that does not exist. " +
+    "Refer to lead-service openapi.json for the exact response shape — api-service forwards it untransformed.",
+  security: authed,
+  request: {
+    params: z.object({
+      id: z.string().openapi({
+        description: "The `id` of a lead as returned by GET /v1/leads. A non-uuid value is a 400 from lead-service.",
+      }),
+    }),
+    query: z.object({
+      brandId: z.string().uuid().optional().openapi({
+        description: "Delivery-overlay scope, same as on the list. A lead that does not belong to this brand is a 404.",
+      }),
+      campaignId: z.string().uuid().optional().openapi({
+        description: "Campaign scope for the delivery overlay, same as on the list.",
+      }),
+    }).passthrough(),
+  },
+  responses: {
+    200: {
+      description: "The lead's full record as returned by lead-service (`{ leadDetail }`).",
+      content: {
+        "application/json": {
+          schema: z.object({}).passthrough().openapi("LeadDetailResponse"),
+        },
+      },
+    },
+    400: { description: "Invalid lead id", content: errorContent },
+    401: { description: "Unauthorized", content: errorContent },
+    404: { description: "No such lead in this caller's org (or brand, when brandId is given)", content: errorContent },
+    500: { description: "Internal error", content: errorContent },
+  },
+});
+
 // ===================================================================
 // QUALIFY
 // ===================================================================

--- a/tests/unit/lead-detail-proxy.auth.test.ts
+++ b/tests/unit/lead-detail-proxy.auth.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+// Own file, deliberately WITHOUT the auth mock the behaviour test uses: this exercises
+// the real `authenticate` / `requireOrg` middleware, so "an unauthenticated call is
+// refused" is a real assertion about the shipped gate and not a property of a stub.
+vi.hoisted(() => {
+  process.env.LEAD_SERVICE_URL = "http://lead.test.local";
+  process.env.LEAD_SERVICE_API_KEY = "lead-test-key";
+  process.env.ADMIN_DISTRIBUTE_API_KEY = "admin-test-key";
+});
+
+import leadsRouter from "../../src/routes/leads.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", leadsRouter);
+  return app;
+}
+
+const LEAD = "22222222-2222-2222-2222-222222222222";
+
+describe("GET /v1/leads/:id — auth gate", () => {
+  beforeEach(() => {
+    // Any outbound call from here means the request got past auth, which is the
+    // failure this file exists to catch.
+    global.fetch = vi.fn().mockImplementation(async () => {
+      throw new Error("unexpected outbound call from an unauthenticated request");
+    });
+  });
+
+  it("refuses a call with no credentials", async () => {
+    const res = await request(buildApp()).get(`/v1/leads/${LEAD}`);
+    expect(res.status).toBe(401);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("refuses a call carrying a wrong platform key", async () => {
+    const res = await request(buildApp())
+      .get(`/v1/leads/${LEAD}`)
+      .set("X-API-Key", "not-the-admin-key");
+    expect(res.status).toBe(401);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("refuses an admin-keyed call that names an org it did not authenticate as", async () => {
+    // The platform key is shared with the dashboard's server-side proxy, so it is not
+    // an identity: without resolvable identity headers the request never reaches
+    // lead-service, so a caller cannot read another org's lead by naming it.
+    const res = await request(buildApp())
+      .get(`/v1/leads/${LEAD}`)
+      .set("X-API-Key", "admin-test-key")
+      .set("x-org-id", "someone-elses-org");
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lead-detail-proxy.behavior.test.ts
+++ b/tests/unit/lead-detail-proxy.behavior.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+/**
+ * GET /v1/leads/:id — pass-through to lead-service GET /orgs/leads/{id}.
+ *
+ * Driven through the real router with a stubbed `fetch`, so these assert what goes
+ * over the wire: the downstream path, the identity headers, the query string and the
+ * body. A source-substring test cannot see what a template literal interpolates, and
+ * cannot see identity at all (CLAUDE.md rule #7, corollaries 2 and 3).
+ */
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = "user_test123";
+    req.orgId = "org_authenticated";
+    req.runId = "run_test789";
+    req.authType = "admin";
+    next();
+  },
+  requireOrg: (_req: any, _res: any, next: any) => next(),
+  requireUser: (_req: any, _res: any, next: any) => next(),
+  AuthenticatedRequest: {},
+}));
+
+import leadsRouter from "../../src/routes/leads.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/v1", leadsRouter);
+  return app;
+}
+
+const LEAD = "22222222-2222-2222-2222-222222222222";
+const BRAND = "11111111-1111-1111-1111-111111111111";
+const CAMPAIGN = "33333333-3333-3333-3333-333333333333";
+
+const DETAIL_BODY = JSON.stringify({
+  leadDetail: {
+    id: LEAD,
+    email: "someone@example.com",
+    lead: { firstName: "Ada", employmentHistory: [{ title: "CTO" }] },
+    audience: { id: "aud-1", name: "Founders", avatarUrl: null },
+    contacted: true,
+    unknownDownstreamField: 7,
+  },
+});
+
+describe("GET /v1/leads/:id — single lead pass-through", () => {
+  let calls: Array<{ url: string; init: any }>;
+
+  beforeEach(() => {
+    calls = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, init: any) => {
+      calls.push({ url, init });
+      return new Response(DETAIL_BODY, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+  });
+
+  function upstream() {
+    expect(calls).toHaveLength(1);
+    return calls[0];
+  }
+
+  it("forwards to lead-service GET /orgs/leads/{id}, not a list query", async () => {
+    const res = await request(buildApp()).get(`/v1/leads/${LEAD}`);
+    expect(res.status).toBe(200);
+
+    const { url, init } = upstream();
+    expect(url.endsWith(`/orgs/leads/${LEAD}`)).toBe(true);
+    expect(url).not.toContain("?id=");
+    expect(url).not.toContain("/orgs/leads?");
+    expect(init.method ?? "GET").toBe("GET");
+  });
+
+  it("returns the upstream record untouched, one record and not a list", async () => {
+    const res = await request(buildApp()).get(`/v1/leads/${LEAD}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(JSON.parse(DETAIL_BODY));
+    expect(Array.isArray(res.body.leadDetail)).toBe(false);
+    // A field this gateway has never heard of survives the hop.
+    expect(res.body.leadDetail.unknownDownstreamField).toBe(7);
+  });
+
+  it("forwards the caller's query string verbatim, order and encoding intact", async () => {
+    const query = `?brandId=${BRAND}&campaignId=${CAMPAIGN}&somethingBrandNew=slice-42&q=a%20b%2Bc`;
+    await request(buildApp()).get(`/v1/leads/${LEAD}${query}`);
+    expect(upstream().url.endsWith(`/orgs/leads/${LEAD}${query}`)).toBe(true);
+  });
+
+  it("sends the AUTHENTICATED org, not one the caller named", async () => {
+    await request(buildApp())
+      .get(`/v1/leads/${LEAD}?brandId=${BRAND}`)
+      .set("x-org-id", "org_someone_else")
+      .set("x-user-id", "user_someone_else");
+
+    const { init } = upstream();
+    expect(init.headers["x-org-id"]).toBe("org_authenticated");
+    expect(init.headers["x-user-id"]).toBe("user_test123");
+  });
+
+  it("cannot be pointed at another org through the query string either", async () => {
+    await request(buildApp()).get(`/v1/leads/${LEAD}?orgId=org_someone_else&brandId=${BRAND}`);
+    const { url, init } = upstream();
+    expect(init.headers["x-org-id"]).toBe("org_authenticated");
+    // The parameter still reaches lead-service verbatim — it just is not identity.
+    expect(url).toContain("orgId=org_someone_else");
+  });
+
+  it("forwards a 404 with its upstream body field-for-field", async () => {
+    global.fetch = vi.fn().mockImplementation(
+      async () =>
+        new Response('{"error":"Lead not found","code":"LEAD_NOT_FOUND"}', {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        })
+    );
+
+    const res = await request(buildApp()).get(`/v1/leads/${LEAD}`);
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Lead not found", code: "LEAD_NOT_FOUND" });
+  });
+
+  it("forwards a 400 on a non-uuid id from lead-service rather than judging it here", async () => {
+    global.fetch = vi.fn().mockImplementation(
+      async () =>
+        new Response('{"error":"id must be a uuid"}', {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        })
+    );
+
+    const res = await request(buildApp()).get("/v1/leads/not-a-uuid");
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "id must be a uuid" });
+  });
+
+  it("does not shadow GET /v1/leads/stats — a literal segment is not a lead id", async () => {
+    const statsCalls: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      statsCalls.push(url);
+      return new Response('{"totalLeads":3}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const res = await request(buildApp()).get(`/v1/leads/stats?brandId=${BRAND}`);
+    expect(res.status).toBe(200);
+    expect(statsCalls[0].endsWith(`/orgs/stats?brandId=${BRAND}`)).toBe(true);
+    expect(statsCalls[0]).not.toContain("/orgs/leads/stats");
+  });
+
+  it("does not shadow GET /v1/leads — the list route still lists", async () => {
+    const listCalls: string[] = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      listCalls.push(url);
+      return new Response('{"leads":[]}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const res = await request(buildApp()).get(`/v1/leads?brandId=${BRAND}`);
+    expect(res.status).toBe(200);
+    expect(listCalls[0].endsWith(`/orgs/leads?brandId=${BRAND}`)).toBe(true);
+  });
+});


### PR DESCRIPTION
A surface with a lead table plus a detail panel can now read the rich record for the ONE lead somebody clicked, instead of holding the rich record for all of them just in case.

## Problem

The only lead read through this gateway is `GET /v1/leads`, which answers for a whole brand. On one production brand that is ~57k rows and well over 100 MB. Two consumers pull that entire body purely so a detail panel can render on click: the dashboard leads page, in a browser tab that polls it, and the public no-login report page, server-side, which then parses it. That body already OOM-killed this gateway once, which is why the list route was moved to a raw byte pipe.

lead-service shipped the read that fixes it (`GET /orgs/leads/{id}`, sales-lead-service#425), keyed on the `id` every row of the existing list already carries. Nothing in front of it exposed the route, so no consumer could reach it.

## What this adds

`GET /v1/leads/:id` -> lead-service `GET /orgs/leads/{id}`.

- **The id is the one a list row already carries**, so a consumer needs nothing it did not already receive from the list it reads through this gateway.
- **The query string goes over verbatim**, read off `req.originalUrl`, exactly as the list route forwards it. `brandId` / `campaignId` decide which scope lead-service answers the delivery overlay for, so the panel agrees with the row the table drew; a parameter this gateway has never heard of reaches lead-service unchanged (CLAUDE.md #11). Nothing is read out of the query here, because this route has no guard of its own to raise.
- **The response is not declared here.** Passthrough schema, per #8: lead-service owns the shape, so a field it adds needs zero edit in this repo.
- **`callExternalService`, not the byte pipe.** One record is comfortably small; #10 is for bodies measured in MB.
- **Upstream failures keep their body.** `respondUpstreamError`, so lead-service 404 and its 400 on a non-uuid id reach the caller field-for-field under the upstream status, instead of being flattened into an `error` string.

## Scope

The org boundary is the authenticated one: `x-org-id` comes from `buildInternalHeaders(req)`, never from the caller, and lead-service scopes the lookup on it rather than checking after the fact, so a lead in another org is a 404 there, indistinguishable from one that does not exist. Naming an org in a header or in the query changes nothing about whose lead is read.

## Route ordering

Registered AFTER the literal `/leads/stats` that landed in #833 while this was in flight: a path parameter matches any single segment, so declaring `/leads/:id` first would swallow `/v1/leads/stats` and send lead-service `stats` as a lead id. A test asserts both sibling leads routes still reach their own downstream.

## Tests

`lead-detail-proxy.behavior.test.ts` drives the real router with a stubbed `fetch` and asserts what goes over the wire: the downstream path (one record, not a list query), the untouched body including a field this gateway has never heard of, the verbatim query string, the AUTHENTICATED org rather than one the caller named in a header or in the query, upstream 404 and 400 bodies forwarded field-for-field, and neither `/v1/leads` nor `/v1/leads/stats` shadowed. `lead-detail-proxy.auth.test.ts` is a separate file with no auth mock, so the refusal of an unauthenticated call is an assertion about the shipped gate and not about a stub.

Full suite: 1604 passing across 157 files. `openapi.json` regenerated.

## Deploy note

The producer (sales-lead-service#425) is not merged yet, so this route answers whatever lead-service answers today until it lands. Purely additive and nothing calls it, so there is no consumer to break in the meantime; `GET /v1/leads` is unchanged.

Filed as shamanic-technologies/distribute.you#3416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
